### PR TITLE
Update hie.yaml for multi-component support

### DIFF
--- a/hie.yaml
+++ b/hie.yaml
@@ -1,1 +1,8 @@
-cradle: {cabal: {component: "lib:spectrometer"}}
+cradle:
+  cabal:
+    - path: "."
+      component: "lib:spectrometer"
+    - path: "./src"
+      component: "lib:spectrometer"
+    - path: "./test"
+      component: "test:tests"


### PR DESCRIPTION
Now that haskell-language-server has an initial release, we can take advantage of its multi-component support.