### PR TITLE
VPS scan integration 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,6 +52,7 @@ jobs:
       run: |
         strip dist-newstyle/build/x86_64-linux/ghc-8.8.2/spectrometer-0.1.0.0/x/fossa/opt/build/fossa/fossa
         strip dist-newstyle/build/x86_64-linux/ghc-8.8.2/spectrometer-0.1.0.0/x/pathfinder/opt/build/pathfinder/pathfinder
+        strip dist-newstyle/build/x86_64-linux/ghc-8.8.2/spectrometer-0.1.0.0/x/vpscli/opt/build/vpscli/vpscli
 
     - uses: actions/upload-artifact@v1
       with:
@@ -62,6 +63,11 @@ jobs:
       with:
         name: pathfinder-linux
         path: dist-newstyle/build/x86_64-linux/ghc-8.8.2/spectrometer-0.1.0.0/x/pathfinder/opt/build/pathfinder/pathfinder
+
+    - uses: actions/upload-artifact@v1
+      with:
+        name: vpscli-linux
+        path: dist-newstyle/build/x86_64-linux/ghc-8.8.2/spectrometer-0.1.0.0/x/vpscli/opt/build/vpscli/vpscli
 
   build-macos:
     name: build-macos
@@ -107,6 +113,7 @@ jobs:
       run: |
         strip dist-newstyle/build/x86_64-osx/ghc-8.8.2/spectrometer-0.1.0.0/x/fossa/opt/build/fossa/fossa
         strip dist-newstyle/build/x86_64-osx/ghc-8.8.2/spectrometer-0.1.0.0/x/pathfinder/opt/build/pathfinder/pathfinder
+        strip dist-newstyle/build/x86_64-osx/ghc-8.8.2/spectrometer-0.1.0.0/x/vpscli/opt/build/vpscli/vpscli
 
     - uses: actions/upload-artifact@v1
       with:
@@ -117,6 +124,11 @@ jobs:
       with:
         name: pathfinder-osx
         path: dist-newstyle/build/x86_64-osx/ghc-8.8.2/spectrometer-0.1.0.0/x/pathfinder/opt/build/pathfinder/pathfinder
+
+    - uses: actions/upload-artifact@v1
+      with:
+        name: vpscli-osx
+        path: dist-newstyle/build/x86_64-osx/ghc-8.8.2/spectrometer-0.1.0.0/x/vpscli/opt/build/vpscli/vpscli
 
   build-windows:
     name: build-windows
@@ -155,6 +167,7 @@ jobs:
       run: |
         strip dist-newstyle/build/x86_64-windows/ghc-8.8.2/spectrometer-0.1.0.0/x/fossa/opt/build/fossa/fossa.exe
         strip dist-newstyle/build/x86_64-windows/ghc-8.8.2/spectrometer-0.1.0.0/x/pathfinder/opt/build/pathfinder/pathfinder.exe
+        strip dist-newstyle/build/x86_64-windows/ghc-8.8.2/spectrometer-0.1.0.0/x/vpscli/opt/build/vpscli/vpscli.exe
 
     - uses: actions/upload-artifact@v1
       with:
@@ -165,3 +178,8 @@ jobs:
       with:
         name: pathfinder-windows.exe
         path: dist-newstyle/build/x86_64-windows/ghc-8.8.2/spectrometer-0.1.0.0/x/pathfinder/opt/build/pathfinder/pathfinder.exe
+
+    - uses: actions/upload-artifact@v1
+      with:
+        name: vpscli-windows.exe
+        path: dist-newstyle/build/x86_64-windows/ghc-8.8.2/spectrometer-0.1.0.0/x/vpscli/opt/build/vpscli/vpscli.exe

--- a/app/vpscli/Main.hs
+++ b/app/vpscli/Main.hs
@@ -1,0 +1,8 @@
+module Main (main) where
+
+import Prelude
+
+import App.VPSScan.Main (appMain)
+
+main :: IO ()
+main = appMain

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -118,6 +118,7 @@ library
     Effect.Logger
     Effect.ReadFS
     Graphing
+    OptionExtensions
     Parse.XML
     Prologue
     Srclib.Converter

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -100,6 +100,11 @@ library
     App.Fossa.Test
     App.Pathfinder.Main
     App.Pathfinder.Scan
+    App.VPSScan.Main
+    App.VPSScan.Scan
+    App.VPSScan.Scan.RunIPR
+    App.VPSScan.Scan.RunSherlock
+    App.VPSScan.Scan.ScotlandYard
     Control.Carrier.Output.IO
     Control.Carrier.TaskPool
     Control.Carrier.Threaded
@@ -167,6 +172,13 @@ executable pathfinder
   import:         lang
   main-is:        Main.hs
   hs-source-dirs: app/pathfinder
