### PR TITLE
Translate graphs to SourceUnits and upload to the CLIv1 endpoint

### DIFF
--- a/hscli.cabal
+++ b/hscli.cabal
@@ -59,6 +59,8 @@ common deps
     , fused-effects                ^>=1.0.2.0
     , fused-effects-exceptions     ^>=1.0.0.0
     , git-config                   ^>=0.1.2
+    , http-client                  ^>=0.6.4.1
+    , http-types                   ^>=0.12.3
     , megaparsec                   ^>=8.0
     , modern-uri                   ^>=0.3.1
     , mtl                          ^>=2.2.2

--- a/hscli.cabal
+++ b/hscli.cabal
@@ -110,6 +110,8 @@ library
     Graphing
     Parse.XML
     Prologue
+    Srclib.Converter
+    Srclib.Types
     Strategy.Carthage
     Strategy.Cocoapods.Podfile
     Strategy.Cocoapods.PodfileLock

--- a/hscli.cabal
+++ b/hscli.cabal
@@ -68,6 +68,7 @@ common deps
     , path-io                      ^>=1.6.0
     , prettyprinter                ^>=1.6
     , prettyprinter-ansi-terminal  ^>=1.1.1
+    , req                          ^>=3.1.0
     , stm                          ^>=2.5.0
     , stm-chans                    ^>=3.0.0
     , text                         ^>=1.2.3
@@ -88,6 +89,7 @@ library
   exposed-modules:
     App
     App.Scan
+    App.Scan.FossaV1
     App.Scan.Graph
     App.Scan.GraphBuilder
     App.Scan.GraphMangler

--- a/src/App.hs
+++ b/src/App.hs
@@ -21,8 +21,9 @@ commands = hsubparser scanCommand
 scanCommand :: Mod CommandFields (IO ())
 scanCommand = command "scan" (info (scanMain <$> scanOptsParser) (progDesc "Scan for projects and their dependencies"))
   where
-  scanOptsParser = ScanCmdOpts <$> basedirOpt <*> debugOpt <*> outputOpt
+  scanOptsParser = ScanCmdOpts <$> basedirOpt <*> debugOpt <*> outputOpt <*> uploadOpt
 
   basedirOpt = strOption (long "basedir" <> short 'd' <> metavar "DIR" <> help "Base directory for scanning" <> value ".")
   debugOpt = switch (long "debug" <> help "Enable debug logging")
   outputOpt = optional (strOption (long "outfile" <> short 'o' <> metavar "FILE" <> help "Output results to a file (default: stdout). Relative paths are relative to the scan root."))
+  uploadOpt = optional (strOption (long "upload" <> metavar "APIKEY" <> help "Upload results to Fossa"))

--- a/src/App/Scan/FossaV1.hs
+++ b/src/App/Scan/FossaV1.hs
@@ -46,7 +46,6 @@ data FossaError
   | OtherError HttpException
   deriving (Show, Generic)
 
--- TODO: IOExceptions?
 uploadAnalysis
   :: Text -- api key
   -> Text -- project name

--- a/src/App/Scan/FossaV1.hs
+++ b/src/App/Scan/FossaV1.hs
@@ -7,7 +7,6 @@ module App.Scan.FossaV1
 import Control.Carrier.Error.Either
 import Data.List (isInfixOf)
 import Data.Text.Encoding (encodeUtf8)
-import Effect.Logger
 import qualified Network.HTTP.Client as HTTP
 import Network.HTTP.Req
 import qualified Network.HTTP.Types as HTTP

