### PR TITLE
Add `DepEnvironment`

### DIFF
--- a/src/DepTypes.hs
+++ b/src/DepTypes.hs
@@ -7,12 +7,15 @@ module DepTypes
 
 import Prologue
 
+-- FIXME: this needs a smart constructor with empty tags/environments/etc.
+-- We've historically relied on the compile error for making sure we fill all
+-- of these fields. Tests should be used to ensure this instead.
 data Dependency = Dependency
   { dependencyType         :: DepType
   , dependencyName         :: Text
   , dependencyVersion      :: Maybe VerConstraint
   , dependencyLocations    :: [Text]
-  , dependencyEnvironments :: [DepEnvironment]
+  , dependencyEnvironments :: [DepEnvironment] -- FIXME: this should be a Set
   , dependencyTags         :: Map Text [Text]
   } deriving (Eq, Ord, Show, Generic)
 

--- a/src/DepTypes.hs
+++ b/src/DepTypes.hs
@@ -20,7 +20,6 @@ data DepEnvironment =
     EnvProduction
   | EnvDevelopment
   | EnvTesting
-  | EnvOther Text
   deriving (Eq, Ord, Show, Generic)
 
 -- | A Dependency type. This corresponds to a "fetcher" on the backend

--- a/src/DepTypes.hs
+++ b/src/DepTypes.hs
@@ -20,6 +20,7 @@ data DepEnvironment =
     EnvProduction
   | EnvDevelopment
   | EnvTesting
+  | EnvOther Text -- ^ Other environments -- specifically for things like gradle configurations
   deriving (Eq, Ord, Show, Generic)
 
 -- | A Dependency type. This corresponds to a "fetcher" on the backend

--- a/src/DepTypes.hs
+++ b/src/DepTypes.hs
@@ -1,5 +1,6 @@
 module DepTypes
   ( Dependency(..)
+  , DepEnvironment(..)
   , DepType(..)
   , VerConstraint(..)
   ) where
@@ -7,12 +8,20 @@ module DepTypes
 import Prologue
 
 data Dependency = Dependency
-  { dependencyType      :: DepType
-  , dependencyName      :: Text
-  , dependencyVersion   :: Maybe VerConstraint
-  , dependencyLocations :: [Text]
-  , dependencyTags      :: Map Text [Text]
+  { dependencyType         :: DepType
+  , dependencyName         :: Text
+  , dependencyVersion      :: Maybe VerConstraint
+  , dependencyLocations    :: [Text]
+  , dependencyEnvironments :: [DepEnvironment]
+  , dependencyTags         :: Map Text [Text]
   } deriving (Eq, Ord, Show, Generic)
+
+data DepEnvironment =
+    EnvProduction
+  | EnvDevelopment
+  | EnvTesting
+  | EnvOther Text
+  deriving (Eq, Ord, Show, Generic)
 
 -- | A Dependency type. This corresponds to a "fetcher" on the backend
 data DepType =

--- a/src/Strategy/Carthage.hs
+++ b/src/Strategy/Carthage.hs
@@ -117,6 +117,7 @@ toDependency entry = Dependency
   , dependencyName = entryToDepName entry
   , dependencyVersion = Just (CEq (resolvedVersion entry))
   , dependencyTags = M.empty
+  , dependencyEnvironments = []
   , dependencyLocations = [] -- TODO: git location?
   }
 

--- a/src/Strategy/Cocoapods/Podfile.hs
+++ b/src/Strategy/Cocoapods/Podfile.hs
@@ -61,6 +61,7 @@ buildGraph podfile = unfold direct (const []) toDependency
                  , dependencyLocations = case M.lookup SourceProperty properties of 
                                             Just repo -> [repo]
                                             _ -> [source podfile]
+                 , dependencyEnvironments = []
                  , dependencyTags = M.empty
                  }
 

--- a/src/Strategy/Cocoapods/PodfileLock.hs
+++ b/src/Strategy/Cocoapods/PodfileLock.hs
@@ -70,6 +70,7 @@ toDependency pkg = foldr applyLabel start
     , dependencyName = pkgName pkg
     , dependencyVersion = Nothing
     , dependencyLocations = []
+    , dependencyEnvironments = []
     , dependencyTags = M.empty
     }
 

--- a/src/Strategy/Go/GlideLock.hs
+++ b/src/Strategy/Go/GlideLock.hs
@@ -53,6 +53,7 @@ buildGraph lockfile = unfold direct (const []) toDependency
                , dependencyName = depName
                , dependencyVersion = Just (CEq $ T.pack (show depVersion))
                , dependencyLocations = []
+               , dependencyEnvironments = []
                , dependencyTags = M.empty
                }
 

--- a/src/Strategy/Go/Types.hs
+++ b/src/Strategy/Go/Types.hs
@@ -50,6 +50,7 @@ golangPackageToDependency pkg = foldr applyLabel start
     , dependencyName = goImportPath pkg
     , dependencyVersion = Nothing
     , dependencyLocations = []
