### PR TITLE
Rust analyzer

### DIFF
--- a/docs/strategies/rust.md
+++ b/docs/strategies/rust.md
@@ -1,0 +1,319 @@
+# Rust Analysis
+
+The rust buildtool ecosystem is nearly exclusive to `cargo`, the package manager
+that ships with rust distributions.
+This table may grow as other tools appear, which is expected in the next 2-3 years.
+
+There are rare, but known cases of generic buildtools being used, like `make`,
+`cmake`, and `ninja`.  These should
+be ignored for a package management tool like spectrometer.
+
+| Strategy | Direct Deps | Deep Deps | Edges | Tags         |
+| ---      | ---         | ---       | ---   | ---          |
+| cargo    | ✅          | ✅        | ✅    | Environment? |
+
+## Project Discovery
+
+Find all files with a `Cargo.toml` file, where no direct or indirect parent also
+contains a `Cargo.toml` file.
+
+For example, given the following tree, we would only examine `root/Cargo.toml`.
+
+```
+root
+├── src1
+│   ├── subpackage
+│   │   ├── Cargo.toml
+│   │   └── ...
+│   └── main.rs
+├── src2
+│   ├── subpackage
+│   │   ├── Cargo.toml
+│   │   └── ...
+│   └── main.rs
+└── Cargo.toml
+```
+
+However, in the following tree, we examine `root/pkg1/Cargo.toml` and
+`root/pkg2/Cargo.toml`, since neither has a parent directory with a `Cargo.toml`
+file.
+
+```
+root
+├── pkg1
+│   ├── Cargo.toml
+│   └── main.rs
+└── pkg2
+    ├── Cargo.toml
+    └── main.rs
+```
+
+## Analysis
+
+First, we invoke `cargo generate-lockfile` to trigger the lockfile build.  This
+downloads the dependency graph info and almost nothing else.  Then, we read the
+output of the `cargo metadata --format-version 1` command (format version 1 is JSON,
+and is currently the only allowed formatting scheme).  This will arrange the data
+into a slightly simpler scheme.
+
+We can interrogate the JSON output for direct and deep dependency info, but it is
+non-trivial to do so.  For more info, see the metadata schema found
+[here](https://doc.rust-lang.org/cargo/commands/cargo-metadata.html)
+
+The analysis of the JSON is slightly complex, but is roughly as follows:
+
+* Check `.workspace_members` for a list of packages which represent the current
+package and any sub packages.  For now we'll call these *local crates*.
+* Examine `.resolve` (a flattened dependency graph), for each of the local crates to
+fetch the list of direct dependencies of that crate.  Call this a *dependency node*.
+* For each dependency node, we are able to retreive some info directly, like its
+version, whether it is platform-specific, what build category it's included in
+(build, dev, or standard), and what features it compiles with.  For any further
+information, we have to compare this package and version with the corresponding
+entry in `.packages`.
+
+## Schema
+
+```json
+{
+    /* Array of all packages in the workspace.
+       It also includes all feature-enabled dependencies unless --no-deps is used.
+    */
+    "packages": [
+        {
+            /* The name of the package. */
+            "name": "my-package",
+            /* The version of the package. */
+            "version": "0.1.0",
+            /* The Package ID, a unique identifier for referring to the package. */
+            "id": "my-package 0.1.0 (path+file:///path/to/my-package)",
+            /* The license value from the manifest, or null. */
+            "license": "MIT/Apache-2.0",
+            /* The license-file value from the manifest, or null. */
+            "license_file": "LICENSE",
+            /* The description value from the manifest, or null. */
+            "description": "Package description.",
+            /* The source ID of the package. This represents where
+               a package is retrieved from.
+               This is null for path dependencies and workspace members.
+               For other dependencies, it is a string with the format:
+               - "registry+URL" for registry-based dependencies.
+                 Example: "registry+https://github.com/rust-lang/crates.io-index"
+               - "git+URL" for git-based dependencies.
+                 Example: "git+https://github.com/rust-lang/cargo?rev=5e85ba14aaa20f8133863373404cb0af69eeef2c#5e85ba14aaa20f8133863373404cb0af69eeef2c"
+            */
+            "source": null,
+            /* Array of dependencies declared in the package's manifest. */
+            "dependencies": [
+                {
+                    /* The name of the dependency. */
+                    "name": "bitflags",
+                    /* The source ID of the dependency. May be null, see
+                       description for the package source.
+                    */
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    /* The version requirement for the dependency.
+                       Dependencies without a version requirement have a value of "*".
+                    */
+                    "req": "^1.0",
+                    /* The dependency kind.
+                       "dev", "build", or null for a normal dependency.
+                    */
+                    "kind": null,
+                    /* If the dependency is renamed, this is the new name for
+                       the dependency as a string.  null if it is not renamed.
+                    */
+                    "rename": null,
+                    /* Boolean of whether or not this is an optional dependency. */
+                    "optional": false,
+                    /* Boolean of whether or not default features are enabled. */
+                    "uses_default_features": true,
+                    /* Array of features enabled. */
+                    "features": [],
+                    /* The target platform for the dependency.
+                       null if not a target dependency.
+                    */
+                    "target": "cfg(windows)",
+                    /* A string of the URL of the registry this dependency is from.
+                       If not specified or null, the dependency is from the default
+                       registry (crates.io).
+                    */
+                    "registry": null
+                }
+            ],
+            /* Array of Cargo targets. */
+            "targets": [
+                {
+                    /* Array of target kinds.
+                       - lib targets list the `crate-type` values from the
+                         manifest such as "lib", "rlib", "dylib",
+                         "proc-macro", etc. (default ["lib"])
+                       - binary is ["bin"]
+                       - example is ["example"]
+                       - integration test is ["test"]
+                       - benchmark is ["bench"]
+                       - build script is ["custom-build"]
+                    */
+                    "kind": [
+                        "bin"
+                    ],
+                    /* Array of crate types.
+                       - lib and example libraries list the `crate-type` values
+                         from the manifest such as "lib", "rlib", "dylib",
+                         "proc-macro", etc. (default ["lib"])
+                       - all other target kinds are ["bin"]
+                    */
+                    "crate_types": [
+                        "bin"
+                    ],
+                    /* The name of the target. */
+                    "name": "my-package",
+                    /* Absolute path to the root source file of the target. */
+                    "src_path": "/path/to/my-package/src/main.rs",
+                    /* The Rust edition of the target.
+                       Defaults to the package edition.
+                    */
+                    "edition": "2018",
+                    /* Array of required features.
+                       This property is not included if no required features are set.
+                    */
+                    "required-features": ["feat1"],
+                    /* Whether or not this target has doc tests enabled, and
+                       the target is compatible with doc testing.
+                    */
+                    "doctest": false
+                }
+            ],
+            /* Set of features defined for the package.
+               Each feature maps to an array of features or dependencies it
+               enables.
+            */
+            "features": {
+                "default": [
+                    "feat1"
+                ],
+                "feat1": [],
+                "feat2": []
+            },
+            /* Absolute path to this package's manifest. */
+            "manifest_path": "/path/to/my-package/Cargo.toml",
+            /* Package metadata.
+               This is null if no metadata is specified.
+            */
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "all-features": true
+                    }
+                }
+            },
+            /* List of registries to which this package may be published.
+               Publishing is unrestricted if null, and forbidden if an empty array. */
+            "publish": [
+                "crates-io"
+            ],
+            /* Array of authors from the manifest.
+               Empty array if no authors specified.
+            */
+            "authors": [
+                "Jane Doe <user@example.com>"
+            ],
+            /* Array of categories from the manifest. */
+            "categories": [
+                "command-line-utilities"
+            ],
+            /* Array of keywords from the manifest. */
+            "keywords": [
+                "cli"
+            ],
+            /* The readme value from the manifest or null if not specified. */
+            "readme": "README.md",
+            /* The repository value from the manifest or null if not specified. */
+            "repository": "https://github.com/rust-lang/cargo",
+            /* The default edition of the package.
+               Note that individual targets may have different editions.
+            */
+            "edition": "2018",
+            /* Optional string that is the name of a native library the package
+               is linking to.
+            */
+            "links": null,
+        }
+    ],
+    /* Array of members of the workspace.
+       Each entry is the Package ID for the package.
+    */
+    "workspace_members": [
+        "my-package 0.1.0 (path+file:///path/to/my-package)",
+    ],
+    // The resolved dependency graph for the entire workspace. The enabled
+    // features are based on the enabled features for the "current" package.
+    // Inactivated optional dependencies are not listed.
+    //
+    // This is null if --no-deps is specified.
+    //
+    // By default, this includes all dependencies for all target platforms.
+    // The `--filter-platform` flag may be used to narrow to a specific
+    // target triple.
+    "resolve": {
+        /* Array of nodes within the dependency graph.
+           Each node is a package.
+        */
+        "nodes": [
+            {
+                /* The Package ID of this node. */
+                "id": "my-package 0.1.0 (path+file:///path/to/my-package)",
+                /* The dependencies of this package, an array of Package IDs. */
+                "dependencies": [
+                    "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                /* The dependencies of this package. This is an alternative to
+                   "dependencies" which contains additional information. In
+                   particular, this handles renamed dependencies.
+                */
+                "deps": [
+                    {
+                        /* The name of the dependency's library target.
+                           If this is a renamed dependency, this is the new
+                           name.
+                        */
+                        "name": "bitflags",
+                        /* The Package ID of the dependency. */
+                        "pkg": "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+                        /* Array of dependency kinds. Added in Cargo 1.40. */
+                        "dep_kinds": [
+                            {
+                                /* The dependency kind.
+                                   "dev", "build", or null for a normal dependency.
+                                */
+                                "kind": null,
+                                /* The target platform for the dependency.
+                                   null if not a target dependency.
+                                */
+                                "target": "cfg(windows)"
+                            }
+                        ]
+                    }
+                ],
+                /* Array of features enabled on this package. */
+                "features": [
+                    "default"
+                ]
+            }
+        ],
+        /* The root package of the workspace.
+           This is null if this is a virtual workspace. Otherwise it is
+           the Package ID of the root package.
+        */
+        "root": "my-package 0.1.0 (path+file:///path/to/my-package)"
+    },
+    /* The absolute path to the build directory where Cargo places its output. */
+    "target_directory": "/path/to/my-package/target",
+    /* The version of the schema for this metadata structure.
+       This will be changed if incompatible changes are ever made.
+    */
+    "version": 1,
+    /* The absolute path to the root of the workspace. */
+    "workspace_root": "/path/to/my-package"
+}
+```

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -126,6 +126,7 @@ library
     Prologue
     Srclib.Converter
     Srclib.Types
+    Strategy.Cargo
     Strategy.Carthage
     Strategy.Clojure
     Strategy.Cocoapods.Podfile

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -197,6 +197,7 @@ test-suite tests
 
   -- cabal-fmt: expand test
   other-modules:
+    Cargo.MetadataTest
     Carthage.CarthageTest
     Clojure.ClojureTest
     Cocoapods.PodfileLockTest

--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -23,6 +23,7 @@ import Effect.Exec (ExecErr(..))
 import Effect.Logger
 import Effect.ReadFS (ReadFSErr(..))
 import qualified Srclib.Converter as Srclib
+import qualified Strategy.Cargo as Cargo
 import qualified Strategy.Carthage as Carthage
 import qualified Strategy.Clojure as Clojure
 import qualified Strategy.Cocoapods.Podfile as Podfile
@@ -203,6 +204,8 @@ discoverFuncs =
   , PodfileLock.discover
 
   , Clojure.discover
+  
+  , Cargo.discover
   ]
 
 updateProgress :: Has Logger sig m => Progress -> m ()