--- a/src/App/Scan/FossaV1.hs
+++ b/src/App/Scan/FossaV1.hs
@@ -1,0 +1,39 @@
+module App.Scan.FossaV1
+  ( uploadAnalysis
+  ) where
+
+import Data.Text.Encoding (decodeUtf8, encodeUtf8)
+import Effect.Logger
+import Network.HTTP.Req
+import Prologue
+import Srclib.Converter (toSourceUnit)
+import Srclib.Types
+import Types
+
+-- TODO: git commit?
+cliVersion :: Text
+cliVersion = "spectrometer"
+
+uploadUrl :: Url 'Https
+uploadUrl = https "app.fossa.com" /: "api" /: "builds" /: "custom"
+
+-- TODO: IOExceptions?
+-- TODO: filter project closures in test/vendor/etc directories
+uploadAnalysis ::
+  ( Has Logger sig m
+  , MonadIO m
+  )
+  => Text -- api key
+  -> Text -- project name
+  -> Text -- project revision
+  -> [ProjectClosure]
+  -> m ()
+uploadAnalysis key name revision closures = do
+  let sourceUnits = map toSourceUnit closures
+      opts = "locator" =: (renderLocator (Locator "custom" name (Just revision)))
+          <> "v" =: cliVersion
+          <> "managedBuild" =: True
+          <> "title" =: name
+          <> header "Authorization" ("token " <> encodeUtf8 key)
+  resp <- runReq defaultHttpConfig $ req POST uploadUrl (ReqBodyJson sourceUnits) bsResponse opts
+  logInfo ("Response from core: " <> (pretty $ decodeUtf8 $ responseBody resp))

--- a/src/App/Scan/FossaV1.hs
+++ b/src/App/Scan/FossaV1.hs
@@ -4,6 +4,7 @@ module App.Scan.FossaV1
   , FossaError(..)
   ) where
 
+import App.Scan.Project
 import Control.Carrier.Error.Either
 import Data.List (isInfixOf)
 import Data.Text.Encoding (encodeUtf8)
@@ -13,7 +14,6 @@ import qualified Network.HTTP.Types as HTTP
 import Prologue
 import Srclib.Converter (toSourceUnit)
 import Srclib.Types
-import Types
 
 -- TODO: git commit?
 cliVersion :: Text
@@ -49,11 +49,11 @@ uploadAnalysis
   :: Text -- api key
   -> Text -- project name
   -> Text -- project revision
-  -> [ProjectClosure]
+  -> [Project]
   -> IO (Either FossaError UploadResponse)
-uploadAnalysis key name revision closures = runError . runFossaReq $ do
-  let filteredClosures = filter (isProductionPath . closureModuleDir) closures
-      sourceUnits = map toSourceUnit filteredClosures
+uploadAnalysis key name revision projects = runError . runFossaReq $ do
+  let filteredProjects = filter (isProductionPath . projectPath) projects
+      sourceUnits = fromMaybe [] $ traverse toSourceUnit filteredProjects
       opts = "locator" =: renderLocator (Locator "custom" name (Just revision))
           <> "v" =: cliVersion
           <> "managedBuild" =: True

--- a/src/App/Scan/FossaV1.hs
+++ b/src/App/Scan/FossaV1.hs
@@ -54,7 +54,7 @@ uploadAnalysis
 uploadAnalysis key name revision closures = runError . runFossaReq $ do
   let filteredClosures = filter (isProductionPath . closureModuleDir) closures
       sourceUnits = map toSourceUnit filteredClosures
-      opts = "locator" =: (renderLocator (Locator "custom" name (Just revision)))
+      opts = "locator" =: renderLocator (Locator "custom" name (Just revision))
           <> "v" =: cliVersion
           <> "managedBuild" =: True
           <> "title" =: name

--- a/src/Graphing.hs
+++ b/src/Graphing.hs
@@ -14,6 +14,7 @@ module Graphing
 
   -- * Manipulating a Graphing
   , gmap
+  , filter
   , pruneUnreachable
 
   -- * Building simple Graphings
@@ -21,7 +22,7 @@ module Graphing
   , unfold
   ) where
 
-import Prologue hiding (empty, parent)
+import Prologue hiding (empty, filter, parent)
 
 import           Algebra.Graph.AdjacencyMap (AdjacencyMap)
 import qualified Algebra.Graph.AdjacencyMap as AM
@@ -48,6 +49,13 @@ gmap f gr = gr { graphingDirect = direct', graphingAdjacent = adjacent' }
   where
   direct' = S.map f (graphingDirect gr)
   adjacent' = AM.gmap f (graphingAdjacent gr)
+
+-- | Filter Graphing elements
+filter :: (ty -> Bool) -> Graphing ty -> Graphing ty
+filter f gr = gr { graphingDirect = direct', graphingAdjacent = adjacent' }
+  where
+    direct' = S.filter f (graphingDirect gr)
+    adjacent' = AM.induce f (graphingAdjacent gr)
 
 -- | The empty Graphing
 empty :: Graphing ty
