### PR TITLE
Paket support

### DIFF
--- a/hscli.cabal
+++ b/hscli.cabal
@@ -125,6 +125,7 @@ library
     Strategy.NuGet.Nuspec
     Strategy.NuGet.PackageReference
     Strategy.NuGet.PackagesConfig
+    Strategy.NuGet.Paket
     Strategy.NuGet.ProjectAssetsJson
     Strategy.NuGet.ProjectJson
     Strategy.Python.PipList
@@ -170,6 +171,7 @@ test-suite tests
     NuGet.NuspecTest
     NuGet.PackageReferenceTest
     NuGet.PackagesConfigTest
+    NuGet.PaketTest
     NuGet.ProjectAssetsJsonTest
     NuGet.ProjectJsonTest
     Python.PipListTest

--- a/src/Strategy/NuGet/Paket.hs
+++ b/src/Strategy/NuGet/Paket.hs
@@ -180,10 +180,10 @@ findDep :: Parser Text
 findDep = lexeme (takeWhile1P (Just "dep") (not . C.isSpace))
 
 findVersion :: Parser Text
-findVersion = between (char '(') (char ')') takeWhile1P (Just "version") (/= ')')
+findVersion = between (char '(') (char ')') $ takeWhile1P (Just "version") (/= ')')
 
 textValue :: Parser Text
-textValue = chunk ' ' *> restOfLine
+textValue = chunk " " *> restOfLine
 
 restOfLine :: Parser Text
 restOfLine = takeWhileP (Just "ignored") (not . isEndLine)

