### PR TITLE
Declared license detector

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,7 +61,7 @@ jobs:
       run: |
         strip dist-newstyle/build/x86_64-linux/ghc-8.8.2/pathfinder-0.1.0.0/x/pathfinder/opt/build/pathfinder/pathfinder
 
-    - uses: actions/upload-pathfinder-artifact@v1
+    - uses: actions/upload-artifact@v1
       with:
         name: pathfinder-linux
         path: dist-newstyle/build/x86_64-linux/ghc-8.8.2/pathfinder-0.1.0.0/x/pathfinder/opt/build/pathfinder/pathfinder

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -166,7 +166,6 @@ jobs:
       id: cache-package
       with:
         path: ~/AppData/Roaming/cabal/packages
-        path: ~/.cabal/packages
         key: ${{ runner.os }}-cabal-packages
 
     - uses: actions/cache@v1
@@ -181,7 +180,6 @@ jobs:
       id: cache-newstyle
       with:
         path: ~/AppData/Roaming/dist-newstyle
-        path: dist-newstyle
         key: ${{ runner.os }}-dist-newstyle
 
     - name: Install ghc/cabal

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,13 +28,6 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    # - uses: actions/cache@v1
-    #   name: Cache cabal store
-    #   id: cache
-    #   with:
-    #     path: ~/.cabal/store
-    #     key: ${{ runner.os }}-cabal-store
-
     - uses: actions/cache@v1
       name: Cache ~/.cabal/packages
       id: cache-package
@@ -97,10 +90,25 @@ jobs:
     - uses: actions/checkout@v2
 
     - uses: actions/cache@v1
-      name: Cache cabal store
+      name: Cache ~/.cabal/packages
+      id: cache-package
+      with:
+        path: ~/.cabal/packages
+        key: ${{ runner.os }}-cabal-packages
+
+    - uses: actions/cache@v1
+      name: Cache ~/.cabal/store
+      id: cache-store
       with:
         path: ~/.cabal/store
         key: ${{ runner.os }}-cabal-store
+
+    - uses: actions/cache@v1
+      name: Cache dist-newstyle
+      id: cache-newstyle
+      with:
+        path: dist-newstyle
+        key: ${{ runner.os }}-dist-newstyle
 
     - name: Install ghcup
       run: |
@@ -154,10 +162,27 @@ jobs:
     - uses: actions/checkout@v2
 
     - uses: actions/cache@v1
-      name: Cache cabal store
+      name: Cache ~/.cabal/packages
+      id: cache-package
+      with:
+        path: ~/AppData/Roaming/cabal/packages
+        path: ~/.cabal/packages
+        key: ${{ runner.os }}-cabal-packages
+
+    - uses: actions/cache@v1
+      name: Cache ~/.cabal/store
+      id: cache-store
       with:
         path: ~/AppData/Roaming/cabal/store
         key: ${{ runner.os }}-cabal-store
+
+    - uses: actions/cache@v1
+      name: Cache dist-newstyle
+      id: cache-newstyle
+      with:
+        path: ~/AppData/Roaming/dist-newstyle
+        path: dist-newstyle
+        key: ${{ runner.os }}-dist-newstyle
 
     - name: Install ghc/cabal
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,12 +59,12 @@ jobs:
 
     - name: Strip pathfinder binary
       run: |
-        strip dist-newstyle/build/x86_64-linux/ghc-8.8.2/pathfinder-0.1.0.0/x/pathfinder/opt/build/pathfinder/pathfinder
+        strip dist-newstyle/build/x86_64-linux/ghc-8.8.2/hscli-0.1.0.0/x/pathfinder/opt/build/pathfinder/pathfinder
 
     - uses: actions/upload-artifact@v1
       with:
         name: pathfinder-linux
-        path: dist-newstyle/build/x86_64-linux/ghc-8.8.2/pathfinder-0.1.0.0/x/pathfinder/opt/build/pathfinder/pathfinder
+        path: dist-newstyle/build/x86_64-linux/ghc-8.8.2/hscli-0.1.0.0/x/pathfinder/opt/build/pathfinder/pathfinder
 
   build-macos:
     name: build-macos

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,6 +114,15 @@ jobs:
         name: hscli-osx
         path: dist-newstyle/build/x86_64-osx/ghc-8.8.2/hscli-0.1.0.0/x/hscli/opt/build/hscli/hscli
 
+    - name: Strip pathfinder binary
+      run: |
+        strip dist-newstyle/build/x86_64-osx/ghc-8.8.2/hscli-0.1.0.0/x/pathfinder/opt/build/pathfinder/pathfinder
+
+    - uses: actions/upload-artifact@v1
+      with:
+        name: pathfinder-osx
+        path: dist-newstyle/build/x86_64-osx/ghc-8.8.2/hscli-0.1.0.0/x/pathfinder/opt/build/pathfinder/pathfinder
+
   build-windows:
     name: build-windows
     runs-on: windows-latest
@@ -154,3 +163,12 @@ jobs:
       with:
         name: hscli-windows.exe
         path: dist-newstyle/build/x86_64-windows/ghc-8.8.2/hscli-0.1.0.0/x/hscli/opt/build/hscli/hscli.exe
+
+    - name: Strip pathfinder binary
+      run: |
+        strip dist-newstyle/build/x86_64-windows/ghc-8.8.2/hscli-0.1.0.0/x/pathfinder/opt/build/pathfinder/pathfinder.exe
+
+    - uses: actions/upload-artifact@v1
+      with:
+        name: pathfinder-windows.exe
+        path: dist-newstyle/build/x86_64-windows/ghc-8.8.2/hscli-0.1.0.0/x/pathfinder/opt/build/pathfinder/pathfinder.exe

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,21 +93,21 @@ jobs:
       id: cache-package
       with:
         path: ~/.cabal/packages
-        key: ${{ runner.os }}-cabal-packages
+        key: ${{ hashFiles ('hscli.cabal') }}-${{ runner.os }}-cabal-packages
 
     - uses: actions/cache@v1
       name: Cache ~/.cabal/store
       id: cache-store
       with:
         path: ~/.cabal/store
-        key: ${{ runner.os }}-cabal-store
+        key: ${{ hashFiles ('hscli.cabal') }}-${{ runner.os }}-cabal-store
 
     - uses: actions/cache@v1
       name: Cache dist-newstyle
       id: cache-newstyle
       with:
         path: dist-newstyle
-        key: ${{ runner.os }}-dist-newstyle
+        key: ${{ hashFiles ('hscli.cabal') }}-${{ runner.os }}-dist-newstyle
 
     - name: Install ghcup
       run: |
@@ -165,14 +165,14 @@ jobs:
       id: cache-package
       with:
         path: ~/AppData/Roaming/cabal/packages
-        key: ${{ runner.os }}-cabal-packages
+        key: ${{ hashFiles ('~/AppData/Roaming/hscli.cabal') }}-${{ runner.os }}-cabal-packages
 
     - uses: actions/cache@v1
       name: Cache ~/.cabal/store
       id: cache-store
       with:
         path: ~/AppData/Roaming/cabal/store