+    , dependencyEnvironments = []
     , dependencyTags = M.empty
     }
 

--- a/src/Strategy/Gradle.hs
+++ b/src/Strategy/Gradle.hs
@@ -130,6 +130,7 @@ buildGraph mapping = run . evalGrapher $ M.traverseWithKey addProject mapping
       , dependencyName = name
       , dependencyVersion = Just (CEq version)
       , dependencyLocations = []
+      , dependencyEnvironments = []
       , dependencyTags = M.empty
       }
 
@@ -138,6 +139,7 @@ buildGraph mapping = run . evalGrapher $ M.traverseWithKey addProject mapping
     , dependencyName = name
     , dependencyVersion = Nothing
     , dependencyLocations = []
+    , dependencyEnvironments = []
     , dependencyTags = M.empty
     }
 

--- a/src/Strategy/Maven/PluginStrategy.hs
+++ b/src/Strategy/Maven/PluginStrategy.hs
@@ -72,6 +72,7 @@ buildGraph PluginOutput{..} = run $ evalGrapher $ do
     , dependencyName = artifactGroupId <> ":" <> artifactArtifactId
     , dependencyVersion = Just (CEq artifactVersion)
     , dependencyLocations = []
+    , dependencyEnvironments = if "test" `elem` artifactScopes then [EnvTesting] else []
     , dependencyTags = M.fromList $
       ("scopes", artifactScopes) :
       [("optional", ["true"]) | artifactOptional]

--- a/src/Strategy/Node/NpmList.hs
+++ b/src/Strategy/Node/NpmList.hs
@@ -54,6 +54,7 @@ buildGraph top = unfold direct getDeps toDependency
                , dependencyName = nodeName
                , dependencyVersion = CEq <$> outputVersion nodeOutput
                , dependencyLocations = []
+               , dependencyEnvironments = []
                , dependencyTags = M.empty
                }
 

--- a/src/Strategy/Node/YarnLock.hs
+++ b/src/Strategy/Node/YarnLock.hs
@@ -73,5 +73,6 @@ buildGraph lockfile = run . evalGrapher $
                      YL.FileRemote url _ -> [url]
                      YL.FileRemoteNoIntegrity url -> [url]
                      YL.GitRemote url rev -> [url <> "@" <> rev]
+               , dependencyEnvironments = []
                , dependencyTags = M.empty
                }

--- a/src/Strategy/NuGet/Nuspec.hs
+++ b/src/Strategy/NuGet/Nuspec.hs
@@ -112,5 +112,6 @@ buildGraph project = unfold direct (const []) toDependency
                  , dependencyName = depID
                  , dependencyVersion = Just (CEq depVersion)
                  , dependencyLocations = []
+                 , dependencyEnvironments = []
                  , dependencyTags = M.empty
                  }

--- a/src/Strategy/NuGet/PackageReference.hs
+++ b/src/Strategy/NuGet/PackageReference.hs
@@ -82,5 +82,6 @@ buildGraph project = unfold direct (const []) toDependency
                , dependencyName = depID
                , dependencyVersion =  fmap CEq depVersion
                , dependencyLocations = []
+               , dependencyEnvironments = []
                , dependencyTags = M.empty
                }

--- a/src/Strategy/NuGet/PackagesConfig.hs
+++ b/src/Strategy/NuGet/PackagesConfig.hs
@@ -67,5 +67,6 @@ buildGraph config = unfold (deps config) (const []) toDependency
                , dependencyName = depID
                , dependencyVersion = Just (CEq depVersion)
                , dependencyLocations = []
+               , dependencyEnvironments = []
                , dependencyTags = M.empty
                }

--- a/src/Strategy/NuGet/Paket.hs
+++ b/src/Strategy/NuGet/Paket.hs
@@ -74,6 +74,7 @@ toDependency pkg = foldr applyLabel start
     , dependencyName = pkgName pkg
     , dependencyVersion = Nothing
     , dependencyLocations = []
+    , dependencyEnvironments = []
     , dependencyTags = M.empty
     }
 

--- a/src/Strategy/NuGet/ProjectAssetsJson.hs
+++ b/src/Strategy/NuGet/ProjectAssetsJson.hs
@@ -85,5 +85,6 @@ buildGraph project = unfold direct deepList toDependency
                , dependencyName = depName
                , dependencyVersion = Just (CEq depVersion)
                , dependencyLocations = []
+               , dependencyEnvironments = []
                , dependencyTags = M.empty
                }

--- a/src/Strategy/NuGet/ProjectJson.hs
+++ b/src/Strategy/NuGet/ProjectJson.hs
@@ -85,6 +85,7 @@ buildGraph project = unfold direct (const []) toDependency
                   Just '*' -> Just (CCompatible version)
                   _ -> Just (CEq version)
                , dependencyLocations = []
