### PR TITLE
Extend the urlOption option parser to pass along the port and other options

### DIFF
--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -23,7 +23,6 @@ import Data.Text.Prettyprint.Doc.Render.Terminal
 import Effect.Exec (ExecErr(..))
 import Effect.Logger
 import Effect.ReadFS (ReadFSErr(..))
-import Network.HTTP.Req
 import qualified Srclib.Converter as Srclib
 import qualified Strategy.Carthage as Carthage
 import qualified Strategy.Cocoapods.Podfile as Podfile
@@ -51,11 +50,12 @@ import qualified Strategy.Python.SetupPy as SetupPy
 import qualified Strategy.Ruby.BundleShow as BundleShow
 import qualified Strategy.Ruby.GemfileLock as GemfileLock
 import Types
+import OptionExtensions
 
 data ScanDestination
-  = UploadScan (Url 'Https) Text ProjectMetadata -- ^ upload to fossa with provided api key and base url
+  = UploadScan UrlOption Text ProjectMetadata -- ^ upload to fossa with provided api key and base url
   | OutputStdout
-  deriving (Eq, Ord, Show, Generic)
+  deriving (Generic)
  
 analyzeMain :: Severity -> ScanDestination -> Maybe Text -> Maybe Text -> IO ()
 analyzeMain logSeverity destination name revision = do

--- a/src/App/Fossa/FossaAPIV1.hs
+++ b/src/App/Fossa/FossaAPIV1.hs
@@ -110,7 +110,7 @@ uploadAnalysis baseurl key ProjectRevision{..} metadata projects = do
   pure (responseBody resp)
 
 mkMetadataOpts :: ProjectMetadata -> Option scheme
-mkMetadataOpts ProjectMetadata{..} = mconcat $ catMaybes $
+mkMetadataOpts ProjectMetadata{..} = mconcat $ catMaybes 
   [ ("branch" =:) <$> projectBranch
   , ("projectURL" =:) <$> projectUrl
   , ("jiraProjectKey" =:) <$> projectJiraKey

--- a/src/App/Fossa/FossaAPIV1.hs
+++ b/src/App/Fossa/FossaAPIV1.hs
@@ -33,6 +33,7 @@ import Prologue
 import Srclib.Converter (toSourceUnit)
 import Srclib.Types
 import Data.Maybe (catMaybes)
+import OptionExtensions
 
 newtype FossaReq a = FossaReq { unFossaReq :: ErrorC FossaError IO a }
   deriving (Functor, Applicative, Monad, MonadIO)
@@ -90,7 +91,7 @@ data ProjectMetadata = ProjectMetadata
   } deriving (Eq, Ord, Show, Generic)
 
 uploadAnalysis
-  :: Url 'Https -- ^ base url
+  :: UrlOption -- ^ base url
   -> Text -- ^ api key
   -> ProjectRevision
   -> ProjectMetadata
@@ -105,7 +106,7 @@ uploadAnalysis baseurl key ProjectRevision{..} metadata projects = do
           <> "title" =: fromMaybe projectName (projectTitle metadata)
           <> header "Authorization" ("token " <> encodeUtf8 key)
           <> mkMetadataOpts metadata
-  resp <- req POST (uploadUrl baseurl) (ReqBodyJson sourceUnits) jsonResponse opts
+  resp <- req POST (uploadUrl $ urlOptionUrl baseurl) (ReqBodyJson sourceUnits) jsonResponse opts
   pure (responseBody resp)
 
 mkMetadataOpts :: ProjectMetadata -> Option scheme

--- a/src/App/Fossa/Main.hs
+++ b/src/App/Fossa/Main.hs
@@ -63,7 +63,7 @@ opts =
     <**> helper
     where
       baseUrl = https "app.fossa.com"
-      urlOpts = UrlOption baseUrl $ mempty
+      urlOpts = UrlOption baseUrl mempty
 
 comm :: Parser Command
 comm = hsubparser

--- a/src/App/Fossa/Test.hs
+++ b/src/App/Fossa/Test.hs
@@ -19,12 +19,13 @@ import Network.HTTP.Req
 import Path.IO
 import System.IO (stderr)
 import System.Exit (exitSuccess, exitFailure)
+import OptionExtensions
 
 pollDelaySeconds :: Int
 pollDelaySeconds = 8
 
 testMain
-  :: Url 'Https -- ^ api base url
+  :: UrlOption -- ^ api base url
   -> Text -- ^ api key
   -> Severity
   -> Int -- ^ timeout (seconds)
@@ -47,10 +48,10 @@ testMain baseurl apiKey logSeverity timeoutSeconds overrideName overrideRevision
 
       logSticky "[ Waiting for build completion... ]"
 
-      waitForBuild baseurl apiKey revision
+      waitForBuild (urlOptionUrl baseurl) apiKey revision
 
       logSticky "[ Waiting for issue scan completion... ]"
-      issues <- waitForIssues baseurl apiKey revision
+      issues <- waitForIssues (urlOptionUrl baseurl) apiKey revision
       logSticky ""
 
       if null (Fossa.issuesIssues issues)

--- a/src/App/Fossa/Test.hs
+++ b/src/App/Fossa/Test.hs
@@ -15,7 +15,6 @@ import qualified Data.Map as M
 import qualified Data.Text as T
 import Data.Text.IO (hPutStrLn)
 import Effect.Logger
-import Network.HTTP.Req
 import Path.IO
 import System.IO (stderr)
 import System.Exit (exitSuccess, exitFailure)
@@ -48,10 +47,10 @@ testMain baseurl apiKey logSeverity timeoutSeconds overrideName overrideRevision
 
       logSticky "[ Waiting for build completion... ]"
 
-      waitForBuild (urlOptionUrl baseurl) apiKey revision
+      waitForBuild baseurl apiKey revision
 
       logSticky "[ Waiting for issue scan completion... ]"
-      issues <- waitForIssues (urlOptionUrl baseurl) apiKey revision
+      issues <- waitForIssues baseurl apiKey revision
       logSticky ""
 
       if null (Fossa.issuesIssues issues)
@@ -134,7 +133,7 @@ renderTestError TestBuildFailed = "The build failed. Check the FOSSA webapp for 
 
 waitForBuild
   :: (Has (Error TestError) sig m, MonadIO m, Has Logger sig m)
-  => Url 'Https
+  => UrlOption
   -> Text -- ^ api key
   -> Fossa.ProjectRevision
   -> m ()
@@ -153,7 +152,7 @@ waitForBuild baseurl key revision = do
 
 waitForIssues
   :: (Has (Error TestError) sig m, MonadIO m, Has Logger sig m)
-  => Url 'Https
+  => UrlOption
   -> Text -- ^ api key
   -> Fossa.ProjectRevision
   -> m Fossa.Issues

--- a/src/App/VPSScan/Main.hs
+++ b/src/App/VPSScan/Main.hs
@@ -54,10 +54,8 @@ runIPROpts = RunIPR.IPROpts
 syOpts :: Parser ScotlandYardOpts
 syOpts = ScotlandYardOpts
                      <$> scotlandYardUrlOpt
-                     <*> scotlandYardPort
                   where
                     scotlandYardUrlOpt = urlOption (long "scotland-yard-url" <> metavar "STRING" <> help "URL for Scotland Yard service")
-                    scotlandYardPort = option auto (long "scotland-yard-port" <> metavar "Port" <> help "Port for Scotland yard service" <> value 8675)
 
 scanCommand :: Mod CommandFields (IO ())
 scanCommand = command "scan" (info (scanMain <$> scanOptsParser) (progDesc "Scan for projects and their dependencies"))

--- a/src/App/VPSScan/Scan.hs
+++ b/src/App/VPSScan/Scan.hs
@@ -21,7 +21,7 @@ import App.VPSScan.Scan.RunIPR
 data ScanCmdOpts = ScanCmdOpts
   { cmdBasedir :: FilePath
   , scanVpsOpts :: VPSOpts
-  } deriving (Eq, Ord, Show, Generic)
+  } 
 
 scanMain :: ScanCmdOpts -> IO ()
 scanMain opts@ScanCmdOpts{..} = do

