### PR TITLE
Sherlock cli fixes

### DIFF
--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -105,6 +105,7 @@ library
     App.VPSScan.Scan.RunIPR
     App.VPSScan.Scan.RunSherlock
     App.VPSScan.Scan.ScotlandYard
+    App.VPSScan.Types
     Control.Carrier.Output.IO
     Control.Carrier.TaskPool
     Control.Carrier.Threaded

--- a/src/App/VPSScan/Main.hs
+++ b/src/App/VPSScan/Main.hs
@@ -31,11 +31,17 @@ runSherlockOpts = RunSherlock.SherlockOpts
                   <*> sherlockUrlOpt
                   <*> sherlockClientTokenOpt
                   <*> sherlockClientIDOpt
+                  <*> organizationIDOpt
+                  <*> projectIDOpt
+                  <*> revisionIDOpt
                 where
                     sherlockCmdPathOpt = strOption (long "sherlock-cli" <> metavar "STRING" <> help "Path to the sherlock-cli executable")
                     sherlockUrlOpt = strOption(long "sherlock-url" <> metavar "STRING" <> help "URL for Sherlock service")
                     sherlockClientTokenOpt = strOption(long "client-token" <> metavar "STRING" <> help "Client token for authentication to Sherlock")
                     sherlockClientIDOpt = strOption(long "client-id" <> metavar "STRING" <> help "Client ID for authentication to Sherlock")
+                    organizationIDOpt = strOption (long "organization" <> metavar "STRING" <> help "Organization ID")
+                    projectIDOpt = strOption (long "project" <> metavar "String" <> help "Project ID")
+                    revisionIDOpt = strOption (long "revision" <> metavar "String" <> help "Revision ID")
 
 runIPROpts :: Parser RunIPR.IPROpts
 runIPROpts = RunIPR.IPROpts

--- a/src/App/VPSScan/Main.hs
+++ b/src/App/VPSScan/Main.hs
@@ -22,13 +22,13 @@ commands = hsubparser scanCommand
 
 
 vpsOpts :: Parser VPSOpts
-vpsOpts = VPSOpts <$> runSherlockOpts <*> runIPROpts <*> syOpts <*> organizationIDOpt <*> projectIDOpt <*> revisionIDOpt 
+vpsOpts = VPSOpts <$> runSherlockOpts <*> runIPROpts <*> syOpts <*> organizationIDOpt <*> projectIDOpt <*> revisionIDOpt
             where
               organizationIDOpt = option auto (long "organization" <> metavar "orgID" <> help "Organization ID")
               projectIDOpt = strOption (long "project" <> metavar "String" <> help "Project ID")
               revisionIDOpt = strOption (long "revision" <> metavar "String" <> help "Revision ID")
 
-runSherlockOpts :: Parser (SherlockOpts)
+runSherlockOpts :: Parser SherlockOpts
 runSherlockOpts = SherlockOpts
                   <$> sherlockCmdPathOpt
                   <*> sherlockUrlOpt