+               , dependencyEnvironments = []
                , dependencyTags = case dependencyType of
                   Nothing -> M.empty
                   Just depType -> M.insert "type" [depType]  M.empty

--- a/src/Strategy/Python/PipList.hs
+++ b/src/Strategy/Python/PipList.hs
@@ -58,6 +58,7 @@ buildGraph xs = unfold xs (const []) toDependency
                , dependencyName = depName
                , dependencyVersion = Just (CEq depVersion)
                , dependencyLocations = []
+               , dependencyEnvironments = []
                , dependencyTags = M.empty
                }
 

--- a/src/Strategy/Python/Util.hs
+++ b/src/Strategy/Python/Util.hs
@@ -30,6 +30,7 @@ buildGraph xs = unfold xs (const []) toDependency
                , dependencyName = depName req
                , dependencyVersion = depVersion req
                , dependencyLocations = []
+               , dependencyEnvironments = []
                , dependencyTags = maybe M.empty toTags (depMarker req)
                }
 

--- a/src/Strategy/Ruby/BundleShow.hs
+++ b/src/Strategy/Ruby/BundleShow.hs
@@ -60,6 +60,7 @@ buildGraph xs = unfold xs (const []) toDependency
                , dependencyName = depName
                , dependencyVersion = Just (CEq depVersion)
                , dependencyLocations = []
+               , dependencyEnvironments = []
                , dependencyTags = M.empty
                }
 

--- a/src/Strategy/Ruby/GemfileLock.hs
+++ b/src/Strategy/Ruby/GemfileLock.hs
@@ -98,6 +98,7 @@ toDependency pkg = foldr applyLabel start
     , dependencyName = pkgName pkg
     , dependencyVersion = Nothing
     , dependencyLocations = []
+    , dependencyEnvironments = []
     , dependencyTags = M.empty
     }
 

--- a/test/Cocoapods/PodfileLockTest.hs
+++ b/test/Cocoapods/PodfileLockTest.hs
@@ -19,6 +19,7 @@ dependencyOne = Dependency { dependencyType = PodType
                            , dependencyName = "one"
                            , dependencyVersion = Just (CEq "1.0.0")
                            , dependencyLocations = []
+                           , dependencyEnvironments = []
                            , dependencyTags = M.empty 
                            }
 
@@ -27,6 +28,7 @@ dependencyTwo = Dependency { dependencyType = PodType
                            , dependencyName = "two"
                            , dependencyVersion = Just (CEq "2.0.0")
                            , dependencyLocations = []
+                           , dependencyEnvironments = []
                            , dependencyTags = M.empty 
                            }
 
@@ -35,6 +37,7 @@ dependencyThree = Dependency { dependencyType = PodType
                              , dependencyName = "three"
                              , dependencyVersion = Just (CEq "3.0.0")
                              , dependencyLocations = []
+                             , dependencyEnvironments = []
                              , dependencyTags = M.empty 
                              }
 
@@ -43,6 +46,7 @@ dependencyFour = Dependency { dependencyType = PodType
                             , dependencyName = "four"
                             , dependencyVersion = Just (CEq "4.0.0")
                             , dependencyLocations = []
+                            , dependencyEnvironments = []
                             , dependencyTags = M.empty 
                             }
 

--- a/test/Cocoapods/PodfileTest.hs
+++ b/test/Cocoapods/PodfileTest.hs
@@ -19,6 +19,7 @@ dependencyOne = Dependency { dependencyType = PodType
                            , dependencyName = "one"
                            , dependencyVersion = Just (CEq "1.0.0")
                            , dependencyLocations = ["test.repo"]
+                           , dependencyEnvironments = []
                            , dependencyTags = M.empty 
                            }
 
@@ -27,6 +28,7 @@ dependencyTwo = Dependency { dependencyType = PodType
                            , dependencyName = "two"
                            , dependencyVersion = Just (CEq "2.0.0")
                            , dependencyLocations = ["custom.repo"]
+                           , dependencyEnvironments = []
                            , dependencyTags = M.empty 
                            }
 
@@ -35,6 +37,7 @@ dependencyThree = Dependency { dependencyType = PodType
                              , dependencyName = "three"
                              , dependencyVersion = Just (CEq "3.0.0")
                              , dependencyLocations = ["test.repo"]
+                             , dependencyEnvironments = []
                              , dependencyTags = M.empty 
                              }
 
@@ -43,6 +46,7 @@ dependencyFour = Dependency { dependencyType = PodType
                              , dependencyName = "four"
                              , dependencyVersion = Nothing
                              , dependencyLocations = ["test.repo"]
+                             , dependencyEnvironments = []
                              , dependencyTags = M.empty 
                              }
 

--- a/test/Go/GlideLockTest.hs
+++ b/test/Go/GlideLockTest.hs
@@ -23,6 +23,7 @@ expected = run . evalGrapher $ do
                , dependencyName = "github.com/pkg/one"
                , dependencyVersion = Just (CEq "100")
                , dependencyLocations = []