-        key: ${{ runner.os }}-cabal-store
+        key: ${{ hashFiles ('~/AppData/Roaming/hscli.cabal') }}-${{ runner.os }}-cabal-store
 
     - uses: actions/cache@v1
       name: Cache dist-newstyle
@@ -180,6 +180,7 @@ jobs:
       with:
         path: ~/AppData/Roaming/dist-newstyle
         key: ${{ runner.os }}-dist-newstyle
+        key: ${{ hashFiles ('~/AppData/Roaming/hscli.cabal') }}-${{ runner.os }}-dist-newstyle
 
     - name: Install ghc/cabal
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -179,7 +179,6 @@ jobs:
       id: cache-newstyle
       with:
         path: ~/AppData/Roaming/dist-newstyle
-        key: ${{ runner.os }}-dist-newstyle
         key: ${{ hashFiles ('~/AppData/Roaming/hscli.cabal') }}-${{ runner.os }}-dist-newstyle
 
     - name: Install ghc/cabal

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,12 +28,12 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - uses: actions/cache@v1
-      name: Cache ~/.cabal/packages
-      id: cache-package
-      with:
-        path: ~/.cabal/packages
-        key: ${{ hashFiles ('hscli.cabal') }}-${{ runner.os }}-cabal-packages
+    # - uses: actions/cache@v1
+    #   name: Cache ~/.cabal/packages
+    #   id: cache-package
+    #   with:
+    #     path: ~/.cabal/packages
+    #     key: ${{ hashFiles ('hscli.cabal') }}-${{ runner.os }}-cabal-packages
 
     - uses: actions/cache@v1
       name: Cache ~/.cabal/store
@@ -42,12 +42,12 @@ jobs:
         path: ~/.cabal/store
         key: ${{ hashFiles ('hscli.cabal') }}-${{ runner.os }}-cabal-store
 
-    - uses: actions/cache@v1
-      name: Cache dist-newstyle
-      id: cache-newstyle
-      with:
-        path: dist-newstyle
-        key: ${{ hashFiles ('hscli.cabal') }}-${{ runner.os }}-dist-newstyle
+    # - uses: actions/cache@v1
+    #   name: Cache dist-newstyle
+    #   id: cache-newstyle
+    #   with:
+    #     path: dist-newstyle
+    #     key: ${{ hashFiles ('hscli.cabal') }}-${{ runner.os }}-dist-newstyle
 
     - name: Install dependencies
       run: |
@@ -165,21 +165,21 @@ jobs:
       id: cache-package
       with:
         path: ~/AppData/Roaming/cabal/packages
-        key: ${{ hashFiles ('~/AppData/Roaming/hscli.cabal') }}-${{ runner.os }}-cabal-packages
+        key: ${{ hashFiles ('%AppData%/Roaming/hscli.cabal') }}-${{ runner.os }}-cabal-packages
 
     - uses: actions/cache@v1
       name: Cache ~/.cabal/store
       id: cache-store
       with:
         path: ~/AppData/Roaming/cabal/store
-        key: ${{ hashFiles ('~/AppData/Roaming/hscli.cabal') }}-${{ runner.os }}-cabal-store
+        key: ${{ hashFiles ('%AppData%/Roaming/hscli.cabal') }}-${{ runner.os }}-cabal-store
 
     - uses: actions/cache@v1
       name: Cache dist-newstyle
       id: cache-newstyle
       with:
         path: ~/AppData/Roaming/dist-newstyle
-        key: ${{ hashFiles ('~/AppData/Roaming/hscli.cabal') }}-${{ runner.os }}-dist-newstyle
+        key: ${{ hashFiles ('%AppData%/Roaming/hscli.cabal') }}-${{ runner.os }}-dist-newstyle
 
     - name: Install ghc/cabal
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,6 +57,15 @@ jobs:
         name: hscli-linux
         path: dist-newstyle/build/x86_64-linux/ghc-8.8.2/hscli-0.1.0.0/x/hscli/opt/build/hscli/hscli
 
+    - name: Strip pathfinder binary
+      run: |
+        strip dist-newstyle/build/x86_64-linux/ghc-8.8.2/pathfinder-0.1.0.0/x/pathfinder/opt/build/pathfinder/pathfinder
+
+    - uses: actions/upload-pathfinder-artifact@v1
+      with:
+        name: pathfinder-linux
+        path: dist-newstyle/build/x86_64-linux/ghc-8.8.2/pathfinder-0.1.0.0/x/pathfinder/opt/build/pathfinder/pathfinder
+
   build-macos:
     name: build-macos
     runs-on: macos-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,21 +33,21 @@ jobs:
       id: cache-package
       with:
         path: ~/.cabal/packages
-        key: ${{ runner.os }}-cabal-packages
+        key: ${{ hashFiles ('hscli.cabal') }}-cabal-packages
 
     - uses: actions/cache@v1
       name: Cache ~/.cabal/store
       id: cache-store
       with:
         path: ~/.cabal/store
-        key: ${{ runner.os }}-cabal-store
+        key: ${{ hashFiles ('hscli.cabal') }}-cabal-store
 
     - uses: actions/cache@v1
       name: Cache dist-newstyle
       id: cache-newstyle
       with:
         path: dist-newstyle
-        key: ${{ runner.os }}-dist-newstyle
+        key: ${{ hashFiles ('hscli.cabal') }}-dist-newstyle
 
     - name: Install dependencies
       if: steps.cache-package.outputs.cache-hit != 'true' || steps.cache-store.outputs.cache-hit != 'true' || steps.cache-newstyle.outputs.cache-hit != 'true'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,15 +28,36 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    # - uses: actions/cache@v1
+    #   name: Cache cabal store
+    #   id: cache
+    #   with:
+    #     path: ~/.cabal/store
+    #     key: ${{ runner.os }}-cabal-store
+
     - uses: actions/cache@v1
-      name: Cache cabal store
-      id: cache
+      name: Cache ~/.cabal/packages
+      id: cache-package
+      with:
+        path: ~/.cabal/packages
+        key: ${{ runner.os }}-${{ matrix.ghc }}-cabal-packages
+
+    - uses: actions/cache@v1
+      name: Cache ~/.cabal/store
+      id: cache-store
       with:
         path: ~/.cabal/store
-        key: ${{ runner.os }}-cabal-store
+        key: ${{ runner.os }}-${{ matrix.ghc }}-cabal-store
+
+    - uses: actions/cache@v1
+      name: Cache dist-newstyle
+      id: cache-newstyle
+      with:
+        path: dist-newstyle
+        key: ${{ runner.os }}-${{ matrix.ghc }}-dist-newstyle
 
     - name: Install dependencies
-      if: steps.cache.outputs.cache-hit != 'true'
+      if: steps.cache-package.outputs.cache-hit != 'true' || steps.cache-store.outputs.cache-hit != 'true' || steps.cache-newstyle.outputs.cache-hit != 'true'
       run: |
         cabal update
         cabal configure --project-file=cabal.project.ci -O2 --enable-tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,26 +28,11 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    # - uses: actions/cache@v1
