### PR TITLE
When filtering IPR results, include results that have Copyrights

### DIFF
--- a/src/App/VPSScan/Scan/RunIPR.hs
+++ b/src/App/VPSScan/Scan/RunIPR.hs
@@ -33,13 +33,21 @@ extractNonEmptyFiles (Object obj) = do
     Array filesArray -> Just filesArray
     _ -> Nothing
 
-  let filtered = V.filter hasLicenses filesAsArray
+  let filtered = V.filter hasLicensesOrCopyrights filesAsArray
       hasLicenses :: Value -> Bool
       hasLicenses (Object file) =
         case HM.lookup "LicenseExpressions" file of
           Just (Object expressions) -> not (HM.null expressions)
           _ -> False
       hasLicenses _ = False
+      hasCopyrights :: Value -> Bool
+      hasCopyrights (Object file) =
+        case HM.lookup "Copyrights" file of
+          Just (Object expressions) -> not (HM.null expressions)
+          _ -> False
+      hasCopyrights _ = False
+      hasLicensesOrCopyrights :: Value -> Bool
+      hasLicensesOrCopyrights value = hasLicenses value || hasCopyrights value
 
   Just $ object ["Files" .= filtered]
 extractNonEmptyFiles _ = Nothing


### PR DESCRIPTION
This was a miss on my part. When the IPR scan returns a result with a non-empty `Copyrights` value, we want to send it to Scotland Yard:

```
   {
      "Path": "license",
      "Copyrights": {
        "0": {
          "CopyrightInstanceID": 0,
          "Holder": "fossa",
          "Years": "2019",
          "Verbatim": "Copyright (c) 2019 fossa",
          "OffsetStart": 24,
          "OffsetEnd": 48
        }
      },
      "LicenseExpressions": {},
      "Associations": {}
    }
```

Previously we were only sending up results that had non-empty `LicenseExpressions`.