+               , dependencyEnvironments = []
                , dependencyTags = M.empty
                }
   direct $ Dependency
@@ -30,6 +31,7 @@ expected = run . evalGrapher $ do
                , dependencyName = "github.com/pkg/three/v3"
                , dependencyVersion = Just (CEq "300")
                , dependencyLocations = []
+               , dependencyEnvironments = []
                , dependencyTags = M.empty
                }
 

--- a/test/Go/GoListTest.hs
+++ b/test/Go/GoListTest.hs
@@ -39,12 +39,14 @@ expected = run . evalGrapher $ do
                       , dependencyName = "github.com/pkg/one"
                       , dependencyVersion = Just (CEq "commithash")
                       , dependencyLocations = []
+                      , dependencyEnvironments = []
                       , dependencyTags = M.empty
                       }
   direct $ Dependency { dependencyType = GoType
                       , dependencyName = "github.com/pkg/two"
                       , dependencyVersion = Just (CEq "v2.0.0")
                       , dependencyLocations = []
+                      , dependencyEnvironments = []
                       , dependencyTags = M.empty
                       }
 

--- a/test/Go/GomodTest.hs
+++ b/test/Go/GomodTest.hs
@@ -37,6 +37,7 @@ expected = run . evalGrapher $ do
              , dependencyName = "github.com/pkg/one"
              , dependencyVersion = Just (CEq "v1.0.0")
              , dependencyLocations = []
+             , dependencyEnvironments = []
              , dependencyTags = M.empty
              }
   direct $ Dependency
@@ -44,6 +45,7 @@ expected = run . evalGrapher $ do
              , dependencyName = "github.com/pkg/overridden"
              , dependencyVersion = Just (CEq "overridden")
              , dependencyLocations = []
+             , dependencyEnvironments = []
              , dependencyTags = M.empty
              }
   direct $ Dependency
@@ -51,6 +53,7 @@ expected = run . evalGrapher $ do
              , dependencyName = "github.com/pkg/three/v3"
              , dependencyVersion = Just (CEq "v3.0.0")
              , dependencyLocations = []
+             , dependencyEnvironments = []
              , dependencyTags = M.empty
              }
 

--- a/test/Go/GopkgLockTest.hs
+++ b/test/Go/GopkgLockTest.hs
@@ -45,6 +45,7 @@ expected = run . evalGrapher $ do
              , dependencyName = "repo/name/A"
              , dependencyVersion = Just (CEq "3012a1dbe2e4bd1391d42b32f0577cb7bbc7f005")
              , dependencyLocations = []
+             , dependencyEnvironments = []
              , dependencyTags = M.empty
              }
   direct $ Dependency
@@ -52,6 +53,7 @@ expected = run . evalGrapher $ do
              , dependencyName = "repo/name/B"
              , dependencyVersion = Just (CEq "12345")
              , dependencyLocations = []
+             , dependencyEnvironments = []
              , dependencyTags = M.empty
              }
   direct $ Dependency
@@ -59,6 +61,7 @@ expected = run . evalGrapher $ do
              , dependencyName = "repo/name/C"
              , dependencyVersion = Just (CEq "12345")
              , dependencyLocations = ["https://someotherlocation/"]
+             , dependencyEnvironments = []
              , dependencyTags = M.empty
              }
 

--- a/test/Go/GopkgTomlTest.hs
+++ b/test/Go/GopkgTomlTest.hs
@@ -69,6 +69,7 @@ expected = run . evalGrapher $ do
              , dependencyName = "cat/fossa"
              , dependencyVersion = Just (CEq "v3.0.0")
              , dependencyLocations = ["https://someotherlocation/"]
+             , dependencyEnvironments = []
              , dependencyTags = M.empty
              }
   direct $ Dependency
@@ -76,6 +77,7 @@ expected = run . evalGrapher $ do
              , dependencyName = "repo/name/A"
              , dependencyVersion = Just (CEq "v1.0.0")
              , dependencyLocations = []
+             , dependencyEnvironments = []
              , dependencyTags = M.empty
              }
   direct $ Dependency
@@ -83,6 +85,7 @@ expected = run . evalGrapher $ do
              , dependencyName = "repo/name/B"
              , dependencyVersion = Just (CEq "overridebranch")
              , dependencyLocations = []
+             , dependencyEnvironments = []
              , dependencyTags = M.empty
              }
   direct $ Dependency
@@ -90,6 +93,7 @@ expected = run . evalGrapher $ do
              , dependencyName = "repo/name/C"
              , dependencyVersion = Just (CEq "branchname")
              , dependencyLocations = []
+             , dependencyEnvironments = []
              , dependencyTags = M.empty
              }
 