--- a/src/DepTypes.hs
+++ b/src/DepTypes.hs
@@ -50,6 +50,7 @@ data DepType =
   | PipType    -- ^ Pip registry
   | PodType    -- ^ Cocoapods registry
   | GoType -- ^ Go dependency
+  | CargoType -- ^ Rust Cargo Dependency
   -- TODO: does this break the "location" abstraction?
   | CarthageType -- ^ A Carthage dependency -- effectively a "git" dependency. Name is repo path and version is tag/branch/hash
   deriving (Eq, Ord, Show, Generic)

--- a/src/Srclib/Converter.hs
+++ b/src/Srclib/Converter.hs
@@ -101,3 +101,4 @@ depTypeToFetcher = \case
   PodType -> "pod"
   GoType -> "go"
   CarthageType -> "cart"
+  CargoType -> "cargo"

--- a/src/Strategy/Cargo.hs
+++ b/src/Strategy/Cargo.hs
@@ -21,7 +21,7 @@ import qualified Data.Map.Strict as M
 import Discovery.Walk
 import Effect.Exec
 import Effect.Grapher
-import Graphing (Graphing)
+import Graphing (Graphing, stripRoot)
 import Types
 
 import qualified Data.Text as T
@@ -196,7 +196,7 @@ addEdge node = do
     edge parentId $ nodePkg dep
 
 buildGraph :: CargoMetadata -> Graphing Dependency