-    #   name: Cache ~/.cabal/packages
-    #   id: cache-package
-    #   with:
-    #     path: ~/.cabal/packages
-    #     key: ${{ hashFiles ('hscli.cabal') }}-${{ runner.os }}-cabal-packages
-
     - uses: actions/cache@v1
       name: Cache ~/.cabal/store
-      id: cache-store
       with:
         path: ~/.cabal/store
         key: ${{ hashFiles ('hscli.cabal') }}-${{ runner.os }}-cabal-store
-
-    # - uses: actions/cache@v1
-    #   name: Cache dist-newstyle
-    #   id: cache-newstyle
-    #   with:
-    #     path: dist-newstyle
-    #     key: ${{ hashFiles ('hscli.cabal') }}-${{ runner.os }}-dist-newstyle
 
     - name: Install dependencies
       run: |
@@ -89,25 +74,11 @@ jobs:
     - uses: actions/checkout@v2
 
     - uses: actions/cache@v1
-      name: Cache ~/.cabal/packages
-      id: cache-package
-      with:
-        path: ~/.cabal/packages
-        key: ${{ hashFiles ('hscli.cabal') }}-${{ runner.os }}-cabal-packages
-
-    - uses: actions/cache@v1
       name: Cache ~/.cabal/store
       id: cache-store
       with:
         path: ~/.cabal/store
         key: ${{ hashFiles ('hscli.cabal') }}-${{ runner.os }}-cabal-store
-
-    - uses: actions/cache@v1
-      name: Cache dist-newstyle
-      id: cache-newstyle
-      with:
-        path: dist-newstyle
-        key: ${{ hashFiles ('hscli.cabal') }}-${{ runner.os }}-dist-newstyle
 
     - name: Install ghcup
       run: |
@@ -161,25 +132,11 @@ jobs:
     - uses: actions/checkout@v2
 
     - uses: actions/cache@v1
-      name: Cache ~/.cabal/packages
-      id: cache-package
-      with:
-        path: ~/AppData/Roaming/cabal/packages
-        key: ${{ hashFiles ('%AppData%/Roaming/hscli.cabal') }}-${{ runner.os }}-cabal-packages
-
-    - uses: actions/cache@v1
       name: Cache ~/.cabal/store
       id: cache-store
       with:
         path: ~/AppData/Roaming/cabal/store
-        key: ${{ hashFiles ('%AppData%/Roaming/hscli.cabal') }}-${{ runner.os }}-cabal-store
-
-    - uses: actions/cache@v1
-      name: Cache dist-newstyle
-      id: cache-newstyle
-      with:
-        path: ~/AppData/Roaming/dist-newstyle
-        key: ${{ hashFiles ('%AppData%/Roaming/hscli.cabal') }}-${{ runner.os }}-dist-newstyle
+        key: ${{ hashFiles ('%AppData/Roaming/hscli.cabal') }}-${{ runner.os }}-cabal-store
 
     - name: Install ghc/cabal
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -136,7 +136,7 @@ jobs:
       id: cache-store
       with:
         path: ~/AppData/Roaming/cabal/store
-        key: ${{ hashFiles ('%AppData/Roaming/hscli.cabal') }}-${{ runner.os }}-cabal-store
+        key: ${{ hashFiles ('**\hscli.cabal') }}-${{ runner.os }}-cabal-store
 
     - name: Install ghc/cabal
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,11 +30,13 @@ jobs:
 
     - uses: actions/cache@v1
       name: Cache cabal store
+      id: cache
       with:
         path: ~/.cabal/store
         key: ${{ runner.os }}-cabal-store
 
     - name: Install dependencies
+      if: steps.cache.outputs.cache-hit != 'true'
       run: |
         cabal update
         cabal configure --project-file=cabal.project.ci -O2 --enable-tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,24 +33,23 @@ jobs:
       id: cache-package
       with:
         path: ~/.cabal/packages
-        key: ${{ hashFiles ('hscli.cabal') }}-cabal-packages
+        key: ${{ hashFiles ('hscli.cabal') }}-${{ runner.os }}-cabal-packages
 
     - uses: actions/cache@v1
       name: Cache ~/.cabal/store
       id: cache-store
       with:
         path: ~/.cabal/store
-        key: ${{ hashFiles ('hscli.cabal') }}-cabal-store
+        key: ${{ hashFiles ('hscli.cabal') }}-${{ runner.os }}-cabal-store
 
     - uses: actions/cache@v1
       name: Cache dist-newstyle
       id: cache-newstyle
       with:
         path: dist-newstyle
-        key: ${{ hashFiles ('hscli.cabal') }}-dist-newstyle
+        key: ${{ hashFiles ('hscli.cabal') }}-${{ runner.os }}-dist-newstyle
 
     - name: Install dependencies
-      if: steps.cache-package.outputs.cache-hit != 'true' || steps.cache-store.outputs.cache-hit != 'true' || steps.cache-newstyle.outputs.cache-hit != 'true'
       run: |
         cabal update
         cabal configure --project-file=cabal.project.ci -O2 --enable-tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,21 +40,21 @@ jobs:
       id: cache-package
       with:
         path: ~/.cabal/packages
-        key: ${{ runner.os }}-${{ matrix.ghc }}-cabal-packages
+        key: ${{ runner.os }}-cabal-packages
 
     - uses: actions/cache@v1
       name: Cache ~/.cabal/store
       id: cache-store
       with:
         path: ~/.cabal/store
-        key: ${{ runner.os }}-${{ matrix.ghc }}-cabal-store
+        key: ${{ runner.os }}-cabal-store
 
     - uses: actions/cache@v1
       name: Cache dist-newstyle
       id: cache-newstyle
       with:
         path: dist-newstyle
-        key: ${{ runner.os }}-${{ matrix.ghc }}-dist-newstyle
+        key: ${{ runner.os }}-dist-newstyle
 
     - name: Install dependencies
       if: steps.cache-package.outputs.cache-hit != 'true' || steps.cache-store.outputs.cache-hit != 'true' || steps.cache-newstyle.outputs.cache-hit != 'true'

--- a/hscli.cabal
+++ b/hscli.cabal
@@ -92,6 +92,8 @@ library
     App.Scan.GraphMangler
     App.Scan.Project
     App.Scan.ProjectInference
+    AppLicense
+    AppLicense.Scan
     Control.Parallel
     DepTypes
     Diagnostics
@@ -134,8 +136,8 @@ library
     Strategy.NuGet.Paket
     Strategy.NuGet.ProjectAssetsJson
     Strategy.NuGet.ProjectJson
-    Strategy.Python.PipList
     Strategy.Python.Pipenv
+    Strategy.Python.PipList
     Strategy.Python.ReqTxt
     Strategy.Python.SetupPy
     Strategy.Python.Util
@@ -149,6 +151,15 @@ executable hscli
   import:         lang
   main-is:        Main.hs
   hs-source-dirs: app
+  build-depends:  hscli
+  ghc-options:
+    -flate-specialise -fspecialize-aggressively -O -threaded
+    -with-rtsopts=-N
+
+executable pathfinder
+  import:         lang
+  main-is:        Main.hs
+  hs-source-dirs: licenseApp
   build-depends:  hscli
   ghc-options:
     -flate-specialise -fspecialize-aggressively -O -threaded
