### PR TITLE
Add haddocks to Parse.XML

### DIFF
--- a/src/Parse/XML.hs
+++ b/src/Parse/XML.hs
@@ -1,3 +1,43 @@
+-- | This modules provides marshalling facilities from XML to datatypes
+--
+-- It's modeled closely after Aeson's @FromJSON@, with a couple of differences.
+--
+-- Aeson's @(.:)@ is replaced by three parsing primitives:
+--
+-- - 'attr', which parses string attributes of an element
+-- - 'child', which looks for the first child element with a given name
+-- - 'children', which looks for all child elements with a given name
+--
+-- Use 'parseXML' to parse from a strict Text to your specific datatype
+--
+-- === Optionality
+--
+-- In Aeson, we use @(.:?) :: FromJSON a => Object -> Text -> Parser (Maybe a)@
+-- to allow for elements that might not exist. In 'FromXML' parsers, we use a
+-- slightly different pattern with 'optional' from 'Alternative':
+--
+-- > data Foo = Foo Text
+-- >
+-- > instance FromXML Foo where
+-- >   parseElement el = do
+-- >     maybeBaz <- optional (child "baz" el)
+-- >     case maybeBaz of
+-- >       Nothing -> pure (Foo "defaultbaz")
+-- >       Just baz -> pure (Foo baz)
+--
+-- Similar to Aeson, which has @(.:!) :: Parser (Maybe a) -> a -> Parser a@ as
+-- a helper for defaults, we have 'defaultsTo' which is meant to be used infix:
+--
+-- > instance FromXML Foo where
+-- >   parseElement el = do
+-- >     baz <- optional (child "baz" el) `defaultsTo` "defaultbaz"
+-- >     pure (Foo baz)
+--
+-- Or with Functor/Applicative syntax:
+--
+-- > instance FromXML Foo where
+-- >   parseElement el =
+-- >     Foo <$> optional (child "baz" el) `defaultsTo` "defaultbaz"
 module Parse.XML
   ( -- * Types
     FromXML(..)
@@ -14,6 +54,8 @@ module Parse.XML
   , defaultsTo
 
   -- * Error formatting
+  , ParseError(..)
+  , ParsePath
   , xmlErrorPretty
   ) where
 
@@ -29,6 +71,11 @@ import qualified Data.Text as T
 import Data.Maybe (fromMaybe)
 import qualified Text.XML.Light as XML
 
+-- | A type that can be converted from XML
+--
+-- This is largely modeled after Aeson's FromJSON class, and has similar
+-- semantics. XML is a little more flexible (everything is modeled as Elements),
+-- so the failure modes are a little less precise.
 class FromXML a where
   parseElement :: XML.Element -> Parser a
 
@@ -37,6 +84,7 @@ instance FromXML XML.Element where
 
 instance FromXML T.Text where
   parseElement = content
+ 
 instance FromXML v => FromXML (M.Map T.Text v) where
   parseElement el = M.fromList <$> traverse mkSingle (XML.elChildren el)
     where
@@ -60,52 +108,102 @@ runParser :: String -> Parser a -> Either ParseError a
 runParser rootName = run . runError . runReader [rootName] . unParser
 
 data ParseError =
-    ParseElementMissing ParsePath String
-  | ParseAttrMissing ParsePath String
-  | ParseXMLDocFailed
-  | UnknownError ParsePath String
+    ParseElementMissing ParsePath String -- ^ A 'child' element was missing
+  | ParseAttrMissing ParsePath String -- ^ An 'attr' was missing
+  | ParseXMLDocFailed -- ^ The input 'T.Text' didn't contain valid XML
+  | UnknownError ParsePath String -- ^ A custom error, likely invoked via 'fail'
   deriving (Eq, Ord, Show)
 
+-- | Pretty-print a ParseError into strict 'T.Text'
 xmlErrorPretty :: ParseError -> T.Text