--- a/src/App/VPSScan/Scan.hs
+++ b/src/App/VPSScan/Scan.hs
@@ -21,7 +21,7 @@ import App.VPSScan.Scan.RunIPR
 data ScanCmdOpts = ScanCmdOpts
   { cmdBasedir :: FilePath
   , scanVpsOpts :: VPSOpts
-  }
+  } deriving Generic
 
 scanMain :: ScanCmdOpts -> IO ()
 scanMain opts@ScanCmdOpts{..} = do

--- a/src/App/VPSScan/Scan.hs
+++ b/src/App/VPSScan/Scan.hs
@@ -21,7 +21,7 @@ import App.VPSScan.Scan.RunIPR
 data ScanCmdOpts = ScanCmdOpts
   { cmdBasedir :: FilePath
   , scanVpsOpts :: VPSOpts
-  } 
+  }
 
 scanMain :: ScanCmdOpts -> IO ()
 scanMain opts@ScanCmdOpts{..} = do

--- a/src/App/VPSScan/Scan/ScotlandYard.hs
+++ b/src/App/VPSScan/Scan/ScotlandYard.hs
@@ -16,6 +16,7 @@ import Control.Algebra
 import Control.Carrier.Error.Either
 import Network.HTTP.Req
 import App.VPSScan.Types