@@ -182,8 +193,8 @@ test-suite tests
     NuGet.PaketTest
     NuGet.ProjectAssetsJsonTest
     NuGet.ProjectJsonTest
-    Python.PipListTest
     Python.PipenvTest
+    Python.PipListTest
     Python.ReqTxtTest
     Python.RequirementsTest
     Python.SetupPyTest

--- a/licenseApp/Main.hs
+++ b/licenseApp/Main.hs
@@ -1,0 +1,9 @@
+
+module Main (main) where
+
+import Prelude
+
+import AppLicense (appMain)
+
+main :: IO ()
+main = appMain

--- a/src/AppLicense.hs
+++ b/src/AppLicense.hs
@@ -52,4 +52,4 @@ scanCmd = info
   (LicenseScan <$> optional (strOption $ long "basedir" <> short 'd' <> metavar "DIR" <> help "Base directory for scanning")
            <*> (fromMaybe False <$> optional (switch $ long "debug" <> help "Enable debug logging"))
   )
-  (progDesc "Scan for dependencies")
+  (progDesc "Scan for licenses")

--- a/src/AppLicense.hs
+++ b/src/AppLicense.hs
@@ -1,0 +1,55 @@
+
+module AppLicense
+  ( appMain
+  ) where
+
+import Prologue
+
+import Options.Applicative
+import Path.IO
+import System.Exit (die)
+
+import AppLicense.Scan (scanMain)
+
+appMain :: IO ()
+appMain = do
+  options <- execParser opts
+
+  currentDir <- getCurrentDir
+
+  case options of
+    LicenseScan basedir debug ->
+      case basedir of
+        Nothing -> scanMain currentDir debug
+        Just dir -> do
+          resolved <- validateDir dir
+          scanMain resolved debug
+
+data CommandOpts = LicenseScan (Maybe FilePath) Bool
+  deriving Show
+
+validateDir :: FilePath -> IO (Path Abs Dir)
+validateDir dir = do
+  absolute <- resolveDir' dir
+  exists <- doesDirExist absolute
+
+  unless exists (die $ "ERROR: Directory " <> show absolute <> " does not exist")
+
+  pure absolute
+
+opts :: ParserInfo CommandOpts
+opts = info (commands <**> helper)
+  ( fullDesc <> header "pathfinder - finds declared licenses in manifest files")
+
+commands :: Parser CommandOpts
+commands = hsubparser
+  ( command "scan" scanCmd
+  -- <> command "other" -- etc
+  )
+
+scanCmd :: ParserInfo CommandOpts
+scanCmd = info
+  (LicenseScan <$> optional (strOption $ long "basedir" <> short 'd' <> metavar "DIR" <> help "Base directory for scanning")
+           <*> (fromMaybe False <$> optional (switch $ long "debug" <> help "Enable debug logging"))
+  )
+  (progDesc "Scan for dependencies")

--- a/src/AppLicense/Scan.hs
+++ b/src/AppLicense/Scan.hs
@@ -19,7 +19,6 @@ import Polysemy.Output
 import Polysemy.Resource
 import System.Exit (die)
 
-import App.Scan.ProjectInference (InferredProject(..), inferProject)
 import Control.Parallel
 import Data.Text.Prettyprint.Doc
 import Data.Text.Prettyprint.Doc.Render.Terminal

--- a/src/AppLicense/Scan.hs
+++ b/src/AppLicense/Scan.hs
@@ -1,0 +1,157 @@
+
+module AppLicense.Scan
+  ( scanMain
+  ) where
+
+import Prologue
+
+import Control.Concurrent
+import Control.Exception (SomeException)
+import Data.Bool (bool)
+import qualified Data.Map as M
+import qualified Data.ByteString.Lazy.Char8 as BL
+import qualified Data.Sequence as S
+import Path.IO
+import Polysemy
+import Polysemy.Async
+import Polysemy.Error
+import Polysemy.Output
+import Polysemy.Resource
+import System.Exit (die)
+
+import App.Scan.ProjectInference (InferredProject(..), inferProject)
+import Control.Parallel
+import Data.Text.Prettyprint.Doc
+import Data.Text.Prettyprint.Doc.Render.Terminal
+import Diagnostics
+import Discovery
+import Effect.Error
+import Effect.Exec
+import Effect.Logger
+import Effect.ReadFS hiding (doesDirExist)
+import Types
+
+scanMain :: Path Abs Dir -> Bool -> IO ()
+scanMain basedir debug = do
+  exists <- doesDirExist basedir
+  unless exists (die $ "ERROR: " <> show basedir <> " does not exist")
+
+  scan basedir
+    & bool ignoreLogger (loggerToIO Debug) debug
+    & asyncToIOFinal
+    & resourceToIOFinal
+    & embedToFinal @IO
+    & runFinal
+
+scan :: Members '[Final IO, Embed IO, Resource, Async, Logger] r => Path Abs Dir -> Sem r ()
+scan basedir = do
+  setCurrentDir basedir
+  capabilities <- embed getNumCapabilities
+
+  (results :: S.Seq CompletedLicenseScan, ()) <- runActions capabilities (map ADiscover licenseDiscoverFuncs) (runAction basedir) updateProgress
+    & outputToIOMonoid S.singleton
+
+  logSticky "[ Combining Analyses ]"
+
+  let projects = mkLicenseScans strategyGroups results
+  embed $ BL.putStrLn $ encode $ projects
+
+data ProjectLicenseScan = ProjectLicenseScan
+  { licenseStrategyType :: Text
+  , licenseStrategyName :: Text
+  , discoveredLicenses  :: [LicenseResult]
+  } deriving (Eq, Ord, Show, Generic)
+
+instance ToJSON ProjectLicenseScan where
+  toJSON ProjectLicenseScan{..} = object
+    [ "type"    .= licenseStrategyType
+    , "name"    .= licenseStrategyName
+    , "files"   .= discoveredLicenses
+    ]
+
+type StrategyGroupName = Text
+mkLicenseScans :: [StrategyGroup] -> S.Seq CompletedLicenseScan -> [ProjectLicenseScan]
+mkLicenseScans groups seqScans = toProjectScan <$> toList seqScans
+  where
+    toProjectScan :: CompletedLicenseScan -> ProjectLicenseScan
+    toProjectScan completedScan =
+      ProjectLicenseScan { licenseStrategyType = completedToGroup completedScan
+                         , licenseStrategyName = completedLicenseName completedScan
+                         , discoveredLicenses = completedLicenses completedScan
+                         }
+
+    completedToGroup :: CompletedLicenseScan -> StrategyGroupName
+    completedToGroup CompletedLicenseScan{completedLicenseName} =
+      -- use the strategy name as a group name if a group doesn't exist
+      fromMaybe completedLicenseName (M.lookup completedLicenseName groupsByStrategy)
+
+    groupsByStrategy :: Map StrategyGroupName StrategyGroupName
+    groupsByStrategy = M.fromList
+      [(stratName, groupName) | StrategyGroup groupName strategies <- groups
+                              , SomeStrategy strat <- strategies
+                              , let stratName = strategyName strat
+                              ]
+
+runAction :: Members '[Final IO, Embed IO, Resource, Logger, Output CompletedLicenseScan] r => Path Abs Dir -> (Action -> Sem r ()) -> Action -> Sem r ()
+runAction basedir enqueue = \case
+  ADiscover Discover{..} -> do
+    let prettyName = fill 20 (annotate (colorDull Cyan) (pretty discoverName <> " "))
+
+    result <- discoverFunc basedir
+      & readFSToIO
+      & readFSErrToCLIErr
+      & execToIO
+      & execErrToCLIErr
+      & errorToIOFinal @CLIErr
+      & fromExceptionSem @SomeException
+      & errorToIOFinal @SomeException
+      & runOutputSem @ConfiguredStrategy (enqueue . AStrategy)
+
+    case result of
+      Left someException -> do
+        logWarn $ prettyName <> annotate (color Red) "Discovery failed with uncaught SomeException"
+        logWarn $ pretty (show someException) <> line
+      Right (Left err) -> do
+        logWarn $ prettyName <> annotate (color Red) "Discovery failed"
+        logDebug $ pretty (show err) <> line
+      Right (Right ()) -> logDebug $ prettyName <> annotate (color Green) "Finished discovery"
+
+  AStrategy (ConfiguredStrategy Strategy{..} opts) -> do
+    let prettyName = annotate (color Cyan) (pretty strategyName)
+        prettyPath = pretty (toFilePath (strategyModule opts))
+
+    result <- strategyLicense opts
+      & readFSToIO
+      & readFSErrToCLIErr
+      & execToIO
+      & execErrToCLIErr
+      & errorToIOFinal @CLIErr
+      & fromExceptionSem @SomeException
+      & errorToIOFinal @SomeException
+
+    case result of
+      Left someException -> do
+        logWarn $ prettyPath <> " " <> prettyName <> " " <> annotate (color Yellow) "Analysis failed with uncaught SomeException"
+        logDebug $ pretty (show someException) <> line
+      Right (Left err) -> do
+        logWarn $ prettyPath <> " " <> prettyName <> " " <> annotate (color Yellow) "Analysis failed"
+        logDebug $ pretty (show err) <> line
+      Right (Right licenses) -> do
+        logInfo $ prettyPath <> " " <> prettyName <> " " <> annotate (color Green) "Analyzed"
+        logDebug (pretty (show licenses))
+        output (CompletedLicenseScan strategyName licenses)
+
+updateProgress :: Member Logger r => Progress -> Sem r ()
+updateProgress Progress{..} =
+  logSticky ( "[ "
+            <> annotate (color Cyan) (pretty pQueued)
+            <> " Waiting / "
+            <> annotate (color Yellow) (pretty pRunning)
+            <> " Running / "
+            <> annotate (color Green) (pretty pCompleted)
+            <> " Completed"
+            <> " ]" )
+
+data Action =
+    ADiscover Discover
+  | AStrategy ConfiguredStrategy