--- a/src/Strategy/NuGet/Paket.hs
+++ b/src/Strategy/NuGet/Paket.hs
@@ -1,0 +1,254 @@
+module Strategy.NuGet.Paket
+  ( discover
+  , strategy
+  , analyze
+  , configure
+  , findSections
+
+  , PaketDep(..)
+  , Section(..)
+  , Remote(..)
+--   , Spec(..)
+--   , SpecDep(..)
+--   , DirectDep(..)
+--   , Section(..)
+  ) where
+
+import Prologue
+
+import qualified Data.Map.Strict as M
+import qualified Data.Text as T
+import qualified Data.Char as C
+import           Polysemy
+import           Polysemy.Input
+import           Polysemy.Output
+
+import           DepTypes
+import           Discovery.Walk
+import           Effect.LabeledGrapher
+import           Effect.ReadFS
+import           Graphing (Graphing)
+import           Types
+import           Text.Megaparsec hiding (label)
+import           Text.Megaparsec.Char
+import qualified Text.Megaparsec.Char.Lexer as L
+
+type Parser = Parsec Void Text
+
+discover :: Discover
+discover = Discover
+  { discoverName = "paket"
+  , discoverFunc = discover'
+  }
+
+discover' :: Members '[Embed IO, Output ConfiguredStrategy] r => Path Abs Dir -> Sem r ()
+discover' = walk $ \_ _ files -> do
+  for_ files $ \f ->
+    when (fileName f == "paket.lock") $ output (configure f)
+  walkContinue
+
+strategy :: Strategy BasicFileOpts
+strategy = Strategy
+  { strategyName = "paket"
+  , strategyAnalyze = \opts -> analyze & fileInputParser findSections (targetFile opts)
+  , strategyModule = parent . targetFile
+  , strategyOptimal = Optimal
+  , strategyComplete = Complete
+  }
+
+configure :: Path Rel File -> ConfiguredStrategy
+configure = ConfiguredStrategy strategy . BasicFileOpts
+
+analyze :: Member (Input [Section]) r => Sem r (Graphing Dependency)
+analyze = buildGraph <$> input
+
+data PaketPkg = PaketPkg { pkgName :: Text }
+  deriving (Eq, Ord, Show, Generic)
+
+type instance PkgLabel PaketPkg = PaketLabel
+
+data PaketLabel =
+    PaketVersion Text
+  | PaketRemote Text
+--   | GitRemote Text (Maybe Text) -- ^ repo url, revision
+--   | OtherRemote Text -- ^ url
+  | GroupName Text -- ^ url
+  deriving (Eq, Ord, Show, Generic)
+
+toDependency :: PaketPkg -> Set PaketLabel -> Dependency
+toDependency pkg = foldr applyLabel start
+  where
+
+  start :: Dependency
+  start = Dependency
+    { dependencyType = NuGetType
+    , dependencyName = pkgName pkg
+    , dependencyVersion = Nothing
+    , dependencyLocations = []
+    , dependencyTags = M.empty
+    }
+
+  applyLabel :: PaketLabel -> Dependency -> Dependency
+  applyLabel (PaketVersion ver) dep = dep { dependencyVersion = Just (CEq ver) }
+  applyLabel (GroupName name) dep = dep { dependencyTags = M.insert "group" (name : (fromMaybe [] (M.lookup "group" $ dependencyTags dep))  ) (dependencyTags dep)} 
+  -- there are going to be conflicts and we should append all of the group keys.
+   -- Others we need are git remote and https remote
+  applyLabel (PaketRemote repo) dep = dep { dependencyLocations = repo : dependencyLocations dep }
+  applyLabel _ dep = dep
+--   applyLabel (OtherRemote loc) dep =
+--     dep { dependencyLocations = loc : dependencyLocations dep }
+  
+buildGraph :: [Section] -> Graphing Dependency
+buildGraph sections = run . withLabeling toDependency $
+      traverse_ addSection sections
+      where
+            addSection :: Member (LabeledGrapher PaketPkg) r => Section -> Sem r ()
+            addSection (GitSection remotes) = traverse_ (addRemote "MAIN") remotes
+            addSection (NugetSection remotes) = traverse_ (addRemote "MAIN") remotes
+            addSection (HTTPSection remotes) =  traverse_ (addRemote "MAIN") remotes
+            addSection (GroupSection group gSections) = traverse_ (addGroupSection group) gSections
+            addSection (UnknownSection _) = pure ()
+
+            addGroupSection :: Member (LabeledGrapher PaketPkg) r => Text -> Section -> Sem r ()
+            addGroupSection group (GitSection remotes) = traverse_ (addRemote group) remotes
+            addGroupSection group (NugetSection remotes) = traverse_ (addRemote group) remotes
+            addGroupSection group (HTTPSection remotes) =  traverse_ (addRemote group) remotes
+            addGroupSection _ _ = pure ()
+
+            addRemote :: Member (LabeledGrapher PaketPkg) r => Text -> Remote -> Sem r ()
+            addRemote group remote = traverse_ (addSpec (PaketRemote $ location remote) (GroupName group)) (dependencies remote) 
+                                                          -- Remote     -- Group Name
+            addSpec :: Member (LabeledGrapher PaketPkg) r => PaketLabel -> PaketLabel -> PaketDep -> Sem r ()
+            addSpec remote group dep = do
+              let pkg = PaketPkg (name dep)
+              -- add edges between spec and specdeps
+              traverse_ (edge pkg . PaketPkg) (transitive dep)
+              -- add a label for version
+              label pkg (PaketVersion (version dep))
+              -- add a label for remote
+              label pkg remote
+              --   label pkg group
+              label pkg group
+              direct pkg
+
+
+type Name = Text
+
+data Section =
+      GitSection [Remote]
+      | NugetSection [Remote]
+      | HTTPSection [Remote]
+      | UnknownSection Text
+      | GroupSection Name [Section]
+      deriving (Eq, Ord, Show, Generic)
+
+data Remote = Remote
+     { location      :: Text
+     , dependencies  :: [PaketDep]
+     } deriving (Eq, Ord, Show, Generic)
+
+data PaketDep = PaketDep
+     { name       :: Text
+     , version    :: Text
+     , transitive :: [Text]
+     } deriving (Eq, Ord, Show, Generic)
+
+data Group = Group
+     { groupName    :: Text
+     , groupSections :: [Section]
+     } deriving (Eq, Ord, Show, Generic)
+
+
+findSections :: Parser [Section]
+findSections = many (try githubSectionParser <|> try httpSectionParser <|> try nugetSectionParser <|> try groupSection <|> try emptySection) <* eof
+
+groupSection :: Parser Section
+groupSection = do
+          _ <- chunk "GROUP"
+          name <- textValue
+          sections <- many (try githubSectionParser <|> try httpSectionParser <|> try nugetSectionParser <|>  try emptySection)
+          pure $ GroupSection name sections
+
+emptySection :: Parser Section
+emptySection = do 
+      emptyLine <- restOfLine
+      guard $ not $ "GROUP" `T.isPrefixOf` emptyLine
+      _ <- eol
+      pure $ UnknownSection emptyLine
+
+httpSectionParser :: Parser Section
+httpSectionParser = L.nonIndented scn (L.indentBlock scn p)
+      where
+        p = do
+          _ <- chunk "HTTP"
+          return (L.IndentMany Nothing (\remotes -> pure $ HTTPSection remotes) remoteParser)
+
+githubSectionParser :: Parser Section
+githubSectionParser = L.nonIndented scn (L.indentBlock scn p)
+      where
+        p = do
+          _ <- chunk "GITHUB"
+          return (L.IndentMany Nothing (\remotes -> pure $ GitSection remotes) remoteParser)
+
+nugetSectionParser :: Parser Section
+nugetSectionParser = L.nonIndented scn (L.indentBlock scn p)
+      where
+        p = do
+          _ <- chunk "NUGET"
+          return (L.IndentMany Nothing (\remotes -> pure $ NugetSection remotes) remoteParser)
+
+-- fieldName,  (value, deps)
+remoteParser :: Parser Remote
+remoteParser = L.indentBlock scn p
+  where
+    p = do
+      _ <- chunk "remote:"
+      value <- textValue
+      return (L.IndentMany Nothing (\specs -> pure $ Remote value specs) specParser)
+
+textValue :: Parser Text
+textValue = do
+      _ <- chunk " "
+      restOfLine
+
+specParser :: Parser PaketDep
+specParser = L.indentBlock scn p
+    where 
+      p = do
+        name <- findDep
+        version <- findVersion
+        _ <- restOfLine
+        pure (L.IndentMany Nothing (\a -> pure $ PaketDep name version a) specsParser)
+      
+specsParser :: Parser Text
+specsParser = do
+      name <- findDep
+      _ <- restOfLine
+      pure name
+
+findDep :: Parser Text
+findDep = lexeme (takeWhile1P (Just "dep") (not . C.isSpace))
+
+findVersion :: Parser Text
+findVersion = do
+      _ <- char '('
+      result <- lexeme (takeWhileP (Just "version") (/= ')'))
+      _ <- char ')'
+      pure result
+
+restOfLine :: Parser Text
+restOfLine = takeWhileP (Just "ignored") (not . isEndLine)
+
+isEndLine :: Char -> Bool
+isEndLine '\n' = True
+isEndLine '\r' = True
+isEndLine _    = False
+
+scn :: Parser ()
+scn =  L.space space1 empty empty
+
+lexeme :: Parser a -> Parser a
+lexeme = L.lexeme sc
+
+sc :: Parser ()
+sc =  L.space (void $ some (char ' ')) empty empty

