### PR TITLE
Move --basedir to common positional argument

### DIFF
--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -75,7 +75,6 @@ analyze ::
   -> Maybe Text -- ^ cli override for revision
   -> m ()
 analyze basedir destination overrideName overrideRevision = do
-  setCurrentDir basedir
   capabilities <- liftIO getNumCapabilities
 
   (closures,(failures,())) <- runOutput @ProjectClosure $ runOutput @ProjectFailure $

--- a/src/App/Fossa/Main.hs
+++ b/src/App/Fossa/Main.hs
@@ -92,8 +92,8 @@ analyzeOpts :: Parser AnalyzeOptions
 analyzeOpts =
   AnalyzeOptions
     <$> switch (long "output" <> short 'o' <> help "Output results to stdout instead of uploading to fossa")
-    <*> baseDirArg
     <*> metadataOpts
+    <*> baseDirArg
 
 metadataOpts :: Parser ProjectMetadata
 metadataOpts =
@@ -127,8 +127,8 @@ data Command
 
 data AnalyzeOptions = AnalyzeOptions
   { analyzeOutput :: Bool
-  , analyzeBaseDir :: FilePath
   , analyzeMetadata :: ProjectMetadata
+  , analyzeBaseDir :: FilePath
   }
 
 data TestOptions = TestOptions

--- a/src/App/Fossa/Main.hs
+++ b/src/App/Fossa/Main.hs
@@ -26,7 +26,7 @@ appMain = do
 
   case optCommand of
     AnalyzeCommand AnalyzeOptions{..} -> do
-      _ <- changeDir analyzeBaseDir
+      changeDir analyzeBaseDir
       if analyzeOutput
         then analyzeMain logSeverity OutputStdout optProjectName optProjectRevision
         else case maybeApiKey of
@@ -34,7 +34,7 @@ appMain = do
           Just key -> analyzeMain logSeverity (UploadScan optBaseUrl key analyzeMetadata) optProjectName optProjectRevision
 
     TestCommand TestOptions{..} -> do
-      _ <- changeDir testBaseDir
+      changeDir testBaseDir
       case maybeApiKey of
         Nothing -> die "A FOSSA API key is required to run this command"
         Just key -> testMain optBaseUrl key logSeverity testTimeout optProjectName optProjectRevision


### PR DESCRIPTION
I'm going to say upfront, I don't like this.  I created this to show the effects of the proposed change in [this thread](https://github.com/fossas/spectrometer/pull/68#discussion_r427705628), and I'm not a fan of it.

That said, it's more intuitive for the user, and more "correct" cli behavior.  But it adds maintenance cost for every new command we add.

EDIT: Some suggestions below have modified the initial implementation, which I did not like, into a refactor where the command modules are taking responsibility for their own validation, which I definitely support.  As our command structure grows, this helps manage the growing complexity of the application.