### PR TITLE
Glide lockfile parsing support

### DIFF
--- a/hscli.cabal
+++ b/hscli.cabal
@@ -108,6 +108,7 @@ library
     Strategy.Go.Gomod
     Strategy.Go.GopkgLock
     Strategy.Go.GopkgToml
+    Strategy.Go.GlideLock
     Strategy.Go.Transitive
     Strategy.Go.Types
     Strategy.Gradle
@@ -145,6 +146,7 @@ test-suite test
     Go.GomodTest
     Go.GopkgLockTest
     Go.GopkgTomlTest
+    Go.GlideLockTest
     Gradle.GradleTest
     GraphUtil
     Python.PipListTest

--- a/src/Discovery.hs
+++ b/src/Discovery.hs
@@ -7,6 +7,7 @@ import qualified Strategy.Go.GoList as GoList
 import qualified Strategy.Go.Gomod as Gomod
 import qualified Strategy.Go.GopkgLock as GopkgLock
 import qualified Strategy.Go.GopkgToml as GopkgToml
+import qualified Strategy.Go.GlideLock as GlideLock
 import qualified Strategy.Gradle as Gradle
 import qualified Strategy.NpmList as NpmList
 import qualified Strategy.Node.YarnLock as YarnLock
@@ -25,6 +26,7 @@ discoverFuncs =
   , Gomod.discover
   , GopkgToml.discover
   , GopkgLock.discover
+  , GlideLock.discover
 
   , Gradle.discover
 
@@ -65,5 +67,6 @@ strategyGroups =
       , SomeStrategy Gomod.strategy
       , SomeStrategy GopkgLock.strategy
       , SomeStrategy GopkgToml.strategy
+      , SomeStrategy GlideLock.strategy
       ]
   ]

--- a/src/Strategy/Go/GlideLock.hs
+++ b/src/Strategy/Go/GlideLock.hs
@@ -19,10 +19,10 @@ import           Polysemy
 import           Polysemy.Input
 import           Polysemy.Output
 
+import           DepTypes
 import           Discovery.Walk
-import           Effect.GraphBuilder
 import           Effect.ReadFS
-import qualified Graph as G
+import           Graphing (Graphing, unfold)
 import           Types
 
 discover :: Discover
@@ -48,20 +48,20 @@ strategy = Strategy
   , strategyComplete = NotComplete
   }
 
-analyze :: Member (Input GlideLockfile) r => Sem r G.Graph
+analyze :: Member (Input GlideLockfile) r => Sem r (Graphing Dependency)
 analyze = buildGraph <$> input
 
-buildGraph :: GlideLockfile -> G.Graph
+buildGraph :: GlideLockfile -> Graphing Dependency
 buildGraph lockfile = unfold direct (const []) toDependency
   where
   direct = imports lockfile
   toDependency GlideDep{..}  =
-    G.Dependency { dependencyType = G.GoType
-                  , dependencyName = depName
-                  , dependencyVersion = Just (G.CEq $ T.pack (show depVersion))
-                  , dependencyLocations = []
-                  , dependencyTags = M.empty
-                  }
+    Dependency { dependencyType = GoType
+               , dependencyName = depName
+               , dependencyVersion = Just (CEq $ T.pack (show depVersion))
+               , dependencyLocations = []
+               , dependencyTags = M.empty
+               }
 
 configure :: Path Rel File -> ConfiguredStrategy
 configure = ConfiguredStrategy strategy . BasicFileOpts