--- a/src/AppLicense/Scan.hs
+++ b/src/AppLicense/Scan.hs
@@ -70,6 +70,7 @@ instance ToJSON ProjectLicenseScan where
     ]
 
 type StrategyGroupName = Text
+
 mkLicenseScans :: [StrategyGroup] -> S.Seq CompletedLicenseScan -> [ProjectLicenseScan]
 mkLicenseScans groups seqScans = toProjectScan <$> toList seqScans
   where

--- a/src/Discovery.hs
+++ b/src/Discovery.hs
@@ -1,5 +1,6 @@
 module Discovery
   ( discoverFuncs
+  , licenseDiscoverFuncs
   , strategyGroups
   ) where
 
@@ -30,6 +31,9 @@ import qualified Strategy.Python.SetupPy as SetupPy
 import qualified Strategy.Ruby.BundleShow as BundleShow
 import qualified Strategy.Ruby.GemfileLock as GemfileLock
 import           Types
+
+licenseDiscoverFuncs :: [Discover]
+licenseDiscoverFuncs = [ Nuspec.discover ]
 
 discoverFuncs :: [Discover]
 discoverFuncs =

--- a/src/Parse/XML.hs
+++ b/src/Parse/XML.hs
@@ -38,7 +38,6 @@ instance FromXML XML.Element where
 
 instance FromXML T.Text where
   parseElement = content
-
 instance FromXML v => FromXML (M.Map T.Text v) where
   parseElement el = M.fromList <$> traverse mkSingle (XML.elChildren el)
     where