-buildGraph meta = run . withLabeling toDependency $ do
+buildGraph meta = stripRoot $ run . withLabeling toDependency $ do
   traverse_ direct $ metadataWorkspaceMembers meta
   traverse_ addEdge $ resolvedNodes $ metadataResolve meta
 

--- a/src/Strategy/Cargo.hs
+++ b/src/Strategy/Cargo.hs
@@ -174,8 +174,8 @@ kindToLabel :: Maybe T.Text -> CargoLabel
 kindToLabel (Just _) = CargoDepKind EnvDevelopment
 kindToLabel Nothing  = CargoDepKind EnvProduction
 
-addLabel_ :: Has (LabeledGrapher PackageId CargoLabel) sig m => NodeDependency -> m ()
-addLabel_ dep = do
+addLabel :: Has (LabeledGrapher PackageId CargoLabel) sig m => NodeDependency -> m ()
+addLabel dep = do
   let pkgId = nodePkg dep
   traverse_ (label pkgId . kindToLabel . nodeDepKind) $ nodeDepKinds dep
 
@@ -183,7 +183,7 @@ addEdge :: Has (LabeledGrapher PackageId CargoLabel) sig m => ResolveNode -> m (
 addEdge node = do
   let parentId = resolveNodeId node
   for_ (resolveNodeDeps node) $ \dep -> do
-    addLabel_ dep
+    addLabel dep
     edge parentId $ nodePkg dep
 
 buildGraph :: Has (LabeledGrapher PackageId CargoLabel) sig m => CargoMetadata -> m ()

--- a/src/Strategy/Cargo.hs
+++ b/src/Strategy/Cargo.hs
@@ -4,8 +4,6 @@ module Strategy.Cargo
   , CargoMetadata(..)
   , NodeDependency(..)
   , NodeDepKind(..)
-  -- , Package(..)
-  -- , PackageDependency(..)
   , PackageId(..)
   , Resolve(..)
   , ResolveNode(..)
@@ -26,9 +24,8 @@ import Types
 
 import qualified Data.Text as T
 
-data CargoLabel = 
-    CargoDepKind DepEnvironment
-  -- | CargoSource T.Text
+newtype CargoLabel = 
+  CargoDepKind DepEnvironment
   deriving (Eq, Ord, Show, Generic)
 
 data PackageId = PackageId
@@ -68,7 +65,7 @@ data ResolveNode = ResolveNode
   , resolveNodeDeps :: [NodeDependency]
   } deriving (Eq, Ord, Show, Generic)
 
