### PR TITLE
Add package-lock.json strategy

### DIFF
--- a/hscli.cabal
+++ b/hscli.cabal
@@ -151,6 +151,7 @@ test-suite test
     Go.GlideLockTest
     Gradle.GradleTest
     GraphUtil
+    Node.NpmLockTest
     Python.PipListTest
     Python.PipenvTest
     Python.ReqTxtTest

--- a/hscli.cabal
+++ b/hscli.cabal
@@ -33,6 +33,7 @@ common lang
     RecordWildCards
     ScopedTypeVariables
     StrictData
+    TupleSections
     TypeApplications
     TypeFamilies
     TypeOperators
@@ -112,6 +113,7 @@ library
     Strategy.Go.Transitive
     Strategy.Go.Types
     Strategy.Gradle
+    Strategy.Node.NpmLock
     Strategy.Node.YarnLock
     Strategy.NpmList
     Strategy.Python.PipList

--- a/src/Discovery.hs
+++ b/src/Discovery.hs
@@ -10,6 +10,7 @@ import qualified Strategy.Go.GopkgToml as GopkgToml
 import qualified Strategy.Go.GlideLock as GlideLock
 import qualified Strategy.Gradle as Gradle
 import qualified Strategy.NpmList as NpmList
+import qualified Strategy.Node.NpmLock as NpmLock
 import qualified Strategy.Node.YarnLock as YarnLock
 import qualified Strategy.Python.Pipenv as Pipenv
 import qualified Strategy.Python.PipList as PipList
@@ -30,6 +31,7 @@ discoverFuncs =
 
   , Gradle.discover
 
+  , NpmLock.discover
   , NpmList.discover
   , YarnLock.discover
 
@@ -50,6 +52,7 @@ strategyGroups =
       ]
   , StrategyGroup "nodejs"
       [ SomeStrategy YarnLock.strategy
+      , SomeStrategy NpmLock.strategy
       , SomeStrategy NpmList.strategy
       ]
   , StrategyGroup "python"