--- a/src/Strategy/Carthage.hs
+++ b/src/Strategy/Carthage.hs
@@ -46,6 +46,7 @@ strategy :: Strategy BasicFileOpts
 strategy = Strategy
   { strategyName = "carthage"
   , strategyAnalyze = fmap (G.gmap toDependency) . analyze
+  , strategyLicense = const (pure [])
   , strategyModule = parent . targetFile
   , strategyOptimal = Optimal
   , strategyComplete = Complete

--- a/src/Strategy/Cocoapods/Podfile.hs
+++ b/src/Strategy/Cocoapods/Podfile.hs
@@ -43,6 +43,7 @@ strategy :: Strategy BasicFileOpts
 strategy = Strategy
   { strategyName = "podfile"
   , strategyAnalyze = \opts -> analyze & fileInputParser parsePodfile (targetFile opts)
+  , strategyLicense = const (pure [])
   , strategyModule = parent . targetFile
   , strategyOptimal = Optimal
   , strategyComplete = Complete

--- a/src/Strategy/Cocoapods/PodfileLock.hs
+++ b/src/Strategy/Cocoapods/PodfileLock.hs
@@ -46,6 +46,7 @@ strategy :: Strategy BasicFileOpts
 strategy = Strategy
   { strategyName = "podfile-lock"
   , strategyAnalyze = \opts -> analyze & fileInputParser findSections (targetFile opts)
+  , strategyLicense = const (pure [])
   , strategyModule = parent . targetFile
   , strategyOptimal = Optimal
   , strategyComplete = Complete

--- a/src/Strategy/Go/GlideLock.hs
+++ b/src/Strategy/Go/GlideLock.hs
@@ -43,6 +43,7 @@ strategy :: Strategy BasicFileOpts
 strategy = Strategy
   { strategyName = "golang-glidelock"
   , strategyAnalyze = \opts -> analyze & fileInputYaml @GlideLockfile (targetFile opts)
+  , strategyLicense = const (pure [])
   , strategyModule = parent . targetFile
   , strategyOptimal = Optimal
   , strategyComplete = NotComplete

--- a/src/Strategy/Go/GoList.hs
+++ b/src/Strategy/Go/GoList.hs
@@ -47,6 +47,7 @@ strategy :: Strategy BasicDirOpts
 strategy = Strategy
   { strategyName = "golang-golist"
   , strategyAnalyze = analyze
+  , strategyLicense = const (pure [])
   , strategyModule = targetDir
   , strategyOptimal = Optimal
   , strategyComplete = NotComplete

--- a/src/Strategy/Go/Gomod.hs
+++ b/src/Strategy/Go/Gomod.hs
@@ -53,6 +53,7 @@ strategy :: Strategy BasicFileOpts
 strategy = Strategy
   { strategyName = "golang-gomod"
   , strategyAnalyze = analyze
+  , strategyLicense = const (pure [])
   , strategyModule = parent . targetFile
   , strategyOptimal = NotOptimal
   , strategyComplete = NotComplete

--- a/src/Strategy/Go/GopkgLock.hs
+++ b/src/Strategy/Go/GopkgLock.hs
@@ -48,6 +48,7 @@ strategy :: Strategy BasicFileOpts
 strategy = Strategy
   { strategyName = "golang-gopkglock"
   , strategyAnalyze = analyze
+  , strategyLicense = const (pure [])
   , strategyModule = parent . targetFile
   , strategyOptimal = Optimal
   , strategyComplete = NotComplete

--- a/src/Strategy/Go/GopkgToml.hs
+++ b/src/Strategy/Go/GopkgToml.hs
@@ -51,6 +51,7 @@ strategy :: Strategy BasicFileOpts
 strategy = Strategy
   { strategyName = "golang-gopkgtoml"
   , strategyAnalyze = analyze
+  , strategyLicense = const (pure [])
   , strategyModule = parent . targetFile
   , strategyOptimal = NotOptimal
   , strategyComplete = NotComplete

--- a/src/Strategy/Gradle.hs
+++ b/src/Strategy/Gradle.hs
@@ -71,6 +71,7 @@ strategy :: Strategy BasicDirOpts
 strategy = Strategy
   { strategyName = "gradle-cli"
   , strategyAnalyze = analyze
+  , strategyLicense = const (pure [])
   , strategyModule = targetDir
   , strategyOptimal = Optimal
   , strategyComplete = Complete

--- a/src/Strategy/Maven/PluginStrategy.hs
+++ b/src/Strategy/Maven/PluginStrategy.hs
@@ -54,6 +54,7 @@ strategy :: Strategy BasicDirOpts
 strategy = Strategy
   { strategyName = "maven-cli"
   , strategyAnalyze = analyze
+  , strategyLicense = const (pure [])
   , strategyModule = targetDir
   , strategyOptimal = Optimal
   , strategyComplete = Complete

--- a/src/Strategy/Maven/Pom.hs
+++ b/src/Strategy/Maven/Pom.hs
@@ -31,6 +31,7 @@ strategy :: Strategy MavenStrategyOpts
 strategy = Strategy
   { strategyName = "maven-pom"
   , strategyAnalyze = pure . strategyGraph
+  , strategyLicense = const (pure [])
   , strategyModule = parent . strategyPath
   , strategyOptimal = NotOptimal
   , strategyComplete = NotComplete

--- a/src/Strategy/Node/NpmLock.hs
+++ b/src/Strategy/Node/NpmLock.hs
@@ -42,6 +42,7 @@ strategy = Strategy
   { strategyName = "nodejs-packagelock"
   , strategyAnalyze = \opts -> analyze
       & fileInputJson @NpmPackageJson (targetFile opts)
+  , strategyLicense = const (pure [])
   , strategyModule = parent . targetFile
   , strategyOptimal = Optimal
   , strategyComplete = Complete

--- a/src/Strategy/Node/PackageJson.hs
+++ b/src/Strategy/Node/PackageJson.hs
@@ -39,6 +39,7 @@ strategy = Strategy
   { strategyName = "nodejs-packagejson"
   , strategyAnalyze = \opts -> analyze
       & fileInputJson @PackageJson (targetFile opts)
+  , strategyLicense = const (pure [])
   , strategyModule = parent. targetFile
   , strategyOptimal = NotOptimal
   , strategyComplete = NotComplete

--- a/src/Strategy/Node/YarnLock.hs
+++ b/src/Strategy/Node/YarnLock.hs
@@ -42,6 +42,7 @@ strategy :: Strategy BasicFileOpts
 strategy = Strategy
   { strategyName = "nodejs-yarnlock"
   , strategyAnalyze = analyze . targetFile
+  , strategyLicense = const (pure [])
   , strategyModule = parent . targetFile
   , strategyOptimal = Optimal
   , strategyComplete = Complete

--- a/src/Strategy/NpmList.hs
+++ b/src/Strategy/NpmList.hs
@@ -36,6 +36,7 @@ strategy :: Strategy BasicDirOpts
 strategy = Strategy
   { strategyName = "nodejs-npm"
   , strategyAnalyze = \opts -> analyze & execInputJson @NpmOutput (targetDir opts) npmListCmd []
+  , strategyLicense = const (pure [])
   , strategyModule = targetDir
   , strategyOptimal = Optimal
   , strategyComplete = Complete

--- a/src/Strategy/NuGet/Nuspec.hs
+++ b/src/Strategy/NuGet/Nuspec.hs
@@ -107,7 +107,7 @@ instance FromXML NuspecLicense where
                   <*> content el
 
 instance FromXML Group where
-  parseElement el = Group <$> optional (children "dependency" el) `defaultsTo` []
+  parseElement el = Group <$> (children "dependency" el)
 
 instance FromXML NuGetDependency where
   parseElement el =

--- a/src/Strategy/NuGet/Nuspec.hs
+++ b/src/Strategy/NuGet/Nuspec.hs
@@ -97,8 +97,7 @@ data NuGetDependency = NuGetDependency
 instance FromXML Nuspec where
   parseElement el = do
     metadata     <- child "metadata" el
-    dependencies <- child "dependencies" metadata
-    Nuspec <$> children "group" dependencies
+    Nuspec <$> optional (child "dependencies" metadata >>= children "group") `defaultsTo` []
            <*> optional (child "license" metadata)
            <*> optional (child "licenseUrl" metadata)
 
@@ -108,7 +107,7 @@ instance FromXML NuspecLicense where
                   <*> content el
 
 instance FromXML Group where
-  parseElement el = Group <$> children "dependency" el
+  parseElement el = Group <$> optional (children "dependency" el) `defaultsTo` []
 
 instance FromXML NuGetDependency where
   parseElement el =

--- a/src/Strategy/NuGet/PackageReference.hs
+++ b/src/Strategy/NuGet/PackageReference.hs
@@ -46,6 +46,7 @@ strategy :: Strategy BasicFileOpts
 strategy = Strategy
   { strategyName = "nuget-packagereference"
   , strategyAnalyze = \opts -> analyze & fileInputXML @PackageReference (targetFile opts)
+  , strategyLicense = const (pure [])
   , strategyModule = parent . targetFile
   , strategyOptimal = NotOptimal
   , strategyComplete = NotComplete

--- a/src/Strategy/NuGet/PackagesConfig.hs
+++ b/src/Strategy/NuGet/PackagesConfig.hs
@@ -40,6 +40,7 @@ strategy :: Strategy BasicFileOpts
 strategy = Strategy
   { strategyName = "nuget-packagesconfig"
   , strategyAnalyze = \opts -> analyze & fileInputXML @PackagesConfig (targetFile opts)
+  , strategyLicense = const (pure [])
   , strategyModule = parent . targetFile
   , strategyOptimal = NotOptimal
   , strategyComplete = NotComplete

--- a/src/Strategy/NuGet/Paket.hs
+++ b/src/Strategy/NuGet/Paket.hs
@@ -47,6 +47,7 @@ strategy :: Strategy BasicFileOpts
 strategy = Strategy
   { strategyName = "paket"
   , strategyAnalyze = \opts -> analyze & fileInputParser findSections (targetFile opts)
+  , strategyLicense = const (pure [])
   , strategyModule = parent . targetFile
   , strategyOptimal = Optimal
   , strategyComplete = Complete

--- a/src/Strategy/NuGet/ProjectAssetsJson.hs
+++ b/src/Strategy/NuGet/ProjectAssetsJson.hs
@@ -41,6 +41,7 @@ strategy = Strategy
   { strategyName = "nuget-projectassetsjson"
   , strategyAnalyze = \opts -> analyze
       & fileInputJson @ProjectAssetsJson (targetFile opts)
+  , strategyLicense = const (pure [])
   , strategyModule = parent. targetFile
   , strategyOptimal = NotOptimal
   , strategyComplete = NotComplete

--- a/src/Strategy/NuGet/ProjectJson.hs
+++ b/src/Strategy/NuGet/ProjectJson.hs
@@ -41,6 +41,7 @@ strategy = Strategy
   { strategyName = "nuget-projectjson"
   , strategyAnalyze = \opts -> analyze
       & fileInputJson @ProjectJson (targetFile opts)
+  , strategyLicense = const (pure [])
   , strategyModule = parent . targetFile
   , strategyOptimal = NotOptimal
   , strategyComplete = NotComplete

--- a/src/Strategy/Python/PipList.hs
+++ b/src/Strategy/Python/PipList.hs
@@ -47,6 +47,7 @@ strategy :: Strategy BasicDirOpts
 strategy = Strategy
   { strategyName = "python-piplist"
   , strategyAnalyze = \opts -> analyze & execInputJson @[PipListDep] (targetDir opts) pipListCmd []
+  , strategyLicense = const (pure [])
   , strategyModule = targetDir
   , strategyOptimal = NotOptimal
   , strategyComplete = NotComplete

--- a/src/Strategy/Python/Pipenv.hs
+++ b/src/Strategy/Python/Pipenv.hs
@@ -60,6 +60,7 @@ strategyWithCmd = Strategy
   , strategyAnalyze = \opts -> analyzeWithCmd
       & fileInputJson @PipfileLock (targetFile opts)
       & execInputJson @[PipenvGraphDep] (parent (targetFile opts)) pipenvGraphCmd []
+  , strategyLicense = const (pure [])
   , strategyModule = parent . targetFile
   , strategyOptimal = Optimal
   , strategyComplete = Complete
@@ -69,6 +70,7 @@ strategyNoCmd :: Strategy BasicFileOpts
 strategyNoCmd = Strategy
   { strategyName = "python-pipfile"
   , strategyAnalyze = \opts -> analyzeNoCmd & fileInputJson @PipfileLock (targetFile opts)
+  , strategyLicense = const (pure [])
   , strategyModule = parent . targetFile
   , strategyOptimal = Optimal
   , strategyComplete = Complete

--- a/src/Strategy/Python/ReqTxt.hs
+++ b/src/Strategy/Python/ReqTxt.hs
@@ -40,6 +40,7 @@ strategy :: Strategy BasicFileOpts
 strategy = Strategy
   { strategyName = "python-requirements"
   , strategyAnalyze = \opts -> analyze & fileInputParser requirementsTxtParser (targetFile opts)
+  , strategyLicense = const (pure [])
   , strategyModule = parent . targetFile
   , strategyOptimal = Optimal
   , strategyComplete = NotComplete

--- a/src/Strategy/Python/SetupPy.hs
+++ b/src/Strategy/Python/SetupPy.hs
@@ -40,6 +40,7 @@ strategy = Strategy
   { strategyName = "python-setuppy"
   , strategyAnalyze = \opts ->
       analyze & fileInputParser installRequiresParser (targetFile opts)
+  , strategyLicense = const (pure [])
   , strategyModule = parent . targetFile
   , strategyOptimal = NotOptimal
   , strategyComplete = NotComplete

--- a/src/Strategy/Ruby/BundleShow.hs
+++ b/src/Strategy/Ruby/BundleShow.hs
@@ -50,6 +50,7 @@ strategy :: Strategy BasicDirOpts
 strategy = Strategy
   { strategyName = "ruby-bundleshow"
   , strategyAnalyze = \opts -> analyze & execInputParser bundleShowParser (targetDir opts) bundleShowCmd []
+  , strategyLicense = const (pure [])
   , strategyModule = targetDir
   , strategyOptimal = NotOptimal
   , strategyComplete = NotComplete

--- a/src/Strategy/Ruby/GemfileLock.hs
+++ b/src/Strategy/Ruby/GemfileLock.hs
@@ -47,6 +47,7 @@ strategy :: Strategy BasicFileOpts
 strategy = Strategy
   { strategyName = "gemfile-lock"
   , strategyAnalyze = \opts -> analyze & fileInputParser findSections (targetFile opts)
+  , strategyLicense = const (pure [])
   , strategyModule = parent . targetFile
   , strategyOptimal = Optimal
   , strategyComplete = Complete

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -174,7 +174,6 @@ instance ToJSON LicenseResult where
 
 ---------- Completed License Scan
 
--- | Completed license scan output.
 data CompletedLicenseScan = CompletedLicenseScan
   { completedLicenseName     :: Text
   , completedLicenses        :: [LicenseResult]

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -12,6 +12,12 @@ module Types
   , SomeStrategy(..)
 
   , CompletedStrategy(..)
+  
+  , CompletedLicenseScan(..)
+
+  , LicenseResult(..)
+  , License(..)
+  , LicenseType(..)
 
   , BasicDirOpts(..)
   , BasicFileOpts(..)
@@ -71,6 +77,7 @@ type StrategyEffs r = Members '[Embed IO, Resource, Logger, Error CLIErr, Exec, 
 data Strategy options = Strategy
   { strategyName     :: Text -- ^ e.g., "python-pipenv"
   , strategyAnalyze  :: forall r. StrategyEffs r => options -> Sem r (Graphing Dependency)
+  , strategyLicense  :: forall r. StrategyEffs r => options -> Sem r [LicenseResult]
   , strategyModule   :: options -> Path Rel Dir -- ^ Determine the module directory for grouping with other strategies
   , strategyOptimal  :: Optimal -- ^ Whether this strategy is considered "optimal" -- i.e., best case analysis for a given project. Notably, this __does not__ imply "complete".
   , strategyComplete :: Complete -- ^ Whether this strategy produces graphs that contain all dependencies for a given project. When @NotComplete@, the backend will run a hasGraph-like analysis to produce the missing dependencies and graph edges
@@ -118,3 +125,63 @@ newtype BasicDirOpts = BasicDirOpts
 newtype BasicFileOpts = BasicFileOpts
   { targetFile :: Path Rel File
   } deriving (Eq, Ord, Show, Generic)
+
+instance FromJSON BasicFileOpts where
+  parseJSON = withObject "BasicFileOpts" $ \obj ->
+    BasicFileOpts <$> obj .: "file"
+
+instance ToJSON BasicFileOpts where
+  toJSON BasicFileOpts{..} = object ["file" .= targetFile]
+
+---------- License
+
+data LicenseResult = LicenseResult
+  { licenseFile   :: Path Rel File
+  , licensesFound :: [License]
+  } deriving (Eq, Ord, Show, Generic)
+
+data License = License
+  { licenseType :: LicenseType
+  , value       :: Text
+  } deriving (Eq, Ord, Show, Generic)
+
+data LicenseType =
+          LicenseURL
+        | LicenseFile
+        | LicenseSPDX
+        | UnknownType
+          deriving (Eq, Ord, Show, Generic)
+
+instance ToJSON License where
+    toJSON License{..} = object
+      [ "type"   .=  textType licenseType
+      , "value"  .=  value
+      ]
+      
+      where
+        textType :: LicenseType -> Text
+        textType = \case
+          LicenseURL  -> "url"
+          LicenseFile -> "file"
+          LicenseSPDX -> "spdx"
+          UnknownType -> "unknown"
+
+instance ToJSON LicenseResult where
+    toJSON LicenseResult{..} = object
+      [ "filepath"  .=  licenseFile
+      , "licenses"  .=  licensesFound
+      ]
+
+---------- Completed License Scan
+
+-- | Completed license scan output.
+data CompletedLicenseScan = CompletedLicenseScan
+  { completedLicenseName     :: Text
+  , completedLicenses        :: [LicenseResult]
+  } deriving (Eq, Ord, Show, Generic)
+
+instance ToJSON CompletedLicenseScan where
+    toJSON CompletedLicenseScan{..} = object
+      [ "name"            .=  completedLicenseName
+      , "licenseResults"  .=  completedLicenses
+      ]

--- a/test/NuGet/NuspecTest.hs
+++ b/test/NuGet/NuspecTest.hs
@@ -59,6 +59,7 @@ depThree = NuGetDependency "three" "3.0.0"
 spec_analyze :: Spec
 spec_analyze = do
   nuspecFile <- runIO (TIO.readFile "test/NuGet/testdata/test.nuspec")
+  nuspecLicenseFile <- runIO (TIO.readFile "test/NuGet/testdata/license.nuspec")
 
   describe "nuspec analyzer" $ do
     it "reads a file and constructs an accurate graph" $ do
@@ -67,6 +68,14 @@ spec_analyze = do
           (groups project) `shouldContain` groupList
           (license project) `shouldBe` (Just $ NuspecLicense "file" "license-file")
           (licenseUrl project) `shouldBe` (Just "https://licence.location.com/LICENSE.md")
+        Left err -> expectationFailure (T.unpack ("could not parse nuspec file: " <> xmlErrorPretty err))
+
+    it "reads a file and extracts the correct license" $ do
+      case parseXML nuspecLicenseFile of
+        Right project -> do
+          (groups project) `shouldBe` groupList
+          (license project) `shouldBe` (Just $ NuspecLicense "file" "license-file")
+          (licenseUrl project) `shouldBe` Nothing
         Left err -> expectationFailure (T.unpack ("could not parse nuspec file: " <> xmlErrorPretty err))
 
     it "constructs an accurate graph" $ do

--- a/test/NuGet/NuspecTest.hs
+++ b/test/NuGet/NuspecTest.hs
@@ -73,8 +73,8 @@ spec_analyze = do
     it "reads a file and extracts the correct license" $ do
       case parseXML nuspecLicenseFile of
         Right project -> do
-          (groups project) `shouldBe` groupList
-          (license project) `shouldBe` (Just $ NuspecLicense "file" "license-file")
+          (groups project) `shouldBe` []
+          (license project) `shouldBe` (Just $ NuspecLicense "file" "LICENSE.txt")
           (licenseUrl project) `shouldBe` Nothing
         Left err -> expectationFailure (T.unpack ("could not parse nuspec file: " <> xmlErrorPretty err))
 

--- a/test/NuGet/NuspecTest.hs
+++ b/test/NuGet/NuspecTest.hs
@@ -42,7 +42,7 @@ dependencyThree = Dependency { dependencyType = NuGetType
                         }
 
 nuspec :: Nuspec
-nuspec = Nuspec groupList
+nuspec = Nuspec groupList Nothing Nothing
 
 groupList :: [Group]
 groupList = [Group [depOne, depTwo], Group [depThree]]
@@ -63,7 +63,10 @@ spec_analyze = do
   describe "nuspec analyzer" $ do
     it "reads a file and constructs an accurate graph" $ do
       case parseXML nuspecFile of
-        Right project -> (groups project) `shouldContain` groupList
+        Right project -> do
+          (groups project) `shouldContain` groupList
+          (license project) `shouldBe` (Just $ License (Just "file") (Just "license-file"))
+          (licenseUrl project) `shouldBe` (Just "https://licence.location.com/LICENSE.md")
         Left err -> expectationFailure (T.unpack ("could not parse nuspec file: " <> xmlErrorPretty err))
 
     it "constructs an accurate graph" $ do

--- a/test/NuGet/NuspecTest.hs
+++ b/test/NuGet/NuspecTest.hs
@@ -65,7 +65,7 @@ spec_analyze = do
       case parseXML nuspecFile of
         Right project -> do
           (groups project) `shouldContain` groupList
-          (license project) `shouldBe` (Just $ License (Just "file") (Just "license-file"))
+          (license project) `shouldBe` (Just $ NuspecLicense "file" "license-file")
           (licenseUrl project) `shouldBe` (Just "https://licence.location.com/LICENSE.md")
         Left err -> expectationFailure (T.unpack ("could not parse nuspec file: " <> xmlErrorPretty err))
 

--- a/test/NuGet/testdata/license.nuspec
+++ b/test/NuGet/testdata/license.nuspec
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+  <metadata>
+    <id>package.with.nuspec.file</id>
+    <version>1.2.3</version>
+    <license type="file">LICENSE.txt</license>
+  </metadata>
+</package>

--- a/test/NuGet/testdata/test.nuspec
+++ b/test/NuGet/testdata/test.nuspec
@@ -3,6 +3,8 @@
   <metadata minClientVersion="2.12">
     <id>NUnit</id>
     <title>NUnit</title>
+    <licenseUrl>https://licence.location.com/LICENSE.md</licenseUrl>
+    <license type="file">license-file</license>
     <version>$version$</version>
     <dependencies>
       <group targetFramework="testone" />


### PR DESCRIPTION
This PR extends spectrometers ability by creating a new binary called `pathfinder` which can be used to detect all declared licenses in a directory. This process leverages the existing parser work that has been done to output license information in the following format which is an array of strategies. License value can be one of `expression`, `url`, `file`, or `unknown`.
```JSON
[
  {
    "name": "nuget-nuspec",
    "files": [
      {
        "filepath": "test/NuGet/testdata/test.nuspec",
        "licenses": [
          {
            "value": "https://licence.location.com/LICENSE.md",
            "type": "url"
          },
          {
            "value": "license-file",
            "type": "file"
          }
        ]
      }
    ],
    "type": "dotnet"
  }
]
```