-data Resolve = Resolve
+newtype Resolve = Resolve
   { resolvedNodes :: [ResolveNode] 
   } deriving (Eq, Ord, Show, Generic)
 

--- a/src/Strategy/Cargo.hs
+++ b/src/Strategy/Cargo.hs
@@ -1,6 +1,15 @@
 module Strategy.Cargo
   ( discover
-  , analyze
+  --
+  , CargoMetadata(..)
+  , NodeDependency(..)
+  , NodeDepKind(..)
+  -- , Package(..)
+  -- , PackageDependency(..)
+  , PackageId(..)
+  , Resolve(..)
+  , ResolveNode(..)
+  , buildGraph
   )
   where
 

--- a/src/Strategy/Cargo.hs
+++ b/src/Strategy/Cargo.hs
@@ -1,0 +1,198 @@
+module Strategy.Cargo
+  ( discover
+  , analyze
+  )
+  where
+
+import Prologue
+
+import Control.Effect.Error
+import Data.Aeson.Types
+import qualified Data.Map.Strict as M
+import Discovery.Walk
+import Effect.Exec
+import Effect.Grapher
+import Graphing (Graphing)
+import Types
+
+import qualified Data.Text as T
+
+data CargoLabel = 
+    CargoDepKind DepEnvironment
+  -- | CargoSource T.Text
+  deriving (Eq, Ord, Show, Generic)
+
+data PackageId = PackageId
+  { pkgIdName :: T.Text
+  , pkgIdVersion :: T.Text
+  , pkgIdSource :: T.Text
+  } deriving (Eq, Ord, Show, Generic)
+
+data PackageDependency = PackageDependency
+  { pkgDepName :: T.Text
+  , pkgDepSource :: T.Text
+  , pkgDepReq :: T.Text
+  , pkgDepKind :: Maybe T.Text
+  } deriving (Eq, Ord, Show, Generic)
+
+data Package = Package
+  { pkgName :: T.Text
+  , pkgVersion :: T.Text
+  , pkgId :: PackageId
+  , pkgLicense :: Maybe T.Text
+  , pkgLicenseFile :: Maybe T.Text
+  , pkgDependencies :: [PackageDependency]
+  } deriving (Eq, Ord, Show, Generic)
+
+data NodeDepKind = NodeDepKind
+  { nodeDepKind :: Maybe T.Text
+  , nodeDepTarget :: Maybe T.Text
+  } deriving (Eq, Ord, Show, Generic)
+
+data NodeDependency = NodeDependency
+  { nodePkg :: PackageId
+  , nodeDepKinds :: [NodeDepKind]
+  } deriving (Eq, Ord, Show, Generic)
+
+data ResolveNode = ResolveNode
+  { resolveNodeId :: PackageId
+  , resolveNodeDeps :: [NodeDependency]
+  } deriving (Eq, Ord, Show, Generic)
+
+data Resolve = Resolve
+  { resolvedNodes :: [ResolveNode] 
+  } deriving (Eq, Ord, Show, Generic)
+
+data CargoMetadata = CargoMetadata
+  { metadataPackages :: [Package]
+  , metadataWorkspaceMembers :: [PackageId]
+  , metadataResolve :: Resolve
+  } deriving (Eq, Ord, Show, Generic)
+
+instance FromJSON PackageDependency where
+  parseJSON = withObject "PackageDependency" $ \obj ->
+    PackageDependency <$> obj .: "name"
+                      <*> obj .: "source"
+                      <*> obj .: "req"
+                      <*> obj .:? "kind"
+
+instance FromJSON Package where
+  parseJSON = withObject "Package" $ \obj ->
+    Package <$> obj .: "name"
+            <*> obj .: "version"
+            <*> (obj .: "id" >>= parsePkgId)
+            <*> obj .:? "license"
+            <*> obj .:? "license_file"
+            <*> obj .: "dependencies"
+
+instance FromJSON NodeDepKind where
+  parseJSON = withObject "NodeDepKind" $ \obj ->
+    NodeDepKind <$> obj .:? "kind"
+                <*> obj .:? "target"
+
+instance FromJSON NodeDependency where
+  parseJSON = withObject "NodeDependency" $ \obj ->
+    NodeDependency <$> (obj .: "pkg" >>= parsePkgId)
+                   <*> obj .: "dep_kinds"
+
+instance FromJSON ResolveNode where
+  parseJSON = withObject "ResolveNode" $ \obj -> 
+    ResolveNode <$> (obj .: "id" >>= parsePkgId)
+                <*> obj .: "deps"
+
+instance FromJSON Resolve where
+  parseJSON = withObject "Resolve" $ \obj ->
+    Resolve <$> obj .: "nodes"
+
+instance FromJSON CargoMetadata where
+  parseJSON = withObject "CargoMetadata" $ \obj ->
+    CargoMetadata <$> obj .: "packages"
+                  <*> (obj .: "workspace_members" >>= traverse parsePkgId)
+                  <*> obj .: "resolve"
+
+discover :: HasDiscover sig m => Path Abs Dir -> m ()
+discover = walk $ \dir _ files ->
+  case find (\f -> fileName f == "Cargo.toml") files of
+    Nothing -> pure WalkContinue
+    Just file -> do
+      runSimpleStrategy "rust-cargo" RustGroup $ fmap (mkProjectClosure dir) (analyze file)
+      pure WalkSkipAll
+
+cargoGenLockfileCmd :: Command
+cargoGenLockfileCmd = Command
+  { cmdNames = ["cargo"]
+  , cmdBaseArgs = ["generate-lockfile"]
+  , cmdAllowErr = Never
+  }
+
+cargoMetadataCmd :: Command
+cargoMetadataCmd = Command
+  { cmdNames = ["cargo"]
+  , cmdBaseArgs = ["metadata"]
+  , cmdAllowErr = Never
+  }
+
+mkProjectClosure :: Path Rel Dir ->  Graphing Dependency -> ProjectClosureBody
+mkProjectClosure dir graph = ProjectClosureBody
+  { bodyModuleDir    = dir
+  , bodyDependencies = dependencies
+  , bodyLicenses     = []
+  }
+  where
+  dependencies = ProjectDependencies
+    { dependenciesGraph    = graph
+    , dependenciesOptimal  = Optimal
+    , dependenciesComplete = Complete
+    }
+
+analyze :: (Has Exec sig m, Has (Error ExecErr) sig m, Effect sig)
+  => Path Rel File -> m (Graphing Dependency)
+analyze manifest = do
+  _ <- execThrow (parent manifest) cargoGenLockfileCmd []
+  meta <- execJson @CargoMetadata (parent manifest) cargoMetadataCmd []
+  --
+  withLabeling toDependency $ buildGraph meta
+
+toDependency :: PackageId -> Set CargoLabel -> Dependency
+toDependency pkg = foldr applyLabel Dependency 
+  { dependencyType = CargoType 
+  , dependencyName = pkgIdName pkg
+  , dependencyVersion = Just $ CEq $ pkgIdVersion pkg
+  , dependencyLocations = []
+  , dependencyEnvironments = []
+  , dependencyTags = M.empty
+  }
+  where
+    applyLabel :: CargoLabel -> Dependency -> Dependency
+    applyLabel (CargoDepKind env) dep = dep { dependencyEnvironments = env : dependencyEnvironments dep }
+
+-- Possible values here are "build", "dev", and null.
+-- Null refers to productions, while dev and build refer to development-time dependencies
+-- Cargo does not differentiate test dependencies and dev dependencies,
+-- so we just simplify it to Development.
+kindToLabel :: Maybe T.Text -> CargoLabel
+kindToLabel (Just _) = CargoDepKind EnvDevelopment
+kindToLabel Nothing  = CargoDepKind EnvProduction
+
+addLabel_ :: Has (LabeledGrapher PackageId CargoLabel) sig m => NodeDependency -> m ()
+addLabel_ dep = do
+  let pkgId = nodePkg dep
+  traverse_ (label pkgId . kindToLabel . nodeDepKind) $ nodeDepKinds dep
+
+addEdge :: Has (LabeledGrapher PackageId CargoLabel) sig m => ResolveNode -> m ()
+addEdge node = do
+  let parentId = resolveNodeId node
+  for_ (resolveNodeDeps node) $ \dep -> do
+    addLabel_ dep
+    edge parentId $ nodePkg dep
+
+buildGraph :: Has (LabeledGrapher PackageId CargoLabel) sig m => CargoMetadata -> m ()
+buildGraph meta = do
+  traverse_ direct $ metadataWorkspaceMembers meta
+  traverse_ addEdge $ resolvedNodes $ metadataResolve meta
+
+parsePkgId :: T.Text -> Parser PackageId
+parsePkgId t = 
+  case T.splitOn " " t of
+    [a,b,c] -> pure $ PackageId a b c
+    _ -> fail "malformed Package ID"

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -146,6 +146,7 @@ data StrategyGroup =
   | RubyGroup
   | CocoapodsGroup
   | ClojureGroup
