### PR TITLE
Add stripRoot to Graphing module

### DIFF
--- a/src/Graphing.hs
+++ b/src/Graphing.hs
@@ -16,6 +16,7 @@ module Graphing
   , gmap
   , filter
   , pruneUnreachable
+  , stripRoot
 
   -- * Building simple Graphings
   , fromList
@@ -60,6 +61,14 @@ filter f gr = gr { graphingDirect = direct', graphingAdjacent = adjacent' }
 -- | The empty Graphing
 empty :: Graphing ty
 empty = Graphing S.empty AM.empty
+
+-- | Strip a given item from the direct set, promote its immediate children to direct items
+stripRoot :: Ord ty => Graphing ty -> Graphing ty
+stripRoot gr = gr { graphingDirect = direct' }
+  where
+  topLayer = graphingDirect gr
+  newDirects = S.unions $ map (flip AM.postSet $ graphingAdjacent gr) $ S.toList topLayer
+  direct' = foldr S.insert S.empty newDirects
 
 -- | Add a direct dependency to this Graphing
 direct :: Ord ty => ty -> Graphing ty -> Graphing ty

--- a/src/Graphing.hs
+++ b/src/Graphing.hs
@@ -62,13 +62,13 @@ filter f gr = gr { graphingDirect = direct', graphingAdjacent = adjacent' }
 empty :: Graphing ty
 empty = Graphing S.empty AM.empty
 
--- | Strip a given item from the direct set, promote its immediate children to direct items
+-- | Strip all items from the direct set, promote their immediate children to direct items
 stripRoot :: Ord ty => Graphing ty -> Graphing ty
 stripRoot gr = gr { graphingDirect = direct' }
   where
-  topLayer = graphingDirect gr
-  newDirects = S.unions $ map (flip AM.postSet $ graphingAdjacent gr) $ S.toList topLayer
-  direct' = foldr S.insert S.empty newDirects
+  roots = S.toList $ graphingDirect gr
+  edgeSet root = AM.postSet root $ graphingAdjacent gr
+  direct' = S.unions $ map edgeSet roots
 
 -- | Add a direct dependency to this Graphing
 direct :: Ord ty => ty -> Graphing ty -> Graphing ty


### PR DESCRIPTION
Expected semantics:
Given some `Graphing a`, remove all items from direct set, and promote the direct descendants of that direct set to be the new direct set.

This is useful when a project is built as the top layer, and should not be included in the dependency graph.