--- a/src/Strategy/NuGet/Paket.hs
+++ b/src/Strategy/NuGet/Paket.hs
@@ -70,9 +70,7 @@ type instance PkgLabel PaketPkg = PaketLabel
 data PaketLabel =
     PaketVersion Text
   | PaketRemote Text
---   | GitRemote Text (Maybe Text) -- ^ repo url, revision
---   | OtherRemote Text -- ^ url
-  | GroupName Text -- ^ url
+  | GroupName Text
   deriving (Eq, Ord, Show, Generic)
 
 toDependency :: PaketPkg -> Set PaketLabel -> Dependency
@@ -91,12 +89,7 @@ toDependency pkg = foldr applyLabel start
   applyLabel :: PaketLabel -> Dependency -> Dependency
   applyLabel (PaketVersion ver) dep = dep { dependencyVersion = Just (CEq ver) }
   applyLabel (GroupName name) dep = dep { dependencyTags = M.insert "group" (name : (fromMaybe [] (M.lookup "group" $ dependencyTags dep))  ) (dependencyTags dep)} 
-  -- there are going to be conflicts and we should append all of the group keys.
-   -- Others we need are git remote and https remote
   applyLabel (PaketRemote repo) dep = dep { dependencyLocations = repo : dependencyLocations dep }
-  applyLabel _ dep = dep
---   applyLabel (OtherRemote loc) dep =
---     dep { dependencyLocations = loc : dependencyLocations dep }
   
 buildGraph :: [Section] -> Graphing Dependency
 buildGraph sections = run . withLabeling toDependency $

