### PR TITLE
Fix argument parser

### DIFF
--- a/src/App/Fossa/Main.hs
+++ b/src/App/Fossa/Main.hs
@@ -19,7 +19,7 @@ import Network.HTTP.Req (https)
 
 appMain :: IO ()
 appMain = do
-  CmdOptions{..} <- customExecParser (prefs showHelpOnError) (info (opts <**> helper) (fullDesc <> header "fossa-cli - Flexible, performant dependency analysis"))
+  CmdOptions{..} <- customExecParser (prefs (showHelpOnError <> subparserInline)) (info (opts <**> helper) (fullDesc <> header "fossa-cli - Flexible, performant dependency analysis"))
   let logSeverity = bool SevInfo SevDebug optDebug
 
   maybeApiKey <- fmap T.pack <$> lookupEnv "FOSSA_API_KEY"


### PR DESCRIPTION
By default, subcommand parsers have awkward behavior wrt argument order. Global arguments can only be referenced after command-local arguments.

Specifically, things like `fossa analyze -d /path/to/dir --output` didn't work, but `fossa analyze --output -d /path/to/dir` did.