@@ -65,5 +65,4 @@ scanCommand = command "scan" (info (scanMain <$> scanOptsParser) (progDesc "Scan
   scanOptsParser = ScanCmdOpts
                    <$> basedirOpt
                    <*> vpsOpts
-
   basedirOpt = strOption (long "basedir" <> short 'd' <> metavar "DIR" <> help "Base directory for scanning" <> value ".")

--- a/src/App/VPSScan/Main.hs
+++ b/src/App/VPSScan/Main.hs
@@ -23,10 +23,14 @@ commands = hsubparser scanCommand
 
 
 vpsOpts :: Parser VPSOpts
-vpsOpts = VPSOpts <$> runSherlockOpts <*> runIPROpts <*> syOpts
+vpsOpts = VPSOpts <$> runSherlockOpts organizationIDOpt projectIDOpt revisionIDOpt <*> runIPROpts <*> syOpts organizationIDOpt projectIDOpt revisionIDOpt 
+            where
+              organizationIDOpt = option auto (long "organization" <> metavar "orgID" <> help "Organization ID")
+              projectIDOpt = strOption (long "project" <> metavar "String" <> help "Project ID")
+              revisionIDOpt = strOption (long "revision" <> metavar "String" <> help "Revision ID")
 
-runSherlockOpts :: Parser (RunSherlock.SherlockOpts)
-runSherlockOpts = RunSherlock.SherlockOpts
+runSherlockOpts :: Parser Int -> Parser Text -> Parser Text -> Parser (RunSherlock.SherlockOpts)
+runSherlockOpts organizationIDOpt projectIDOpt revisionIDOpt = RunSherlock.SherlockOpts
                   <$> sherlockCmdPathOpt
                   <*> sherlockUrlOpt
                   <*> sherlockClientTokenOpt
@@ -39,9 +43,6 @@ runSherlockOpts = RunSherlock.SherlockOpts
                     sherlockUrlOpt = strOption(long "sherlock-url" <> metavar "STRING" <> help "URL for Sherlock service")
                     sherlockClientTokenOpt = strOption(long "client-token" <> metavar "STRING" <> help "Client token for authentication to Sherlock")
                     sherlockClientIDOpt = strOption(long "client-id" <> metavar "STRING" <> help "Client ID for authentication to Sherlock")
-                    organizationIDOpt = strOption (long "organization" <> metavar "STRING" <> help "Organization ID")
-                    projectIDOpt = strOption (long "project" <> metavar "String" <> help "Project ID")
-                    revisionIDOpt = strOption (long "revision" <> metavar "String" <> help "Revision ID")
 
 runIPROpts :: Parser RunIPR.IPROpts
 runIPROpts = RunIPR.IPROpts
@@ -53,8 +54,9 @@ runIPROpts = RunIPR.IPROpts
                     nomosCmdPathOpt = strOption (long "nomossa" <> metavar "STRING" <> help "Path to the nomossa executable")
                     pathfinderCmdPathOpt = strOption (long "pathfinder" <> metavar "STRING" <> help "Path to the pathfinder executable")
 
-syOpts :: Parser ScotlandYard.ScotlandYardOpts
-syOpts = ScotlandYard.ScotlandYardOpts
+-- org IDs are ints. project and revision IDs are strings
+syOpts :: Parser Int -> Parser Text -> Parser Text -> Parser ScotlandYard.ScotlandYardOpts
+syOpts organizationIDOpt projectIDOpt revisionIDOpt = ScotlandYard.ScotlandYardOpts
                      <$> scotlandYardUrlOpt
                      <*> scotlandYardPort
                      <*> organizationIDOpt
@@ -62,10 +64,7 @@ syOpts = ScotlandYard.ScotlandYardOpts
                      <*> revisionIDOpt
                   where
                     scotlandYardUrlOpt = urlOption (long "scotland-yard-url" <> metavar "STRING" <> help "URL for Scotland Yard service")
-                    scotlandYardPort = option auto (long "scotland-yard-port" <> metavar "Port" <> help "Port for Scotland yard service" <> value 8080)
-                    organizationIDOpt = strOption (long "organization" <> metavar "STRING" <> help "Organization ID")
-                    projectIDOpt = strOption (long "project" <> metavar "String" <> help "Project ID")
-                    revisionIDOpt = strOption (long "revision" <> metavar "String" <> help "Revision ID")
+                    scotlandYardPort = option auto (long "scotland-yard-port" <> metavar "Port" <> help "Port for Scotland yard service" <> value 8675)
 
 scanCommand :: Mod CommandFields (IO ())
 scanCommand = command "scan" (info (scanMain <$> scanOptsParser) (progDesc "Scan for projects and their dependencies"))

--- a/src/App/VPSScan/Main.hs
+++ b/src/App/VPSScan/Main.hs
@@ -6,10 +6,9 @@ import Prologue
 
 import Options.Applicative
 
-import App.VPSScan.Scan (VPSOpts(..), ScanCmdOpts(..), scanMain)
-import qualified App.VPSScan.Scan.RunSherlock as RunSherlock
+import App.VPSScan.Scan (ScanCmdOpts(..), scanMain)
+import App.VPSScan.Types
 import qualified App.VPSScan.Scan.RunIPR as RunIPR
-import qualified App.VPSScan.Scan.ScotlandYard as ScotlandYard
 import OptionExtensions
 
 appMain :: IO ()
@@ -23,21 +22,18 @@ commands = hsubparser scanCommand
 
 
 vpsOpts :: Parser VPSOpts
-vpsOpts = VPSOpts <$> runSherlockOpts organizationIDOpt projectIDOpt revisionIDOpt <*> runIPROpts <*> syOpts organizationIDOpt projectIDOpt revisionIDOpt 
+vpsOpts = VPSOpts <$> runSherlockOpts <*> runIPROpts <*> syOpts <*> organizationIDOpt <*> projectIDOpt <*> revisionIDOpt 
             where
               organizationIDOpt = option auto (long "organization" <> metavar "orgID" <> help "Organization ID")
               projectIDOpt = strOption (long "project" <> metavar "String" <> help "Project ID")
               revisionIDOpt = strOption (long "revision" <> metavar "String" <> help "Revision ID")
 
-runSherlockOpts :: Parser Int -> Parser Text -> Parser Text -> Parser (RunSherlock.SherlockOpts)
-runSherlockOpts organizationIDOpt projectIDOpt revisionIDOpt = RunSherlock.SherlockOpts
+runSherlockOpts :: Parser (SherlockOpts)
+runSherlockOpts = SherlockOpts
                   <$> sherlockCmdPathOpt
                   <*> sherlockUrlOpt
                   <*> sherlockClientTokenOpt
                   <*> sherlockClientIDOpt
-                  <*> organizationIDOpt
-                  <*> projectIDOpt
-                  <*> revisionIDOpt
                 where
                     sherlockCmdPathOpt = strOption (long "sherlock-cli" <> metavar "STRING" <> help "Path to the sherlock-cli executable")
                     sherlockUrlOpt = strOption(long "sherlock-url" <> metavar "STRING" <> help "URL for Sherlock service")
@@ -55,13 +51,10 @@ runIPROpts = RunIPR.IPROpts
                     pathfinderCmdPathOpt = strOption (long "pathfinder" <> metavar "STRING" <> help "Path to the pathfinder executable")
 
 -- org IDs are ints. project and revision IDs are strings
-syOpts :: Parser Int -> Parser Text -> Parser Text -> Parser ScotlandYard.ScotlandYardOpts
-syOpts organizationIDOpt projectIDOpt revisionIDOpt = ScotlandYard.ScotlandYardOpts
+syOpts :: Parser ScotlandYardOpts
+syOpts = ScotlandYardOpts
                      <$> scotlandYardUrlOpt
                      <*> scotlandYardPort
-                     <*> organizationIDOpt
-                     <*> projectIDOpt
-                     <*> revisionIDOpt
                   where
                     scotlandYardUrlOpt = urlOption (long "scotland-yard-url" <> metavar "STRING" <> help "URL for Scotland Yard service")
                     scotlandYardPort = option auto (long "scotland-yard-port" <> metavar "Port" <> help "Port for Scotland yard service" <> value 8675)

--- a/src/App/VPSScan/Scan.hs
+++ b/src/App/VPSScan/Scan.hs
@@ -51,7 +51,7 @@ vpsScan ::
   ) => Path Abs Dir -> ScanCmdOpts -> m ()
 vpsScan basedir ScanCmdOpts{..} = do
   let vpsOpts@VPSOpts{..} = scanVpsOpts
-  response <- tagError Couldn'tGetScanId =<< createScotlandYardScan vpsScotlandYard vpsOpts
+  response <- tagError Couldn'tGetScanId =<< createScotlandYardScan vpsOpts
 
   trace $ "Running scan on directory " ++ show basedir
   let scanId = responseScanId response
@@ -59,7 +59,7 @@ vpsScan basedir ScanCmdOpts{..} = do
   trace "Starting IPR scan"
   iprResult <- tagError IPRFailed =<< execIPR basedir vpsIpr
   trace "IPR scan completed. Posting results to Scotland Yard"
-  tagError Couldn'tUpload =<< uploadIPRResults vpsScotlandYard vpsOpts scanId iprResult
+  tagError Couldn'tUpload =<< uploadIPRResults vpsOpts scanId iprResult
   trace "Running Sherlock scan"
   tagError SherlockFailed =<< execSherlock basedir scanId vpsOpts
   trace "Scan complete"

--- a/src/App/VPSScan/Scan.hs
+++ b/src/App/VPSScan/Scan.hs
@@ -61,7 +61,7 @@ vpsScan basedir ScanCmdOpts{..} = do
   trace "IPR scan completed. Posting results to Scotland Yard"
   tagError Couldn'tUpload =<< uploadIPRResults vpsScotlandYard vpsOpts scanId iprResult
   trace "Running Sherlock scan"
-  tagError SherlockFailed =<< execSherlock basedir scanId vpsSherlock vpsOpts
+  tagError SherlockFailed =<< execSherlock basedir scanId vpsOpts
   trace "Scan complete"
 
 tagError :: Has (Error e') sig m => (e -> e') -> Either e a -> m a

--- a/src/App/VPSScan/Scan.hs
+++ b/src/App/VPSScan/Scan.hs
@@ -52,15 +52,18 @@ vpsScan ::
 vpsScan basedir ScanCmdOpts{..} = do
   let vpsOpts@VPSOpts{..} = scanVpsOpts
   response <- tagError Couldn'tGetScanId =<< createScotlandYardScan vpsOpts
+  let scanId = responseScanId response
 
   trace $ "Running scan on directory " ++ show basedir
-  let scanId = responseScanId response
   trace $ "Scan ID from Scotland yard is " ++ show scanId
   trace "Starting IPR scan"
+
   iprResult <- tagError IPRFailed =<< execIPR basedir vpsIpr
   trace "IPR scan completed. Posting results to Scotland Yard"
+
   tagError Couldn'tUpload =<< uploadIPRResults vpsOpts scanId iprResult
   trace "Running Sherlock scan"
+
   tagError SherlockFailed =<< execSherlock basedir scanId vpsOpts
   trace "Scan complete"
 

--- a/src/App/VPSScan/Scan.hs
+++ b/src/App/VPSScan/Scan.hs
@@ -13,6 +13,7 @@ import System.Exit (exitFailure, die)
 
 import Network.HTTP.Req (HttpException)
 
+import App.VPSScan.Types
 import App.VPSScan.Scan.RunSherlock
 import App.VPSScan.Scan.ScotlandYard
 import App.VPSScan.Scan.RunIPR
@@ -20,12 +21,6 @@ import App.VPSScan.Scan.RunIPR
 data ScanCmdOpts = ScanCmdOpts
   { cmdBasedir :: FilePath
   , scanVpsOpts :: VPSOpts
-  } deriving (Eq, Ord, Show, Generic)
-
-data VPSOpts = VPSOpts
-  { vpsSherlock :: SherlockOpts
-  , vpsIpr :: IPROpts
-  , vpsScotlandYard :: ScotlandYardOpts
   } deriving (Eq, Ord, Show, Generic)
 
 scanMain :: ScanCmdOpts -> IO ()
@@ -55,8 +50,8 @@ vpsScan ::
   , Has Trace sig m
   ) => Path Abs Dir -> ScanCmdOpts -> m ()
 vpsScan basedir ScanCmdOpts{..} = do