@@ -86,7 +94,7 @@ unfold seed getDeps toDependency = foldr addNode empty seed
 -- | Build a graphing from a list, where all list elements are treated as direct
 -- dependencies
 fromList :: Ord ty => [ty] -> Graphing ty
-fromList nodes = Graphing (S.fromList nodes) (AM.overlays (map AM.vertex nodes))
+fromList nodes = Graphing (S.fromList nodes) (AM.vertices nodes)
 
 -- | Remove unreachable vertices from the graph
 --

--- a/src/Srclib/Converter.hs
+++ b/src/Srclib/Converter.hs
@@ -1,0 +1,96 @@
+module Srclib.Converter
+  ( toSourceUnit
+  ) where
+
+import Prelude
+
+import qualified Algebra.Graph.AdjacencyMap as AM
+import Control.Applicative ((<|>))
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Set as Set
+import DepTypes
+import Graphing (Graphing)
+import qualified Graphing
+import Srclib.Types
+import Types
+
+toSourceUnit :: ProjectClosure -> SourceUnit
+toSourceUnit ProjectClosure{..} = SourceUnit
+  { sourceUnitName = renderedPath
+  , sourceUnitType = SourceUnitTypeDummyCLI
+  , sourceUnitManifest = renderedPath
+  , sourceUnitBuild = SourceUnitBuild
+    { buildArtifact = "default"
+    , buildSucceeded = True
+    , buildImports = imports
+    , buildDependencies = deps
+    }
+  }
+  where
+    imports :: [Locator]
+    imports = Set.toList $ Graphing.graphingDirect locatorGraph
+
+    deps :: [SourceUnitDependency]
+    deps = map (mkSourceUnitDependency locatorAdjacent) (AM.vertexList locatorAdjacent)
+
+    locatorAdjacent :: AM.AdjacencyMap Locator
+    locatorAdjacent = Graphing.graphingAdjacent locatorGraph
+
+    locatorGraph :: Graphing Locator
+    locatorGraph = Graphing.gmap toLocator filteredGraph
+
+    filteredGraph :: Graphing Dependency
+    filteredGraph = Graphing.filter (\d -> isProdDep d && isSupportedType d) graph
+
+    graph :: Graphing Dependency
+    graph = dependenciesGraph $ closureDependencies
+
+    renderedPath :: Text
+    renderedPath = Text.pack (show closureModuleDir) <> "/" <> closureStrategyName
+
+mkSourceUnitDependency :: AM.AdjacencyMap Locator -> Locator -> SourceUnitDependency
+mkSourceUnitDependency gr locator = SourceUnitDependency
+  { sourceDepLocator = locator
+  , sourceDepImports = Set.toList $ AM.postSet locator gr
+  }
+
+isProdDep :: Dependency -> Bool
+isProdDep Dependency{dependencyEnvironments} =
+  null dependencyEnvironments || EnvProduction `elem` dependencyEnvironments
+
+-- core can't handle subprojects
+isSupportedType :: Dependency -> Bool
+isSupportedType Dependency{dependencyType} = dependencyType /= SubprojectType
+
+toLocator :: Dependency -> Locator
+toLocator dep = Locator
+  { locatorFetcher = depTypeToFetcher (dependencyType dep)
+  , locatorProject = dependencyName dep
+  , locatorRevision = verConstraintToRevision =<< dependencyVersion dep
+  }
+
+verConstraintToRevision :: VerConstraint -> Maybe Text
+verConstraintToRevision = \case
+  CEq ver -> Just ver
+  CURI _ -> Nothing -- we can't represent this in a locator
+  CCompatible ver -> Just ver
+  CAnd a b -> verConstraintToRevision a <|> verConstraintToRevision b
+  COr a b -> verConstraintToRevision a <|> verConstraintToRevision b
+  CLess ver -> Just ver -- ugh
+  CLessOrEq ver -> Just ver -- ugh
+  CGreater ver -> Just ver -- ugh
+  CGreaterOrEq ver -> Just ver -- ugh
+  CNot _ -> Nothing -- we can't represent this in a locator
+
+depTypeToFetcher :: DepType -> Text
+depTypeToFetcher = \case
+  SubprojectType -> "mvn" -- FIXME. I knew SubprojectType would come back to bite us.
+  GemType -> "gem"
+  MavenType -> "mvn"
+  NodeJSType -> "npm"
+  NuGetType -> "nuget"
+  PipType -> "pip"
+  PodType -> "pod"
+  GoType -> "go"
+  CarthageType -> "cart"