--- a/test/Gradle/GradleTest.hs
+++ b/test/Gradle/GradleTest.hs
@@ -19,6 +19,7 @@ projectOne = Dependency
   , dependencyName = ":projectOne"
   , dependencyVersion = Nothing
   , dependencyLocations = []
+  , dependencyEnvironments = []
   , dependencyTags = M.empty
   }
 
@@ -28,6 +29,7 @@ projectTwo = Dependency
   , dependencyName = ":projectTwo"
   , dependencyVersion = Nothing
   , dependencyLocations = []
+  , dependencyEnvironments = []
   , dependencyTags = M.empty
   }
 
@@ -37,6 +39,7 @@ projectThree = Dependency
   , dependencyName = ":projectThree"
   , dependencyVersion = Nothing
   , dependencyLocations = []
+  , dependencyEnvironments = []
   , dependencyTags = M.empty
   }
 
@@ -46,6 +49,7 @@ packageOne = Dependency
   , dependencyName = "mygroup:packageOne"
   , dependencyVersion = Just (CEq "1.0.0")
   , dependencyLocations = []
+  , dependencyEnvironments = []
   , dependencyTags = M.empty
   }
 
@@ -55,6 +59,7 @@ packageTwo = Dependency
   , dependencyName = "mygroup:packageTwo"
   , dependencyVersion = Just (CEq "2.0.0")
   , dependencyLocations = []
+  , dependencyEnvironments = []
   , dependencyTags = M.empty
   }
 

--- a/test/Maven/PluginStrategyTest.hs
+++ b/test/Maven/PluginStrategyTest.hs
@@ -19,6 +19,7 @@ packageOne = Dependency
   , dependencyName = "mygroup:packageOne"
   , dependencyVersion = Just (CEq "1.0.0")
   , dependencyLocations = []
+  , dependencyEnvironments = [EnvTesting]
   , dependencyTags = M.fromList [("scopes", ["compile", "test"])]
   }
 
@@ -28,6 +29,7 @@ packageTwo = Dependency
   , dependencyName = "mygroup:packageTwo"
   , dependencyVersion = Just (CEq "2.0.0")
   , dependencyLocations = []
+  , dependencyEnvironments = []
   , dependencyTags = M.fromList [("scopes", ["compile"]), ("optional", ["true"])]
   }
 

--- a/test/Node/NpmLockTest.hs
+++ b/test/Node/NpmLockTest.hs
@@ -48,7 +48,8 @@ packageOne = Dependency
   , dependencyName = "packageOne"
   , dependencyVersion = Just (CEq "1.0.0")
   , dependencyLocations = ["https://example.com/one.tgz"]
-  , dependencyTags = M.fromList [("environment", ["production"])]
+  , dependencyEnvironments = [EnvProduction]
+  , dependencyTags = M.empty
   }
 
 packageTwo :: Dependency
@@ -57,7 +58,8 @@ packageTwo = Dependency
   , dependencyName = "packageTwo"
   , dependencyVersion = Just (CEq "2.0.0")
   , dependencyLocations = ["https://example.com/two.tgz"]
-  , dependencyTags = M.fromList [("environment", ["development"])]
+  , dependencyEnvironments = [EnvDevelopment]
+  , dependencyTags = M.empty
   }
 
 packageThree :: Dependency
@@ -66,7 +68,8 @@ packageThree = Dependency
   , dependencyName = "packageThree"
   , dependencyVersion = Just (CEq "3.0.0")
   , dependencyLocations = []
-  , dependencyTags = M.fromList [("environment", ["development"])]
+  , dependencyEnvironments = [EnvDevelopment]
+  , dependencyTags = M.empty
   }
 
 spec_npmLockBuildGraph :: Spec

--- a/test/Node/PackageJsonTest.hs
+++ b/test/Node/PackageJsonTest.hs
@@ -24,7 +24,8 @@ packageOne = Dependency
   , dependencyName = "packageOne"
   , dependencyVersion = Just (CCompatible "^1.0.0")
   , dependencyLocations = []
-  , dependencyTags = M.fromList [("environment", ["production"])]
+  , dependencyEnvironments = [EnvProduction]
+  , dependencyTags = M.empty
   }
 
 packageTwo :: Dependency
@@ -33,7 +34,8 @@ packageTwo = Dependency
   , dependencyName = "packageTwo"
   , dependencyVersion = Just (CCompatible "^2.0.0")
   , dependencyLocations = []
-  , dependencyTags = M.fromList [("environment", ["development"])]
+  , dependencyEnvironments = [EnvDevelopment]
+  , dependencyTags = M.empty
   }
 
 spec_packageJsonBuildGraph :: Spec

--- a/test/NuGet/NuspecTest.hs
+++ b/test/NuGet/NuspecTest.hs
@@ -20,6 +20,7 @@ dependencyOne = Dependency { dependencyType = NuGetType
                         , dependencyName = "one"
                         , dependencyVersion = Just (CEq "1.0.0")
                         , dependencyLocations = []
+                        , dependencyEnvironments = []
                         , dependencyTags = M.empty
                         }
 