-  let VPSOpts{..} = scanVpsOpts
-  response <- tagError Couldn'tGetScanId =<< createScotlandYardScan vpsScotlandYard
+  let vpsOpts@VPSOpts{..} = scanVpsOpts
+  response <- tagError Couldn'tGetScanId =<< createScotlandYardScan vpsScotlandYard vpsOpts
 
   trace $ "Running scan on directory " ++ show basedir
   let scanId = responseScanId response
@@ -64,9 +59,9 @@ vpsScan basedir ScanCmdOpts{..} = do
   trace "Starting IPR scan"
   iprResult <- tagError IPRFailed =<< execIPR basedir vpsIpr
   trace "IPR scan completed. Posting results to Scotland Yard"
-  tagError Couldn'tUpload =<< uploadIPRResults vpsScotlandYard scanId iprResult
+  tagError Couldn'tUpload =<< uploadIPRResults vpsScotlandYard vpsOpts scanId iprResult
   trace "Running Sherlock scan"
-  tagError SherlockFailed =<< execSherlock basedir scanId vpsSherlock
+  tagError SherlockFailed =<< execSherlock basedir scanId vpsSherlock vpsOpts
   trace "Scan complete"
 
 tagError :: Has (Error e') sig m => (e -> e') -> Either e a -> m a