--- a/src/Strategy/Go/GlideLock.hs
+++ b/src/Strategy/Go/GlideLock.hs
@@ -1,0 +1,91 @@
+module Strategy.Go.GlideLock
+  ( discover
+  , strategy
+  , analyze
+  , configure
+
+  , GlideLockfile(..)
+  , GlideDep(..)
+
+  , buildGraph
+  )
+  where
+
+import Prologue hiding ((.=))
+
+import qualified Data.Map.Strict as M
+import qualified Data.Text as T
+import           Polysemy
+import           Polysemy.Input
+import           Polysemy.Output
+
+import           Discovery.Walk
+import           Effect.GraphBuilder
+import           Effect.ReadFS
+import qualified Graph as G
+import           Types
+
+discover :: Discover
+discover = Discover
+  { discoverName = "gopkglock"
+  , discoverFunc = discover'
+  }
+
+discover' :: Members '[Embed IO, Output ConfiguredStrategy] r => Path Abs Dir -> Sem r ()
+discover' = walk $ \_ _ files ->
+  case find (\f -> fileName f == "glide.lock") files of
+    Nothing -> walkContinue
+    Just file  -> do
+      output (configure file)
+      walkContinue
+
+strategy :: Strategy BasicFileOpts
+strategy = Strategy
+  { strategyName = "golang-glidelock"
+  , strategyAnalyze = \opts -> analyze & fileInputYaml @GlideLockfile (targetFile opts)
+  , strategyModule = parent . targetFile
+  , strategyOptimal = Optimal
+  , strategyComplete = NotComplete
+  }
+
+analyze :: Member (Input GlideLockfile) r => Sem r G.Graph
+analyze = buildGraph <$> input
+
+buildGraph :: GlideLockfile -> G.Graph
+buildGraph lockfile = unfold direct (const []) toDependency
+  where
+  direct = imports lockfile
+  toDependency GlideDep{..}  =
+    G.Dependency { dependencyType = G.GoType
+                  , dependencyName = depName
+                  , dependencyVersion = Just (G.CEq $ T.pack (show depVersion))
+                  , dependencyLocations = []
+                  , dependencyTags = M.empty
+                  }
+
+configure :: Path Rel File -> ConfiguredStrategy
+configure = ConfiguredStrategy strategy . BasicFileOpts
+
+data GlideLockfile = GlideLockfile
+  { hash    :: Integer
+  , updated :: Text
+  , imports :: [GlideDep]
+  } deriving (Eq, Ord, Show, Generic)
+
+data GlideDep = GlideDep
+  { depName    :: Text
+  , depVersion :: Integer
+  , depRepo    :: Maybe Text
+  } deriving (Eq, Ord, Show, Generic)
+
+instance FromJSON GlideLockfile where
+  parseJSON = withObject "GlideLockfile" $ \obj ->
+    GlideLockfile <$> obj .: "hash"
+                  <*> obj .: "updated"
+                  <*> obj .: "imports"
+
+instance FromJSON GlideDep where
+  parseJSON = withObject "GlideDep" $ \obj ->
+    GlideDep <$> obj .:  "name"
+               <*> obj .: "version"
+               <*> obj .:? "repo"

--- a/test/Go/GlideLockTest.hs
+++ b/test/Go/GlideLockTest.hs
@@ -1,0 +1,66 @@
+module Go.GlideLockTest
+  ( spec_analyze
+  ) where
+
+import Prologue
+
+import qualified Data.Map.Strict as M
+import qualified Data.Text.IO as TIO
+import           Polysemy
+import           Polysemy.Input
+import           Text.Megaparsec
+
+import           Effect.GraphBuilder
+import qualified Graph as G
+import           Strategy.Go.GlideLock
+
+import Test.Hspec.Megaparsec
+import Test.Tasty.Hspec
+
+expected :: G.Graph
+expected = run . evalGraphBuilder G.empty $ do
+  ref1 <- addNode (G.Dependency
+                        { dependencyType = G.GoType
+                        , dependencyName = "github.com/pkg/one"
+                        , dependencyVersion = Just (G.CEq "100")
+                        , dependencyLocations = []
+                        , dependencyTags = M.empty
+                        })
+  ref2 <- addNode (G.Dependency
+                        { dependencyType = G.GoType
+                        , dependencyName = "github.com/pkg/three/v3"
+                        , dependencyVersion = Just (G.CEq "300")
+                        , dependencyLocations = []
+                        , dependencyTags = M.empty
+                        })
+  addDirect ref1
+  addDirect ref2
+
+glideLockfile :: GlideLockfile
+glideLockfile = 
+  GlideLockfile { hash = 123
+  , updated = "now"
+  , imports = 
+    [ GlideDep 
+        { depName = "github.com/pkg/one"
+        , depVersion = 100
+        , depRepo = Just "testRepo"
+    }
+    , GlideDep 
+        { depName = "github.com/pkg/three/v3"
+        , depVersion = 300
+        , depRepo = Just "testRepo"
+    }
+  ]
+  }
+
+spec_analyze :: Spec
+spec_analyze = do
+  testFile <- runIO (TIO.readFile "test/Go/testdata/glide.lock")
+
+  describe "glide lock analyzer" $
+    it "produces the expected output" $ do
+      let result = analyze
+            & runInputConst @GlideLockfile glideLockfile
+            & run
+      result `shouldBe` expected

--- a/test/Go/testdata/glide.lock
+++ b/test/Go/testdata/glide.lock
@@ -1,0 +1,11 @@
+hash: 12345
+updated: 2018-10-12T14:37:49.968644-07:00
+imports:
+- name: fossas/package-one
+  version: 1000
+  subpackages:
+  - compute
+- name: rsc.io/letsencrypt
+  version: 2000
+  repo: fossas/privatefork
+testImports: []

--- a/test/Go/testdata/glide.lock
+++ b/test/Go/testdata/glide.lock
@@ -1,11 +1,11 @@
 hash: 12345
 updated: 2018-10-12T14:37:49.968644-07:00
 imports:
-- name: fossas/package-one
-  version: 1000
+- name: github.com/pkg/one
+  version: 100
   subpackages:
   - compute
-- name: rsc.io/letsencrypt
-  version: 2000
+- name: github.com/pkg/three/v3
+  version: 300
   repo: fossas/privatefork
 testImports: []


### PR DESCRIPTION
This PR adds support for parsing `glide.lock` files. The file is yaml formatted and as a result this PR added supporting functions to parse yaml files into Aeson data. Fortunately the `Data.yaml` package supports this out of the box.