### PR TITLE
Disambiguate Polysemy FromJSON instance usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# Cabal build artifacts
+dist-newstyle
+dist
+
+# Visual Studio Code local preferences
+.vscode

--- a/cabal.project.local
+++ b/cabal.project.local
@@ -1,0 +1,1 @@
+tests: True

--- a/hie.yaml
+++ b/hie.yaml
@@ -1,0 +1,3 @@
+cradle:
+  cabal:
+    component: "lib:hscli"

--- a/src/Strategy/Python/Pipenv.hs
+++ b/src/Strategy/Python/Pipenv.hs
@@ -24,6 +24,7 @@ import Prologue
 import qualified Data.Map.Strict as M
 import qualified Data.Text as T
 import           Polysemy
+import           Polysemy.Error hiding (catch)
 import           Polysemy.Input
 import           Polysemy.State
 import           Polysemy.Output
@@ -35,7 +36,6 @@ import           Effect.ReadFS
 import qualified Graph as G
 import           Types
 
-import           Polysemy.Error hiding (catch)
 import Diagnostics
 
 discover :: Discover

--- a/src/Strategy/Python/Pipenv.hs
+++ b/src/Strategy/Python/Pipenv.hs
@@ -35,6 +35,9 @@ import           Effect.ReadFS
 import qualified Graph as G
 import           Types
 
+import           Polysemy.Error hiding (catch)
+import Diagnostics
+
 discover :: Discover
 discover = Discover
   { discoverName = "pipenv"
@@ -71,7 +74,7 @@ strategyWithCmd = Strategy
 strategyNoCmd :: Strategy BasicFileOpts
 strategyNoCmd = Strategy
   { strategyName = "python-pipfile"
-  , strategyAnalyze = \opts -> analyzeNoCmd & fileInputJson (targetFile opts)
+  , strategyAnalyze = \opts -> analyzeNoCmd & (fileInputJson :: (Members '[ReadFS, Error CLIErr] r) => Path b File -> InterpreterFor (Input PipfileLock) r) (targetFile opts)
   , strategyModule = parent . targetFile
   , strategyOptimal = Optimal
   , strategyComplete = Complete


### PR DESCRIPTION
I added some configuration files so `ghcide` doesn't blow up in my face immediately.

The important part of this diff is the change in `Pipenv.hs`. Since `fileInputJson :: (FromJSON a, Members '[ReadFS, Error CLIErr] r) => Path b File -> InterpreterFor (Input a) r`, and the uasge of `fileInputJson` in `Pipenv.hs:77` applies no additional constraints, GHC is unable to disambiguate the type variable `a`. This diff explicitly types `a` to be `PipfileLock` to remove that ambiguity.