### PR TITLE
Erlang support with rebar3

### DIFF
--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -131,6 +131,7 @@ library
     Strategy.Clojure
     Strategy.Cocoapods.Podfile
     Strategy.Cocoapods.PodfileLock
+    Strategy.Erlang.Rebar3Tree
     Strategy.Go.GlideLock
     Strategy.Go.GoList
     Strategy.Go.Gomod
@@ -197,6 +198,7 @@ test-suite unit-tests
 
   -- cabal-fmt: expand test
   other-modules:
+<<<<<<< HEAD
     App.Fossa.FossaAPIV1Spec
     Cargo.MetadataSpec
     Carthage.CarthageSpec
@@ -210,6 +212,19 @@ test-suite unit-tests
     Go.GopkgTomlSpec
     Googlesource.RepoManifestSpec
     Gradle.GradleSpec
+=======
+    Carthage.CarthageTest
+    Cocoapods.PodfileLockTest
+    Cocoapods.PodfileTest
+    Erlang.Rebar3TreeTest
+    Go.GlideLockTest
+    Go.GoListTest
+    Go.GomodTest
+    Go.GopkgLockTest
+    Go.GopkgTomlTest
+    Googlesource.RepoManifestTest
+    Gradle.GradleTest
+>>>>>>> initial parser and tests
     GraphUtil
     GraphingSpec
     Maven.PluginStrategySpec

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -198,13 +198,13 @@ test-suite unit-tests
 
   -- cabal-fmt: expand test
   other-modules:
-<<<<<<< HEAD
     App.Fossa.FossaAPIV1Spec
     Cargo.MetadataSpec
     Carthage.CarthageSpec
     Clojure.ClojureSpec
     Cocoapods.PodfileLockSpec
     Cocoapods.PodfileSpec
+    Erlang.Rebar3TreeSpec
     Go.GlideLockSpec
     Go.GoListSpec
     Go.GomodSpec
@@ -212,19 +212,6 @@ test-suite unit-tests
     Go.GopkgTomlSpec
     Googlesource.RepoManifestSpec
     Gradle.GradleSpec
-=======
-    Carthage.CarthageTest
-    Cocoapods.PodfileLockTest
-    Cocoapods.PodfileTest
-    Erlang.Rebar3TreeTest
-    Go.GlideLockTest
-    Go.GoListTest
-    Go.GomodTest
-    Go.GopkgLockTest
-    Go.GopkgTomlTest
-    Googlesource.RepoManifestTest
-    Gradle.GradleTest
->>>>>>> initial parser and tests
     GraphUtil
     GraphingSpec
     Maven.PluginStrategySpec

--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -28,6 +28,7 @@ import qualified Strategy.Carthage as Carthage
 import qualified Strategy.Clojure as Clojure
 import qualified Strategy.Cocoapods.Podfile as Podfile
 import qualified Strategy.Cocoapods.PodfileLock as PodfileLock
+import qualified Strategy.Erlang.Rebar3Tree as Rebar3Tree
 import qualified Strategy.Go.GoList as GoList
 import qualified Strategy.Go.Gomod as Gomod
 import qualified Strategy.Go.GopkgLock as GopkgLock
@@ -166,7 +167,9 @@ renderCause e = fromMaybe renderSomeException $
 
 discoverFuncs :: HasDiscover sig m => [Path Abs Dir -> m ()]
 discoverFuncs =
