### PR TITLE
Nuspec, packages.config, and package reference support

### DIFF
--- a/hscli.cabal
+++ b/hscli.cabal
@@ -120,6 +120,7 @@ library
     Strategy.Node.YarnLock
     Strategy.NpmList
     Strategy.NuGet.PackagesConfig
+    Strategy.NuGet.PackageReference
     Strategy.NuGet.ProjectAssetsJson
     Strategy.NuGet.ProjectJson
     Strategy.NuGet.Nuspec
@@ -163,6 +164,7 @@ test-suite tests
     Node.NpmLockTest
     Node.PackageJsonTest
     NuGet.PackagesConfigTest
+    NuGet.PackageReferenceTest
     NuGet.ProjectAssetsJsonTest
     NuGet.ProjectJsonTest
     NuGet.NuspecTest

--- a/hscli.cabal
+++ b/hscli.cabal
@@ -75,7 +75,7 @@ common deps
     , vector                       ^>=0.12.0.3
     , yaml                         ^>=0.11.1
     , yarn-lock                    ^>=0.6.2
-    , xml
+    , xml                          ^>=1.3.14
 
 library
   import:          lang

--- a/hscli.cabal
+++ b/hscli.cabal
@@ -73,9 +73,9 @@ common deps
     , typed-process                ^>=0.2.6
     , unordered-containers         ^>=0.2.10
     , vector                       ^>=0.12.0.3
+    , xml                          ^>=1.3.14
     , yaml                         ^>=0.11.1
     , yarn-lock                    ^>=0.6.2
-    , xml                          ^>=1.3.14
 
 library
   import:          lang
@@ -119,11 +119,11 @@ library
     Strategy.Node.PackageJson
     Strategy.Node.YarnLock
     Strategy.NpmList
-    Strategy.NuGet.PackagesConfig
+    Strategy.NuGet.Nuspec
     Strategy.NuGet.PackageReference
+    Strategy.NuGet.PackagesConfig
     Strategy.NuGet.ProjectAssetsJson
     Strategy.NuGet.ProjectJson
-    Strategy.NuGet.Nuspec
     Strategy.Python.PipList
     Strategy.Python.Pipenv
     Strategy.Python.ReqTxt
@@ -163,11 +163,11 @@ test-suite tests
     Maven.MavenTest
     Node.NpmLockTest
     Node.PackageJsonTest
-    NuGet.PackagesConfigTest
+    NuGet.NuspecTest
     NuGet.PackageReferenceTest
+    NuGet.PackagesConfigTest
     NuGet.ProjectAssetsJsonTest
     NuGet.ProjectJsonTest
-    NuGet.NuspecTest
     Python.PipListTest
     Python.PipenvTest
     Python.ReqTxtTest

--- a/hscli.cabal
+++ b/hscli.cabal
@@ -75,6 +75,7 @@ common deps
     , vector                       ^>=0.12.0.3
     , yaml                         ^>=0.11.1
     , yarn-lock                    ^>=0.6.2
+    , xml
 
 library
   import:          lang
@@ -118,8 +119,10 @@ library
     Strategy.Node.PackageJson
     Strategy.Node.YarnLock
     Strategy.NpmList
+    Strategy.NuGet.PackagesConfig
     Strategy.NuGet.ProjectAssetsJson
     Strategy.NuGet.ProjectJson
+    Strategy.NuGet.Nuspec
     Strategy.Python.PipList
     Strategy.Python.Pipenv
     Strategy.Python.ReqTxt
@@ -159,8 +162,10 @@ test-suite tests
     Maven.MavenTest
     Node.NpmLockTest
     Node.PackageJsonTest
+    NuGet.PackagesConfigTest
     NuGet.ProjectAssetsJsonTest
     NuGet.ProjectJsonTest
+    NuGet.NuspecTest
     Python.PipListTest
     Python.PipenvTest
     Python.ReqTxtTest