--- a/src/Srclib/Types.hs
+++ b/src/Srclib/Types.hs
@@ -1,0 +1,38 @@
+module Srclib.Types
+  ( SourceUnit(..)
+  , SourceUnitType(..)
+  , SourceUnitBuild(..)
+  , SourceUnitDependency(..)
+  , Locator(..)
+  ) where
+
+import Prologue
+
+data SourceUnit = SourceUnit
+  { sourceUnitName :: Text -- TODO: does core use this anywhere? if not, let's just use the filepath again
+  , sourceUnitType :: SourceUnitType
+  , sourceUnitManifest :: Text -- ^ path to manifest file
+  , sourceUnitBuild :: SourceUnitBuild
+  } deriving (Eq, Ord, Show, Generic)
+
+data SourceUnitType = SourceUnitTypeDummyCLI
+  deriving (Eq, Ord, Show, Generic)
+
+data SourceUnitBuild = SourceUnitBuild
+  { buildArtifact :: Text -- ^ always "default"
+  , buildSucceeded :: Bool -- ^ always true
+  , buildImports :: [Locator]
+  , buildDependencies :: [SourceUnitDependency]
+  } deriving (Eq, Ord, Show, Generic)
+
+data SourceUnitDependency = SourceUnitDependency
+  { sourceDepLocator :: Locator
+  , sourceDepImports :: [Locator] -- omitempty
+  -- , sourceDepData :: Aeson.Value
+  } deriving (Eq, Ord, Show, Generic)
+
+data Locator = Locator
+  { locatorFetcher :: Text
+  , locatorProject :: Text
+  , locatorRevision :: Maybe Text
+  } deriving (Eq, Ord, Show, Generic)

--- a/src/Srclib/Types.hs
+++ b/src/Srclib/Types.hs
@@ -36,3 +36,38 @@ data Locator = Locator
   , locatorProject :: Text
   , locatorRevision :: Maybe Text
   } deriving (Eq, Ord, Show, Generic)
+
+
+-- TODO: "NormalizeGitURL", if/when we get git locators
+renderLocator :: Locator -> Text
+renderLocator Locator{..} =
+  locatorFetcher <> "+" <> locatorProject <> "$" <> fromMaybe "" locatorRevision
+
+instance ToJSON SourceUnit where
+  toJSON SourceUnit{..} = object
+    [ "Name" .= sourceUnitName
+    , "Type" .= sourceUnitType
+    , "Manifest" .= sourceUnitManifest
+    , "Build" .= sourceUnitBuild
+    ]
+
+instance ToJSON SourceUnitBuild where
+  toJSON SourceUnitBuild{..} = object
+    [ "Artifact" .= buildArtifact
+    , "Succeeded" .= buildSucceeded
+    , "Imports" .= buildImports
+    , "Dependencies" .= buildDependencies
+    ]
+
+instance ToJSON SourceUnitDependency where
+  toJSON SourceUnitDependency{..} = object
+    [ "locator" .= sourceDepLocator
+    , "imports" .= sourceDepImports
+    ]
+
+instance ToJSON SourceUnitType where
+  toJSON SourceUnitTypeDummyCLI = "dummy-cli"
+
+instance ToJSON Locator where
+  -- render as text
+  toJSON = toJSON . renderLocator

--- a/src/Srclib/Types.hs
+++ b/src/Srclib/Types.hs
@@ -9,7 +9,7 @@ module Srclib.Types
 import Prologue
 
 data SourceUnit = SourceUnit