+import OptionExtensions (UrlOption(..))
 
 newtype HTTP a = HTTP { unHTTP :: ErrorC HttpException IO a }
   deriving (Functor, Applicative, Monad, MonadIO)
@@ -46,7 +47,7 @@ createScan :: VPSOpts -> HTTP ScanResponse
 createScan VPSOpts{..} = do
   let body = object ["organizationId" .= organizationID, "revisionId" .= revisionID, "projectId" .= projectID]
       ScotlandYardOpts{..} = vpsScotlandYard
-  resp <- req POST (createScanEndpoint scotlandYardUrl projectID) (ReqBodyJson body) jsonResponse (port scotlandYardPort <> header "Content-Type" "application/json")
+  resp <- req POST (createScanEndpoint (urlOptionUrl scotlandYardUrl) projectID) (ReqBodyJson body) jsonResponse (urlOptionOptions scotlandYardUrl <> header "Content-Type" "application/json")
   pure (responseBody resp)
 
 -- Given the results from a run of IPR, a scan ID and a URL for Scotland Yard,
@@ -55,7 +56,7 @@ createScan VPSOpts{..} = do
 postIprResults :: ToJSON a => VPSOpts -> Text -> a -> HTTP ()
 postIprResults VPSOpts{..} scanId value = do
   let ScotlandYardOpts{..} = vpsScotlandYard
-  _ <- req POST (scanDataEndpoint scotlandYardUrl projectID scanId) (ReqBodyJson value) ignoreResponse $ (port scotlandYardPort <> header "Content-Type" "application/json")
+  _ <- req POST (scanDataEndpoint (urlOptionUrl scotlandYardUrl) projectID scanId) (ReqBodyJson value) ignoreResponse $ (urlOptionOptions scotlandYardUrl <> header "Content-Type" "application/json")
   pure ()
 
 ----- scotland yard effect

--- a/src/App/VPSScan/Scan/ScotlandYard.hs
+++ b/src/App/VPSScan/Scan/ScotlandYard.hs
@@ -56,7 +56,7 @@ createScan VPSOpts{..} = do
 postIprResults :: ToJSON a => VPSOpts -> Text -> a -> HTTP ()
 postIprResults VPSOpts{..} scanId value = do
   let ScotlandYardOpts{..} = vpsScotlandYard
-  _ <- req POST (scanDataEndpoint (urlOptionUrl scotlandYardUrl) projectID scanId) (ReqBodyJson value) ignoreResponse $ (urlOptionOptions scotlandYardUrl <> header "Content-Type" "application/json")
+  _ <- req POST (scanDataEndpoint (urlOptionUrl scotlandYardUrl) projectID scanId) (ReqBodyJson value) ignoreResponse (urlOptionOptions scotlandYardUrl <> header "Content-Type" "application/json")
   pure ()
 
 ----- scotland yard effect

--- a/src/App/VPSScan/Types.hs
+++ b/src/App/VPSScan/Types.hs
@@ -9,7 +9,7 @@ import qualified App.VPSScan.Scan.RunIPR as RunIPR
 import OptionExtensions (UrlOption)
 
 data ScotlandYardOpts = ScotlandYardOpts
-  { scotlandYardUrl :: UrlOption }
+  { scotlandYardUrl :: UrlOption } deriving Generic
 
 data SherlockOpts = SherlockOpts
   { sherlockCmdPath :: String
@@ -25,4 +25,4 @@ data VPSOpts = VPSOpts
   , organizationID :: Int
   , projectID :: Text
   , revisionID :: Text
-  }
+  } deriving Generic

--- a/src/App/VPSScan/Types.hs
+++ b/src/App/VPSScan/Types.hs
@@ -5,13 +5,11 @@ ScotlandYardOpts(..))
 where
 
 import Prologue
-import Network.HTTP.Req
 import qualified App.VPSScan.Scan.RunIPR as RunIPR
+import OptionExtensions (UrlOption)
 
 data ScotlandYardOpts = ScotlandYardOpts