+  | RustGroup
   deriving (Eq, Ord, Show, Generic)
 
 -- FIXME: we also need to annotate dep graphs with Path Rel File -- merge these somehow?

--- a/test/Cargo/MetadataTest.hs
+++ b/test/Cargo/MetadataTest.hs
@@ -1,0 +1,54 @@
+module Cargo.MetadataTest
+  ( spec_parse
+  ) where
+
+import Prologue
+
+import qualified Data.Text as T
+import qualified Data.ByteString.Lazy as BL
+
+import Strategy.Cargo
+
+import qualified Test.Tasty.Hspec as Test
+
+expectedMetadata :: CargoMetadata
+expectedMetadata = CargoMetadata [] [jfmtId] $ Resolve expectedResolveNodes
+
+expectedResolveNodes :: [ResolveNode]
+expectedResolveNodes = [ansiTermNode, clapNode, jfmtNode]
+
+registrySource :: T.Text
+registrySource = "(registry+https://github.com/rust-lang/crates.io-index)"
+
+mkPkgId :: T.Text -> T.Text -> PackageId
+mkPkgId name ver = PackageId name ver registrySource
+
+ansiTermId :: PackageId
+ansiTermId = mkPkgId "ansi_term" "0.11.0"
+
+clapId :: PackageId
+clapId = mkPkgId "clap" "2.33.0"
+
+jfmtId :: PackageId
+jfmtId = PackageId "jfmt" "1.0.0" "(path+file:///path/to/jfmt.rs)"
+
+ansiTermNode :: ResolveNode
+ansiTermNode = ResolveNode ansiTermId []
+
+clapNode :: ResolveNode
+clapNode = ResolveNode clapId [NodeDependency ansiTermId [NodeDepKind Nothing $ Just "cfg(not(windows))"]]
+
+jfmtNode :: ResolveNode
+jfmtNode = ResolveNode jfmtId [NodeDependency clapId [nullKind]]
+
+nullKind :: NodeDepKind
+nullKind = NodeDepKind Nothing Nothing
+
+spec_parse :: Test.Spec
+spec_parse = 
+  Test.describe "cargo metadata parser" $ do
+    metaBytes <- Test.runIO $ BL.readFile "test/Cargo/testdata/expected-metadata.json"
+    Test.it "should properly construct a resolution tree" $ 
+      case eitherDecode metaBytes of
+        Left err -> Test.expectationFailure $ "failed to parse: " ++ err
+        Right result -> result `Test.shouldBe` expectedMetadata