--- a/src/Strategy/NuGet/Paket.hs
+++ b/src/Strategy/NuGet/Paket.hs
@@ -8,10 +8,6 @@ module Strategy.NuGet.Paket
   , PaketDep(..)
   , Section(..)
   , Remote(..)
---   , Spec(..)
---   , SpecDep(..)
---   , DirectDep(..)
---   , Section(..)
   ) where
 
 import Prologue
@@ -62,7 +58,7 @@ configure = ConfiguredStrategy strategy . BasicFileOpts
 analyze :: Member (Input [Section]) r => Sem r (Graphing Dependency)
 analyze = buildGraph <$> input
 
-data PaketPkg = PaketPkg { pkgName :: Text }
+newtype PaketPkg = PaketPkg { pkgName :: Text }
   deriving (Eq, Ord, Show, Generic)
 
 type instance PkgLabel PaketPkg = PaketLabel
@@ -103,7 +99,7 @@ buildGraph sections = run . withLabeling toDependency $
             addSection _ (UnknownSection _) = pure ()
 
             addRemote :: Member (LabeledGrapher PaketPkg) r => Text -> Text -> Remote -> Sem r ()
-            addRemote group loc remote = traverse_ (addSpec (DepLocation $ loc) (PaketRemote $ location remote) (GroupName group)) (dependencies remote) 
+            addRemote group loc remote = traverse_ (addSpec (DepLocation loc) (PaketRemote $ location remote) (GroupName group)) (dependencies remote) 
 
             addSpec :: Member (LabeledGrapher PaketPkg) r => PaketLabel -> PaketLabel -> PaketLabel -> PaketDep -> Sem r ()
             addSpec loc remote group dep = do

--- a/test/NuGet/PaketTest.hs
+++ b/test/NuGet/PaketTest.hs
@@ -18,64 +18,65 @@ import qualified Test.Tasty.Hspec as T
 
 dependencyOne :: Dependency
 dependencyOne = Dependency { dependencyType = NuGetType
-                        , dependencyName = "one"
-                        , dependencyVersion = Just (CEq "1.0.0")
-                        , dependencyLocations = ["nuget.com"]
-                        , dependencyTags = M.fromList [("group", ["MAIN"])]
-                        }
+                           , dependencyName = "one"
+                           , dependencyVersion = Just (CEq "1.0.0")
+                           , dependencyLocations = ["nuget.com"]
+                           , dependencyTags = M.fromList [("group", ["MAIN"])]
+                           }
 
 dependencyTwo :: Dependency
 dependencyTwo = Dependency { dependencyType = NuGetType
-                        , dependencyName = "two"
-                        , dependencyVersion = Just (CEq "2.0.0")
-                        , dependencyLocations = ["nuget.com"]
-                        , dependencyTags = M.fromList [("group", ["MAIN"])]
-                        }
+                           , dependencyName = "two"
+                           , dependencyVersion = Just (CEq "2.0.0")
+                           , dependencyLocations = ["nuget-v2.com", "nuget.com"]
+                           , dependencyTags = M.fromList [("group", ["MAIN", "TEST"])]
+                           }
 
 dependencyThree :: Dependency
 dependencyThree = Dependency { dependencyType = NuGetType
-                        , dependencyName = "three"
-                        , dependencyVersion = Just (CEq "3.0.0")
-                        , dependencyLocations = ["custom-site.com"]
-                        , dependencyTags = M.fromList [("group", ["MAIN"])]
-                        }
+                             , dependencyName = "three"
+                             , dependencyVersion = Just (CEq "3.0.0")
+                             , dependencyLocations = ["custom-site.com"]
+                             , dependencyTags = M.fromList [("group", ["MAIN"])]
+                             }
 
 dependencyFour :: Dependency
 dependencyFour = Dependency { dependencyType = NuGetType
-                        , dependencyName = "four"
-                        , dependencyVersion = Just (CEq "4.0.0")
-                        , dependencyLocations = ["nuget-v2.com"]
-                        , dependencyTags = M.fromList [("group", ["TEST"])]
-                        }
+                            , dependencyName = "four"
+                            , dependencyVersion = Just (CEq "4.0.0")
+                            , dependencyLocations = ["nuget-v2.com"]
+                            , dependencyTags = M.fromList [("group", ["TEST"])]
+                            }
 
 dependencyFive :: Dependency
 dependencyFive = Dependency { dependencyType = NuGetType
-                        , dependencyName = "five"
-                        , dependencyVersion = Just (CEq "5.0.0")
-                        , dependencyLocations = ["nuget-v2.com"]
-                        , dependencyTags = M.fromList [("group", ["TEST"])]
-                        }
+                            , dependencyName = "five"
+                            , dependencyVersion = Just (CEq "5.0.0")
+                            , dependencyLocations = ["nuget-v2.com"]
+                            , dependencyTags = M.fromList [("group", ["TEST"])]
+                            }
 
 dependencySix :: Dependency
 dependencySix = Dependency { dependencyType = NuGetType
-                        , dependencyName = "six"
-                        , dependencyVersion = Just (CEq "6.0.0")
-                        , dependencyLocations = ["github.com"]
-                        , dependencyTags = M.fromList [("group", ["TEST"])]
-                        }
+                           , dependencyName = "six"
+                           , dependencyVersion = Just (CEq "6.0.0")
+                           , dependencyLocations = ["github.com"]
+                           , dependencyTags = M.fromList [("group", ["TEST"])]
+                           }
 
 nugetSection :: Section
 nugetSection = NugetSection [Remote "nuget.com" [PaketDep "one" "1.0.0" ["two"]
-                                 , PaketDep "two" "2.0.0" []
-                                 ]]
+                                                , PaketDep "two" "2.0.0" []
+                                                ]]
 
 httpSection :: Section
 httpSection = HTTPSection [Remote "custom-site.com" [PaketDep "three" "3.0.0" []]]
 
 nugetGroupRemote :: Remote
 nugetGroupRemote = Remote "nuget-v2.com" [PaketDep "four" "4.0.0" ["five"]
-                                 , PaketDep "five" "5.0.0" []
-                                 ]
+                                         , PaketDep "five" "5.0.0" []
+                                         , PaketDep "two" "2.0.0" []
+                                         ]
 
 gitGroupRemote :: Remote
 gitGroupRemote = Remote "github.com" [PaketDep "six" "6.0.0" []]