@@ -28,6 +29,7 @@ dependencyTwo = Dependency { dependencyType = NuGetType
                         , dependencyName = "two"
                         , dependencyVersion = Just (CEq "2.0.0")
                         , dependencyLocations = []
+                        , dependencyEnvironments = []
                         , dependencyTags = M.empty
                         }
 
@@ -36,6 +38,7 @@ dependencyThree = Dependency { dependencyType = NuGetType
                         , dependencyName = "three"
                         , dependencyVersion = Just (CEq "3.0.0")
                         , dependencyLocations = []
+                        , dependencyEnvironments = []
                         , dependencyTags = M.empty
                         }
 

--- a/test/NuGet/PackageReferenceTest.hs
+++ b/test/NuGet/PackageReferenceTest.hs
@@ -20,6 +20,7 @@ dependencyOne = Dependency { dependencyType = NuGetType
                            , dependencyName = "one"
                            , dependencyVersion = Just (CEq "1.0.0")
                            , dependencyLocations = []
+                           , dependencyEnvironments = []
                            , dependencyTags = M.empty
                            }
 
@@ -28,6 +29,7 @@ dependencyTwo = Dependency { dependencyType = NuGetType
                            , dependencyName = "two"
                            , dependencyVersion = Just (CEq "2.0.0")
                            , dependencyLocations = []
+                           , dependencyEnvironments = []
                            , dependencyTags = M.empty
                            }
 
@@ -36,6 +38,7 @@ dependencyThree = Dependency { dependencyType = NuGetType
                              , dependencyName = "three"
                              , dependencyVersion = Just (CEq "3.0.0")
                              , dependencyLocations = []
+                             , dependencyEnvironments = []
                              , dependencyTags = M.empty
                              }
 
@@ -44,6 +47,7 @@ dependencyFour = Dependency { dependencyType = NuGetType
                             , dependencyName = "four"
                             , dependencyVersion = Nothing
                             , dependencyLocations = []
+                            , dependencyEnvironments = []
                             , dependencyTags = M.empty
                             }
 

--- a/test/NuGet/PackagesConfigTest.hs
+++ b/test/NuGet/PackagesConfigTest.hs
@@ -18,6 +18,7 @@ dependencyOne = Dependency { dependencyType = NuGetType
                         , dependencyName = "one"
                         , dependencyVersion = Just (CEq "1.0.0")
                         , dependencyLocations = []
+                        , dependencyEnvironments = []
                         , dependencyTags = M.empty
                         }
 
@@ -26,6 +27,7 @@ dependencyTwo = Dependency { dependencyType = NuGetType
                         , dependencyName = "two"
                         , dependencyVersion = Just (CEq "2.0.0")
                         , dependencyLocations = []
+                        , dependencyEnvironments = []
                         , dependencyTags = M.empty
                         }
 

--- a/test/NuGet/PaketTest.hs
+++ b/test/NuGet/PaketTest.hs
@@ -19,6 +19,7 @@ dependencyOne = Dependency { dependencyType = NuGetType
                            , dependencyName = "one"
                            , dependencyVersion = Just (CEq "1.0.0")
                            , dependencyLocations = ["nuget.com"]
+                           , dependencyEnvironments = []
                            , dependencyTags = M.fromList [("location", ["NUGET"]), ("group", ["MAIN"])]
                            }
 
@@ -27,6 +28,7 @@ dependencyTwo = Dependency { dependencyType = NuGetType
                            , dependencyName = "two"
                            , dependencyVersion = Just (CEq "2.0.0")
                            , dependencyLocations = ["nuget-v2.com", "nuget.com"]
+                           , dependencyEnvironments = []
                            , dependencyTags = M.fromList [("location", ["NUGET"]), ("group", ["MAIN", "TEST"])]
                            }
 
@@ -35,6 +37,7 @@ dependencyThree = Dependency { dependencyType = NuGetType
                              , dependencyName = "three"
                              , dependencyVersion = Just (CEq "3.0.0")
                              , dependencyLocations = ["custom-site.com"]
+                             , dependencyEnvironments = []
                              , dependencyTags = M.fromList [("location", ["HTTP"]), ("group", ["MAIN"])]
                              }
 
@@ -43,6 +46,7 @@ dependencyFour = Dependency { dependencyType = NuGetType
                             , dependencyName = "four"
                             , dependencyVersion = Just (CEq "4.0.0")
                             , dependencyLocations = ["nuget-v2.com"]
+                            , dependencyEnvironments = []
                             , dependencyTags = M.fromList [("location", ["NUGET"]), ("group", ["TEST"])]
                             }
 