+  build-depends:  spectrometer
+  ghc-options:    -threaded -with-rtsopts=-N
+
+executable vpscli
+  import:         lang
+  main-is:        Main.hs
+  hs-source-dirs: app/vpscli
   build-depends:  spectrometer
   ghc-options:    -threaded -with-rtsopts=-N
 

--- a/src/App/Fossa/Main.hs
+++ b/src/App/Fossa/Main.hs
@@ -9,13 +9,13 @@ import App.Fossa.Analyze (analyzeMain, ScanDestination(..))
 import App.Fossa.FossaAPIV1 (ProjectMetadata(..))
 import App.Fossa.Test (testMain)
 import Effect.Logger
-import Network.HTTP.Req (useURI, https, Url, Scheme(..))
+import Network.HTTP.Req (https, Url, Scheme(..))
 import Options.Applicative
 import Path.IO (resolveDir', doesDirExist, setCurrentDir)
 import System.Environment (lookupEnv)
 import System.Exit (die)
 import qualified Data.Text as T
-import Text.URI (mkURI)
+import OptionExtensions
 
 appMain :: IO ()
 appMain = do
@@ -61,15 +61,6 @@ opts =
     <*> optional (strOption (long "revision" <> help "this repository's current revision hash (default: VCS hash HEAD)"))
     <*> comm
     <**> helper
-
-urlOption :: Mod OptionFields (Url scheme) -> Parser (Url scheme)
-urlOption = option parseUrl
-  where
-    parseUrl :: ReadM (Url scheme)
-    parseUrl = maybeReader (\s -> mkURI (T.pack s) >>= useURI >>= \res ->
-                               case res of
-                                 Left (url,_) -> pure $ coerce url
-                                 Right (url,_) -> pure $ coerce url)
 
 comm :: Parser Command
 comm = hsubparser

--- a/src/App/VPSScan/Main.hs
+++ b/src/App/VPSScan/Main.hs
@@ -39,7 +39,7 @@ runSherlockOpts = RunSherlock.SherlockOpts
                     sherlockClientTokenOpt = strOption(long "client-token" <> metavar "STRING" <> help "Client token for authentication to Sherlock (only necessary for vendored package scans)")
                     sherlockClientIDOpt = strOption(long "client-id" <> metavar "STRING" <> help "Client ID for authentication to Sherlock (only necessary for vendored package scans)")
 
-runIPROpts :: Parser (RunIPR.IPROpts)
+runIPROpts :: Parser RunIPR.IPROpts
 runIPROpts = RunIPR.IPROpts
                   <$> iprCmdPathOpt
                   <*> nomosCmdPathOpt
@@ -49,7 +49,7 @@ runIPROpts = RunIPR.IPROpts
                     nomosCmdPathOpt = strOption (long "nomossa" <> metavar "STRING" <> help "Path to the nomossa executable (only necessary for vendored package scans)")
                     pathfinderCmdPathOpt = strOption (long "pathfinder" <> metavar "STRING" <> help "Path to the pathfinder executable (only necessary for vendored package scans)")
 
-syOpts :: Parser (ScotlandYard.ScotlandYardOpts)
+syOpts :: Parser ScotlandYard.ScotlandYardOpts
 syOpts = ScotlandYard.ScotlandYardOpts
                      <$> scotlandYardUrlOpt
                      <*> scotlandYardPort
@@ -68,8 +68,8 @@ urlOption :: Mod OptionFields (Url scheme) -> Parser (Url scheme)
 urlOption = option parseUrl
   where
     parseUrl :: ReadM (Url scheme)
-    parseUrl = maybeReader (\s -> mkURI (T.pack s) >>= useURI >>= \res ->
-                               case res of
+    parseUrl = maybeReader (\s -> mkURI (T.pack s) >>= useURI >>=
+                              \case
                                  Left (url,_) -> pure $ coerce url
                                  Right (url,_) -> pure $ coerce url)
 

--- a/src/App/VPSScan/Main.hs
+++ b/src/App/VPSScan/Main.hs
@@ -7,12 +7,10 @@ import Prologue
 import Options.Applicative
 
 import App.VPSScan.Scan (VPSOpts(..), ScanCmdOpts(..), scanMain)
-import Network.HTTP.Req (Url, useURI)
-import Text.URI (mkURI)
-import qualified Data.Text as T
 import qualified App.VPSScan.Scan.RunSherlock as RunSherlock
 import qualified App.VPSScan.Scan.RunIPR as RunIPR
 import qualified App.VPSScan.Scan.ScotlandYard as ScotlandYard
+import OptionExtensions
 
 appMain :: IO ()
 appMain = join (customExecParser (prefs showHelpOnEmpty) opts)
@@ -62,16 +60,6 @@ syOpts = ScotlandYard.ScotlandYardOpts
                     organizationIDOpt = strOption (long "organization" <> metavar "STRING" <> help "Organization ID (only necessary for vendored package scans)")
                     projectIDOpt = strOption (long "project" <> metavar "String" <> help "Project ID (only necessary for vendored package scans")
                     revisionIDOpt = strOption (long "revision" <> metavar "String" <> help "Project ID (only necessary for vendored package scans")
-
--- FIXME remove me when this is rebased
-urlOption :: Mod OptionFields (Url scheme) -> Parser (Url scheme)
-urlOption = option parseUrl
-  where
-    parseUrl :: ReadM (Url scheme)
-    parseUrl = maybeReader (\s -> mkURI (T.pack s) >>= useURI >>=
-                              \case
-                                 Left (url,_) -> pure $ coerce url
-                                 Right (url,_) -> pure $ coerce url)
 
 scanCommand :: Mod CommandFields (IO ())
 scanCommand = command "scan" (info (scanMain <$> scanOptsParser) (progDesc "Scan for projects and their dependencies"))

--- a/src/App/VPSScan/Main.hs
+++ b/src/App/VPSScan/Main.hs
@@ -1,0 +1,83 @@
+module App.VPSScan.Main
+  ( appMain
+  ) where
+
+import Prologue
+
+import Options.Applicative
+
+import App.VPSScan.Scan (VPSOpts(..), ScanCmdOpts(..), scanMain)
+import Network.HTTP.Req (Url, useURI)
+import Text.URI (mkURI)
+import qualified Data.Text as T
+import qualified App.VPSScan.Scan.RunSherlock as RunSherlock
+import qualified App.VPSScan.Scan.RunIPR as RunIPR
+import qualified App.VPSScan.Scan.ScotlandYard as ScotlandYard
+
+appMain :: IO ()
+appMain = join (customExecParser (prefs showHelpOnEmpty) opts)
+
+opts :: ParserInfo (IO ())
+opts = info (commands <**> helper) (fullDesc <> header "hscli - fossa-cli, but functional")
+
+commands :: Parser (IO ())
+commands = hsubparser scanCommand
+
+
+vpsOpts :: Parser VPSOpts
+vpsOpts = VPSOpts <$> runSherlockOpts <*> runIPROpts <*> syOpts
+
+runSherlockOpts :: Parser (RunSherlock.SherlockOpts)
+runSherlockOpts = RunSherlock.SherlockOpts
+                  <$> sherlockCmdPathOpt
+                  <*> sherlockUrlOpt
+                  <*> sherlockClientTokenOpt
+                  <*> sherlockClientIDOpt
+                where
+                    sherlockCmdPathOpt = strOption (long "sherlock-cli" <> metavar "STRING" <> help "Path to the sherlock-cli executable (only necessary for vendored package scans)")
+                    sherlockUrlOpt = strOption(long "sherlock-url" <> metavar "STRING" <> help "URL for Sherlock service (only necessary for vendored package scans)")
+                    sherlockClientTokenOpt = strOption(long "client-token" <> metavar "STRING" <> help "Client token for authentication to Sherlock (only necessary for vendored package scans)")
+                    sherlockClientIDOpt = strOption(long "client-id" <> metavar "STRING" <> help "Client ID for authentication to Sherlock (only necessary for vendored package scans)")
+
+runIPROpts :: Parser (RunIPR.IPROpts)
+runIPROpts = RunIPR.IPROpts
+                  <$> iprCmdPathOpt
+                  <*> nomosCmdPathOpt
+                  <*> pathfinderCmdPathOpt
+                where
+                    iprCmdPathOpt = strOption (long "ipr" <> metavar "STRING" <> help "Path to the IPR executable (only necessary for vendored package scans)")
+                    nomosCmdPathOpt = strOption (long "nomossa" <> metavar "STRING" <> help "Path to the nomossa executable (only necessary for vendored package scans)")
+                    pathfinderCmdPathOpt = strOption (long "pathfinder" <> metavar "STRING" <> help "Path to the pathfinder executable (only necessary for vendored package scans)")
+
+syOpts :: Parser (ScotlandYard.ScotlandYardOpts)
+syOpts = ScotlandYard.ScotlandYardOpts
+                     <$> scotlandYardUrlOpt
+                     <*> scotlandYardPort
+                     <*> organizationIDOpt
+                     <*> projectIDOpt
+                     <*> revisionIDOpt
+                  where
+                    scotlandYardUrlOpt = urlOption (long "scotland-yard-url" <> metavar "STRING" <> help "URL for Scotland Yard service (only necessary for vendored package scans)")
+                    scotlandYardPort = option auto (long "scotland-yard-port" <> metavar "Port" <> help "Port for Scotland yard service" <> value 8080)
+                    organizationIDOpt = strOption (long "organization" <> metavar "STRING" <> help "Organization ID (only necessary for vendored package scans)")
+                    projectIDOpt = strOption (long "project" <> metavar "String" <> help "Project ID (only necessary for vendored package scans")
+                    revisionIDOpt = strOption (long "revision" <> metavar "String" <> help "Project ID (only necessary for vendored package scans")
+
+-- FIXME remove me when this is rebased
+urlOption :: Mod OptionFields (Url scheme) -> Parser (Url scheme)
+urlOption = option parseUrl
+  where
+    parseUrl :: ReadM (Url scheme)
+    parseUrl = maybeReader (\s -> mkURI (T.pack s) >>= useURI >>= \res ->
+                               case res of
+                                 Left (url,_) -> pure $ coerce url
+                                 Right (url,_) -> pure $ coerce url)
+
+scanCommand :: Mod CommandFields (IO ())
+scanCommand = command "scan" (info (scanMain <$> scanOptsParser) (progDesc "Scan for projects and their dependencies"))
+  where
+  scanOptsParser = ScanCmdOpts
+                   <$> basedirOpt
+                   <*> vpsOpts
+
+  basedirOpt = strOption (long "basedir" <> short 'd' <> metavar "DIR" <> help "Base directory for scanning" <> value ".")

--- a/src/App/VPSScan/Main.hs
+++ b/src/App/VPSScan/Main.hs
@@ -16,7 +16,7 @@ appMain :: IO ()
 appMain = join (customExecParser (prefs showHelpOnEmpty) opts)
 
 opts :: ParserInfo (IO ())
-opts = info (commands <**> helper) (fullDesc <> header "hscli - fossa-cli, but functional")
+opts = info (commands <**> helper) (fullDesc <> header "vpscli -- FOSSA Vendored Package Scan CLI")
 
 commands :: Parser (IO ())
 commands = hsubparser scanCommand

--- a/src/App/VPSScan/Main.hs
+++ b/src/App/VPSScan/Main.hs
@@ -32,10 +32,10 @@ runSherlockOpts = RunSherlock.SherlockOpts
                   <*> sherlockClientTokenOpt
                   <*> sherlockClientIDOpt
                 where
-                    sherlockCmdPathOpt = strOption (long "sherlock-cli" <> metavar "STRING" <> help "Path to the sherlock-cli executable (only necessary for vendored package scans)")
-                    sherlockUrlOpt = strOption(long "sherlock-url" <> metavar "STRING" <> help "URL for Sherlock service (only necessary for vendored package scans)")
-                    sherlockClientTokenOpt = strOption(long "client-token" <> metavar "STRING" <> help "Client token for authentication to Sherlock (only necessary for vendored package scans)")
-                    sherlockClientIDOpt = strOption(long "client-id" <> metavar "STRING" <> help "Client ID for authentication to Sherlock (only necessary for vendored package scans)")
+                    sherlockCmdPathOpt = strOption (long "sherlock-cli" <> metavar "STRING" <> help "Path to the sherlock-cli executable")
+                    sherlockUrlOpt = strOption(long "sherlock-url" <> metavar "STRING" <> help "URL for Sherlock service")
+                    sherlockClientTokenOpt = strOption(long "client-token" <> metavar "STRING" <> help "Client token for authentication to Sherlock")
+                    sherlockClientIDOpt = strOption(long "client-id" <> metavar "STRING" <> help "Client ID for authentication to Sherlock")
 
 runIPROpts :: Parser RunIPR.IPROpts
 runIPROpts = RunIPR.IPROpts
@@ -43,9 +43,9 @@ runIPROpts = RunIPR.IPROpts
                   <*> nomosCmdPathOpt
                   <*> pathfinderCmdPathOpt
                 where
-                    iprCmdPathOpt = strOption (long "ipr" <> metavar "STRING" <> help "Path to the IPR executable (only necessary for vendored package scans)")
-                    nomosCmdPathOpt = strOption (long "nomossa" <> metavar "STRING" <> help "Path to the nomossa executable (only necessary for vendored package scans)")
-                    pathfinderCmdPathOpt = strOption (long "pathfinder" <> metavar "STRING" <> help "Path to the pathfinder executable (only necessary for vendored package scans)")
+                    iprCmdPathOpt = strOption (long "ipr" <> metavar "STRING" <> help "Path to the IPR executable")
+                    nomosCmdPathOpt = strOption (long "nomossa" <> metavar "STRING" <> help "Path to the nomossa executable")
+                    pathfinderCmdPathOpt = strOption (long "pathfinder" <> metavar "STRING" <> help "Path to the pathfinder executable")
 
 syOpts :: Parser ScotlandYard.ScotlandYardOpts
 syOpts = ScotlandYard.ScotlandYardOpts
@@ -55,11 +55,11 @@ syOpts = ScotlandYard.ScotlandYardOpts
                      <*> projectIDOpt
                      <*> revisionIDOpt
                   where
-                    scotlandYardUrlOpt = urlOption (long "scotland-yard-url" <> metavar "STRING" <> help "URL for Scotland Yard service (only necessary for vendored package scans)")
+                    scotlandYardUrlOpt = urlOption (long "scotland-yard-url" <> metavar "STRING" <> help "URL for Scotland Yard service")
                     scotlandYardPort = option auto (long "scotland-yard-port" <> metavar "Port" <> help "Port for Scotland yard service" <> value 8080)
-                    organizationIDOpt = strOption (long "organization" <> metavar "STRING" <> help "Organization ID (only necessary for vendored package scans)")
-                    projectIDOpt = strOption (long "project" <> metavar "String" <> help "Project ID (only necessary for vendored package scans")
-                    revisionIDOpt = strOption (long "revision" <> metavar "String" <> help "Project ID (only necessary for vendored package scans")
+                    organizationIDOpt = strOption (long "organization" <> metavar "STRING" <> help "Organization ID")
+                    projectIDOpt = strOption (long "project" <> metavar "String" <> help "Project ID")
+                    revisionIDOpt = strOption (long "revision" <> metavar "String" <> help "Revision ID")
 
 scanCommand :: Mod CommandFields (IO ())
 scanCommand = command "scan" (info (scanMain <$> scanOptsParser) (progDesc "Scan for projects and their dependencies"))

--- a/src/App/VPSScan/Scan.hs
+++ b/src/App/VPSScan/Scan.hs
@@ -1,0 +1,83 @@
+module App.VPSScan.Scan
+  ( scanMain
+  , ScanCmdOpts(..)
+  , VPSOpts(..)
+  ) where
+
+import Prologue
+
+import Control.Carrier.Error.Either
+import Control.Carrier.Trace.Printing
+import Path.IO
+import System.Exit (exitFailure, die)
+
+import Network.HTTP.Req (HttpException)
+
+import App.VPSScan.Scan.RunSherlock
+import App.VPSScan.Scan.ScotlandYard
+import App.VPSScan.Scan.RunIPR
+
+data ScanCmdOpts = ScanCmdOpts
+  { cmdBasedir :: FilePath
+  , scanVpsOpts :: VPSOpts
+  } deriving (Eq, Ord, Show, Generic)
+
+data VPSOpts = VPSOpts
+  { vpsSherlock :: SherlockOpts
+  , vpsIpr :: IPROpts
+  , vpsScotlandYard :: ScotlandYardOpts
+  } deriving (Eq, Ord, Show, Generic)
+
+scanMain :: ScanCmdOpts -> IO ()
+scanMain opts@ScanCmdOpts{..} = do
+  basedir <- validateDir cmdBasedir
+  result <- runError @VPSError $ runScotlandYard $ runSherlock $ runIPR $ runTrace $ vpsScan basedir opts
+  case result of
+    Left err -> do
+      print err
+      exitFailure
+    Right _ -> pure ()
+
+----- main logic
+
+data VPSError
+  = IPRFailed IPRError
+  | SherlockFailed SherlockError
+  | Couldn'tGetScanId HttpException
+  | Couldn'tUpload HttpException
+  deriving (Show, Generic)
+
+vpsScan ::
+  ( Has ScotlandYard sig m
+  , Has IPR sig m
+  , Has Sherlock sig m
+  , Has (Error VPSError) sig m
+  , Has Trace sig m
+  ) => Path Abs Dir -> ScanCmdOpts -> m ()
+vpsScan basedir ScanCmdOpts{..} = do
+  let VPSOpts{..} = scanVpsOpts
+  response <- tagError Couldn'tGetScanId =<< createScotlandYardScan vpsScotlandYard
+ 
+  trace $ "Running scan on directory " ++ show basedir
+  let scanId = responseScanId response
+  trace $ "Scan ID from Scotland yard is " ++ show scanId
+  trace "Starting IPR scan"
+  iprResult <- tagError IPRFailed =<< execIPR basedir vpsIpr
+  trace "IPR scan completed. Posting results to Scotland Yard"
+  tagError Couldn'tUpload =<< uploadIPRResults vpsScotlandYard scanId iprResult
+  trace "Running Sherlock scan"
+  tagError SherlockFailed =<< execSherlock basedir scanId vpsSherlock
+  trace "Scan complete"
+
+tagError :: Has (Error e') sig m => (e -> e') -> Either e a -> m a
+tagError f (Left e) = throwError (f e)
+tagError _ (Right a) = pure a
+
+validateDir :: FilePath -> IO (Path Abs Dir)
+validateDir dir = do
+  absolute <- resolveDir' dir
+  exists <- doesDirExist absolute
+
+  unless exists (die $ "ERROR: Directory " <> show absolute <> " does not exist")
+
+  pure absolute

--- a/src/App/VPSScan/Scan.hs
+++ b/src/App/VPSScan/Scan.hs
@@ -57,7 +57,7 @@ vpsScan ::
 vpsScan basedir ScanCmdOpts{..} = do
   let VPSOpts{..} = scanVpsOpts
   response <- tagError Couldn'tGetScanId =<< createScotlandYardScan vpsScotlandYard
- 
+
   trace $ "Running scan on directory " ++ show basedir
   let scanId = responseScanId response
   trace $ "Scan ID from Scotland yard is " ++ show scanId

--- a/src/App/VPSScan/Scan/RunIPR.hs
+++ b/src/App/VPSScan/Scan/RunIPR.hs
@@ -23,7 +23,7 @@ data IPROpts = IPROpts
   } deriving (Eq, Ord, Show, Generic)
 
 iprCmdArgs :: Path Abs Dir -> IPROpts -> [String]
-iprCmdArgs baseDir IPROpts{..} = ["-target", (toFilePath baseDir), "-nomossa", nomosCmdPath, "-pathfinder", pathfinderCmdPath]
+iprCmdArgs baseDir IPROpts{..} = ["-target", toFilePath baseDir, "-nomossa", nomosCmdPath, "-pathfinder", pathfinderCmdPath]
 
 extractNonEmptyFiles :: Value -> Maybe Array
 extractNonEmptyFiles (Object obj) = do

--- a/src/App/VPSScan/Scan/RunIPR.hs
+++ b/src/App/VPSScan/Scan/RunIPR.hs
@@ -33,7 +33,6 @@ extractNonEmptyFiles (Object obj) = do
     _ -> Nothing
 
   let filtered = V.filter hasLicenses filesAsArray
-
       hasLicenses :: Value -> Bool
       hasLicenses (Object file) =
         case HM.lookup "LicenseExpressions" file of
@@ -62,7 +61,7 @@ execIPR :: Has IPR sig m => Path Abs Dir -> IPROpts -> m (Either IPRError Array)
 execIPR basedir iprOpts = send (ExecIPR basedir iprOpts pure)
 
 ----- production ipr interpreter
- 
+
 newtype IPRC m a = IPRC { runIPR :: m a }
   deriving (Functor, Applicative, Monad, MonadIO)
 

--- a/src/App/VPSScan/Scan/RunIPR.hs
+++ b/src/App/VPSScan/Scan/RunIPR.hs
@@ -1,0 +1,82 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module App.VPSScan.Scan.RunIPR
+  ( IPROpts(..)
+  , IPR(..)
+  , IPRC(..)
+  , execIPR
+  , IPRError(..)
+  ) where
+
+import qualified Data.HashMap.Strict as HM
+import qualified Data.Text as T
+import qualified Data.Vector as V
+import Prologue
+
+import Control.Carrier.Error.Either
+import Effect.Exec
+
+data IPROpts = IPROpts
+  { iprCmdPath :: String
+  , nomosCmdPath :: String
+  , pathfinderCmdPath :: String
+  } deriving (Eq, Ord, Show, Generic)
+
+iprCmdArgs :: Path Abs Dir -> IPROpts -> [String]
+iprCmdArgs baseDir IPROpts{..} = ["-target", (toFilePath baseDir), "-nomossa", nomosCmdPath, "-pathfinder", pathfinderCmdPath]
+
+extractNonEmptyFiles :: Value -> Maybe Array
+extractNonEmptyFiles (Object obj) = do
+  files <- HM.lookup "Files" obj
+  filesAsArray <- case files of
+    Array filesArray -> Just filesArray
+    _ -> Nothing
+
+  let filtered = V.filter hasLicenses filesAsArray
+
+      hasLicenses :: Value -> Bool
+      hasLicenses (Object file) =
+        case HM.lookup "LicenseExpressions" file of
+          Just (Object expressions) -> not (HM.null expressions)
+          _ -> False
+      hasLicenses _ = False
+
+  pure filtered
+extractNonEmptyFiles _ = Nothing
+
+----- ipr effect
+
+data IPRError
+  = NoFilesEntryInOutput
+  | IPRCommandFailed Text
+  deriving (Eq, Ord, Show, Generic)
+
+data IPR m k
+  = ExecIPR (Path Abs Dir) IPROpts (Either IPRError Array -> m k)
+  deriving Generic1
+
+instance HFunctor IPR
+instance Effect IPR
+
+execIPR :: Has IPR sig m => Path Abs Dir -> IPROpts -> m (Either IPRError Array)
+execIPR basedir iprOpts = send (ExecIPR basedir iprOpts pure)
+
+----- production ipr interpreter
+ 
+newtype IPRC m a = IPRC { runIPR :: m a }
+  deriving (Functor, Applicative, Monad, MonadIO)
+
+instance (Algebra sig m, MonadIO m, Effect sig) => Algebra (IPR :+: sig) (IPRC m) where
+  alg (R other) = IPRC (alg (handleCoercible other))
+  alg (L (ExecIPR basedir opts@IPROpts{..} k)) = (k =<<) . IPRC $ do
+    let iprCommand :: Command
+        iprCommand = Command [iprCmdPath] [] Never
+
+    maybeValue <- runError @ExecErr $ runExecIO $ execJson basedir iprCommand $ iprCmdArgs basedir opts
+    case maybeValue of
+      Left err -> pure (Left (IPRCommandFailed (T.pack (show err))))
+      Right value -> do
+        let maybeExtracted = extractNonEmptyFiles value
+        case maybeExtracted of
+          Nothing -> pure (Left NoFilesEntryInOutput)
+          Just extracted -> pure (Right extracted)

--- a/src/App/VPSScan/Scan/RunSherlock.hs
+++ b/src/App/VPSScan/Scan/RunSherlock.hs
@@ -1,0 +1,56 @@
+module App.VPSScan.Scan.RunSherlock
+  ( SherlockOpts(..)
+  , Sherlock(..)
+  , SherlockC(..)
+  , SherlockError(..)
+  , execSherlock
+  ) where
+import Prologue
+
+import Control.Carrier.Error.Either
+import Effect.Exec
+import qualified Data.Text as T
+
+data SherlockOpts = SherlockOpts
+  { sherlockCmdPath :: String
+  , sherlockUrl :: String
+  , sherlockClientToken :: String
+  , sherlockClientID :: String
+  } deriving (Eq, Ord, Show, Generic)
+
+sherlockCmdArgs :: String -> SherlockOpts -> [String]
+sherlockCmdArgs scanId SherlockOpts{..} = [ "--scan-id", scanId
+                                          , "--sherlock-client-token", sherlockClientToken
+                                          , "--sherlock-client-id", sherlockClientID
+                                          ]
+
+----- sherlock effect
+
+data SherlockError
+  = SherlockCommandFailed Text
+  deriving (Eq, Ord, Show, Generic)
+
+data Sherlock m k
+  = ExecSherlock (Path Abs Dir) Text SherlockOpts (Either SherlockError () -> m k)
+  deriving Generic1
+
+execSherlock :: Has Sherlock sig m => Path Abs Dir -> Text -> SherlockOpts -> m (Either SherlockError ())
+execSherlock basedir scanId opts = send (ExecSherlock basedir scanId opts pure)
+
+instance HFunctor Sherlock
+instance Effect Sherlock
+
+----- production sherlock interpreter
+
+newtype SherlockC m a = SherlockC { runSherlock :: m a }
+  deriving (Functor, Applicative, Monad, MonadIO)
+
+instance (Algebra sig m, MonadIO m, Effect sig) => Algebra (Sherlock :+: sig) (SherlockC m) where
+  alg (R other) = SherlockC (alg (handleCoercible other))
+  alg (L (ExecSherlock basedir scanId opts@SherlockOpts{..} k)) = (k =<<) . SherlockC $ do
+    let sherlockCommand :: Command
+        sherlockCommand = Command [sherlockCmdPath] [] Never
+    result <- runExecIO $ exec basedir sherlockCommand $ sherlockCmdArgs (T.unpack scanId) opts
+    case result of
+      Left err -> pure (Left (SherlockCommandFailed (T.pack (show err))))
+      Right _ -> pure (Right ())

--- a/src/App/VPSScan/Scan/ScotlandYard.hs
+++ b/src/App/VPSScan/Scan/ScotlandYard.hs
@@ -1,0 +1,91 @@
+module App.VPSScan.Scan.ScotlandYard
+  ( createScan
+  , postIprResults
+  , ScotlandYardOpts(..)
+  , HTTP(..)
+  , runHTTP
+  , ScanResponse(..)
+  , ScotlandYard(..)
+  , ScotlandYardC(..)
+  , createScotlandYardScan
+  , uploadIPRResults
+  )
+where
+import Prologue
+
+import Control.Algebra
+import Control.Carrier.Error.Either
+import Network.HTTP.Req
+
+data ScotlandYardOpts = ScotlandYardOpts
+  { scotlandYardUrl :: Url 'Https
+  , scotlandYardPort :: Int
+  , organizationID :: Text
+  , projectID :: Text
+  , revisionID :: Text
+  } deriving (Eq, Ord, Show, Generic)
+
+newtype HTTP a = HTTP { unHTTP :: ErrorC HttpException IO a }
+  deriving (Functor, Applicative, Monad, MonadIO)
+
+runHTTP :: MonadIO m => HTTP a -> m (Either HttpException a)
+runHTTP = liftIO . runError @HttpException . unHTTP
+
+instance MonadHttp HTTP where
+  handleHttpException = HTTP . throwError
+
+-- /projects/{projectID}/scans
+createScanEndpoint :: Url 'Https -> Text -> Url 'Https
+createScanEndpoint baseurl projectId = baseurl /: "projects" /: projectId /: "scans"
+
+-- /projects/{projectID}/scans/{scanID}/discovered_licenses
+scanDataEndpoint :: Url 'Https -> Text -> Text -> Url 'Https
+scanDataEndpoint baseurl projectId scanId = baseurl /: "projects" /: projectId /: "scans" /: scanId /: "discovered_licenses"
+
+data ScanResponse = ScanResponse
+  { responseScanId :: Text
+  } deriving (Eq, Ord, Show, Generic)
+
+instance FromJSON ScanResponse where
+  parseJSON = withObject "ScanResponse" $ \obj ->
+    ScanResponse <$> obj .: "scanId"
+
+createScan :: ScotlandYardOpts -> HTTP ScanResponse
+createScan ScotlandYardOpts{..} = do
+  let body = object ["organizationId" .= organizationID, "revisionId" .= revisionID]
+  resp <- req POST (createScanEndpoint scotlandYardUrl projectID) (ReqBodyJson body) jsonResponse $ port scotlandYardPort
+  pure (responseBody resp)
+
+-- Given the results from a run of IPR, a scan ID and a URL for Scotland Yard,
+-- post the IRP result to the "Upload Scan Data" endpoint on Scotland Yard
+-- POST /scans/{scanID}/discovered_licenses
+postIprResults :: ToJSON a => ScotlandYardOpts -> Text -> a -> HTTP ()
+postIprResults ScotlandYardOpts{..} scanId value = do
+  _ <- req POST (scanDataEndpoint scotlandYardUrl projectID scanId) (ReqBodyJson value) ignoreResponse $ port scotlandYardPort
+  pure ()
+
+----- scotland yard effect
+
+data ScotlandYard m k
+  = CreateScotlandYardScan ScotlandYardOpts (Either HttpException ScanResponse -> m k) -- TODO: add Scotland yard error type
+  | UploadIPRResults ScotlandYardOpts Text Array (Either HttpException () -> m k) -- TODO: add scotland yard error type
+  deriving Generic1
+
+instance HFunctor ScotlandYard
+instance Effect ScotlandYard
+
+createScotlandYardScan :: Has ScotlandYard sig m => ScotlandYardOpts -> m (Either HttpException ScanResponse)
+createScotlandYardScan opts = send (CreateScotlandYardScan opts pure)
+
+uploadIPRResults :: Has ScotlandYard sig m => ScotlandYardOpts -> Text -> Array -> m (Either HttpException ())
+uploadIPRResults opts scanId value = send (UploadIPRResults opts scanId value pure)
+
+----- scotland yard production interpreter
+
+newtype ScotlandYardC m a = ScotlandYardC { runScotlandYard :: m a }
+  deriving (Functor, Applicative, Monad, MonadIO)
+
+instance (Algebra sig m, MonadIO m) => Algebra (ScotlandYard :+: sig) (ScotlandYardC m) where
+  alg (R other) = ScotlandYardC (alg (handleCoercible other))
+  alg (L (CreateScotlandYardScan scotlandYardOpts k)) = (k =<<) . ScotlandYardC $ runHTTP $ createScan scotlandYardOpts
+  alg (L (UploadIPRResults scotlandYardOpts scanId value k)) = (k =<<) . ScotlandYardC $ runHTTP $ postIprResults scotlandYardOpts scanId value

--- a/src/OptionExtensions.hs
+++ b/src/OptionExtensions.hs
@@ -1,0 +1,18 @@
+module OptionExtensions
+  (urlOption)
+where
+
+import Prologue
+import Options.Applicative
+import qualified Data.Text as T
+import Network.HTTP.Req (Url, useURI)
+import Text.URI (mkURI)
+
+urlOption :: Mod OptionFields (Url scheme) -> Parser (Url scheme)
+urlOption = option parseUrl
+  where
+    parseUrl :: ReadM (Url scheme)
+    parseUrl = maybeReader (\s -> mkURI (T.pack s) >>= useURI >>=
+                              \case
+                                 Left (url,_) -> pure $ coerce url
+                                 Right (url,_) -> pure $ coerce url)


### PR DESCRIPTION
Create a new binary called `vpscli` that runs a VPS scan.

The VPS Scan will:

1. POST to Scotland Yard to create a new scan
2. Shell out to sherlock to run a fingerprint scan and upload those results to the sherlock API
3. Shell out to IPR to do a license scan
4. Filter the IPR results, retaining only files that have license info and upload the IPR results to Scotland Yard

An example command line with all of the require command line options:

```
./vpscli scan --sherlock-cli ~/fossa/vps-core/fake-sherlock --sherlock-url http://example.org --client-token 123 --client-id 456 --ipr ~/fossa/vps-core/ramjet-cli-ipr --nomossa ~/fossa/vps-core/nomossa --pathfinder ~/fossa/vps-core/pathfinder --scotland-yard-url http://localhost:8080 --organization scott --project tester --revision 1 --basedir unzipped_epub
```