### PR TITLE
Use ghc 8.8

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,10 +20,9 @@ name: Build & Test
 on: [push]
 
 jobs:
-  build-linux:
-    name: build-linux
+  build-ubuntu:
+    name: build-ubuntu
     runs-on: ubuntu-latest
-    container: quay.io/fossa/haskell-static-alpine
 
     steps:
     - uses: actions/checkout@v2
@@ -32,7 +31,19 @@ jobs:
       name: Cache cabal store
       with:
         path: ~/.cabal/store
-        key: ${{ runner.os }}-cabal-store
+        key: ubuntu-cabal-store
+
+    - name: Install ghcup
+      run: |
+        mkdir -p ~/.ghcup/bin && curl https://gitlab.haskell.org/haskell/ghcup/raw/master/ghcup > ~/.ghcup/bin/ghcup && chmod +x ~/.ghcup/bin/ghcup
+        echo "::add-path::$HOME/.ghcup/bin"
+        echo "::add-path::$HOME/.cabal/bin"
+
+    - name: Install ghc/cabal
+      run: |
+        ghcup install 8.8.2
+        ghcup set 8.8.2
+        ghcup install-cabal
 
     - name: Install dependencies
       run: |
@@ -50,12 +61,49 @@ jobs:
 
     - name: Strip binary
       run: |
-        strip dist-newstyle/build/x86_64-linux/ghc-8.6.5/hscli-0.1.0.0/x/hscli/opt/build/hscli/hscli
+        strip dist-newstyle/build/x86_64-linux/ghc-8.8.2/hscli-0.1.0.0/x/hscli/opt/build/hscli/hscli
 
     - uses: actions/upload-artifact@v1
       with:
         name: hscli-linux
-        path: dist-newstyle/build/x86_64-linux/ghc-8.6.5/hscli-0.1.0.0/x/hscli/opt/build/hscli/hscli
+        path: dist-newstyle/build/x86_64-linux/ghc-8.8.2/hscli-0.1.0.0/x/hscli/opt/build/hscli/hscli
+
+# build-linux:
+#   name: build-linux
+#   runs-on: ubuntu-latest
+#   container: quay.io/fossa/haskell-static-alpine
+
+#   steps:
+#   - uses: actions/checkout@v2
+
+#   - uses: actions/cache@v1
+#     name: Cache cabal store
+#     with:
+#       path: ~/.cabal/store
+#       key: ${{ runner.os }}-cabal-store
+
+#   - name: Install dependencies
+#     run: |
+#       cabal update
+#       cabal configure --project-file=cabal.project.ci -O2 --enable-tests
+#       cabal build --project-file=cabal.project.ci --only-dependencies
+
+#   - name: Build
+#     run: |
+#       cabal build --project-file=cabal.project.ci
+
+#   - name: Run tests
+#     run: |
+#       cabal test --project-file=cabal.project.ci
+
+#   - name: Strip binary
+#     run: |
+#       strip dist-newstyle/build/x86_64-linux/ghc-8.8.2/hscli-0.1.0.0/x/hscli/opt/build/hscli/hscli
+
+#   - uses: actions/upload-artifact@v1
+#     with:
+#       name: hscli-linux
+#       path: dist-newstyle/build/x86_64-linux/ghc-8.8.2/hscli-0.1.0.0/x/hscli/opt/build/hscli/hscli
 
   build-macos:
     name: build-macos
@@ -78,8 +126,8 @@ jobs:
 
     - name: Install ghc/cabal
       run: |
-        ghcup install 8.6.5
-        ghcup set 8.6.5
+        ghcup install 8.8.2
+        ghcup set 8.8.2
         ghcup install-cabal
 
     - name: Install dependencies
@@ -98,12 +146,12 @@ jobs:
 
     - name: Strip binary
       run: |
-        strip dist-newstyle/build/x86_64-osx/ghc-8.6.5/hscli-0.1.0.0/x/hscli/opt/build/hscli/hscli
+        strip dist-newstyle/build/x86_64-osx/ghc-8.8.2/hscli-0.1.0.0/x/hscli/opt/build/hscli/hscli
 
     - uses: actions/upload-artifact@v1
       with:
         name: hscli-osx
-        path: dist-newstyle/build/x86_64-osx/ghc-8.6.5/hscli-0.1.0.0/x/hscli/opt/build/hscli/hscli
+        path: dist-newstyle/build/x86_64-osx/ghc-8.8.2/hscli-0.1.0.0/x/hscli/opt/build/hscli/hscli
 
   build-windows:
     name: build-windows
@@ -120,8 +168,8 @@ jobs:
 
     - name: Install ghc/cabal
       run: |
-        choco install ghc --version=8.6.5
-        echo '::add-path::C:\ProgramData\chocolatey\lib\ghc\tools\ghc-8.6.5\bin'
+        choco install ghc --version=8.8.2
+        echo '::add-path::C:\ProgramData\chocolatey\lib\ghc\tools\ghc-8.8.2\bin'
 
     - name: Install dependencies
       run: |
