### PR TITLE
Add strategy design docs

### DIFF
--- a/docs/strategies.md
+++ b/docs/strategies.md
@@ -1,8 +1,9 @@
 # Analysis Strategies
 
-We support dependency analysis for the following languages:
+We support dependency analysis for the following languages/ecosystems:
 
 - [golang](strategies/golang.md) (gomodules, dep, glide)
+- [gradle](strategies/gradle.md)
 - [maven](strategies/maven.md)
 - [nodejs](strategies/nodejs.md) (yarn, npmcli)
 - [python](strategies/python.md) (pipenv, setuptools)

--- a/docs/strategies.md
+++ b/docs/strategies.md
@@ -3,5 +3,6 @@
 We support dependency analysis for the following languages:
 
 - [golang](strategies/golang.md) (gomodules, dep, glide)
+- [maven](strategies/maven.md)
 - [nodejs](strategies/nodejs.md) (yarn, npmcli)
 - [python](strategies/python.md) (pipenv, setuptools)

--- a/docs/strategies.md
+++ b/docs/strategies.md
@@ -1,27 +1,6 @@
-<!-- markdown-toc start - Don't edit this section. Run M-x markdown-toc-refresh-toc -->
-**Table of Contents**
-
-- [Analysis Strategies](#analysis-strategies)
-    - [Python](#python)
-
-<!-- markdown-toc end -->
-
 # Analysis Strategies
 
-TODO: Common tags
-TODO: what the columns mean
-TODO: pinned versions column?
+We support dependency analysis for the following languages:
 
-## Python
-
-| Strategy                       | Direct Deps | Deep Deps | Edges | Tags                        |
-| ---                            | ---         | ---       | ---   | ---                         |
-| [pipenv][pipenv]               | Yes         | Yes       | Yes   | Environment                 |
-| [pipfile][pipenv]              | Yes         | Yes       | No    | Environment                 |
-| [requirements.txt][setuptools] | Yes         | No        | No    | PEP-508 Environment Markers |
-| [setup.py][setuptools]         | Yes         | No        | No    | PEP-508 Environment Markers |
-| [piplist][piplist]             | Maybe       | Maybe     | No    |                             |
-
-[pipenv]: strategies/python/pipenv.md
-[setuptools]: strategies/python/setuptools.md
-[piplist]: strategies/python/piplist.md
+- [golang](strategies/golang.md) (gomodules, dep, glide)
+- [python](strategies/python.md) (pipenv, setuptools)

--- a/docs/strategies.md
+++ b/docs/strategies.md
@@ -1,0 +1,27 @@
+<!-- markdown-toc start - Don't edit this section. Run M-x markdown-toc-refresh-toc -->
+**Table of Contents**
+
+- [Analysis Strategies](#analysis-strategies)
+    - [Python](#python)
+
+<!-- markdown-toc end -->
+
+# Analysis Strategies
+
+TODO: Common tags
+TODO: what the columns mean
+TODO: pinned versions column?
+
+## Python
+
+| Strategy                       | Direct Deps | Deep Deps | Edges | Tags                        |
+| ---                            | ---         | ---       | ---   | ---                         |
+| [pipenv][pipenv]               | Yes         | Yes       | Yes   | Environment                 |
+| [pipfile][pipenv]              | Yes         | Yes       | No    | Environment                 |
+| [requirements.txt][setuptools] | Yes         | No        | No    | PEP-508 Environment Markers |
+| [setup.py][setuptools]         | Yes         | No        | No    | PEP-508 Environment Markers |
+| [piplist][piplist]             | Maybe       | Maybe     | No    |                             |
+
+[pipenv]: strategies/python/pipenv.md
+[setuptools]: strategies/python/setuptools.md
+[piplist]: strategies/python/piplist.md

--- a/docs/strategies.md
+++ b/docs/strategies.md
@@ -3,4 +3,5 @@
 We support dependency analysis for the following languages:
 
 - [golang](strategies/golang.md) (gomodules, dep, glide)
+- [nodejs](strategies/nodejs.md) (yarn, npmcli)
 - [python](strategies/python.md) (pipenv, setuptools)

--- a/docs/strategies.md
+++ b/docs/strategies.md
@@ -6,4 +6,5 @@ We support dependency analysis for the following languages/ecosystems:
 - [gradle](strategies/gradle.md)
 - [maven](strategies/maven.md)
 - [nodejs](strategies/nodejs.md) (yarn, npmcli)
+- [ruby](strategies/ruby.md) (bundler)
 - [python](strategies/python.md) (pipenv, setuptools)

--- a/docs/strategies/golang.md
+++ b/docs/strategies/golang.md
@@ -1,0 +1,38 @@
+# Golang Analysis
+
+Historically, the Golang buildtool ecosystem has been very fragmented: many
+tools like dep, Glide, Govendor, etc have tried to address issues around build
+reproducibility, versioning and vendoring of dependencies.
+
+As of Golang 1.11, we have first-class support for "modules", which solves
+issues previously seen around versioning and build reproducibility.
+
+Because modules address those issues so well, the other tooling has largely gone
+into maintenance mode, with the notable exception of dep. As such, golang
+analysis in spectrometer primarily targets Golang 1.11+ modules and dep. Support
+for Glide is also included, because it's still commonly used.
+
+| Strategy                             | Direct Deps | Deep Deps | Edges | Tags |
+| ---                                  | ---         | ---       | ---   | ---  |
+| [golist][gomodules] (golang modules) | ✅          | ✅        | 🔶    |      |
+| [gomod][gomodules] (golang modules)  | ✅          | ❌        | 🔶    |      |
+| [gopkglock][godep] (dep)             | ✅          | ✅        | 🔶    |      |
+| [gopkgtoml][godep] (dep)             | ✅          | 🔶        | 🔶    |      |
+| [glide][glide]                       | ✅          | ✅        | ❌    |      |
+
+[gomodules]: golang/gomodules.md
+[godep]: golang/godep.md
+[glide]: golang/glide.md
+
+## 🔶 Edges and deep dependencies
+
+Most strategies (except for gomod, where it would be redundant -- golist
+supersedes gomod) use `go list -json all` to hydrate edges and transitive
+dependencies. Package imports are recursively traversed, ignoring `Standard`
+(system) packages.
+
+`go list` behaves slightly differently depending on the context:
+
+- in a gomodules project, packages can contain a `Module` field that contains a
+pinned `Version`. The version will otherwise be unspecified
+- `go list` includes vendored packages in both gomodules and non-gomodules projects.

--- a/docs/strategies/golang/glide.md
+++ b/docs/strategies/golang/glide.md
@@ -1,0 +1,26 @@
+# Glide
+
+Glide is very commonly encountered as a buildtool for older golang projects.
+Though deprecated, it's prevalent enough among existing projects that it
+warrants support in spectrometer.
+
+## Project Discovery
+
+Find all files named `glide.lock`
+
+## Analysis
+
+`glide.lock` is a yaml-formatted file containing pinned package versions:
+
+```yaml
+hash: 12345
+updated: 2018-10-12T14:37:49.968644-07:00
+imports:
+- name: github.com/pkg/one
+  version: 100
+  subpackages:
+  - compute
+- name: github.com/pkg/three/v3
+  version: 300
+  repo: fossas/privatefork
+```

--- a/docs/strategies/golang/godep.md
+++ b/docs/strategies/golang/godep.md
@@ -1,0 +1,26 @@
+# Dep
+
+Dep is an alternative toolchain for golang dependency management. Though go
+modules are the blessed form of dependency management, dep is exploring
+alternatives in the dependency management space, and hasn't been deprecated.
+
+## Project Discovery
+
+`gopkglock`: Find all files named `Gopkg.lock`
+
+`gopkgtoml`: Find all files named `Gopkg.toml`
+
+## Analysis: gopkglock
+
+We parse [projects][depprojects] from Gopkg.lock. This is more comprehensive
+than GopkgToml, as it contains pinned versions of all of our direct _and_
+transitive dependencies. We also pick up on `source` locations from GopkgLock
+
+[depprojects]: https://golang.github.io/dep/docs/Gopkg.toml.html#dependency-rules-constraint-and-override
+
+## Analysis: gopkgtoml
+
+We parse [dependency rules][deprules] from Gopkg.toml. `override`s are similar
+to [gomod replaces](gomodules.md).
+
+[deprules]: https://golang.github.io/dep/docs/Gopkg.toml.html#dependency-rules-constraint-and-override

--- a/docs/strategies/golang/gomodules.md
+++ b/docs/strategies/golang/gomodules.md
@@ -1,0 +1,56 @@
+# Golang Modules
+
+Golang 1.11 has first-class support for "modules", which is now the preferred
+way to do dependency management.
+
+## Project Discovery
+
+Find all files named `go.mod`
+
+## Analysis: golist
+
+Discovery: find go.mod files
+
+We run `go list -m all`, which produces, e.g.,:
+
+```
+github.com/skyrocknroll/go-mod-example
+github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc
+github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf
+github.com/davecgh/go-spew v1.1.1
+github.com/gorilla/mux v1.6.2
+github.com/konsorten/go-windows-terminal-sequences v1.0.1
+github.com/pmezard/go-difflib v1.0.0
+github.com/sirupsen/logrus v1.2.0
+github.com/stretchr/objx v0.1.1
+github.com/stretchr/testify v1.2.2
+golang.org/x/crypto v0.0.0-20180904163835-0709b304e793
+golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33
+gopkg.in/alecthomas/kingpin.v2 v2.2.6
+```
+
+where the first line references the current module, and the remaining lines are
+package imports and pinned version separated by a space. For package
+dependencies that aren't using gomodules, a pseudo-version
+(`v0.0.0-TIMESTAMP-COMMITID`) is present instead. We use the commit ID as the
+version.
+
+## Analysis: gomod
+
+We parse the go.mod file, which looks something like:
+
+```
+module our/package/path
+
+require (
+    github.com/example/one v1.2.3
+    github.com/example/two v2.3.4
+)
+
+replace github.com/example/two => github.com/example/other v2.0.0
+```
+
+where:
+
+- `replace` rewrites `require`s. In this example, our requires resolve to
+  `[github.com/example/one v1.2.3, github.com/example/other v2.0.0]`

--- a/docs/strategies/gradle.md
+++ b/docs/strategies/gradle.md
@@ -1,0 +1,27 @@
+# Gradle Analysis
+
+When using gradle, users specify dependencies and plugins with a groovy DSL.
+This makes accurate dependency analysis particularly difficult: groovy projects
+tend to contain several (sub)projects with their own buildscripts, and plugins
+that add dependencies of their own.
+
+To accurately determine the entire project/dependency structure, we use an
+external script
+
+| Strategy   | Direct Deps | Deep Deps | Edges | Tags |
+| ---        | ---         | ---       | ---   | ---  |
+| initscript | Yes         | Yes       | Yes   |      |
+
+## Project Discovery
+
+find `build.gradle*` files, and run `gradle tasks` in those directories. When
+`gradle tasks` succeeds, skip all subdirectories. `gradle tasks` ensures that we
+have a valid gradle project to analyze.
+
+## Analysis
+
+1. Unpack our init script to a temporary directory
+2. Invoke the init script with `gradle jsonDeps -Ipath/to/init.gradle`
+
+Currently, we only record the `default` configuration dependencies of each
+project. Subprojects are also included in the graph.

--- a/docs/strategies/gradle.md
+++ b/docs/strategies/gradle.md
@@ -6,11 +6,11 @@ tend to contain several (sub)projects with their own buildscripts, and plugins
 that add dependencies of their own.
 
 To accurately determine the entire project/dependency structure, we use an
-external script
+external script.
 
 | Strategy   | Direct Deps | Deep Deps | Edges | Tags |
 | ---        | ---         | ---       | ---   | ---  |
-| initscript | Yes         | Yes       | Yes   |      |
+| initscript | ✅          | ✅        | ✅    |      |
 
 ## Project Discovery
 

--- a/docs/strategies/maven.md
+++ b/docs/strategies/maven.md
@@ -13,7 +13,7 @@ be pretty solid.
 
 | Strategy    | Direct Deps | Deep Deps | Edges | Tags |
 | ---         | ---         | ---       | ---   | ---  |
-| mavenplugin | Yes         | Yes       | Yes   |      |
+| mavenplugin | ✅          | ✅        | ✅    |      |
 
 ## Project Discovery
 

--- a/docs/strategies/maven.md
+++ b/docs/strategies/maven.md
@@ -1,0 +1,28 @@
+# Maven Analysis
+
+Maven projects are notoriously difficult to resolve into final dependency
+graphs. While many dependencies are declared as XML, these dependency
+declarations can span many buildscripts and user settings files. What's worse:
+maven plugins are often used to apply dependencies to the project, and some
+maven plugins allow arbitrary executable code -- similar to gradle.
+
+To work around this, we're using the maven cli in conjunction with the [depgraph
+maven plugin](https://github.com/ferstl/depgraph-maven-plugin), version 3.3.0.
+This plugin is used by some Jenkins and Apache projects, so we can expect it to
+be pretty solid.
+
+| Strategy    | Direct Deps | Deep Deps | Edges | Tags |
+| ---         | ---         | ---       | ---   | ---  |
+| mavenplugin | Yes         | Yes       | Yes   |      |
+
+## Project Discovery
+
+find `pom.xml` files, and run `mvn validate` in those directories. When
+`mvn validate` succeeds, skip all subdirectories. `mvn validate` ensure that we
+have a valid maven project to analyze
+
+## Analysis
+
+1. unpack the embedded plugin to a temporary directory
+2. install it to the local maven repository (`mvn install:install-file ...`)
+3. invoke the plugin in the top-level project

--- a/docs/strategies/nodejs.md
+++ b/docs/strategies/nodejs.md
@@ -1,0 +1,14 @@
+# NodeJS Analysis
+
+The nodejs buildtool ecosystem consists of two major toolchains: the `npm` cli and `yarn`
+
+| Strategy                   | Direct Deps              | Deep Deps | Edges | Tags        |
+| ---                        | ---                      | ---       | ---   | ---         |
+| [yarnlock][yarn]           | ✅ not labeled as direct | ✅        | ❌    |             |
+| [npmlock][npm] (npmcli)    | ✅                       | ✅        | ✅    | Environment |
+| [npmlist][npm] (npmcli)    | ✅                       | ✅        | ✅    |             |
+| [packagejson][packagejson] | ✅                       | ❌        | ❌    | Environment |
+
+[yarn]: nodejs/yarn.md
+[npm]: nodejs/npmcli.md
+[packagejson]: nodejs/packagejson.md

--- a/docs/strategies/nodejs/npmcli.md
+++ b/docs/strategies/nodejs/npmcli.md
@@ -1,0 +1,59 @@
+# Npm (cli)
+
+The npm cli is the canonical package manager for nodejs projects.
+
+## Project Discovery
+
+`npmlist`: Find all directories containing a file named `package.json` (package manifests)
+
+`npmlock`: Find all files named `package-lock.json`, not descending into
+directories named `node_modules`
+
+## Analysis: npmlist
+
+Running `npm ls --json` outputs a tree of all the installed dependencies, their
+version, and their transitive dependencies. Adding `--production` or
+`--development` allows us to determine the dependencies which are used only in
+production or in development. Running `npm ls --json --production` and merging
+the results with `npm ls --json --development` provides us with all of the
+information we are interested in about npm dependencies.
+
+## Analysis: npmlock
+
+The package lock json file is generated when npm modifies `node_modules` or
+`package.json` and describes the exact dependency tree generated.
+
+> Note: In old versions of npm, package-lock.json was only modified when dependencies were installed.
+
+This dependency tree contains information about a dependency's version, its transitive dependencies, the URL where the dependency is located at, and whether or not the dependency is used as a development dependency or not. The transitive dependency information is listed in an unintuitvie way. Under each dependency there may be two fields, `requires` and `dependencies` as in the following example:
+
+```json
+    "babel-code-frame": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+      "requires": {
+        "chalk": "1.1.3",
+        "esutils": "2.0.3",
+        "js-tokens": "3.0.2"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+        },
+        "js-tokens": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+          "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+        }
+      }
+    }
+```
+
+The `requires` field signifies all of the dependencies that are needed by the dependency in order to properly function.
+
+The `dependencies` field signifies all of the dependencies included in `babel-code-frame`'s `node_modules` folder within the top level `node_modules` folder. Notice that these dependencies are not always included in the `requires` section.
+
+> Note: `npm-shrinkwrap.json` is an identically formatted file that can be used for [publishing packages](https://docs.npmjs.com/cli/shrinkwrap).

--- a/docs/strategies/nodejs/packagejson.md
+++ b/docs/strategies/nodejs/packagejson.md
@@ -1,0 +1,20 @@
+# package.json
+
+package.json is a common build manifest used by both yarn and npmcli.
+
+## Project Discovery
+
+`npmlock`: Find all files named `package.json`, not descending into directories
+named `node_modules`
+
+## Analysis
+
+`package.json` is a user modified file that specifies which dependencies are
+mandatory in order to run your project. This file lists dependencies with their
+version specifier. These dependencies are user specified and map nearly 1:1 with
+direct dependencies, however users may also specify their desired version for
+transitive dependencies which would invalidate the assumption that all
+dependencies specified here are direct.
+
+There is also a different block for development dependencies which allows us to
+accurately determine part of the tags available for node.

--- a/docs/strategies/nodejs/yarn.md
+++ b/docs/strategies/nodejs/yarn.md
@@ -1,0 +1,32 @@
+# Yarn
+
+Yarn is a spiritual successor to the npm cli. Yarn automatically updates the
+`yarn.lock` file when the yarn CLI is used to modify the dependencies present in
+the project. The `yarn.lock` file contains information about a dependency's
+transitive dependencies, its location, and its resolved version.
+
+## Project Discovery
+
+Find all files named `yarn.lock`
+
+## Analysis
+
+yarn.lock has its own bespoke format. Dependencies typically look something
+like:
+
+```
+"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.5.5":
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.5.5.tgz#bc0782f6d69f7b7d49531219699b988f669a8f9d"
+  integrity sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==
+  dependencies:
+    "@babel/highlight" "^7.0.0"
+```
+
+where:
+
+- `resolved` is the exact location of the dependency
+- `version` is a pinned dependency
+- the section "keys" contain constraints used by other packages to refer to this
+  dependency
+- `dependencies` is a list of constraints for dependencies of this package

--- a/docs/strategies/python.md
+++ b/docs/strategies/python.md
@@ -1,0 +1,16 @@
+# Python Analysis
+
+The python buildtool ecosystem consists of two major toolchains: setuptools
+(requirements.txt, setup.py), and pipenv.
+
+| Strategy                                    | Direct Deps | Deep Deps | Edges | Tags                        |
+| ---                                         | ---         | ---       | ---   | ---                         |
+| [pipenv][pipenv] (pipenv)                   | ✅          | ✅        | ✅    | Environment                 |
+| [pipfile][pipenv] (pipenv)                  | ✅          | ✅        | ❌    | Environment                 |
+| [requirements.txt][setuptools] (setuptools) | ✅          | ❌        | ❌    | PEP-508 Environment Markers |
+| [setup.py][setuptools] (setuptools)         | ✅          | ❌        | ❌    | PEP-508 Environment Markers |
+| [piplist][piplist]                          | Maybe       | Maybe     | ❌    |                             |
+
+[pipenv]: python/pipenv.md
+[setuptools]: python/setuptools.md
+[piplist]: python/piplist.md

--- a/docs/strategies/python/pipenv.md
+++ b/docs/strategies/python/pipenv.md
@@ -1,0 +1,29 @@
+# Pipenv/Pipfile
+
+This is a modern approach to defining python project dependencies, providing
+very precise, complete dependency graphs for a python project.
+
+## Project Discovery
+
+Find all files named `Pipfile.lock`
+
+## Analysis
+
+We parse `Pipfile.lock` -- a json-structured file -- to find:
+
+- `sources` - repositories/locations that can be referenced by packages
+- `default` - production dependencies
+- `develop` - development dependencies
+
+Dependencies may contain an `index` field -- this is a reference to a repository
+in the top-level `sources`.
+
+Dependencies contain pinned `version` information.
+
+Notably missing: edges between dependencies. This is where the Pipenv strategy
+diverges from Pipfile.
+
+## Pipenv-specific
+
+When possible, we use `pipenv graph --json-tree` to hydrate the edges between
+dependencies. This will fail unless `pipenv install` has been run in that directory.

--- a/docs/strategies/python/piplist.md
+++ b/docs/strategies/python/piplist.md
@@ -1,0 +1,15 @@
+# Piplist
+
+This is a really poor strategy that's used only in the worst-case: it includes
+packages found in the global environment, and may not contain project
+dependencies if `pip install` hasn't yet been run.
+
+## Project Discovery
+
+Find directories containing `setup.py` or `requirements.txt`
+
+## Analysis
+
+We run `pip list --format=json` and parse the output -- in the worst case, this
+only provides global dependencies; in the best case, the global dependencies
+will include our project's direct and deep dependencies.

--- a/docs/strategies/python/setuptools.md
+++ b/docs/strategies/python/setuptools.md
@@ -1,0 +1,36 @@
+# Setuptools (requirements.txt/setup.py)
+
+requirements.txt, alongside setup.py, is the most common -- yet imprecise --
+approach to dependency management in python projects.
+
+## Project Discovery
+
+`requirementstxt`: Find all files named `requirements.txt`
+
+`setuppy`: Find all files named `setup.py`
+
+## Analysis: requirementstxt
+
+requirements.txt contains direct dependencies, and is parsed compliant to its
+[file format spec][requirements-file-format].
+
+pip-cli options, URLs, absolute paths, and relative paths are ignored -- though
+this may be revisited in the future.
+
+Dependencies found in requirements.txt have a spec defined by
+[PEP-508][pep-508]. Dependencies often have version ranges and environment
+markers (e.g. python version, OS, ...). The resulting graph contains packages
+tagged with environment markers.
+
+## Analysis: setuppy
+
+setup.py is naively scanned for its `install_requires=[...]` field, which often
+fails on projects encountered in the wild. Short of implementing a robust python
+parser, or running a python script in their environment (which may have
+unintended consequences!), reliable output from setup.py is difficult to obtain.
+
+Entries in the `install_requires` array are parsed compliant to the
+[PEP-508][pep-508] spec, similar to requirements.txt
+
+[requirements-file-format]: https://pip.pypa.io/en/stable/reference/pip_install/#requirements-file-format
+[pep-508]: https://www.python.org/dev/peps/pep-0508/

--- a/docs/strategies/ruby.md
+++ b/docs/strategies/ruby.md
@@ -1,0 +1,97 @@
+# Ruby Analysis
+
+Ruby projects use a buildtool called `bundler` to manage their dependencies. We
+parse a lockfile or run the `bundle` cli to determine dependencies.
+
+| Strategy    | Direct Deps  | Deep Deps    | Edges | Tags |
+| ---         | ---          | ---          | ---   | ---  |
+| gemfilelock | ✅           | ✅           | ✅    |      |
+| bundleshow  | ✅ unlabeled | ✅ unlabeled | ❌    |      |
+
+## Project Discovery
+
+`gemfilelock`: Find all files named `Gemfile.lock`
+
+`bundleshow`: Find directories containing a `Gemfile` or `Gemfile.lock`
+
+## Analysis: gemfilelock
+
+> TLDR: A perfect dependency graph will be found and dependencies location will also be known.
+ 
+The lockfile strategy attempts to parse Bundler's `Gemfile.lock` lockfile. This file is created by bundler itself after a build is completed and can be distributed in order to maintain reproducible builds. It contains the following information about a Ruby project:
+- The location for each dependency. These locations are each separate sections and the ones of note are `GIT`, `PATH`, and `GEM` which provide their remote in the `remote: <location>` line.
+- Each dependencies required dependencies. These required dependencies are listed in the remote sections directly following each dependency from that remote.
+- All direct dependencies, listed in the `DEPENDENCIES` section.
+- Platforms that this ruby project is compatible with, listed in the `PLATFORMS` sections.
+- Version of `bundler` that was used to create the lockfile.
+
+The Lockfile strategy relies on parsing this `Gemfile.lock` file and extracting
+information from each of these sections. This strategy takes the following steps
+to create an accurate dependency graph. Example `Gemfile.lock`:
+
+```
+GIT
+  remote: https://github.com/matthewd/rb-inotify.git
+  revision: 856730aad4b285969e8dd621e44808a7c5af4242
+  branch: close-handling
+  specs:
+    rb-inotify (0.9.9)
+      ffi (~> 1.0)
+PATH
+  remote: .
+  specs:
+    activesupport (6.0.0.alpha)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+    rails (6.0.0.alpha)
+      sprockets-rails (>= 2.0.0)
+GEM
+  remote: https://rubygems.org/
+  specs:
+    concurrent-ruby (1.0.5)
+    ffi (1.9.21)
+    i18n (1.0.1)
+      concurrent-ruby (~> 1.0)
+    minitest (5.11.3)
+    rack (2.0.5)
+    sprockets-rails (3.2.1)
+      actionpack (>= 4.0)
+      activesupport (>= 4.0)
+      sprockets (>= 3.0.0)
+PLATFORMS
+  java
+  ruby
+  x64-mingw32
+  x86-mingw32
+DEPENDENCIES
+  rails!
+  rake (>= 11.1)
+  rb-inotify!
+BUNDLED WITH
+   1.16.2
+```
+
+## Analysis: bundleshow
+
+Running `bundle show` displays information about all dependencies used by a
+project, and their pinned versions. It doesn't label which dependencies are
+direct or deep, and doesn't tell us edges between dependencies
+
+Example output:
+
+```
+Gems included by the bundle:
+  * CFPropertyList (3.0.1)
+  * addressable (2.7.0)
+  * ast (2.4.0)
+  * atomos (0.1.3)
+  * babosa (1.0.2)
+  * binding_of_caller (0.8.0)
+  * builder (3.2.3)
+  * bundler (1.17.2)
+  * byebug (11.0.1)
+  * claide (1.0.3)
+  * claide-plugins (0.9.2)
+  * coderay (1.1.2)
+```


### PR DESCRIPTION
[rendered docs](https://github.com/fossas/spectrometer/blob/designdocs/docs/strategies.md)

This moves much of the content from `rfcs` into this repo

Open questions:

- should `gradle` and `maven` be combined into a single `java` category?
- is there additional detail we should include for some of these?