--- a/test/NuGet/PaketTest.hs
+++ b/test/NuGet/PaketTest.hs
@@ -101,8 +101,8 @@ spec_analyze = do
                   ] graph
 
   paketLockFile <- T.runIO (TIO.readFile "test/NuGet/testdata/paket.lock")
-  T.describe "paket lock parser" $ do
-    T.it "parses error messages into an empty list" $ do
+  T.describe "paket lock parser" $
+    T.it "parses error messages into an empty list" $
       case runParser findSections "" paketLockFile of
         Left _ -> T.expectationFailure "failed to parse"
         Right result -> do

--- a/test/NuGet/PaketTest.hs
+++ b/test/NuGet/PaketTest.hs
@@ -21,7 +21,7 @@ dependencyOne = Dependency { dependencyType = NuGetType
                            , dependencyName = "one"
                            , dependencyVersion = Just (CEq "1.0.0")
                            , dependencyLocations = ["nuget.com"]
-                           , dependencyTags = M.fromList [("group", ["MAIN"])]
+                           , dependencyTags = M.fromList [("location", ["NUGET"]), ("group", ["MAIN"])]
                            }
 
 dependencyTwo :: Dependency
@@ -29,7 +29,7 @@ dependencyTwo = Dependency { dependencyType = NuGetType
                            , dependencyName = "two"
                            , dependencyVersion = Just (CEq "2.0.0")
                            , dependencyLocations = ["nuget-v2.com", "nuget.com"]
-                           , dependencyTags = M.fromList [("group", ["MAIN", "TEST"])]
+                           , dependencyTags = M.fromList [("location", ["NUGET"]), ("group", ["MAIN", "TEST"])]
                            }
 
 dependencyThree :: Dependency
@@ -37,7 +37,7 @@ dependencyThree = Dependency { dependencyType = NuGetType
                              , dependencyName = "three"
                              , dependencyVersion = Just (CEq "3.0.0")
                              , dependencyLocations = ["custom-site.com"]
-                             , dependencyTags = M.fromList [("group", ["MAIN"])]
+                             , dependencyTags = M.fromList [("location", ["HTTP"]), ("group", ["MAIN"])]
                              }
 
 dependencyFour :: Dependency