--- a/test/Cargo/MetadataTest.hs
+++ b/test/Cargo/MetadataTest.hs
@@ -10,6 +10,7 @@ import qualified Data.Map.Strict as M
 import qualified Data.Text as T
 
 import DepTypes
+import Graphing
 import GraphUtil
 import Strategy.Cargo
 
@@ -46,9 +47,6 @@ clapDep = mkDep "clap" "2.33.0" [EnvProduction]
 jfmtId :: PackageId
 jfmtId = PackageId "jfmt" "1.0.0" "(path+file:///path/to/jfmt.rs)"
 
-jfmtDep :: Dependency
-jfmtDep = mkDep "jfmt" "1.0.0" []
-
 ansiTermNode :: ResolveNode
 ansiTermNode = ResolveNode ansiTermId []
 
@@ -73,9 +71,9 @@ spec_parse =
 spec_graph :: Test.Spec
 spec_graph = 
   Test.describe "cargo metadata graph" $ do
-    let graph = buildGraph expectedMetadata
+    let graph = pruneUnreachable $ buildGraph expectedMetadata
 
     Test.it "should build the correct graph" $ do
-      expectDeps [ansiTermDep, clapDep, jfmtDep] graph
-      expectEdges [(jfmtDep, clapDep), (clapDep, ansiTermDep)] graph
-      expectDirect [jfmtDep] graph
+      expectDeps [ansiTermDep, clapDep] graph
+      expectEdges [(clapDep, ansiTermDep)] graph
+      expectDirect [clapDep] graph