--- a/src/Strategy/Node/NpmLock.hs
+++ b/src/Strategy/Node/NpmLock.hs
@@ -1,0 +1,135 @@
+module Strategy.Node.NpmLock
+  ( discover
+  , analyze
+  , strategy
+  )
+  where
+
+import Prologue
+
+import qualified Data.Map.Strict as M
+import           Polysemy
+import           Polysemy.Input
+import           Polysemy.Output
+
+import           Discovery.Walk
+import           Effect.Graphing
+import           Effect.ReadFS
+import qualified Graph as G
+import           Types
+
+discover :: Discover
+discover = Discover
+  { discoverName = "npm-packagelock"
+  , discoverFunc = discover'
+  }
+
+discover' :: Members '[Embed IO, Output ConfiguredStrategy] r => Path Abs Dir -> Sem r ()
+discover' = walk $ \_ subdirs files -> do
+  case find (\f -> fileName f == "package-lock.json") files of
+    Just file -> output (configure file)
+    Nothing -> pure ()
+
+  walkSkipNamed ["node_modules/"] subdirs
+
+strategy :: Strategy BasicFileOpts
+strategy = Strategy
+  { strategyName = "nodejs-packagelock"
+  , strategyAnalyze = \opts -> analyze
+      & fileInputJson @NpmPackageJson (targetFile opts)
+  , strategyModule = parent . targetFile
+  , strategyOptimal = Optimal
+  , strategyComplete = Complete
+  }
+
+configure :: Path Rel File -> ConfiguredStrategy
+configure = ConfiguredStrategy strategy . BasicFileOpts
+
+data NpmPackageJson = NpmPackageJson
+  { packageName         :: Text
+  , packageVersion      :: Text
+  , packageDependencies :: Map Text NpmDep
+  } deriving (Eq, Ord, Show, Generic)
+
+data NpmDep = NpmDep
+  { depVersion      :: Text
+  , depDev          :: Maybe Bool
+  , depResolved     :: Maybe Text
+  , depRequires     :: Maybe (Map Text Text) -- ^ name to version spec
+  , depDependencies :: Maybe (Map Text NpmDep)
+  } deriving (Eq, Ord, Show, Generic)
+
+instance FromJSON NpmPackageJson where
+  parseJSON = withObject "NpmPackageJson" $ \obj ->
+    NpmPackageJson <$> obj .: "name"
+                   <*> obj .: "version"
+                   <*> obj .: "dependencies"
+
+instance FromJSON NpmDep where
+  parseJSON = withObject "NpmDep" $ \obj ->
+    NpmDep <$> obj .:  "version"
+           <*> obj .:? "dev"
+           <*> obj .:? "resolved"
+           <*> obj .:? "requires"
+           <*> obj .:? "dependencies"
+
+analyze :: Member (Input NpmPackageJson) r => Sem r G.Graph
+analyze = buildGraph <$> input
+
+data NpmPackage = NpmPackage
+  { pkgName    :: Text
+  , pkgVersion :: Text
+  } deriving (Eq, Ord, Show, Generic)
+
+type instance PkgLabel NpmPackage = NpmPackageLabel
+
+data NpmPackageLabel = NpmPackageEnv Text | NpmPackageLocation Text
+  deriving (Eq, Ord, Show, Generic)
+
+buildGraph :: NpmPackageJson -> G.Graph
+buildGraph packageJson = run . graphingToGraph @NpmPackage toDependency $ do
+  _ <- M.traverseWithKey addDirect (packageDependencies packageJson)
+  _ <- M.traverseWithKey addDep (packageDependencies packageJson)
+  pure ()
+
+  where
+  addDirect :: Member (Graphing NpmPackage) r => Text -> NpmDep -> Sem r ()
+  addDirect name NpmDep{depVersion} = direct (NpmPackage name depVersion)
+
+  addDep :: Member (Graphing NpmPackage) r => Text -> NpmDep -> Sem r ()
+  addDep name NpmDep{..} = do
+    let pkg = NpmPackage name depVersion
+
+    case depDev of
+      Just True -> label pkg (NpmPackageEnv "development")
+      _         -> label pkg (NpmPackageEnv "production")
+
+    traverse_ (label pkg . NpmPackageLocation) depResolved
+
+    -- add edges to required packages
+    case depRequires of
+      Nothing -> pure ()
+      Just required ->
+        void $ M.traverseWithKey (\reqName reqVer -> edge pkg (NpmPackage reqName reqVer)) required
+
+    -- add dependency nodes
+    case depDependencies of
+      Nothing -> pure ()
+      Just deps ->
+        void $ M.traverseWithKey addDep deps
+
+  toDependency :: NpmPackage -> Set NpmPackageLabel -> G.Dependency
+  toDependency pkg = foldr addLabel (start pkg)
+
+  addLabel :: NpmPackageLabel -> G.Dependency -> G.Dependency
+  addLabel (NpmPackageEnv env) dep = dep { G.dependencyTags = M.insertWith (++) "environment" [env] (G.dependencyTags dep) }
+  addLabel (NpmPackageLocation loc) dep = dep { G.dependencyLocations = loc : G.dependencyLocations dep }
+
+  start :: NpmPackage -> G.Dependency
+  start NpmPackage{..} = G.Dependency
+    { dependencyType = G.NodeJSType
+    , dependencyName = pkgName
+    , dependencyVersion = Just $ G.CEq pkgVersion
+    , dependencyLocations = []
+    , dependencyTags = M.empty
+    }

--- a/src/Strategy/Node/NpmLock.hs
+++ b/src/Strategy/Node/NpmLock.hs
@@ -1,7 +1,11 @@
 module Strategy.Node.NpmLock
   ( discover
   , analyze
+  , buildGraph
   , strategy
+
+  , NpmPackageJson(..)
+  , NpmDep(..)
   )
   where
 

--- a/test/Node/NpmLockTest.hs
+++ b/test/Node/NpmLockTest.hs
@@ -6,8 +6,8 @@ import Prologue
 
 import qualified Data.Map.Strict as M
 
-import qualified Graph as G
-import           Strategy.Node.NpmLock
+import DepTypes
+import Strategy.Node.NpmLock
 
 import GraphUtil
 import Test.Tasty.Hspec
@@ -42,29 +42,29 @@ mockInput = NpmPackageJson
     ]
   }
 