--- a/src/Discovery.hs
+++ b/src/Discovery.hs
@@ -16,6 +16,8 @@ import qualified Strategy.Node.PackageJson as PackageJson
 import qualified Strategy.Node.YarnLock as YarnLock
 import qualified Strategy.NuGet.ProjectAssetsJson as ProjectAssetsJson
 import qualified Strategy.NuGet.ProjectJson as ProjectJson
+import qualified Strategy.NuGet.Nuspec as Nuspec
+import qualified Strategy.NuGet.PackagesConfig as PackagesConfig
 import qualified Strategy.Python.Pipenv as Pipenv
 import qualified Strategy.Python.PipList as PipList
 import qualified Strategy.Python.ReqTxt as ReqTxt
@@ -44,8 +46,10 @@ discoverFuncs =
   , YarnLock.discover
   , PackageJson.discover
 
+  , PackagesConfig.discover
   , ProjectAssetsJson.discover
   , ProjectJson.discover
+  , Nuspec.discover
 
   , PipList.discover
   , Pipenv.discover
@@ -61,8 +65,10 @@ discoverFuncs =
 strategyGroups :: [StrategyGroup]
 strategyGroups =
   [ StrategyGroup "dotnet"
-      [ SomeStrategy ProjectAssetsJson.strategy
+      [ SomeStrategy PackagesConfig.strategy
+      , SomeStrategy ProjectAssetsJson.strategy
       , SomeStrategy ProjectJson.strategy
+      , SomeStrategy Nuspec.strategy
       ]
   , StrategyGroup "gradle"
       [ SomeStrategy Gradle.strategy

--- a/src/Discovery.hs
+++ b/src/Discovery.hs
@@ -14,10 +14,11 @@ import qualified Strategy.NpmList as NpmList
 import qualified Strategy.Node.NpmLock as NpmLock
 import qualified Strategy.Node.PackageJson as PackageJson
 import qualified Strategy.Node.YarnLock as YarnLock
+import qualified Strategy.NuGet.PackagesConfig as PackagesConfig
+import qualified Strategy.NuGet.PackageReference as PackageReference
 import qualified Strategy.NuGet.ProjectAssetsJson as ProjectAssetsJson
 import qualified Strategy.NuGet.ProjectJson as ProjectJson
 import qualified Strategy.NuGet.Nuspec as Nuspec
-import qualified Strategy.NuGet.PackagesConfig as PackagesConfig
 import qualified Strategy.Python.Pipenv as Pipenv
 import qualified Strategy.Python.PipList as PipList
 import qualified Strategy.Python.ReqTxt as ReqTxt
@@ -41,12 +42,13 @@ discoverFuncs =
 
   , Maven.discover
 
+  , PackageJson.discover
   , NpmLock.discover
   , NpmList.discover
   , YarnLock.discover
-  , PackageJson.discover
 
   , PackagesConfig.discover
+  , PackageReference.discover
   , ProjectAssetsJson.discover
   , ProjectJson.discover
   , Nuspec.discover
@@ -66,6 +68,7 @@ strategyGroups :: [StrategyGroup]
 strategyGroups =
   [ StrategyGroup "dotnet"
       [ SomeStrategy PackagesConfig.strategy
+      , SomeStrategy PackageReference.strategy
       , SomeStrategy ProjectAssetsJson.strategy
       , SomeStrategy ProjectJson.strategy
       , SomeStrategy Nuspec.strategy

--- a/src/Strategy/NuGet/Nuspec.hs
+++ b/src/Strategy/NuGet/Nuspec.hs
@@ -1,0 +1,109 @@
+module Strategy.NuGet.Nuspec
+  ( discover
+  , strategy
+  , buildGraph
+  , analyze
+  , parseNuspec
+
+  ) where
+
+import Prologue
+
+import qualified Data.Map.Strict as M
+import qualified Data.Text as T
+import qualified Data.List as L
+import           Polysemy
+import           Polysemy.Error
+import           Polysemy.Output
+import qualified Text.XML.Light as XML
+
+import           Diagnostics
+import           DepTypes
+import           Discovery.Walk
+import           Effect.ReadFS
+import           Graphing (Graphing, unfold)
+import           Types
+
+discover :: Discover
+discover = Discover
+  { discoverName = "nuspec"
+  , discoverFunc = discover'
+  }
+
+discover' :: Members '[Embed IO, Output ConfiguredStrategy] r => Path Abs Dir -> Sem r ()
+discover' = walk $ \_ _ files -> do
+  case find (\f -> L.isSuffixOf ".nuspec" (fileName f)) files of
+    Just file -> output (configure file)
+    Nothing -> pure ()
+
+  walkContinue
+
+strategy :: Strategy BasicFileOpts
+strategy = Strategy
+  { strategyName = "nuget-nuspec"
+  , strategyAnalyze = analyze
+  , strategyModule = parent . targetFile
+  , strategyOptimal = NotOptimal
+  , strategyComplete = NotComplete
+  }
+
+analyze :: Members '[ReadFS, Error ReadFSErr] r => BasicFileOpts -> Sem r (Graphing Dependency)
+analyze BasicFileOpts{..} = do
+      contents <- readContentsBS targetFile
+      let nuspecGroups = parseNuspec =<< XML.parseXMLDoc contents
+      
+      case nuspecGroups of
+        Just gs -> pure $ buildGraph gs
+        Nothing -> undefined
+
+data Group = Group
+  { dependencies  :: [NuGetDependency]
+  } deriving (Eq, Ord, Show, Generic)
+
+data NuGetDependency = NuGetDependency
+  { depID        :: String
+  , depVersion   :: String
+  } deriving (Eq, Ord, Show, Generic)
+
+parseNuspec :: XML.Element -> Maybe [Group]
+parseNuspec nuspec = do
+  guard (XML.qName (XML.elName nuspec) == "package")
+  parseGroups =<< childByName "metadata" nuspec
+  where
+
+  parseGroups :: XML.Element -> Maybe [Group]
+  parseGroups el = traverse parseGroup . childrenByName "group" =<< childByName "dependencies" el
+
+  parseGroup :: XML.Element -> Maybe Group
+  parseGroup el = fmap Group $ traverse parseDependency $ childrenByName "dependency" el
+
+  parseDependency :: XML.Element -> Maybe NuGetDependency
+  parseDependency el = do
+    depIds  <- attrByName "id" el
+    version <- attrByName "version" el
+
+    pure (NuGetDependency depIds version)
+
+  attrByName :: String -> XML.Element -> Maybe String
+  attrByName name element = XML.findAttrBy (\elName -> XML.qName elName == name) element 
+
+  childByName :: String -> XML.Element -> Maybe XML.Element
+  childByName name = XML.filterChildName (\elName -> XML.qName elName == name)
+
+  childrenByName :: String -> XML.Element -> [XML.Element]
+  childrenByName name = XML.filterChildrenName (\elName -> XML.qName elName == name)
+
+buildGraph :: [Group] -> Graphing Dependency
+buildGraph project = unfold direct (const []) toDependency
+    where
+    direct = foldr (\x y -> y ++ dependencies x) [] project
+    toDependency NuGetDependency{..} =
+      Dependency { dependencyType = NuGetType
+               , dependencyName = T.pack depID
+               , dependencyVersion = Just (CEq $ T.pack depVersion)
+               , dependencyLocations = []
+               , dependencyTags = M.empty
+               }
+
+configure :: Path Rel File -> ConfiguredStrategy
+configure = ConfiguredStrategy strategy . BasicFileOpts

--- a/src/Strategy/NuGet/PackageReference.hs
+++ b/src/Strategy/NuGet/PackageReference.hs
@@ -1,0 +1,115 @@
+module Strategy.NuGet.PackageReference
+  ( discover
+  , strategy
+  , buildGraph
+  , analyze
+  , parsePackageReference
+
+  ) where
+
+import Prologue
+
+import qualified Data.Map.Strict as M
+import qualified Data.Text as T
+import qualified Data.List as L
+import           Polysemy
+import           Polysemy.Error
+import           Polysemy.Output
+import qualified Text.XML.Light as XML
+
+import           Diagnostics
+import           DepTypes
+import           Discovery.Walk
+import           Effect.ReadFS
+import           Graphing (Graphing, unfold)
+import           Types
+
+discover :: Discover
+discover = Discover
+  { discoverName = "packagereference"
+  , discoverFunc = discover'
+  }
+
+discover' :: Members '[Embed IO, Output ConfiguredStrategy] r => Path Abs Dir -> Sem r ()
+discover' = walk $ \_ _ files -> do
+  case find isPackageRefFile files of
+    Just file -> output (configure file)
+    Nothing -> pure ()
+
+  walkContinue
+ 
+  where 
+      isPackageRefFile :: Path Rel File -> Bool
+      isPackageRefFile file = any (\x -> L.isSuffixOf x (fileName file)) [".csproj", ".xproj", ".vbproj", ".dbproj", ".fsproj"]
+
+strategy :: Strategy BasicFileOpts
+strategy = Strategy
+  { strategyName = "nuget-packagereference"
+  , strategyAnalyze = analyze
+  , strategyModule = parent . targetFile
+  , strategyOptimal = NotOptimal
+  , strategyComplete = NotComplete
+  }
+
+analyze :: Members '[ReadFS, Error ReadFSErr] r => BasicFileOpts -> Sem r (Graphing Dependency)
+analyze BasicFileOpts{..} = do
+      contents <- readContentsBS targetFile
+      let packageReference = parsePackageReference =<< XML.parseXMLDoc contents
+      
+      case packageReference of
+        Just gs -> pure $ buildGraph gs
+        Nothing -> undefined
+
+data ItemGroup = ItemGroup
+  { dependencies        :: [PackageReference]
+  } deriving (Eq, Ord, Show, Generic)
+
+data PackageReference = PackageReference
+  { depID        :: String
+  , depVersion   :: Maybe String
+  } deriving (Eq, Ord, Show, Generic)
+
+parsePackageReference :: XML.Element -> Maybe [ItemGroup]
+parsePackageReference project = do
+  guard (XML.qName (XML.elName project) == "Project")
+  traverse parseItemGroup $ childrenByName "ItemGroup" project
+  where
+
+  parseItemGroup :: XML.Element -> Maybe ItemGroup
+  parseItemGroup el = fmap ItemGroup $ traverse parsePackage $ childrenByName "PackageReference" el 
+
+  parsePackage :: XML.Element -> Maybe PackageReference
+  parsePackage el = do
+    include <- attrByName "Include" el
+    let version = stringByName "Version" el
+
+    pure (PackageReference include version)
+
+  stringByName :: String -> XML.Element -> Maybe String
+  stringByName name = fmap XML.strContent . childByName name
+
+  attrByName :: String -> XML.Element -> Maybe String
+  attrByName name element = XML.findAttrBy (\elName -> XML.qName elName == name) element 
+
+  childByName :: String -> XML.Element -> Maybe XML.Element
+  childByName name = XML.filterChildName (\elName -> XML.qName elName == name)
+
+  childrenByName :: String -> XML.Element -> [XML.Element]
+  childrenByName name = XML.filterChildrenName (\elName -> XML.qName elName == name)
+
+buildGraph :: [ItemGroup] -> Graphing Dependency
+buildGraph project = unfold direct (const []) toDependency
+    where
+    direct = foldr (\x y -> y ++ dependencies x) [] project
+    toDependency PackageReference{..} =
+      Dependency { dependencyType = NuGetType
+               , dependencyName = T.pack depID
+               , dependencyVersion = case depVersion of
+                                       Nothing -> Nothing
+                                       Just ver -> Just (CEq $ T.pack ver)
+               , dependencyLocations = []
+               , dependencyTags = M.empty
+               }
+
+configure :: Path Rel File -> ConfiguredStrategy
+configure = ConfiguredStrategy strategy . BasicFileOpts

--- a/src/Strategy/NuGet/PackagesConfig.hs
+++ b/src/Strategy/NuGet/PackagesConfig.hs
@@ -52,7 +52,7 @@ analyze BasicFileOpts{..} = do
       let packagesConfig = parsePackagesConfig =<< XML.parseXMLDoc contents
       case packagesConfig of
         Just gs -> pure $ buildGraph gs
-        Nothing -> undefined
+        Nothing -> throw (FileParseError (fromRelFile targetFile) "this file was unable to be parsed as a packages.config file")
 
 data NuGetDependency = NuGetDependency
   { depID        :: String

--- a/src/Strategy/NuGet/PackagesConfig.hs
+++ b/src/Strategy/NuGet/PackagesConfig.hs
@@ -1,0 +1,93 @@
+module Strategy.NuGet.PackagesConfig
+  ( discover
+  , strategy
+  , buildGraph
+  , analyze
+  , parsePackagesConfig
+
+  ) where
+
+import Prologue
+
+import qualified Data.Map.Strict as M
+import qualified Data.Text as T
+import           Polysemy
+import           Polysemy.Error
+import           Polysemy.Output
+import qualified Text.XML.Light as XML
+
+import           Diagnostics
+import           DepTypes
+import           Discovery.Walk
+import           Effect.ReadFS
+import           Graphing (Graphing, unfold)
+import           Types
+
+discover :: Discover
+discover = Discover
+  { discoverName = "packagesconfig"
+  , discoverFunc = discover'
+  }
+
+discover' :: Members '[Embed IO, Output ConfiguredStrategy] r => Path Abs Dir -> Sem r ()
+discover' = walk $ \_ _ files -> do
+  case find (\f -> (fileName f) == "packages.config") files of
+    Just file -> output (configure file)
+    Nothing -> pure ()
+
+  walkContinue
+
+strategy :: Strategy BasicFileOpts
+strategy = Strategy
+  { strategyName = "nuget-packagesconfig"
+  , strategyAnalyze = analyze
+  , strategyModule = parent . targetFile
+  , strategyOptimal = NotOptimal
+  , strategyComplete = NotComplete
+  }
+
+analyze :: Members '[ReadFS, Error ReadFSErr] r => BasicFileOpts -> Sem r (Graphing Dependency)
+analyze BasicFileOpts{..} = do
+      contents <- readContentsBS targetFile
+      let packagesConfig = parsePackagesConfig =<< XML.parseXMLDoc contents
+      case packagesConfig of
+        Just gs -> pure $ buildGraph gs
+        Nothing -> undefined
+
+data NuGetDependency = NuGetDependency
+  { depID        :: String
+  , depVersion   :: String
+  } deriving (Eq, Ord, Show, Generic)
+
+parsePackagesConfig :: XML.Element -> Maybe [NuGetDependency]
+parsePackagesConfig packagesConfig = do
+  guard (XML.qName (XML.elName packagesConfig) == "packages")
+  traverse parsePackage $ childrenByName "package" packagesConfig
+  where
+
+  parsePackage :: XML.Element -> Maybe NuGetDependency
+  parsePackage el = do
+    elID  <- attrByName "id" el
+    version <- attrByName "version" el
+
+    pure (NuGetDependency elID version)
+
+  attrByName :: String -> XML.Element -> Maybe String
+  attrByName name element = XML.findAttrBy (\elName -> XML.qName elName == name) element 
+
+  childrenByName :: String -> XML.Element -> [XML.Element]
+  childrenByName name = XML.filterChildrenName (\elName -> XML.qName elName == name)
+
+buildGraph :: [NuGetDependency] -> Graphing Dependency
+buildGraph dependencies = unfold dependencies (const []) toDependency
+    where
+    toDependency NuGetDependency{..} =
+      Dependency { dependencyType = NuGetType
+               , dependencyName = T.pack depID
+               , dependencyVersion = Just (CEq $ T.pack depVersion)
+               , dependencyLocations = []
+               , dependencyTags = M.empty
+               }
+
+configure :: Path Rel File -> ConfiguredStrategy
+configure = ConfiguredStrategy strategy . BasicFileOpts

--- a/src/Strategy/NuGet/ProjectAssetsJson.hs
+++ b/src/Strategy/NuGet/ProjectAssetsJson.hs
@@ -29,7 +29,7 @@ discover = Discover
   }
 
 discover' :: Members '[Embed IO, Output ConfiguredStrategy] r => Path Abs Dir -> Sem r ()
-discover' = walk $ \_ subdirs files -> do
+discover' = walk $ \_ _ files -> do
   case find (\f -> fileName f == "project.assets.json") files of
     Just file -> output (configure file)
     Nothing -> pure ()

--- a/test/NuGet/NuspecTest.hs
+++ b/test/NuGet/NuspecTest.hs
@@ -1,0 +1,55 @@
+{-# language TemplateHaskell #-}
+
+module NuGet.NuspecTest
+  ( spec_analyze
+  ) where
+
+import Prologue
+
+import qualified Data.Map.Strict as M
+import qualified Data.ByteString.Lazy as BL
+import qualified Text.XML.Light as XML
+import DepTypes
+import GraphUtil
+import Strategy.NuGet.Nuspec
+import Test.Tasty.Hspec
+
+dependencyOne :: Dependency
+dependencyOne = Dependency { dependencyType = NuGetType
+                        , dependencyName = "one"
+                        , dependencyVersion = Just (CEq "1.0.0")
+                        , dependencyLocations = []
+                        , dependencyTags = M.empty
+                        }
+
+dependencyTwo :: Dependency
+dependencyTwo = Dependency { dependencyType = NuGetType
+                        , dependencyName = "two"
+                        , dependencyVersion = Just (CEq "2.0.0")
+                        , dependencyLocations = []
+                        , dependencyTags = M.empty
+                        }
+
+dependencyThree :: Dependency
+dependencyThree = Dependency { dependencyType = NuGetType
+                        , dependencyName = "three"
+                        , dependencyVersion = Just (CEq "3.0.0")
+                        , dependencyLocations = []
+                        , dependencyTags = M.empty
+                        }
+
+spec_analyze :: Spec
+spec_analyze = do
+  nuspecFile <- runIO (BL.readFile "test/NuGet/testdata/test.nuspec")
+
+  describe "nuspec analyzer" $ do
+    it "reads a file and constructs an accurate graph" $ do
+      case parseNuspec =<< XML.parseXMLDoc nuspecFile of
+        Just groups -> do
+          let graph = buildGraph groups
+
+          expectDeps [dependencyOne, dependencyTwo, dependencyThree] graph
+          expectDirect [dependencyOne, dependencyTwo, dependencyThree] graph
+          expectEdges [] graph
+
+        Nothing -> expectationFailure "could not parse nuspec file"

--- a/test/NuGet/PackageReferenceTest.hs
+++ b/test/NuGet/PackageReferenceTest.hs
@@ -12,6 +12,8 @@ import qualified Text.XML.Light as XML
 import DepTypes
 import GraphUtil
 import Strategy.NuGet.PackageReference
+import Polysemy
+import Polysemy.Input
 import Test.Tasty.Hspec
 
 dependencyOne :: Dependency
@@ -46,18 +48,33 @@ dependencyFour = Dependency { dependencyType = NuGetType
                             , dependencyTags = M.empty
                             }
 
+itemGroupList :: [ItemGroup]
+itemGroupList = [ItemGroup [refOne, refTwo], ItemGroup [refThree, refFour]]
+
+refOne :: PackageReference
+refOne = PackageReference "one" $ Just "1.0.0"
+
+refTwo :: PackageReference
+refTwo = PackageReference "two" $ Just "2.0.0"
+
+refThree :: PackageReference
+refThree = PackageReference "three" $ Just "3.0.0"
+
+refFour :: PackageReference
+refFour = PackageReference "four" Nothing
+
 spec_analyze :: Spec
 spec_analyze = do
   refFile <- runIO (BL.readFile "test/NuGet/testdata/test.csproj")
 
-  describe "Package Reference analyzer" $ do
-    it "reads a file and constructs an accurate graph" $ do
+  describe "Package Reference parser" $ do
+    it "reads a file and constructs an accurate list of item groups" $ do
       case parsePackageReference =<< XML.parseXMLDoc refFile of
-        Just groups -> do
-          let graph = buildGraph groups
+        Just groups -> groups `shouldContain` itemGroupList
+        Nothing -> expectationFailure "could not parse package reference file"
 
+    it "constructs an accurate graph" $ do
+          let graph = analyze & runInputConst @[ItemGroup] itemGroupList & run
           expectDeps [dependencyOne, dependencyTwo, dependencyThree, dependencyFour] graph
           expectDirect [dependencyOne, dependencyTwo, dependencyThree, dependencyFour] graph
           expectEdges [] graph
-
-        Nothing -> expectationFailure "could not parse package reference file"

--- a/test/NuGet/PackageReferenceTest.hs
+++ b/test/NuGet/PackageReferenceTest.hs
@@ -1,0 +1,63 @@
+{-# language TemplateHaskell #-}
+
+module NuGet.PackageReferenceTest
+  ( spec_analyze
+  ) where
+
+import Prologue
+
+import qualified Data.Map.Strict as M
+import qualified Data.ByteString.Lazy as BL
+import qualified Text.XML.Light as XML
+import DepTypes
+import GraphUtil
+import Strategy.NuGet.PackageReference
+import Test.Tasty.Hspec
+
+dependencyOne :: Dependency
+dependencyOne = Dependency { dependencyType = NuGetType
+                           , dependencyName = "one"
+                           , dependencyVersion = Just (CEq "1.0.0")
+                           , dependencyLocations = []
+                           , dependencyTags = M.empty
+                           }
+
+dependencyTwo :: Dependency
+dependencyTwo = Dependency { dependencyType = NuGetType
+                           , dependencyName = "two"
+                           , dependencyVersion = Just (CEq "2.0.0")
+                           , dependencyLocations = []
+                           , dependencyTags = M.empty
+                           }
+
+dependencyThree :: Dependency
+dependencyThree = Dependency { dependencyType = NuGetType
+                             , dependencyName = "three"
+                             , dependencyVersion = Just (CEq "3.0.0")
+                             , dependencyLocations = []
+                             , dependencyTags = M.empty
+                             }
+
+dependencyFour :: Dependency
+dependencyFour = Dependency { dependencyType = NuGetType
+                            , dependencyName = "four"
+                            , dependencyVersion = Nothing
+                            , dependencyLocations = []
+                            , dependencyTags = M.empty
+                            }
+
+spec_analyze :: Spec
+spec_analyze = do
+  refFile <- runIO (BL.readFile "test/NuGet/testdata/test.csproj")
+
+  describe "Package Reference analyzer" $ do
+    it "reads a file and constructs an accurate graph" $ do
+      case parsePackageReference =<< XML.parseXMLDoc refFile of
+        Just groups -> do
+          let graph = buildGraph groups
+
+          expectDeps [dependencyOne, dependencyTwo, dependencyThree, dependencyFour] graph
+          expectDirect [dependencyOne, dependencyTwo, dependencyThree, dependencyFour] graph
+          expectEdges [] graph
+
+        Nothing -> expectationFailure "could not parse package reference file"

--- a/test/NuGet/PackagesConfigTest.hs
+++ b/test/NuGet/PackagesConfigTest.hs
@@ -1,0 +1,47 @@
+{-# language TemplateHaskell #-}
+
+module NuGet.PackagesConfigTest
+  ( spec_analyze
+  ) where
+
+import Prologue
+
+import qualified Data.Map.Strict as M
+import qualified Data.ByteString.Lazy as BL
+import qualified Text.XML.Light as XML
+import DepTypes
+import GraphUtil
+import Strategy.NuGet.PackagesConfig
+import Test.Tasty.Hspec
+
+dependencyOne :: Dependency
+dependencyOne = Dependency { dependencyType = NuGetType
+                        , dependencyName = "one"
+                        , dependencyVersion = Just (CEq "1.0.0")
+                        , dependencyLocations = []
+                        , dependencyTags = M.empty
+                        }
+
+dependencyTwo :: Dependency
+dependencyTwo = Dependency { dependencyType = NuGetType
+                        , dependencyName = "two"
+                        , dependencyVersion = Just (CEq "2.0.0")
+                        , dependencyLocations = []
+                        , dependencyTags = M.empty
+                        }
+
+spec_analyze :: Spec
+spec_analyze = do
+  nuspecFile <- runIO (BL.readFile "test/NuGet/testdata/packages.config")
+
+  describe "packages.config analyzer" $ do
+    it "reads a file and constructs an accurate graph" $ do
+      case parsePackagesConfig =<< XML.parseXMLDoc nuspecFile of
+        Just groups -> do
+          let graph = buildGraph groups
+
+          expectDeps [dependencyOne, dependencyTwo] graph
+          expectDirect [dependencyOne, dependencyTwo] graph
+          expectEdges [] graph
+
+        Nothing -> expectationFailure "could not parse packages.config file"

--- a/test/NuGet/testdata/packages.config
+++ b/test/NuGet/testdata/packages.config
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="one" version="1.0.0" />
+  <package id="two" version="2.0.0" />
+</packages>

--- a/test/NuGet/testdata/test.csproj
+++ b/test/NuGet/testdata/test.csproj
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <None Include="app.config">
+      <SubType>Designer</SubType>
+    </None>
+    <None Include="PowerShell.psd1">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\temp\.csproj">
+      <Project>{4729246b-ee53-4760-bce3-05f14640dfb0}</Project>
+      <Name>Web.Client</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="one">
+      <Version>1.0.0</Version>
+    </PackageReference>
+    <PackageReference Include="two">
+      <Version>2.0.0</Version>
+    </PackageReference>
+    <PackageReference Include="four">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="three">
+      <Version>3.0.0</Version>
+    </PackageReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="BeforeBuild" Condition="'$(Revision)' != '' ">
+    <FileUpdate Files="..\properties\GlobalAssemblyInfo.cs" Regex="(?&lt;=AssemblyVersion\(&quot;\d+\.\d+\.\d+\.)(\*)" ReplacementText="$(Revision)" />
+  </Target>
+  <Target Name="UpdatePowerShellManifest" AfterTargets="CopyFilesToOutputDirectory">
+    <GetFileVersion AssemblyPath="$(OutputPath)PowerShell.dll">
+      <Output TaskParameter="Version" PropertyName="FileVersion" />
+    </GetFileVersion>
+    <Message Text="File version is $(FileVersion)" />
+    <!-- ModuleVersion = '18.3.2.60001' -->
+    <FileUpdate Files="$(OutputPath)PowerShell.psd1" Regex="(?&lt;=ModuleVersion\s=\s)\'.*'" ReplacementText="'$(FileVersion)'" />
+  </Target>
+</Project>

--- a/test/NuGet/testdata/test.csproj
+++ b/test/NuGet/testdata/test.csproj
@@ -21,12 +21,14 @@
     <PackageReference Include="two">
       <Version>2.0.0</Version>
     </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="three">
+      <Version>3.0.0</Version>
+    </PackageReference>
     <PackageReference Include="four">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="three">
-      <Version>3.0.0</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/test/NuGet/testdata/test.nuspec
+++ b/test/NuGet/testdata/test.nuspec
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<package xmlns="test">
+  <metadata minClientVersion="2.12">
+    <id>NUnit</id>
+    <title>NUnit</title>
+    <version>$version$</version>
+    <dependencies>
+      <group targetFramework="testone" />
+      <group targetFramework="testtwo">
+        <dependency id="one" version="1.0.0" />
+        <dependency id="two" version="2.0.0" />
+      </group>
+      <group targetFramework="testthree">
+        <dependency id="three" version="3.0.0" />
+      </group>
+    </dependencies>
+  </metadata>
+</package>


### PR DESCRIPTION
This PR adds support for parsing `.nuspec`, `packages.config`, and package reference files for dependencies.