--- a/src/App/VPSScan/Scan/RunSherlock.hs
+++ b/src/App/VPSScan/Scan/RunSherlock.hs
@@ -16,7 +16,7 @@ data SherlockOpts = SherlockOpts
   , sherlockUrl :: String
   , sherlockClientToken :: String
   , sherlockClientID :: String
-  , organizationID :: Text
+  , organizationID :: Int
   , projectID :: Text
   , revisionID :: Text
   } deriving (Eq, Ord, Show, Generic)
@@ -26,9 +26,9 @@ sherlockCmdArgs scanId SherlockOpts{..} = [ "--scan-id", scanId
                                           , "--sherlock-api-secret-key", sherlockClientToken
                                           , "--sherlock-api-client-id", sherlockClientID
                                           , "--sherlock-api-host", sherlockUrl
-                                          , "--organization-id", T.unpack organizationID
-                                          , "--project-id", T.unpack projectID
-                                          , "--revision-id", T.unpack revisionID
+                                          , "--organization-id", show organizationID
+                                          , "--project-id",  T.unpack projectID
+                                          , "--revision-id",  T.unpack revisionID
                                           ]
 
 ----- sherlock effect

--- a/src/App/VPSScan/Scan/RunSherlock.hs
+++ b/src/App/VPSScan/Scan/RunSherlock.hs
@@ -1,6 +1,5 @@
 module App.VPSScan.Scan.RunSherlock