--- a/test/Cargo/MetadataTest.hs
+++ b/test/Cargo/MetadataTest.hs
@@ -1,15 +1,20 @@
 module Cargo.MetadataTest
   ( spec_parse
+  , spec_graph
   ) where
 
 import Prologue
 
-import qualified Data.Text as T
 import qualified Data.ByteString.Lazy as BL
+import qualified Data.Map.Strict as M
+import qualified Data.Text as T
 
+import DepTypes
+import GraphUtil
 import Strategy.Cargo
 
 import qualified Test.Tasty.Hspec as Test
+
 
 expectedMetadata :: CargoMetadata
 expectedMetadata = CargoMetadata [] [jfmtId] $ Resolve expectedResolveNodes
@@ -23,14 +28,26 @@ registrySource = "(registry+https://github.com/rust-lang/crates.io-index)"
 mkPkgId :: T.Text -> T.Text -> PackageId
 mkPkgId name ver = PackageId name ver registrySource
 
+mkDep :: Text -> Text -> [DepEnvironment] -> Dependency
+mkDep name version envs = Dependency CargoType name (Just $ CEq version) [] envs M.empty
+
 ansiTermId :: PackageId
 ansiTermId = mkPkgId "ansi_term" "0.11.0"
+
+ansiTermDep :: Dependency
+ansiTermDep = mkDep "ansi_term" "0.11.0" [EnvProduction]
 
 clapId :: PackageId
 clapId = mkPkgId "clap" "2.33.0"
 
