### PR TITLE
Simplify and document filetree walking

### DIFF
--- a/src/Strategy/Carthage.hs
+++ b/src/Strategy/Carthage.hs
@@ -26,12 +26,12 @@ import qualified Graphing as G
 import Types
 
 discover :: HasDiscover sig m => Path Abs Dir -> m ()
-discover = walk $ \_ subdirs files ->
+discover = walk $ \_ _ files ->
   case find (\f -> fileName f == "Cartfile.resolved") files of
-    Nothing -> walkContinue
+    Nothing -> pure WalkContinue
     Just file -> do
       runSimpleStrategy "carthage-lock" CarthageGroup $ fmap (mkProjectClosure file) (analyze file)
-      walkSkipAll subdirs
+      pure WalkSkipAll
 
 mkProjectClosure :: Path Rel File -> G.Graphing ResolvedEntry -> ProjectClosureBody
 mkProjectClosure file graph = ProjectClosureBody

--- a/src/Strategy/Cocoapods/Podfile.hs
+++ b/src/Strategy/Cocoapods/Podfile.hs
@@ -30,7 +30,7 @@ discover = walk $ \_ _ files -> do
     Nothing -> pure ()
     Just file -> runSimpleStrategy "cocoapods-podfile" CocoapodsGroup $ analyze file
 
-  walkContinue
+  pure WalkContinue
 
 analyze :: (Has ReadFS sig m, Has (Error ReadFSErr) sig m) => Path Rel File -> m ProjectClosureBody
 analyze file = mkProjectClosure file <$> readContentsParser parsePodfile file

--- a/src/Strategy/Cocoapods/PodfileLock.hs
+++ b/src/Strategy/Cocoapods/PodfileLock.hs
@@ -33,7 +33,7 @@ discover = walk $ \_ _ files -> do
     Nothing -> pure ()
     Just file -> runSimpleStrategy "cocoapods-podfilelock" CocoapodsGroup $ analyze file
 
-  walkContinue
+  pure WalkContinue
 
 analyze :: (Has ReadFS sig m, Has (Error ReadFSErr) sig m) => Path Rel File -> m ProjectClosureBody
 analyze file = mkProjectClosure file <$> readContentsParser findSections file

--- a/src/Strategy/Go/GlideLock.hs
+++ b/src/Strategy/Go/GlideLock.hs
@@ -26,7 +26,7 @@ discover = walk $ \_ _ files -> do
     Nothing -> pure ()
     Just file -> runSimpleStrategy "golang-glidelock" GolangGroup $ analyze file
 
-  walkContinue
+  pure WalkContinue
 
 analyze :: ( Has ReadFS sig m , Has (Error ReadFSErr) sig m) => Path Rel File -> m ProjectClosureBody
 analyze file = mkProjectClosure file <$> readContentsYaml @GlideLockfile file