@@ -45,7 +45,7 @@ dependencyFour = Dependency { dependencyType = NuGetType
                             , dependencyName = "four"
                             , dependencyVersion = Just (CEq "4.0.0")
                             , dependencyLocations = ["nuget-v2.com"]
-                            , dependencyTags = M.fromList [("group", ["TEST"])]
+                            , dependencyTags = M.fromList [("location", ["NUGET"]), ("group", ["TEST"])]
                             }
 
 dependencyFive :: Dependency
@@ -53,7 +53,7 @@ dependencyFive = Dependency { dependencyType = NuGetType
                             , dependencyName = "five"
                             , dependencyVersion = Just (CEq "5.0.0")
                             , dependencyLocations = ["nuget-v2.com"]
-                            , dependencyTags = M.fromList [("group", ["TEST"])]
+                            , dependencyTags = M.fromList [("location", ["NUGET"]), ("group", ["TEST"])]
                             }
 
 dependencySix :: Dependency
@@ -61,16 +61,16 @@ dependencySix = Dependency { dependencyType = NuGetType
                            , dependencyName = "six"
                            , dependencyVersion = Just (CEq "6.0.0")
                            , dependencyLocations = ["github.com"]
-                           , dependencyTags = M.fromList [("group", ["TEST"])]
+                           , dependencyTags = M.fromList [("location", ["GITHUB"]), ("group", ["TEST"])]
                            }
 
 nugetSection :: Section