@@ -51,6 +55,7 @@ dependencyFive = Dependency { dependencyType = NuGetType
                             , dependencyName = "five"
                             , dependencyVersion = Just (CEq "5.0.0")
                             , dependencyLocations = ["nuget-v2.com"]
+                            , dependencyEnvironments = []
                             , dependencyTags = M.fromList [("location", ["NUGET"]), ("group", ["TEST"])]
                             }
 
@@ -59,6 +64,7 @@ dependencySix = Dependency { dependencyType = NuGetType
                            , dependencyName = "six"
                            , dependencyVersion = Just (CEq "6.0.0")
                            , dependencyLocations = ["github.com"]
+                           , dependencyEnvironments = []
                            , dependencyTags = M.fromList [("location", ["GITHUB"]), ("group", ["TEST"])]
                            }
 

--- a/test/NuGet/ProjectAssetsJsonTest.hs
+++ b/test/NuGet/ProjectAssetsJsonTest.hs
@@ -21,6 +21,7 @@ dependencyOne = Dependency { dependencyType = NuGetType
                         , dependencyName = "one"
                         , dependencyVersion = Just (CEq "1.0.0")
                         , dependencyLocations = []
+                        , dependencyEnvironments = []
                         , dependencyTags = M.empty
                         }
 
@@ -29,6 +30,7 @@ dependencyTwo = Dependency { dependencyType = NuGetType
                         , dependencyName = "two"
                         , dependencyVersion = Just (CEq "2.0.0")
                         , dependencyLocations = []
+                        , dependencyEnvironments = []
                         , dependencyTags = M.empty
                         }
 
@@ -37,6 +39,7 @@ dependencyThree = Dependency { dependencyType = NuGetType
                         , dependencyName = "three"
                         , dependencyVersion = Just (CEq "3.0.0")
                         , dependencyLocations = []
+                        , dependencyEnvironments = []
                         , dependencyTags = M.empty
                         }
 
@@ -45,6 +48,7 @@ dependencyFour = Dependency { dependencyType = NuGetType
                         , dependencyName = "four"
                         , dependencyVersion = Just (CEq "4.0.0")
                         , dependencyLocations = []
+                        , dependencyEnvironments = []
                         , dependencyTags = M.empty
                         }
 

--- a/test/NuGet/ProjectJsonTest.hs
+++ b/test/NuGet/ProjectJsonTest.hs
@@ -21,6 +21,7 @@ dependencyOne = Dependency { dependencyType = NuGetType
                         , dependencyName = "one"
                         , dependencyVersion = Just (CEq "1.0.0")
                         , dependencyLocations = []
+                        , dependencyEnvironments = []
                         , dependencyTags = M.empty
                         }
 
@@ -29,6 +30,7 @@ dependencyTwo = Dependency { dependencyType = NuGetType
                         , dependencyName = "two"
                         , dependencyVersion = Just (CCompatible "2.*")
                         , dependencyLocations = []
+                        , dependencyEnvironments = []
                         , dependencyTags = M.empty
                         }
 
@@ -37,7 +39,8 @@ dependencyThree = Dependency { dependencyType = NuGetType
                         , dependencyName = "three"
                         , dependencyVersion = Just (CEq "3.0.0")
                         , dependencyLocations = []
-                        , dependencyTags = M.fromList [ ("type", ["test"]) ]
+                        , dependencyEnvironments = []
+                        , dependencyTags = M.fromList [ ("type", ["sometype"]) ]
                         }
 
 spec_analyze :: Spec

--- a/test/NuGet/testdata/project.json
+++ b/test/NuGet/testdata/project.json
@@ -1,14 +1,12 @@
 {
       "version": "1",
-      "compilationOptions": {
-            "test": true
-      },
+      "compilationOptions": {},
       "dependencies": {
             "one": "1.0.0",
             "two": "2.*",
             "three": {
                   "version": "3.0.0",
-                  "type": "test"
+                  "type": "sometype"
             }
       },
       "code": [

--- a/test/Python/PipListTest.hs
+++ b/test/Python/PipListTest.hs
@@ -19,12 +19,14 @@ expected = run . evalGrapher $ do
                         , dependencyName = "pkgOne"
                         , dependencyVersion = Just (CEq "1.0.0")
                         , dependencyLocations = []
+                        , dependencyEnvironments = []
                         , dependencyTags = M.empty
                         }
   direct $ Dependency { dependencyType = PipType
                         , dependencyName = "pkgTwo"
                         , dependencyVersion = Just (CEq "2.0.0")
                         , dependencyLocations = []
+                        , dependencyEnvironments = []
                         , dependencyTags = M.empty
                         }
 

--- a/test/Python/PipenvTest.hs
+++ b/test/Python/PipenvTest.hs
@@ -62,7 +62,8 @@ depOne = Dependency
   , dependencyName = "pkgOne"
   , dependencyVersion = Just (CEq "1.0.0")
   , dependencyLocations = []
-  , dependencyTags = M.fromList [("environment", ["development"])]
+  , dependencyEnvironments = [EnvDevelopment]
+  , dependencyTags = M.empty
   }
 
 depTwo :: Dependency