-  ( SherlockOpts(..)
-  , Sherlock(..)
+  ( Sherlock(..)
   , SherlockC(..)
   , SherlockError(..)
   , execSherlock
@@ -10,19 +9,10 @@ import Prologue
 import Control.Carrier.Error.Either
 import Effect.Exec
 import qualified Data.Text as T
+import App.VPSScan.Types
 
-data SherlockOpts = SherlockOpts
-  { sherlockCmdPath :: String
-  , sherlockUrl :: String
-  , sherlockClientToken :: String
-  , sherlockClientID :: String
-  , organizationID :: Int
-  , projectID :: Text
-  , revisionID :: Text
-  } deriving (Eq, Ord, Show, Generic)
-
-sherlockCmdArgs :: String -> SherlockOpts -> [String]
-sherlockCmdArgs scanId SherlockOpts{..} = [ "--scan-id", scanId
+sherlockCmdArgs :: String -> SherlockOpts ->  VPSOpts -> [String]
+sherlockCmdArgs scanId SherlockOpts{..} VPSOpts{..} = [ "--scan-id", scanId
                                           , "--sherlock-api-secret-key", sherlockClientToken
                                           , "--sherlock-api-client-id", sherlockClientID
                                           , "--sherlock-api-host", sherlockUrl
@@ -38,11 +28,11 @@ data SherlockError
   deriving (Eq, Ord, Show, Generic)
 
 data Sherlock m k
-  = ExecSherlock (Path Abs Dir) Text SherlockOpts (Either SherlockError () -> m k)
+  = ExecSherlock (Path Abs Dir) Text SherlockOpts VPSOpts (Either SherlockError () -> m k)
   deriving Generic1
 
-execSherlock :: Has Sherlock sig m => Path Abs Dir -> Text -> SherlockOpts -> m (Either SherlockError ())
-execSherlock basedir scanId opts = send (ExecSherlock basedir scanId opts pure)
+execSherlock :: Has Sherlock sig m => Path Abs Dir -> Text -> SherlockOpts -> VPSOpts -> m (Either SherlockError ())
+execSherlock basedir scanId sYopts vpsOpts = send (ExecSherlock basedir scanId sYopts vpsOpts pure)
 
 instance HFunctor Sherlock
 instance Effect Sherlock
@@ -54,10 +44,10 @@ newtype SherlockC m a = SherlockC { runSherlock :: m a }
 
 instance (Algebra sig m, MonadIO m, Effect sig) => Algebra (Sherlock :+: sig) (SherlockC m) where
   alg (R other) = SherlockC (alg (handleCoercible other))
-  alg (L (ExecSherlock basedir scanId opts@SherlockOpts{..} k)) = (k =<<) . SherlockC $ do
+  alg (L (ExecSherlock basedir scanId sYopts@SherlockOpts{..} vpsOpts@VPSOpts{..} k)) = (k =<<) . SherlockC $ do
     let sherlockCommand :: Command
         sherlockCommand = Command [sherlockCmdPath] ["scan", toFilePath basedir] Never
-    result <- runExecIO $ exec basedir sherlockCommand $ sherlockCmdArgs (T.unpack scanId) opts
+    result <- runExecIO $ exec basedir sherlockCommand $ sherlockCmdArgs (T.unpack scanId) sYopts vpsOpts
     case result of
       Left err -> pure (Left (SherlockCommandFailed (T.pack (show err))))
       Right _ -> pure (Right ())

--- a/src/App/VPSScan/Scan/ScotlandYard.hs
+++ b/src/App/VPSScan/Scan/ScotlandYard.hs
@@ -20,7 +20,7 @@ import Network.HTTP.Req
 data ScotlandYardOpts = ScotlandYardOpts
   { scotlandYardUrl :: Url 'Https
   , scotlandYardPort :: Int
-  , organizationID :: Text
+  , organizationID :: Int
   , projectID :: Text
   , revisionID :: Text
   } deriving (Eq, Ord, Show, Generic)
@@ -52,8 +52,8 @@ instance FromJSON ScanResponse where
 
 createScan :: ScotlandYardOpts -> HTTP ScanResponse
 createScan ScotlandYardOpts{..} = do
-  let body = object ["organizationId" .= organizationID, "revisionId" .= revisionID]
-  resp <- req POST (createScanEndpoint scotlandYardUrl projectID) (ReqBodyJson body) jsonResponse $ port scotlandYardPort
+  let body = object ["organizationId" .= organizationID, "revisionId" .= revisionID, "projectId" .= projectID]
+  resp <- req POST (createScanEndpoint scotlandYardUrl projectID) (ReqBodyJson body) jsonResponse (port scotlandYardPort <> header "Content-Type" "application/json")
   pure (responseBody resp)
 
 -- Given the results from a run of IPR, a scan ID and a URL for Scotland Yard,

--- a/src/App/VPSScan/Scan/ScotlandYard.hs
+++ b/src/App/VPSScan/Scan/ScotlandYard.hs
@@ -1,7 +1,6 @@
 module App.VPSScan.Scan.ScotlandYard
   ( createScan
   , postIprResults
-  , ScotlandYardOpts(..)
   , HTTP(..)
   , runHTTP
   , ScanResponse(..)
@@ -16,14 +15,7 @@ import Prologue
 import Control.Algebra
 import Control.Carrier.Error.Either
 import Network.HTTP.Req
-
-data ScotlandYardOpts = ScotlandYardOpts
-  { scotlandYardUrl :: Url 'Https
-  , scotlandYardPort :: Int
-  , organizationID :: Int
-  , projectID :: Text
-  , revisionID :: Text
-  } deriving (Eq, Ord, Show, Generic)
+import App.VPSScan.Types
 
 newtype HTTP a = HTTP { unHTTP :: ErrorC HttpException IO a }
   deriving (Functor, Applicative, Monad, MonadIO)
@@ -50,35 +42,35 @@ instance FromJSON ScanResponse where
   parseJSON = withObject "ScanResponse" $ \obj ->
     ScanResponse <$> obj .: "scanId"
 
-createScan :: ScotlandYardOpts -> HTTP ScanResponse
-createScan ScotlandYardOpts{..} = do
+createScan :: ScotlandYardOpts -> VPSOpts -> HTTP ScanResponse
+createScan ScotlandYardOpts{..} VPSOpts{..} = do
   let body = object ["organizationId" .= organizationID, "revisionId" .= revisionID, "projectId" .= projectID]
   resp <- req POST (createScanEndpoint scotlandYardUrl projectID) (ReqBodyJson body) jsonResponse (port scotlandYardPort <> header "Content-Type" "application/json")
   pure (responseBody resp)
 
 -- Given the results from a run of IPR, a scan ID and a URL for Scotland Yard,
--- post the IRP result to the "Upload Scan Data" endpoint on Scotland Yard
+-- post the IPR result to the "Upload Scan Data" endpoint on Scotland Yard
 -- POST /scans/{scanID}/discovered_licenses
-postIprResults :: ToJSON a => ScotlandYardOpts -> Text -> a -> HTTP ()
-postIprResults ScotlandYardOpts{..} scanId value = do
+postIprResults :: ToJSON a => ScotlandYardOpts -> VPSOpts -> Text -> a -> HTTP ()
+postIprResults ScotlandYardOpts{..} VPSOpts{..} scanId value = do
   _ <- req POST (scanDataEndpoint scotlandYardUrl projectID scanId) (ReqBodyJson value) ignoreResponse $ port scotlandYardPort
   pure ()
 
 ----- scotland yard effect
 
 data ScotlandYard m k
-  = CreateScotlandYardScan ScotlandYardOpts (Either HttpException ScanResponse -> m k) -- TODO: add Scotland yard error type
-  | UploadIPRResults ScotlandYardOpts Text Array (Either HttpException () -> m k) -- TODO: add scotland yard error type
+  = CreateScotlandYardScan ScotlandYardOpts VPSOpts (Either HttpException ScanResponse -> m k) -- TODO: add Scotland yard error type
+  | UploadIPRResults ScotlandYardOpts VPSOpts Text Array (Either HttpException () -> m k) -- TODO: add scotland yard error type
   deriving Generic1
 
 instance HFunctor ScotlandYard
 instance Effect ScotlandYard
 
-createScotlandYardScan :: Has ScotlandYard sig m => ScotlandYardOpts -> m (Either HttpException ScanResponse)
-createScotlandYardScan opts = send (CreateScotlandYardScan opts pure)
+createScotlandYardScan :: Has ScotlandYard sig m => ScotlandYardOpts -> VPSOpts -> m (Either HttpException ScanResponse)
+createScotlandYardScan sYopts vpsOpts = send (CreateScotlandYardScan sYopts vpsOpts pure)
 
-uploadIPRResults :: Has ScotlandYard sig m => ScotlandYardOpts -> Text -> Array -> m (Either HttpException ())
-uploadIPRResults opts scanId value = send (UploadIPRResults opts scanId value pure)
+uploadIPRResults :: Has ScotlandYard sig m => ScotlandYardOpts -> VPSOpts -> Text -> Array -> m (Either HttpException ())
+uploadIPRResults sYopts vpsOpts scanId value = send (UploadIPRResults sYopts vpsOpts scanId value pure)
 
 ----- scotland yard production interpreter
 
@@ -87,5 +79,5 @@ newtype ScotlandYardC m a = ScotlandYardC { runScotlandYard :: m a }
 
 instance (Algebra sig m, MonadIO m) => Algebra (ScotlandYard :+: sig) (ScotlandYardC m) where
   alg (R other) = ScotlandYardC (alg (handleCoercible other))
-  alg (L (CreateScotlandYardScan scotlandYardOpts k)) = (k =<<) . ScotlandYardC $ runHTTP $ createScan scotlandYardOpts
-  alg (L (UploadIPRResults scotlandYardOpts scanId value k)) = (k =<<) . ScotlandYardC $ runHTTP $ postIprResults scotlandYardOpts scanId value
+  alg (L (CreateScotlandYardScan scotlandYardOpts vpsOpts k)) = (k =<<) . ScotlandYardC $ runHTTP $ createScan scotlandYardOpts vpsOpts
+  alg (L (UploadIPRResults scotlandYardOpts vpsOpts scanId value k)) = (k =<<) . ScotlandYardC $ runHTTP $ postIprResults scotlandYardOpts vpsOpts scanId value

--- a/src/App/VPSScan/Types.hs
+++ b/src/App/VPSScan/Types.hs
@@ -1,0 +1,30 @@
+module App.VPSScan.Types
+(VPSOpts(..),
+SherlockOpts(..),
+ScotlandYardOpts(..))
+where
+
+import Prologue
+import Network.HTTP.Req
+import qualified App.VPSScan.Scan.RunIPR as RunIPR
+
+data ScotlandYardOpts = ScotlandYardOpts
+  { scotlandYardUrl :: Url 'Https
+  , scotlandYardPort :: Int
+  } deriving (Eq, Ord, Show, Generic)
+
+data SherlockOpts = SherlockOpts
+  { sherlockCmdPath :: String
+  , sherlockUrl :: String
+  , sherlockClientToken :: String
+  , sherlockClientID :: String
+  } deriving (Eq, Ord, Show, Generic)
+
+data VPSOpts = VPSOpts
+  { vpsSherlock :: SherlockOpts
+  , vpsIpr :: RunIPR.IPROpts
+  , vpsScotlandYard :: ScotlandYardOpts
+  , organizationID :: Int
+  , projectID :: Text
+  , revisionID :: Text
+  } deriving (Eq, Ord, Show, Generic)


### PR DESCRIPTION
Fixing various misses encountered while integrating with Scotland Yard and Sherlock.

- Sherlock requires organization ID, project ID and revision ID too, so move those up into the `VPSOpts` structure 
- organization ID must be an integer so that it gets passed as one when POSTing JSON
- we need to set the `Content-Type=application/json` header when POSTing to Scotland Yard