+clapDep :: Dependency
+clapDep = mkDep "clap" "2.33.0" [EnvProduction]
+
 jfmtId :: PackageId
 jfmtId = PackageId "jfmt" "1.0.0" "(path+file:///path/to/jfmt.rs)"
+
+jfmtDep :: Dependency
+jfmtDep = mkDep "jfmt" "1.0.0" []
 
 ansiTermNode :: ResolveNode
 ansiTermNode = ResolveNode ansiTermId []
@@ -52,3 +69,13 @@ spec_parse =
       case eitherDecode metaBytes of
         Left err -> Test.expectationFailure $ "failed to parse: " ++ err
         Right result -> result `Test.shouldBe` expectedMetadata
+
+spec_graph :: Test.Spec
+spec_graph = 
+  Test.describe "cargo metadata graph" $ do
+    let graph = buildGraph expectedMetadata
+
+    Test.it "should build the correct graph" $ do
+      expectDeps [ansiTermDep, clapDep, jfmtDep] graph
+      expectEdges [(jfmtDep, clapDep), (clapDep, ansiTermDep)] graph
+      expectDirect [jfmtDep] graph

--- a/test/Cargo/testdata/expected-metadata.json
+++ b/test/Cargo/testdata/expected-metadata.json
@@ -1,0 +1,42 @@
+{
+    "packages": [],
+    "workspace_members": [
+        "jfmt 1.0.0 (path+file:///path/to/jfmt.rs)"
+    ],
+    "resolve": {
+        "nodes": [
+            {
+                "id": "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                "deps": []
+            },
+            {
+                "id": "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                "deps": [
+                    {
+                        "pkg": "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(not(windows))"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "id": "jfmt 1.0.0 (path+file:///path/to/jfmt.rs)",
+                "deps": [
+                    {
+                        "pkg": "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+}


### PR DESCRIPTION
Rust analyzer

check https://github.com/fossas/spectrometer/blob/a1b57a99721af76261d6165456cd84580d3ff34c/docs/strategies/rust.md for details on the abstract analysis process.

Please note that `Strategy.Cargo (Package, PackageDependency)` are added for future use, when determining licenses.  Since we don't hold that info yet, we are not using that code.