-xmlErrorPretty (ParseElementMissing path childName) =
-  "Missing child at " <> renderPath path <> "; childName: " <> T.pack childName
-xmlErrorPretty (ParseAttrMissing path attrName) =
-  "Missing attribute at " <> renderPath path <> "; attrName: " <> T.pack attrName
-xmlErrorPretty (UnknownError path err) =
-  "UnknownError at " <> renderPath path <> "; err: " <> T.pack err
-xmlErrorPretty ParseXMLDocFailed = "parseXMLDoc failed"
+xmlErrorPretty = \case
+  ParseElementMissing path childName -> "Missing child at " <> renderPath path <> "; childName: " <> T.pack childName
+  ParseAttrMissing path attrName -> "Missing attribute at " <> renderPath path <> "; attrName: " <> T.pack attrName
+  UnknownError path err -> "UnknownError at " <> renderPath path <> "; err: " <> T.pack err
+  ParseXMLDocFailed -> "parseXMLDoc failed"
 
+-- | Render a ParsePath as 'T.Text'
 renderPath :: ParsePath -> T.Text
 renderPath [] = "[no path]"
 renderPath xs = (\path -> "[" <> path <> "]") . T.intercalate "." . map T.pack . reverse $ xs
 
-type ParsePath = [String] -- reversed parse path
+-- | Reversed parse path. As we parse into elements, we /prepend/ them to this list
+type ParsePath = [String]
 
+-- | Parse a 'FromXML' value from a strict 'T.Text'
 parseXML :: FromXML a => T.Text -> Either ParseError a
 parseXML inp =
   case XML.parseXMLDoc inp of
     Nothing -> Left ParseXMLDocFailed
     Just root -> runParser (XML.qName (XML.elName root)) (parseElement root)
 
+-- | Parse an attribute from an XML Element. This will fail if the attribute
+-- does not exist
+--
+-- For example, given the following as @el@:
+--
+-- > <myelement attrOne="foo" attrTwo="bar"></myelement>
+--
+-- this would succeed:
+--
+-- > (,) <$> attr "attrOne" el <*> attr "attrTwo" el
 attr :: String -> XML.Element -> Parser T.Text
 attr attrName el =
   case XML.findAttrBy (\elName -> XML.qName elName == attrName) el of
     Nothing -> Parser $ ask >>= \path -> throwError (ParseAttrMissing path attrName)
     Just a  -> pure (T.pack a)
 
+-- | Find a child of an XML Element by its name. This will fail if a child with
+-- the given name does not exist
+--
+-- For example, given the following as @el@:
+--
+-- > <foo><bar></bar></foo>
+--
+-- @child "bar" el@ would succeed.
+--
+-- If there are multiple children with the same name, this returns the first
 child :: FromXML a => String -> XML.Element -> Parser a
 child childName el =
   case XML.filterChildName (\elName -> XML.qName elName == childName) el of
     Nothing -> Parser $ ask >>= \path -> throwError (ParseElementMissing path childName)
     Just a  -> subparse childName a
 
+-- | Find all children of an XML element with a given name. __This never
+-- fails__, and will return an empty list if no elements are found.
+--
+-- For example, given the following as @el@:
+--
+-- > <foo><bar></bar><bar></bar></foo>
+--
+-- @children "bar" el@ would produce a two-element list.
+-- @children "baz" el@ would produce an empty list.
 children :: FromXML a => String -> XML.Element -> Parser [a]
 children name = traverse (subparse name) . XML.filterChildrenName (\elName -> XML.qName elName == name)
 
+-- | Get the string content from an XML Element
+--
+-- For example, given the following as @el@:
+--
+-- > <foo>bar baz quux</foo>
+--
+-- @content el@ would produce "bar baz quux"
 content :: XML.Element -> Parser T.Text
 content = pure . T.pack . XML.strContent
 
--- default an optional field to a specific value
+-- | Helper function to default an optional field to a specific value
+--
+-- This is meant to be used in conjunction with 'optional' from 'Alternative'
+--
+-- For example, given this datatype and parser:
+--
+-- > data Foo = Foo Text
+-- >
+-- > instance FromXML Foo where
+-- >   parseElement el = Foo <$> optional (child "bar" el >>= content) `defaultsTo` "baz"
+--
+-- If the "bar" child exists, we produce the content of that element. Otherwise,
+-- we produce "baz"
 defaultsTo :: Parser (Maybe a) -> a -> Parser a
 defaultsTo fa a = fmap (fromMaybe a) fa
 


### PR DESCRIPTION
This adds documentation to the `Parse.XML` module.

You can run `cabal haddock` to generate the local HTML docs. Eventually I'd like to auto-build these as a useful resource (and as a dash docset) for folks working on spectrometer