-  [ GoList.discover
+  [ Rebar3Tree.discover
+
+  , GoList.discover
   , Gomod.discover
   , GopkgToml.discover
   , GopkgLock.discover

--- a/src/DepTypes.hs
+++ b/src/DepTypes.hs
@@ -44,6 +44,7 @@ data DepType =
     SubprojectType -- ^ A first-party subproject
   | GemType    -- ^ Gem registry
   | GooglesourceType  -- ^ android.googlesource.com
+  | HexType    -- ^ Hex registry
   | MavenType -- ^ Maven registry
   | NodeJSType -- ^ NPM registry (or similar)
   | NuGetType -- ^ Nuget registry

--- a/src/DepTypes.hs
+++ b/src/DepTypes.hs
@@ -42,6 +42,7 @@ data DepEnvironment =
 -- | A Dependency type. This corresponds to a "fetcher" on the backend
 data DepType =
     SubprojectType -- ^ A first-party subproject
+  | GitType -- ^ Repository in Github
   | GemType    -- ^ Gem registry
   | GooglesourceType  -- ^ android.googlesource.com
   | HexType    -- ^ Hex registry

--- a/src/Srclib/Converter.hs
+++ b/src/Srclib/Converter.hs
@@ -93,7 +93,9 @@ depTypeToFetcher :: DepType -> Text
 depTypeToFetcher = \case
   SubprojectType -> "mvn" -- FIXME. I knew SubprojectType would come back to bite us.
   GooglesourceType -> "git" -- FIXME. Yet another thing that's coming back to bite us
+  GitType -> "git"
   GemType -> "gem"
+  HexType -> "hex"
   MavenType -> "mvn"
   NodeJSType -> "npm"
   NuGetType -> "nuget"

--- a/src/Strategy/Carthage.hs
+++ b/src/Strategy/Carthage.hs
@@ -96,7 +96,7 @@ analyze topPath = evalGrapher $ do
 entryToCheckoutName :: ResolvedEntry -> Text
 entryToCheckoutName entry =
   case resolvedType entry of
-    GitType -> resolvedName entry
+    GitEntry -> resolvedName entry
     -- this is safe because T.splitOn always returns a non-empty list
     GithubType -> Unsafe.last . T.splitOn "/" $ resolvedName entry
     BinaryType -> resolvedName entry
@@ -104,7 +104,7 @@ entryToCheckoutName entry =
 entryToDepName :: ResolvedEntry -> Text
 entryToDepName entry =
   case resolvedType entry of
-    GitType -> resolvedName entry
+    GitEntry -> resolvedName entry
     GithubType -> "https://github.com/" <> resolvedName entry
     BinaryType -> resolvedName entry
 
@@ -130,7 +130,7 @@ parseSingleEntry :: Parser ResolvedEntry
 parseSingleEntry = L.nonIndented scn $ do
   entryType <- lexeme $ choice
     [ GithubType <$ chunk "github"
-    , GitType    <$ chunk "git"
+    , GitEntry    <$ chunk "git"
     , BinaryType <$ chunk "binary"
     ]
 
@@ -163,5 +163,5 @@ data ResolvedEntry = ResolvedEntry
   , resolvedVersion :: Text
   } deriving (Eq, Ord, Show, Generic)
 
-data EntryType = GithubType | GitType | BinaryType
+data EntryType = GithubType | GitEntry | BinaryType
   deriving (Eq, Ord, Show, Generic)

--- a/src/Strategy/Erlang/Rebar3Tree.hs
+++ b/src/Strategy/Erlang/Rebar3Tree.hs
@@ -12,6 +12,7 @@ import Prologue
 
 import Control.Carrier.Error.Either
 import qualified Data.Map.Strict as M
+import qualified Data.Text as T
 import Text.Megaparsec
 import Text.Megaparsec.Char
 
@@ -72,8 +73,14 @@ buildGraph deps = run . withLabeling toDependency $ do
     applyLabel (RebarSource src) dep = dep { dependencyLocations = src : dependencyLocations dep }
 
     start =
-      Dependency { dependencyType = HexType
-                 , dependencyName = depName pkg
+      Dependency { dependencyType =
+                      case T.isInfixOf (T.pack "github.com") (depLocation pkg) of
+                      True -> GitType
+                      False -> HexType
+                 , dependencyName =
+                      case T.isInfixOf (T.pack "github.com") (depLocation pkg) of
+                      True -> depLocation pkg
+                      False -> depName pkg
                  , dependencyVersion = Just (CEq (depVersion pkg))
                  , dependencyLocations = []
                  , dependencyEnvironments = []

--- a/src/Strategy/Erlang/Rebar3Tree.hs
+++ b/src/Strategy/Erlang/Rebar3Tree.hs
@@ -54,6 +54,12 @@ mkProjectClosure dir deps = ProjectClosureBody
     , dependenciesComplete = NotComplete
     }
 
+type RebarGrapher = LabeledGrapher Rebar3Dep RebarLabel
+
+data RebarLabel =
+    RebarSource Text -- location
+  deriving (Eq, Ord, Show, Generic)
+
 buildGraph :: [Rebar3Dep] -> Graphing Dependency
 buildGraph deps = run . withLabeling toDependency $ do
   traverse_ direct deps

--- a/src/Strategy/Erlang/Rebar3Tree.hs
+++ b/src/Strategy/Erlang/Rebar3Tree.hs
@@ -1,0 +1,128 @@
+module Strategy.Erlang.Rebar3Tree
+  ( discover
+  , analyze
+
+  , buildGraph
+  , rebar3TreeParser
+  , Rebar3Dep(..)
+  )
+  where
+
+import Prologue
+
+import Control.Carrier.Error.Either
+import qualified Data.Map.Strict as M
+import Text.Megaparsec
+import Text.Megaparsec.Char
+
+import DepTypes
+import Discovery.Walk
+import Effect.Exec
+import Graphing (Graphing)
+import qualified Graphing
+import Types
+
+discover :: HasDiscover sig m => Path Abs Dir -> m ()
+discover = walk $ \dir _ files -> do
+  case find (\f -> fileName f `elem` ["rebar.config"]) files of
+    Nothing -> pure ()
+    Just _  -> runSimpleStrategy "erlang-rebar3tree" ErlangGroup $ analyze dir
+
+  pure WalkContinue
+
+rebar3TreeCmd :: Command
+rebar3TreeCmd = Command
+  { cmdNames = ["rebar3"]
+  , cmdBaseArgs = ["tree", "-v"]
+  , cmdAllowErr = Never
+  }
+
+analyze :: (Has Exec sig m, Has (Error ExecErr) sig m) => Path Rel Dir -> m ProjectClosureBody
+analyze dir = mkProjectClosure dir <$> execParser rebar3TreeParser dir rebar3TreeCmd []
+
+mkProjectClosure :: Path Rel Dir -> [Rebar3Dep] -> ProjectClosureBody
+mkProjectClosure dir deps = ProjectClosureBody
+  { bodyModuleDir    = dir
+  , bodyDependencies = dependencies
+  , bodyLicenses     = []
+  }
+  where
+  dependencies = ProjectDependencies
+    { dependenciesGraph    = buildGraph deps
+    , dependenciesOptimal  = NotOptimal
+    , dependenciesComplete = NotComplete
+    }
+
+buildGraph :: [Rebar3Dep] -> Graphing Dependency
+buildGraph = Graphing.fromList . map toDependency
+  where
+  toDependency Rebar3Dep{..} =
+    Dependency { dependencyType = HexType
+               , dependencyName = depName
+               , dependencyVersion = Just (CEq depVersion)
+               , dependencyLocations = []
+               , dependencyEnvironments = []
+               , dependencyTags = M.empty
+               }
+
+data Rebar3Dep = Rebar3Dep
+  { depName     :: Text
+  , depVersion  :: Text
+  , depLocation :: Text
+  , subDeps     :: [Rebar3Dep]
+  } deriving (Eq, Ord, Show, Generic)
+
+type Parser = Parsec Void Text
+
+rebar3TreeParser :: Parser [Rebar3Dep]
+rebar3TreeParser = concat <$> ((try (rebarDep 0) <|> ignoredLine) `sepBy` eol) <* eof
+  where
+  isEndLine :: Char -> Bool
+  isEndLine '\n' = True
+  isEndLine '\r' = True
+  isEndLine _    = False
+
+  -- ignore content until the end of the line
+  ignored :: Parser ()
+  ignored = do
+        i <- takeWhileP (Just "ignored") (not . isEndLine)
+        _ <- traceM $ show i
+        pure ()
+
+  ignoredLine :: Parser [Rebar3Dep]
+  ignoredLine = do
+    ignored
+    pure []
+
+  findName :: Parser Text
+  findName = takeWhileP (Just "dep") (/= '─')
+
+  findVersion :: Parser Text
+  findVersion = takeWhileP (Just "version") (/= ' ')
+
+  findLocation :: Parser Text
+  findLocation = takeWhileP (Just "location") (/= ')')
+
+  rebarDep :: Integer -> Parser [Rebar3Dep]
+  rebarDep depth = do
+    _ <- chunk " "
+    countSlash <- many "  │"
+    _ <- satisfy (\_ -> (fromIntegral (length countSlash)) == depth)
+
+    _ <- chunk "  & " <|> chunk "  ├─ " <|> chunk " ├─ " <|> chunk " └─ " 
+    dep <- findName
+    _ <- chunk "─"
+    version <- findVersion
+    _ <- chunk " ("
+    location <- findLocation
+    _ <- chunk ")"
+   
+    deps <- many $ try $ rebarRecurse $ depth + 1
+
+    pure [Rebar3Dep dep version location (concat deps)]
+  
+  rebarRecurse :: Integer -> Parser [Rebar3Dep]
+  rebarRecurse depth = do
+    _ <- chunk "\n"
+    deps <- rebarDep depth
+    pure deps

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -137,6 +137,7 @@ data ProjectDependencies = ProjectDependencies
 data StrategyGroup =
     CarthageGroup
   | DotnetGroup
+  | ErlangGroup
   | GolangGroup
   | GooglesourceGroup
   | GradleGroup

--- a/test/Erlang/Rebar3TreeSpec.hs
+++ b/test/Erlang/Rebar3TreeSpec.hs
@@ -1,5 +1,5 @@
-module Erlang.Rebar3TreeTest
-  ( spec_analyze
+module Erlang.Rebar3TreeSpec
+  ( spec
   ) where
 
 import Prologue
@@ -14,7 +14,7 @@ import Graphing (Graphing)
 import Strategy.Erlang.Rebar3Tree
 import GraphUtil
 
-import Test.Tasty.Hspec
+import Test.Hspec
 
 dependencyOne :: Dependency
 dependencyOne = Dependency { dependencyType = GitType
@@ -100,8 +100,8 @@ depFive = Rebar3Dep
           , subDeps = []
           }         
 
-spec_analyze :: Spec
-spec_analyze = do
+spec :: Spec
+spec = do
   contents <- runIO (TIO.readFile "test/Erlang/testdata/rebar3tree")
 
   describe "rebar3 tree analyzer" $

--- a/test/Erlang/Rebar3TreeSpec.hs
+++ b/test/Erlang/Rebar3TreeSpec.hs
@@ -9,8 +9,7 @@ import qualified Data.Text.IO as TIO
 import Text.Megaparsec
 
 import DepTypes
-import Effect.Grapher
-import Graphing (Graphing)
+import Graphing()
 import Strategy.Erlang.Rebar3Tree
 import GraphUtil
 

--- a/test/Erlang/Rebar3TreeTest.hs
+++ b/test/Erlang/Rebar3TreeTest.hs
@@ -12,40 +12,47 @@ import DepTypes
 import Effect.Grapher
 import Graphing (Graphing)
 import Strategy.Erlang.Rebar3Tree
+import GraphUtil
 
 import Test.Tasty.Hspec
 
-expected :: Graphing Dependency
-expected = run . evalGrapher $ do
-  direct $ Dependency { dependencyType = HexType
+dependencyOne :: Dependency
+dependencyOne = Dependency { dependencyType = HexType
                       , dependencyName = "one"
                       , dependencyVersion = Just (CEq "1.0.0")
                       , dependencyLocations = []
                       , dependencyEnvironments = []
                       , dependencyTags = M.empty
                       }
-  direct $ Dependency { dependencyType = HexType
+
+dependencyTwo :: Dependency
+dependencyTwo = Dependency { dependencyType = HexType
                       , dependencyName = "two"
                       , dependencyVersion = Just (CEq "2.0.0")
                       , dependencyLocations = []
                       , dependencyEnvironments = []
                       , dependencyTags = M.empty
                       }
-  direct $ Dependency { dependencyType = HexType
+dependencyThree :: Dependency
+dependencyThree = Dependency { dependencyType = HexType
                       , dependencyName = "three"
                       , dependencyVersion = Just (CEq "3.0.0")
                       , dependencyLocations = []
                       , dependencyEnvironments = []
                       , dependencyTags = M.empty
                       }
-  direct $ Dependency { dependencyType = HexType
+
+dependencyFour :: Dependency
+dependencyFour = Dependency { dependencyType = HexType
                       , dependencyName = "four"
                       , dependencyVersion = Just (CEq "4.0.0")
                       , dependencyLocations = []
                       , dependencyEnvironments = []
                       , dependencyTags = M.empty
                       }
-  direct $ Dependency { dependencyType = HexType
+
+dependencyFive :: Dependency
+dependencyFive = Dependency { dependencyType = HexType
                       , dependencyName = "five"
                       , dependencyVersion = Just (CEq "5.0.0")
                       , dependencyLocations = []
@@ -99,8 +106,10 @@ spec_analyze = do
 
   describe "rebar3 tree analyzer" $
     it "produces the expected output" $ do
-      let result = buildGraph [depOne, depFive]
-      result `shouldBe` expected
+      let res = buildGraph [depOne, depFive]
+      expectDeps [dependencyOne, dependencyTwo, dependencyThree, dependencyFour, dependencyFive] res
+      expectDirect [dependencyOne, dependencyFive] res
+      expectEdges [(dependencyOne, dependencyTwo), (dependencyOne, dependencyFour), (dependencyTwo, dependencyThree)] res
 
   describe "rebar3 tree parser" $ do
     it "parses ideal rebar3 tree output" $ do

--- a/test/Erlang/Rebar3TreeTest.hs
+++ b/test/Erlang/Rebar3TreeTest.hs
@@ -17,8 +17,8 @@ import GraphUtil
 import Test.Tasty.Hspec
 
 dependencyOne :: Dependency
-dependencyOne = Dependency { dependencyType = HexType
-                      , dependencyName = "one"
+dependencyOne = Dependency { dependencyType = GitType
+                      , dependencyName = "https://github.com/dep/one"
                       , dependencyVersion = Just (CEq "1.0.0")
                       , dependencyLocations = []
                       , dependencyEnvironments = []
@@ -43,8 +43,8 @@ dependencyThree = Dependency { dependencyType = HexType
                       }
 
 dependencyFour :: Dependency
-dependencyFour = Dependency { dependencyType = HexType
-                      , dependencyName = "four"
+dependencyFour = Dependency { dependencyType = GitType
+                      , dependencyName = "https://github.com/dep/four"
                       , dependencyVersion = Just (CEq "4.0.0")
                       , dependencyLocations = []
                       , dependencyEnvironments = []
@@ -72,7 +72,7 @@ depTwo :: Rebar3Dep
 depTwo = Rebar3Dep 
           { depName = "two"
           , depVersion = "2.0.0"
-          , depLocation = "https://github.com/dep/two"
+          , depLocation = "hex package"
           , subDeps = [depThree]
           }         
 
@@ -80,7 +80,7 @@ depThree :: Rebar3Dep
 depThree = Rebar3Dep 
           { depName = "three"
           , depVersion = "3.0.0"
-          , depLocation = "https://github.com/dep/three"
+          , depLocation = "hex package"
           , subDeps = []
           }         
 

--- a/test/Erlang/testdata/rebar3tree
+++ b/test/Erlang/testdata/rebar3tree
@@ -1,0 +1,5 @@
+   ├─ one─1.0.0 (https://github.com/dep/one)
+   │  ├─ two─2.0.0 (https://github.com/dep/two)
+   │  │  └─ three─3.0.0 (https://github.com/dep/three)
+   │  └─ four─4.0.0 (https://github.com/dep/four)
+   └─ five─5.0.0 (hex package)

--- a/test/Erlang/testdata/rebar3tree
+++ b/test/Erlang/testdata/rebar3tree
@@ -1,5 +1,5 @@
    ├─ one─1.0.0 (https://github.com/dep/one)
-   │  ├─ two─2.0.0 (https://github.com/dep/two)
-   │  │  └─ three─3.0.0 (https://github.com/dep/three)
+   │  ├─ two─2.0.0 (hex package)
+   │  │  └─ three─3.0.0 (hex package)
    │  └─ four─4.0.0 (https://github.com/dep/four)
    └─ five─5.0.0 (hex package)


### PR DESCRIPTION
This PR adds support for Erlang through the rebar3 package manager by parsing the output from the command `rebar3 tree -v` for dependencies. Example output
```
   ├─ one─1.0.0 (https://github.com/dep/one)
   │  ├─ two─2.0.0 (https://github.com/dep/two)
   │  │  └─ three─3.0.0 (https://github.com/dep/three)
   │  └─ four─4.0.0 (https://github.com/dep/four)
   └─ five─5.0.0 (hex package)
```