### PR TITLE
Fix graph unfold utility

### DIFF
--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -211,6 +211,7 @@ test-suite unit-tests
     Googlesource.RepoManifestSpec
     Gradle.GradleSpec
     GraphUtil
+    GraphingSpec
     Maven.PluginStrategySpec
     Node.NpmLockSpec
     Node.PackageJsonSpec

--- a/src/Graphing.hs
+++ b/src/Graphing.hs
@@ -92,13 +92,17 @@ edge parent child gr = gr { graphingAdjacent = adjacent' }
 -- - A way to convert a dependency @toDependency@
 --
 -- __Unfold does not work for recursive inputs__
-unfold :: Ord res => [dep] -> (dep -> [dep]) -> (dep -> res) -> Graphing res
-unfold seed getDeps toDependency = foldr addNode empty seed
+unfold :: forall dep res. Ord res => [dep] -> (dep -> [dep]) -> (dep -> res) -> Graphing res
+unfold seed getDeps toDependency = Graphing
+  { graphingDirect = S.fromList (map toDependency seed)
+  , graphingAdjacent = AM.vertices (map toDependency seed) `AM.overlay` AM.edges [(toDependency parentDep, toDependency childDep) | (parentDep,childDep) <- edgesFrom seed]
+  }
   where
-  addNode dep gr = direct res (foldr (edge res . toDependency) gr children)
-    where
-    children = getDeps dep
-    res = toDependency dep
+    edgesFrom :: [dep] -> [(dep,dep)]
+    edgesFrom nodes = do
+      node <- nodes
+      let children = getDeps node
+      map (node,) children ++ edgesFrom children
 
 -- | Build a graphing from a list, where all list elements are treated as direct
 -- dependencies

--- a/src/Strategy/Node/NpmLock.hs
+++ b/src/Strategy/Node/NpmLock.hs
@@ -70,7 +70,7 @@ mkProjectClosure file lock = ProjectClosureBody
   dependencies = ProjectDependencies
     { dependenciesGraph    = buildGraph lock
     , dependenciesOptimal  = Optimal
-    , dependenciesComplete = Complete
+    , dependenciesComplete = NotComplete
     }
 
 data NpmPackage = NpmPackage

--- a/test/GraphingSpec.hs
+++ b/test/GraphingSpec.hs
@@ -1,0 +1,20 @@
+module GraphingSpec
+  ( spec
+  )
+  where
+
+import Test.Hspec
+import Prelude
+import Graphing
+import GraphUtil
+
+spec :: Spec
+spec = do
+  describe "unfold" $ do
+    it "should unfold deeply" $ do
+      let graph :: Graphing Int
+          graph = unfold [10] (\x -> if x > 0 then [x-2] else []) id
+
+      expectDirect [10] graph
+      expectDeps [10, 8, 6, 4, 2, 0] graph
+      expectEdges [(10,8), (8,6), (6,4), (4,2), (2,0)] graph


### PR DESCRIPTION
`unfold` is only used in two strategies -- and it was incorrectly stopping at the second level of dependencies.