--- a/src/Strategy/Go/GoList.hs
+++ b/src/Strategy/Go/GoList.hs
@@ -1,3 +1,5 @@
+{-# language TemplateHaskell #-}
+
 module Strategy.Go.GoList
   ( discover
   , analyze
@@ -22,12 +24,12 @@ import Strategy.Go.Types
 import Types
 
 discover :: HasDiscover sig m => Path Abs Dir -> m ()
-discover = walk $ \_ subdirs files -> do
+discover = walk $ \_ _ files -> do
   case find (\f -> fileName f == "go.mod") files of
     Nothing -> pure ()
     Just file  -> runSimpleStrategy "golang-golist" GolangGroup $ analyze (parent file)
 
-  walkSkipNamed ["vendor/"] subdirs
+  pure $ WalkSkipSome [$(mkRelDir "vendor")]
 
 data Require = Require
   { reqPackage :: Text

--- a/src/Strategy/Go/Gomod.hs
+++ b/src/Strategy/Go/Gomod.hs
@@ -1,3 +1,5 @@
+{-# language TemplateHaskell #-}
+
 module Strategy.Go.Gomod
   ( discover
   , analyze
@@ -28,12 +30,12 @@ import Strategy.Go.Types
 import Types
 
 discover :: HasDiscover sig m => Path Abs Dir -> m ()
-discover = walk $ \_ subdirs files -> do
+discover = walk $ \_ _ files -> do
   case find (\f -> fileName f == "go.mod") files of
     Nothing -> pure ()
     Just file -> runSimpleStrategy "golang-gomod" GolangGroup $ analyze file
 
-  walkSkipNamed ["vendor/"] subdirs
+  pure $ WalkSkipSome [$(mkRelDir "vendor")]
 
 data Statement =
     RequireStatement Text Text -- ^ package, version

--- a/src/Strategy/Go/GopkgLock.hs
+++ b/src/Strategy/Go/GopkgLock.hs
@@ -1,3 +1,5 @@
+{-# language TemplateHaskell #-}
+
 module Strategy.Go.GopkgLock
   ( discover
   , analyze
@@ -24,12 +26,12 @@ import Toml (TomlCodec, (.=))
 import Types
 
 discover :: HasDiscover sig m => Path Abs Dir -> m ()
-discover = walk $ \_ subdirs files -> do
+discover = walk $ \_ _ files -> do
   case find (\f -> fileName f == "Gopkg.lock") files of
     Nothing -> pure ()
     Just file -> runSimpleStrategy "golang-gopkglock" GolangGroup $ analyze file
 
-  walkSkipNamed ["vendor/"] subdirs
+  pure $ WalkSkipSome [$(mkRelDir "vendor")]
 
 golockCodec :: TomlCodec GoLock
 golockCodec = GoLock

--- a/src/Strategy/Go/GopkgToml.hs
+++ b/src/Strategy/Go/GopkgToml.hs
@@ -1,3 +1,5 @@
+{-# language TemplateHaskell #-}
+
 module Strategy.Go.GopkgToml
   ( discover
 
@@ -27,12 +29,12 @@ import Strategy.Go.Types
 import Types
 
 discover :: HasDiscover sig m => Path Abs Dir -> m ()
-discover = walk $ \_ subdirs files -> do
+discover = walk $ \_ _ files -> do
   case find (\f -> fileName f == "Gopkg.toml") files of
     Nothing -> pure ()
     Just file -> runSimpleStrategy "golang-gopkgtoml" GolangGroup $ analyze file
 
-  walkSkipNamed ["vendor/"] subdirs
+  pure $ WalkSkipSome [$(mkRelDir "vendor")]
 
 gopkgCodec :: TomlCodec Gopkg
 gopkgCodec = Gopkg

--- a/src/Strategy/Gradle.hs
+++ b/src/Strategy/Gradle.hs
@@ -37,12 +37,12 @@ gradleJsonDepsCmd = Command
   }
 
 discover :: HasDiscover sig m => Path Abs Dir -> m ()
-discover = walk $ \_ subdirs files -> do
+discover = walk $ \_ _ files -> do
   case find (\f -> fileName f == "build.gradle") files of
-    Nothing -> walkContinue
+    Nothing -> pure WalkContinue
     Just file -> do
       runSimpleStrategy "gradle-cli" GradleGroup $ analyze (parent file)
-      walkSkipAll subdirs
+      pure WalkSkipAll
 
 initScript :: ByteString
 initScript = $(embedFile "scripts/jsondeps.gradle")

--- a/src/Strategy/Maven/PluginStrategy.hs
+++ b/src/Strategy/Maven/PluginStrategy.hs
@@ -19,12 +19,12 @@ import Strategy.Maven.Plugin
 import Types
 
 discover :: HasDiscover sig m => Path Abs Dir -> m ()
-discover = walk $ \_ subdirs files -> do
+discover = walk $ \_ _ files -> do
   case find (\f -> fileName f == "pom.xml") files of
-    Nothing -> walkContinue
+    Nothing -> pure WalkContinue
     Just file -> do
       runSimpleStrategy "maven-cli" MavenGroup $ analyze (parent file)
-      walkSkipAll subdirs
+      pure WalkSkipAll
 
 analyze ::
   ( Has (Lift IO) sig m

--- a/src/Strategy/Maven/Pom/Closure.hs
+++ b/src/Strategy/Maven/Pom/Closure.hs
@@ -32,7 +32,7 @@ findPomFiles dir = do
         Just file -> modify @[Path Rel File] (file:)
         Nothing -> pure ()
 
-      walkContinue
+      pure WalkContinue
 
   -- FIXME: exceptions
   traverse (liftIO . PIO.makeAbsolute) relPaths

--- a/src/Strategy/Node/NpmList.hs
+++ b/src/Strategy/Node/NpmList.hs
@@ -1,3 +1,5 @@
+{-# language TemplateHaskell #-}
+
 module Strategy.Node.NpmList
   ( discover
   , analyze
@@ -14,12 +16,12 @@ import Graphing (Graphing, unfold)
 import Types
 
 discover :: HasDiscover sig m => Path Abs Dir -> m ()
-discover = walk $ \dir subdirs files -> do
+discover = walk $ \dir _ files -> do
   case find (\f -> fileName f == "package.json") files of
     Nothing -> pure ()
     Just _ -> runSimpleStrategy "nodejs-npmlist" NodejsGroup $ analyze dir
 
-  walkSkipNamed ["node_modules/"] subdirs
+  pure (WalkSkipSome [$(mkRelDir "node_modules")])
 
 npmListCmd :: Command
 npmListCmd = Command

--- a/src/Strategy/Node/NpmLock.hs
+++ b/src/Strategy/Node/NpmLock.hs
@@ -1,3 +1,5 @@
+{-# language TemplateHaskell #-}
+
 module Strategy.Node.NpmLock
   ( discover
   , analyze
@@ -20,12 +22,12 @@ import Graphing (Graphing)
 import Types
 
 discover :: HasDiscover sig m => Path Abs Dir -> m ()
-discover = walk $ \_ subdirs files -> do
+discover = walk $ \_ _ files -> do
   case find (\f -> fileName f == "package-lock.json") files of
     Nothing -> pure ()
     Just file -> runSimpleStrategy "npm-packagelock" NodejsGroup $ analyze file
 
-  walkSkipNamed ["node_modules/"] subdirs
+  pure (WalkSkipSome [$(mkRelDir "node_modules")])
 
 data NpmPackageJson = NpmPackageJson
   { packageName         :: Text

--- a/src/Strategy/Node/PackageJson.hs
+++ b/src/Strategy/Node/PackageJson.hs
@@ -1,3 +1,5 @@
+{-# language TemplateHaskell #-}
+
 module Strategy.Node.PackageJson
   ( discover
   , buildGraph
@@ -17,12 +19,12 @@ import Graphing (Graphing)
 import Types
 
 discover :: HasDiscover sig m => Path Abs Dir -> m ()
-discover = walk $ \_ subdirs files -> do
+discover = walk $ \_ _ files -> do
   case find (\f -> fileName f == "package.json") files of
     Nothing -> pure ()
     Just file -> runSimpleStrategy "nodejs-packagejson" NodejsGroup $ analyze file
 
-  walkSkipNamed ["node_modules/"] subdirs
+  pure (WalkSkipSome [$(mkRelDir "node_modules")])
 
 data PackageJson = PackageJson
   { packageDeps    :: Map Text Text

--- a/src/Strategy/Node/YarnLock.hs
+++ b/src/Strategy/Node/YarnLock.hs
@@ -1,3 +1,5 @@
+{-# language TemplateHaskell #-}
+
 module Strategy.Node.YarnLock
   ( discover
   , analyze
@@ -20,12 +22,12 @@ import Graphing (Graphing)
 import Types
 
 discover :: HasDiscover sig m => Path Abs Dir -> m ()
-discover = walk $ \_ subdirs files -> do
+discover = walk $ \_ _ files -> do
   case find (\f -> fileName f == "yarn.lock") files of
     Nothing -> pure ()
     Just file -> runSimpleStrategy "nodejs-yarnlock" NodejsGroup $ analyze file
 
-  walkSkipNamed ["node_modules/"] subdirs
+  pure (WalkSkipSome [$(mkRelDir "node_modules")])
 
 analyze :: (Has ReadFS sig m, Has (Error ReadFSErr) sig m) => Path Rel File -> m ProjectClosureBody
 analyze lockfile = do

--- a/src/Strategy/NuGet/Nuspec.hs
+++ b/src/Strategy/NuGet/Nuspec.hs
@@ -31,7 +31,7 @@ discover = walk $ \_ _ files -> do
     Nothing -> pure ()
     Just file -> runSimpleStrategy "nuget-nuspec" DotnetGroup $ analyze file
 
-  walkContinue
+  pure WalkContinue
 
 analyze :: (Has ReadFS sig m, Has (Error ReadFSErr) sig m) => Path Rel File -> m ProjectClosureBody
 analyze file = mkProjectClosure file <$> readContentsXML @Nuspec file

--- a/src/Strategy/NuGet/PackageReference.hs
+++ b/src/Strategy/NuGet/PackageReference.hs
@@ -27,7 +27,7 @@ discover = walk $ \_ _ files -> do
     Nothing -> pure ()
     Just file -> runSimpleStrategy "nuget-packagereference" DotnetGroup $ analyze file
 
-  walkContinue
+  pure WalkContinue
  
   where 
       isPackageRefFile :: Path Rel File -> Bool

--- a/src/Strategy/NuGet/PackagesConfig.hs
+++ b/src/Strategy/NuGet/PackagesConfig.hs
@@ -24,7 +24,7 @@ discover = walk $ \_ _ files -> do
     Nothing -> pure ()
     Just file -> runSimpleStrategy "nuget-packagesconfig" DotnetGroup $ analyze file
 
-  walkContinue
+  pure WalkContinue
 
 instance FromXML PackagesConfig where
   parseElement el = PackagesConfig <$> children "package" el

--- a/src/Strategy/NuGet/Paket.hs
+++ b/src/Strategy/NuGet/Paket.hs
@@ -34,7 +34,7 @@ discover = walk $ \_ _ files -> do
     Nothing -> pure ()
     Just file -> runSimpleStrategy "paket-paketlock" DotnetGroup $ analyze file
 
-  walkContinue
+  pure WalkContinue
 
 analyze :: (Has ReadFS sig m, Has (Error ReadFSErr) sig m) => Path Rel File -> m ProjectClosureBody
 analyze file = mkProjectClosure file <$> readContentsParser findSections file

--- a/src/Strategy/NuGet/ProjectAssetsJson.hs
+++ b/src/Strategy/NuGet/ProjectAssetsJson.hs
@@ -25,7 +25,7 @@ discover = walk $ \_ _ files -> do
     Nothing -> pure ()
     Just file -> runSimpleStrategy "nuget-projectassetsjson" DotnetGroup $ analyze file
 
-  walkContinue
+  pure WalkContinue
 
 data ProjectAssetsJson = ProjectAssetsJson
   { targets     :: M.Map Text (M.Map Text DependencyInfo)

--- a/src/Strategy/NuGet/ProjectJson.hs
+++ b/src/Strategy/NuGet/ProjectJson.hs
@@ -25,7 +25,7 @@ discover = walk $ \_ _ files -> do
     Nothing -> pure ()
     Just file -> runSimpleStrategy "nuget-projectjson" DotnetGroup $ analyze file
 
-  walkContinue
+  pure WalkContinue
 
 data ProjectJson = ProjectJson
   { dependencies     :: Map Text DependencyInfo

--- a/src/Strategy/Python/PipList.hs
+++ b/src/Strategy/Python/PipList.hs
@@ -25,7 +25,7 @@ discover = walk $ \dir _ files -> do
     Nothing -> pure ()
     Just _ -> runSimpleStrategy "python-piplist" PythonGroup $ analyze dir
 
-  walkContinue
+  pure WalkContinue
 
 pipListCmd :: Command
 pipListCmd = Command

--- a/src/Strategy/Python/Pipenv.hs
+++ b/src/Strategy/Python/Pipenv.hs
@@ -31,7 +31,7 @@ discover = walk $ \_ _ files -> do
     Nothing -> pure ()
     Just file -> runSimpleStrategy "python-pipenv" PythonGroup $ analyze file
 
-  walkContinue
+  pure WalkContinue
 
 pipenvGraphCmd :: Command
 pipenvGraphCmd = Command

--- a/src/Strategy/Python/ReqTxt.hs
+++ b/src/Strategy/Python/ReqTxt.hs
@@ -25,7 +25,7 @@ discover = walk $ \_ _ files -> do
   for_ txtFiles $ \file ->
     runSimpleStrategy "python-requirements" PythonGroup $ analyze file
 
-  walkContinue
+  pure WalkContinue
 
 analyze :: (Has ReadFS sig m, Has (Error ReadFSErr) sig m) => Path Rel File -> m ProjectClosureBody
 analyze file = mkProjectClosure file <$> readContentsParser requirementsTxtParser file

--- a/src/Strategy/Python/SetupPy.hs
+++ b/src/Strategy/Python/SetupPy.hs
@@ -22,7 +22,7 @@ discover = walk $ \_ _ files -> do
     Just file -> runSimpleStrategy "python-setuppy" PythonGroup $
       analyze file
 
-  walkContinue
+  pure WalkContinue
 
 analyze :: (Has ReadFS sig m, Has (Error ReadFSErr) sig m) => Path Rel File -> m ProjectClosureBody
 analyze file = mkProjectClosure file <$> readContentsParser installRequiresParser file

--- a/src/Strategy/Ruby/BundleShow.hs
+++ b/src/Strategy/Ruby/BundleShow.hs
@@ -27,7 +27,7 @@ discover = walk $ \dir _ files -> do
     Nothing -> pure ()
     Just _  -> runSimpleStrategy "ruby-bundleshow" RubyGroup $ analyze dir
 
-  walkContinue
+  pure WalkContinue
 
 bundleShowCmd :: Command
 bundleShowCmd = Command

--- a/src/Strategy/Ruby/GemfileLock.hs
+++ b/src/Strategy/Ruby/GemfileLock.hs
@@ -33,7 +33,7 @@ discover = walk $ \_ _ files -> do
     when (fileName f == "Gemfile.lock") $
       runSimpleStrategy "ruby-gemfilelock" RubyGroup $ analyze f
 
-  walkContinue
+  pure WalkContinue
 
 type Remote = Text
 type Revision = Text


### PR DESCRIPTION
This adds a thin wrapper around `path-io`'s `walkDirRel`

`walkDirRel` isn't great because the subdirs and files passed into the walk function are relative to _the current directory_, not the base directory of the filetree traversal.

Additionally, having our own interface opens up potential fusing of filetree traversals / moving to other filetree traversal backends that provide fusing.