-nugetSection = NugetSection [Remote "nuget.com" [PaketDep "one" "1.0.0" ["two"]
+nugetSection = StandardSection "NUGET" [Remote "nuget.com" [PaketDep "one" "1.0.0" ["two"]
                                                 , PaketDep "two" "2.0.0" []
                                                 ]]
 
 httpSection :: Section
-httpSection = HTTPSection [Remote "custom-site.com" [PaketDep "three" "3.0.0" []]]
+httpSection = StandardSection "HTTP" [Remote "custom-site.com" [PaketDep "three" "3.0.0" []]]
 
 nugetGroupRemote :: Remote
 nugetGroupRemote = Remote "nuget-v2.com" [PaketDep "four" "4.0.0" ["five"]
@@ -82,7 +82,7 @@ gitGroupRemote :: Remote
 gitGroupRemote = Remote "github.com" [PaketDep "six" "6.0.0" []]
 
 groupSection :: Section
-groupSection = GroupSection "TEST" [ NugetSection [nugetGroupRemote], GitSection [gitGroupRemote] ]
+groupSection = GroupSection "TEST" [ StandardSection "NUGET" [nugetGroupRemote], StandardSection "GITHUB" [gitGroupRemote] ]
 
 paketLockSections :: [Section]
 paketLockSections = [nugetSection, httpSection, groupSection]

--- a/test/NuGet/PaketTest.hs
+++ b/test/NuGet/PaketTest.hs
@@ -1,0 +1,110 @@
+module NuGet.PaketTest
+  ( spec_analyze
+  ) where
+
+import Prologue
+
+import qualified Data.Map.Strict as M
+import           Polysemy
+import           Polysemy.Input
+import qualified Data.Text.IO as TIO
+import           Text.Megaparsec
+
+import DepTypes
+import Strategy.NuGet.Paket
+import GraphUtil
+
+import qualified Test.Tasty.Hspec as T
+
+dependencyOne :: Dependency
+dependencyOne = Dependency { dependencyType = NuGetType
+                        , dependencyName = "one"
+                        , dependencyVersion = Just (CEq "1.0.0")
+                        , dependencyLocations = ["nuget.com"]
+                        , dependencyTags = M.fromList [("group", ["MAIN"])]
+                        }
+
+dependencyTwo :: Dependency
+dependencyTwo = Dependency { dependencyType = NuGetType
+                        , dependencyName = "two"
+                        , dependencyVersion = Just (CEq "2.0.0")
+                        , dependencyLocations = ["nuget.com"]
+                        , dependencyTags = M.fromList [("group", ["MAIN"])]
+                        }
+
+dependencyThree :: Dependency
+dependencyThree = Dependency { dependencyType = NuGetType
+                        , dependencyName = "three"
+                        , dependencyVersion = Just (CEq "3.0.0")
+                        , dependencyLocations = ["custom-site.com"]
+                        , dependencyTags = M.fromList [("group", ["MAIN"])]
+                        }
+
+dependencyFour :: Dependency
+dependencyFour = Dependency { dependencyType = NuGetType
+                        , dependencyName = "four"
+                        , dependencyVersion = Just (CEq "4.0.0")
+                        , dependencyLocations = ["nuget-v2.com"]
+                        , dependencyTags = M.fromList [("group", ["TEST"])]
+                        }
+
+dependencyFive :: Dependency
+dependencyFive = Dependency { dependencyType = NuGetType
+                        , dependencyName = "five"
+                        , dependencyVersion = Just (CEq "5.0.0")
+                        , dependencyLocations = ["nuget-v2.com"]
+                        , dependencyTags = M.fromList [("group", ["TEST"])]
+                        }
+
+dependencySix :: Dependency
+dependencySix = Dependency { dependencyType = NuGetType
+                        , dependencyName = "six"
+                        , dependencyVersion = Just (CEq "6.0.0")
+                        , dependencyLocations = ["github.com"]
+                        , dependencyTags = M.fromList [("group", ["TEST"])]
+                        }
+
+nugetSection :: Section
+nugetSection = NugetSection [Remote "nuget.com" [PaketDep "one" "1.0.0" ["two"]
+                                 , PaketDep "two" "2.0.0" []
+                                 ]]
+
+httpSection :: Section
+httpSection = HTTPSection [Remote "custom-site.com" [PaketDep "three" "3.0.0" []]]
+
+nugetGroupRemote :: Remote
+nugetGroupRemote = Remote "nuget-v2.com" [PaketDep "four" "4.0.0" ["five"]
+                                 , PaketDep "five" "5.0.0" []
+                                 ]
+
+gitGroupRemote :: Remote
+gitGroupRemote = Remote "github.com" [PaketDep "six" "6.0.0" []]
+
+groupSection :: Section
+groupSection = GroupSection "TEST" [ NugetSection [nugetGroupRemote], GitSection [gitGroupRemote] ]
+
+paketLockSections :: [Section]
+paketLockSections = [nugetSection, httpSection, groupSection]
+
+spec_analyze :: T.Spec
+spec_analyze = do
+  T.describe "paket lock analyzer" $
+    T.it "produces the expected output" $ do
+      let graph = analyze
+            & runInputConst @[Section] paketLockSections
+            & run
+      expectDeps [dependencyOne, dependencyTwo, dependencyThree, dependencyFour, dependencyFive, dependencySix] graph
+      expectDirect [dependencyOne, dependencyTwo, dependencyThree, dependencyFour, dependencyFive, dependencySix] graph
+      expectEdges [ (dependencyOne, dependencyTwo)
+                  , (dependencyFour, dependencyFive)
+                  ] graph
+
+  paketLockFile <- T.runIO (TIO.readFile "test/NuGet/testdata/paket.lock")
+  T.describe "paket lock parser" $ do
+    T.it "parses error messages into an empty list" $ do
+      case runParser findSections "" paketLockFile of
+        Left _ -> T.expectationFailure "failed to parse"
+        Right result -> do
+            result `T.shouldContain` [nugetSection]
+            result `T.shouldContain` [httpSection]
+            result `T.shouldContain` [groupSection]

--- a/test/NuGet/testdata/paket.lock
+++ b/test/NuGet/testdata/paket.lock
@@ -16,6 +16,7 @@ NUGET
      four (4.0.0)
        five (>1.0.0)
      five (5.0.0)
+     two (2.0.0)
 
 GITHUB
   remote: github.com

--- a/test/NuGet/testdata/paket.lock
+++ b/test/NuGet/testdata/paket.lock
@@ -1,0 +1,22 @@
+REDIRECTS: ON
+STRATEGY: MAX
+NUGET
+  remote: nuget.com
+    one (1.0.0)
+      two (>1.0.0)
+    two (2.0.0)
+
+HTTP
+  remote: custom-site.com
+    three (3.0.0)
+      
+GROUP TEST
+NUGET
+  remote: nuget-v2.com
+     four (4.0.0)
+       five (>1.0.0)
+     five (5.0.0)
+
+GITHUB
+  remote: github.com
+    six (6.0.0)


### PR DESCRIPTION
This PR introduces support for the Paket package manager.

Small todos left
1. Add a test for dependencies that are located in multiple groups.
2. Remove comments.
3. Refactor a little bit.