### PR TITLE
fix go.mod parsing

### DIFF
--- a/src/Strategy/Go/Gomod.hs
+++ b/src/Strategy/Go/Gomod.hs
@@ -128,7 +128,7 @@ gomodParser = do
 
   -- parse the body of a single replace (wihtout the leading "replace" lexeme)
   singleReplace :: Parser Statement
-  singleReplace = ReplaceStatement <$> packageName <* lexeme (chunk "=>") <*> packageName <*> semver
+  singleReplace = ReplaceStatement <$> packageName <* optional semver <* lexeme (chunk "=>") <*> packageName <*> semver
 
   -- top-level exclude statements
   -- e.g.:
@@ -161,7 +161,7 @@ gomodParser = do
 
   -- package name, e.g., golang.org/x/text
   packageName :: Parser Text
-  packageName = T.pack <$> lexeme (some (alphaNumChar <|> char '.' <|> char '/' <|> char '-'))
+  packageName = T.pack <$> lexeme (some (alphaNumChar <|> char '.' <|> char '/' <|> char '-' <|> char '_'))
 
   -- semver, e.g.:
   --   v0.0.0-20190101000000-abcdefabcdef

--- a/src/Strategy/Go/Gomod.hs
+++ b/src/Strategy/Go/Gomod.hs
@@ -126,7 +126,7 @@ gomodParser = do
   replaceStatements :: Parser [Statement]
   replaceStatements = block "replace" singleReplace
 
-  -- parse the body of a single replace (wihtout the leading "replace" lexeme)
+  -- parse the body of a single replace (without the leading "replace" lexeme)
   singleReplace :: Parser Statement
   singleReplace = ReplaceStatement <$> packageName <* optional semver <* lexeme (chunk "=>") <*> packageName <*> semver
 

--- a/test/Go/GomodTest.hs
+++ b/test/Go/GomodTest.hs
@@ -80,11 +80,13 @@ spec_gomodParse = do
                                         , Require "repo/C" "v1.1.0"
                                         , Require "repo/name/D" "v4.0.0"
                                         , Require "repo/E" "v8.0.0+incompatible"
+                                        , Require "repo/F_underscore" "v1.0.0"
                                         ]
                         , modReplaces = M.fromList
                             [ ("repo/B", Require "alias/repo/B" "v0.1.0")
                             , ("repo/C", Require "alias/repo/C" "v0.0.0-20180207000608-000000000003")
                             , ("repo/E", Require "alias/repo/E" "v0.0.0-20170808103936-000000000005+incompatible")
+                            , ("repo/F_underscore", Require "repo/F_underscore" "v2.0.0")
                             ]
                         , modExcludes = [ Require "repo/B" "v0.9.0"
                                         , Require "repo/C" "v1.0.0"

--- a/test/Go/testdata/go.mod.edgecases
+++ b/test/Go/testdata/go.mod.edgecases
@@ -12,6 +12,7 @@ require (
 	repo/C v1.1.0
 	repo/name/D v4.0.0 // indirect
 	repo/E v8.0.0+incompatible
+	repo/F_underscore v1.0.0
 )
 
 replace repo/B => alias/repo/B v0.1.0
@@ -19,6 +20,7 @@ replace repo/B => alias/repo/B v0.1.0
 replace (
 	repo/C => alias/repo/C v0.0.0-20180207000608-000000000003
 	repo/E => alias/repo/E v0.0.0-20170808103936-000000000005+incompatible
+    repo/F_underscore v1.0.0 => repo/F_underscore v2.0.0
 )
 
 exclude repo/B v0.9.0


### PR DESCRIPTION
- `replace` directives may have a semver on the left side of the fat arrow
- Package names may contain underscores