@@ -71,7 +72,8 @@ depTwo = Dependency
   , dependencyName = "pkgTwo"
   , dependencyVersion = Just (CEq "2.0.0")
   , dependencyLocations = ["https://my-package-index/"]
-  , dependencyTags = M.fromList [("environment", ["production"])]
+  , dependencyEnvironments = [EnvProduction]
+  , dependencyTags = M.empty
   }
 
 depThree :: Dependency
@@ -80,7 +82,8 @@ depThree = Dependency
   , dependencyName = "pkgThree"
   , dependencyVersion = Just (CEq "3.0.0")
   , dependencyLocations = []
-  , dependencyTags = M.fromList [("environment", ["production"])]
+  , dependencyEnvironments = [EnvProduction]
+  , dependencyTags = M.empty
   }
 
 xit :: String -> Expectation -> SpecWith (Arg Expectation)

--- a/test/Python/ReqTxtTest.hs
+++ b/test/Python/ReqTxtTest.hs
@@ -33,18 +33,21 @@ expected = run . evalGrapher $ do
                           Just (CAnd (CGreaterOrEq "1.0.0")
                                      (CLess "2.0.0"))
                       , dependencyLocations = []
+                      , dependencyEnvironments = []
                       , dependencyTags = M.empty
                       }
   direct $ Dependency { dependencyType = PipType
                       , dependencyName = "pkgTwo"
                       , dependencyVersion = Nothing
                       , dependencyLocations = []
+                      , dependencyEnvironments = []
                       , dependencyTags = M.empty
                       }
   direct $ Dependency { dependencyType = PipType
                       , dependencyName = "pkgThree"
                       , dependencyVersion = Just (CURI "https://example.com/")
                       , dependencyLocations = []
+                      , dependencyEnvironments = []
                       , dependencyTags = M.empty
                       }
 

--- a/test/Python/SetupPyTest.hs
+++ b/test/Python/SetupPyTest.hs
@@ -33,18 +33,21 @@ expected = run . evalGrapher $ do
                           Just (CAnd (CGreaterOrEq "1.0.0")
                                      (CLess "2.0.0"))
                       , dependencyLocations = []
+                      , dependencyEnvironments = []
                       , dependencyTags = M.empty
                       }
   direct $ Dependency { dependencyType = PipType
                       , dependencyName = "pkgTwo"
                       , dependencyVersion = Nothing
                       , dependencyLocations = []
+                      , dependencyEnvironments = []
                       , dependencyTags = M.empty
                       }
   direct $ Dependency { dependencyType = PipType
                       , dependencyName = "pkgThree"
                       , dependencyVersion = Just (CURI "https://example.com/")
                       , dependencyLocations = []
+                      , dependencyEnvironments = []
                       , dependencyTags = M.empty
                       }
 

--- a/test/Ruby/BundleShowTest.hs
+++ b/test/Ruby/BundleShowTest.hs
@@ -21,12 +21,14 @@ expected = run . evalGrapher $ do
                       , dependencyName = "pkgOne"
                       , dependencyVersion = Just (CEq "1.0.0")
                       , dependencyLocations = []
+                      , dependencyEnvironments = []
                       , dependencyTags = M.empty
                       }
   direct $ Dependency { dependencyType = GemType
                       , dependencyName = "pkgTwo"
                       , dependencyVersion = Just (CEq "2.0.0")
                       , dependencyLocations = []
+                      , dependencyEnvironments = []
                       , dependencyTags = M.empty
                       }
 

--- a/test/Ruby/GemfileLockTest.hs
+++ b/test/Ruby/GemfileLockTest.hs
@@ -19,6 +19,7 @@ dependencyOne = Dependency { dependencyType = GemType
                         , dependencyName = "dep-one"
                         , dependencyVersion = Just (CEq "1.0.0")
                         , dependencyLocations = ["temp@12345"]
+                        , dependencyEnvironments = []
                         , dependencyTags = M.empty
                         }
 
@@ -27,6 +28,7 @@ dependencyTwo = Dependency { dependencyType = GemType
                         , dependencyName = "dep-two"
                         , dependencyVersion = Just (CEq "2.0.0")
                         , dependencyLocations = ["remote"]
+                        , dependencyEnvironments = []
                         , dependencyTags = M.empty
                         }
 
@@ -35,6 +37,7 @@ dependencyThree = Dependency { dependencyType = GemType
                         , dependencyName = "dep-three"
                         , dependencyVersion = Just (CEq "3.0.0")
                         , dependencyLocations = ["remote"]
+                        , dependencyEnvironments = []
                         , dependencyTags = M.empty
                         }
 


### PR DESCRIPTION
This formalizes environments as a concrete sum type, so we can filter out test/dev dependencies when converting to the v1 format

This also fixes a bug wrt `classifier` in the maven pom strategy