@@ -139,9 +187,9 @@ jobs:
 
     - name: Strip binary
       run: |
-        strip dist-newstyle/build/x86_64-windows/ghc-8.6.5/hscli-0.1.0.0/x/hscli/opt/build/hscli/hscli.exe
+        strip dist-newstyle/build/x86_64-windows/ghc-8.8.2/hscli-0.1.0.0/x/hscli/opt/build/hscli/hscli.exe
 
     - uses: actions/upload-artifact@v1
       with:
         name: hscli-windows.exe
-        path: dist-newstyle/build/x86_64-windows/ghc-8.6.5/hscli-0.1.0.0/x/hscli/opt/build/hscli/hscli.exe
+        path: dist-newstyle/build/x86_64-windows/ghc-8.8.2/hscli-0.1.0.0/x/hscli/opt/build/hscli/hscli.exe

--- a/hscli.cabal
+++ b/hscli.cabal
@@ -7,7 +7,7 @@ extra-source-files:
   scripts/*.gradle
 
 common lang
-  build-depends:      base ^>=4.12
+  build-depends:      base >=4.12 && <4.14
   default-language:   Haskell2010
   default-extensions:
     NoImplicitPrelude
@@ -23,7 +23,6 @@ common lang
     GeneralizedNewtypeDeriving
     InstanceSigs
     LambdaCase
-    MonadFailDesugaring
     MultiParamTypeClasses
     MultiWayIf
     NamedFieldPuns
@@ -49,7 +48,7 @@ common lang
 common deps
   build-depends:
     , aeson                        ^>=1.4.5
-    , algebraic-graphs             ^>=0.4
+    , algebraic-graphs             ^>=0.5
     , async                        ^>=2.2.2
     , attoparsec                   ^>=0.13.2.3
     , bytestring                   ^>=0.10.8
@@ -57,7 +56,7 @@ common deps
     , file-embed                   ^>=0.0.11
     , filepath                     ^>=1.4.2.1
     , git-config                   ^>=0.1.2
-    , megaparsec                   ^>=8
+    , megaparsec                   ^>=8.0
     , modern-uri                   ^>=0.3.1
     , mtl                          ^>=2.2.2
     , optics                       ^>=0.2
@@ -65,7 +64,7 @@ common deps
     , path                         ^>=0.7
     , path-io                      ^>=1.6.0
     , polysemy                     ^>=1.2.1
-    , prettyprinter                ^>=1.5.1
+    , prettyprinter                ^>=1.6
     , prettyprinter-ansi-terminal  ^>=1.1.1
     , stm                          ^>=2.5.0
     , stm-chans                    ^>=3.0.0

--- a/src/Effect/ReadFS.hs
+++ b/src/Effect/ReadFS.hs
@@ -37,7 +37,6 @@ import qualified Data.Text as T
 import           Data.Text.Encoding (decodeUtf8)
 import           Data.Yaml (decodeEither', prettyPrintParseException)
 import           Parse.XML (FromXML, parseXML, xmlErrorPretty)
-import           Path (Dir, File, Path, toFilePath)
 import qualified Path.IO as PIO
 import           Polysemy
 import           Polysemy.Error hiding (catch)

--- a/src/Parse/XML.hs
+++ b/src/Parse/XML.hs
@@ -18,7 +18,6 @@ import Prelude
 
 import Control.Applicative (Alternative)
 import Control.Monad (MonadPlus)
-import Control.Monad.Fail (MonadFail)
 import qualified Data.Text as T
 import Polysemy
 import Polysemy.Error

--- a/src/Prologue.hs
+++ b/src/Prologue.hs
@@ -16,7 +16,6 @@ import Data.Bifunctor as X
 import Data.ByteString as X (ByteString)
 import Data.Foldable as X
 import Data.Function as X ((&))
-import Data.Functor as X (void)
 import Data.List as X (isPrefixOf, isSuffixOf)
 import Data.Map.Strict as X (Map)
 import Data.Maybe as X (fromMaybe)

--- a/src/Strategy/NpmList.hs
+++ b/src/Strategy/NpmList.hs
@@ -8,7 +8,6 @@ module Strategy.NpmList
 import Prologue
 
 import qualified Data.Map.Strict as M
-import Data.Text (Text)
 import Polysemy
 import Polysemy.Input
 import Polysemy.Output


### PR DESCRIPTION
required changes:
- `base` upper bound was relaxed
- resolve a bunch of warnings wrt imports that ghc 8.6.5 didn't pick up
- remove `MonadFailDesugaring` (it's on by default as of 8.6.5 and is a warning now)
- version bounds were bumped for a couple of dependencies
- we're temporarily building on ubuntu, rather than statically building on alpine, because 8.8.2 is broken for alpine