-  { scotlandYardUrl :: Url 'Https
-  , scotlandYardPort :: Int
-  } deriving (Eq, Ord, Show, Generic)
+  { scotlandYardUrl :: UrlOption } 
 
 data SherlockOpts = SherlockOpts
   { sherlockCmdPath :: String
@@ -27,4 +25,4 @@ data VPSOpts = VPSOpts
   , organizationID :: Int
   , projectID :: Text
   , revisionID :: Text
-  } deriving (Eq, Ord, Show, Generic)
+  } 

--- a/src/App/VPSScan/Types.hs
+++ b/src/App/VPSScan/Types.hs
@@ -9,7 +9,7 @@ import qualified App.VPSScan.Scan.RunIPR as RunIPR
 import OptionExtensions (UrlOption)
 
 data ScotlandYardOpts = ScotlandYardOpts
-  { scotlandYardUrl :: UrlOption } 
+  { scotlandYardUrl :: UrlOption }
 
 data SherlockOpts = SherlockOpts
   { sherlockCmdPath :: String
@@ -25,4 +25,4 @@ data VPSOpts = VPSOpts
   , organizationID :: Int
   , projectID :: Text
   , revisionID :: Text
-  } 
+  }

--- a/src/OptionExtensions.hs
+++ b/src/OptionExtensions.hs
@@ -1,18 +1,24 @@
 module OptionExtensions
-  (urlOption)
+  (urlOption, UrlOption(..))
 where
 
 import Prologue
 import Options.Applicative
 import qualified Data.Text as T
-import Network.HTTP.Req (Url, useURI)
+import Network.HTTP.Req --(Url, Option, useURI)
 import Text.URI (mkURI)
 
-urlOption :: Mod OptionFields (Url scheme) -> Parser (Url scheme)
+data UrlOption = UrlOption  
+  { urlOptionUrl :: Url 'Https
+  , urlOptionOptions :: Option 'Https
+  } 
+  -- deriving (Eq, Ord, Show, Generic)
+
+urlOption :: Mod OptionFields UrlOption -> Parser UrlOption
 urlOption = option parseUrl
   where
-    parseUrl :: ReadM (Url scheme)
+    parseUrl :: ReadM UrlOption
     parseUrl = maybeReader (\s -> mkURI (T.pack s) >>= useURI >>=
                               \case
-                                 Left (url,_) -> pure $ coerce url
-                                 Right (url,_) -> pure $ coerce url)
+                                 Left (url, opts) -> pure (UrlOption (coerce url) opts)
+                                 Right (url, opts) -> pure (UrlOption (coerce url) opts))

--- a/src/OptionExtensions.hs
+++ b/src/OptionExtensions.hs
@@ -5,7 +5,7 @@ where
 import Prologue
 import Options.Applicative
 import qualified Data.Text as T
-import Network.HTTP.Req
+import Network.HTTP.Req (Url, useURI, Scheme( Https ), Option)
 import Text.URI (mkURI)
 
 data UrlOption = UrlOption

--- a/src/OptionExtensions.hs
+++ b/src/OptionExtensions.hs
@@ -8,10 +8,10 @@ import qualified Data.Text as T
 import Network.HTTP.Req --(Url, Option, useURI)
 import Text.URI (mkURI)
 
-data UrlOption = UrlOption  
+data UrlOption = UrlOption
   { urlOptionUrl :: Url 'Https
   , urlOptionOptions :: Option 'Https
-  } 
+  }
   -- deriving (Eq, Ord, Show, Generic)
 
 urlOption :: Mod OptionFields UrlOption -> Parser UrlOption

--- a/src/OptionExtensions.hs
+++ b/src/OptionExtensions.hs
@@ -5,14 +5,14 @@ where
 import Prologue
 import Options.Applicative
 import qualified Data.Text as T
-import Network.HTTP.Req --(Url, Option, useURI)
+import Network.HTTP.Req
 import Text.URI (mkURI)
 
 data UrlOption = UrlOption
   { urlOptionUrl :: Url 'Https
   , urlOptionOptions :: Option 'Https
   }
-  -- deriving (Eq, Ord, Show, Generic)
+  deriving Generic
 
 urlOption :: Mod OptionFields UrlOption -> Parser UrlOption
 urlOption = option parseUrl


### PR DESCRIPTION
Before, if you passed in a URL like `http://localhost:8080` as a command line arg, the port was ignored. Now it is not.

This required changing the `urlOption` option parser to return both the URL and the URL options, so a new data type called `UrlOption` was used for this.

One unfortunate side-effect of this is that `UrlOption` has a `Network.HTTP.Req.Option` as one of its members, and `Option` does not implement the `Eq`, `Ord` or `Show` classes. This flows through to a bunch of the data types. It doesn't seem to cause a problem here, and I'm not sure how I'd fix it if it was.