-  { sourceUnitName :: Text -- TODO: does core use this anywhere? if not, let's just use the filepath again
+  { sourceUnitName :: Text
   , sourceUnitType :: SourceUnitType
   , sourceUnitManifest :: Text -- ^ path to manifest file
   , sourceUnitBuild :: SourceUnitBuild

--- a/src/Srclib/Types.hs
+++ b/src/Srclib/Types.hs
@@ -4,6 +4,7 @@ module Srclib.Types
   , SourceUnitBuild(..)
   , SourceUnitDependency(..)
   , Locator(..)
+  , renderLocator
   ) where
 
 import Prologue

--- a/src/Strategy/Cocoapods/Podfile.hs
+++ b/src/Strategy/Cocoapods/Podfile.hs
@@ -18,7 +18,8 @@ import qualified Data.Text as T
 import DepTypes
 import Discovery.Walk
 import Effect.ReadFS
-import Graphing (Graphing, unfold)
+import Graphing (Graphing)
+import qualified Graphing
 import Types
 import Text.Megaparsec hiding (label)
 import Text.Megaparsec.Char
@@ -49,7 +50,7 @@ mkProjectClosure file podfile = ProjectClosureBody
     }
 
 buildGraph :: Podfile -> Graphing Dependency
-buildGraph podfile = unfold direct (const []) toDependency
+buildGraph podfile = Graphing.fromList (map toDependency direct)
     where
     direct = pods podfile
     toDependency Pod{..} =

--- a/src/Strategy/Go/GlideLock.hs
+++ b/src/Strategy/Go/GlideLock.hs
@@ -17,7 +17,8 @@ import qualified Data.Text as T
 import DepTypes
 import Discovery.Walk
 import Effect.ReadFS
-import Graphing (Graphing, unfold)
+import Graphing (Graphing)
+import qualified Graphing
 import Types
 
 discover :: HasDiscover sig m => Path Abs Dir -> m ()
@@ -45,7 +46,7 @@ mkProjectClosure file lock = ProjectClosureBody
     }
 
 buildGraph :: GlideLockfile -> Graphing Dependency
-buildGraph lockfile = unfold direct (const []) toDependency
+buildGraph lockfile = Graphing.fromList (map toDependency direct)
   where
   direct = imports lockfile
   toDependency GlideDep{..}  =

--- a/src/Strategy/Node/YarnLock.hs
+++ b/src/Strategy/Node/YarnLock.hs
@@ -64,7 +64,7 @@ buildGraph lockfile = run . evalGrapher $
                , dependencyName =
                    case YL.name key of
                      YL.SimplePackageKey name -> name
-                     YL.ScopedPackageKey scope name -> scope <> "/" <> name
+                     YL.ScopedPackageKey scope name -> "@" <> scope <> "/" <> name
                , dependencyVersion = Just (CEq (YL.version package))
                , dependencyLocations =
                    case YL.remote package of

--- a/src/Strategy/NuGet/Nuspec.hs
+++ b/src/Strategy/NuGet/Nuspec.hs
@@ -21,7 +21,8 @@ import DepTypes
 import qualified Data.Text as T
 import Discovery.Walk
 import Effect.ReadFS
-import Graphing (Graphing, unfold)
+import Graphing (Graphing)
+import qualified Graphing
 import Parse.XML
 import Types
 
@@ -104,7 +105,7 @@ instance FromXML NuGetDependency where
                     <*> attr "version" el
 
 buildGraph :: Nuspec -> Graphing Dependency
-buildGraph project = unfold direct (const []) toDependency
+buildGraph project = Graphing.fromList (map toDependency direct)
     where
     direct = concatMap dependencies (groups project)
     toDependency NuGetDependency{..} =

--- a/src/Strategy/NuGet/PackageReference.hs
+++ b/src/Strategy/NuGet/PackageReference.hs
@@ -17,7 +17,8 @@ import qualified Data.List as L
 import DepTypes
 import Discovery.Walk
 import Effect.ReadFS
-import Graphing (Graphing, unfold)
+import Graphing (Graphing)
+import qualified Graphing
 import Parse.XML
 import Types
 
@@ -74,7 +75,7 @@ instance FromXML Package where
             <*> optional (child "Version" el)
 
 buildGraph :: PackageReference -> Graphing Dependency
-buildGraph project = unfold direct (const []) toDependency
+buildGraph project = Graphing.fromList (map toDependency direct)
     where
     direct = concatMap dependencies (groups project)
     toDependency Package{..} =