-packageOne :: G.Dependency
-packageOne = G.Dependency
-  { dependencyType = G.NodeJSType
+packageOne :: Dependency
+packageOne = Dependency
+  { dependencyType = NodeJSType
   , dependencyName = "packageOne"
-  , dependencyVersion = Just (G.CEq "1.0.0")
+  , dependencyVersion = Just (CEq "1.0.0")
   , dependencyLocations = ["https://example.com/one.tgz"]
   , dependencyTags = M.fromList [("environment", ["production"])]
   }
 
-packageTwo :: G.Dependency
-packageTwo = G.Dependency
-  { dependencyType = G.NodeJSType
+packageTwo :: Dependency
+packageTwo = Dependency
+  { dependencyType = NodeJSType
   , dependencyName = "packageTwo"
-  , dependencyVersion = Just (G.CEq "2.0.0")
+  , dependencyVersion = Just (CEq "2.0.0")
   , dependencyLocations = ["https://example.com/two.tgz"]
   , dependencyTags = M.fromList [("environment", ["development"])]
   }
 
-packageThree :: G.Dependency
-packageThree = G.Dependency
-  { dependencyType = G.NodeJSType
+packageThree :: Dependency
+packageThree = Dependency
+  { dependencyType = NodeJSType
   , dependencyName = "packageThree"
-  , dependencyVersion = Just (G.CEq "3.0.0")
+  , dependencyVersion = Just (CEq "3.0.0")
   , dependencyLocations = []
   , dependencyTags = M.fromList [("environment", ["development"])]
   }

--- a/test/Node/NpmLockTest.hs
+++ b/test/Node/NpmLockTest.hs
@@ -1,0 +1,82 @@
+module Node.NpmLockTest
+  ( spec_npmLockBuildGraph
+  ) where
+
+import Prologue
+
+import qualified Data.Map.Strict as M
+
+import qualified Graph as G
+import           Strategy.Node.NpmLock
+
+import GraphUtil
+import Test.Tasty.Hspec
+
+mockInput :: NpmPackageJson
+mockInput = NpmPackageJson
+  { packageName = "example"
+  , packageVersion = "1.0.0"
+  , packageDependencies = M.fromList
+    [ ("packageOne", NpmDep
+        { depVersion = "1.0.0"
+        , depDev = Nothing
+        , depResolved = Just "https://example.com/one.tgz"
+        , depRequires = Just (M.fromList [("packageTwo", "2.0.0")])
+        , depDependencies = Just (M.fromList
+            [ ("packageTwo", NpmDep
+                { depVersion = "2.0.0"
+                , depDev = Just True
+                , depResolved = Just "https://example.com/two.tgz"
+                , depRequires = Just (M.fromList [("packageThree", "3.0.0")])
+                , depDependencies = Nothing
+                })
+            ])
+        })
+    , ("packageThree", NpmDep
+        { depVersion = "3.0.0"
+        , depDev = Just True
+        , depResolved = Nothing
+        , depRequires = Just (M.fromList [("packageOne", "1.0.0")])
+        , depDependencies = Nothing
+        })
+    ]
+  }
+
+packageOne :: G.Dependency
+packageOne = G.Dependency
+  { dependencyType = G.NodeJSType
+  , dependencyName = "packageOne"
+  , dependencyVersion = Just (G.CEq "1.0.0")
+  , dependencyLocations = ["https://example.com/one.tgz"]
+  , dependencyTags = M.fromList [("environment", ["production"])]
+  }
+
+packageTwo :: G.Dependency
+packageTwo = G.Dependency
+  { dependencyType = G.NodeJSType
+  , dependencyName = "packageTwo"
+  , dependencyVersion = Just (G.CEq "2.0.0")
+  , dependencyLocations = ["https://example.com/two.tgz"]
+  , dependencyTags = M.fromList [("environment", ["development"])]
+  }
+
+packageThree :: G.Dependency
+packageThree = G.Dependency
+  { dependencyType = G.NodeJSType
+  , dependencyName = "packageThree"
+  , dependencyVersion = Just (G.CEq "3.0.0")
+  , dependencyLocations = []
+  , dependencyTags = M.fromList [("environment", ["development"])]
+  }
+
+spec_npmLockBuildGraph :: Spec
+spec_npmLockBuildGraph = do
+  describe "buildGraph" $ do
+    it "should produce expected output" $ do
+      let graph = buildGraph mockInput
+      expectDeps [packageOne, packageTwo, packageThree] graph
+      expectDirect [packageOne, packageThree] graph
+      expectEdges [ (packageOne, packageTwo)
+                  , (packageTwo, packageThree)
+                  , (packageThree, packageOne)
+                  ] graph


### PR DESCRIPTION
Interestingly, the package-lock strategy gives us better graphs than `npm list`: package-lock contains location information, and gives us environment information with a single pass