--- a/src/Strategy/NuGet/PackagesConfig.hs
+++ b/src/Strategy/NuGet/PackagesConfig.hs
@@ -14,7 +14,8 @@ import qualified Data.Map.Strict as M
 import DepTypes
 import Discovery.Walk
 import Effect.ReadFS
-import Graphing (Graphing, unfold)
+import Graphing (Graphing)
+import qualified Graphing
 import Parse.XML
 import Types
 
@@ -60,7 +61,7 @@ data NuGetDependency = NuGetDependency
   } deriving (Eq, Ord, Show, Generic)
 
 buildGraph :: PackagesConfig -> Graphing Dependency
-buildGraph config = unfold (deps config) (const []) toDependency
+buildGraph = Graphing.fromList . map toDependency . deps
     where
     toDependency NuGetDependency{..} =
       Dependency { dependencyType = NuGetType

--- a/src/Strategy/NuGet/ProjectJson.hs
+++ b/src/Strategy/NuGet/ProjectJson.hs
@@ -16,7 +16,8 @@ import Data.Aeson.Types
 import DepTypes
 import Discovery.Walk
 import Effect.ReadFS
-import Graphing (Graphing, unfold)
+import Graphing (Graphing)
+import qualified Graphing
 import Types
 
 discover :: HasDiscover sig m => Path Abs Dir -> m ()
@@ -75,7 +76,7 @@ data NuGetDependency = NuGetDependency
   } deriving Show
 
 buildGraph :: ProjectJson -> Graphing Dependency
-buildGraph project = unfold direct (const []) toDependency
+buildGraph project = Graphing.fromList (map toDependency direct)
     where
     direct = (\(name, dep) -> NuGetDependency name (depVersion dep) (depType dep)) <$> M.toList (dependencies project)
     toDependency NuGetDependency{..} =

--- a/src/Strategy/Python/PipList.hs
+++ b/src/Strategy/Python/PipList.hs
@@ -16,7 +16,8 @@ import qualified Data.Map.Strict as M
 import DepTypes
 import Discovery.Walk
 import Effect.Exec
-import Graphing
+import Graphing (Graphing)
+import qualified Graphing
 import Types
 
 discover :: HasDiscover sig m => Path Abs Dir -> m ()
@@ -51,7 +52,7 @@ mkProjectClosure dir deps = ProjectClosureBody
     }
 
 buildGraph :: [PipListDep] -> Graphing Dependency
-buildGraph xs = unfold xs (const []) toDependency
+buildGraph = Graphing.fromList . map toDependency
   where
   toDependency PipListDep{..} =
     Dependency { dependencyType = PipType

--- a/src/Strategy/Python/Util.hs
+++ b/src/Strategy/Python/Util.hs
@@ -20,10 +20,11 @@ import           Text.Megaparsec.Char
 import qualified Text.URI as URI
 
 import DepTypes
-import Graphing
+import Graphing (Graphing)
+import qualified Graphing
 
 buildGraph :: [Req] -> Graphing Dependency
-buildGraph xs = unfold xs (const []) toDependency
+buildGraph = Graphing.fromList . map toDependency
   where
   toDependency req =
     Dependency { dependencyType = PipType

--- a/src/Strategy/Ruby/BundleShow.hs
+++ b/src/Strategy/Ruby/BundleShow.hs
@@ -18,7 +18,8 @@ import Text.Megaparsec.Char
 import DepTypes
 import Discovery.Walk
 import Effect.Exec
-import Graphing
+import Graphing (Graphing)
+import qualified Graphing
 import Types
 
 discover :: HasDiscover sig m => Path Abs Dir -> m ()
@@ -53,7 +54,7 @@ mkProjectClosure dir deps = ProjectClosureBody
     }
 
 buildGraph :: [BundleShowDep] -> Graphing Dependency
-buildGraph xs = unfold xs (const []) toDependency
+buildGraph = Graphing.fromList . map toDependency
   where
   toDependency BundleShowDep{..} =
     Dependency { dependencyType = GemType


### PR DESCRIPTION
This adds a new `--upload APIKEY` argument to `scan`. When present, we upload results to the v1 API endpoint

- [x] convert `ProjectClosure` to `SourceUnit`
- [x] add cli command for running analysis and uploading to the old endpoint