### PR TITLE
Only run IPR scan if all of the IPR options are provided

### DIFF
--- a/src/App/VPSScan/Main.hs
+++ b/src/App/VPSScan/Main.hs
@@ -45,10 +45,12 @@ runIPROpts = RunIPR.IPROpts
                   <$> iprCmdPathOpt
                   <*> nomosCmdPathOpt
                   <*> pathfinderCmdPathOpt
+                  <*> iprEnabledOpt
                 where
-                    iprCmdPathOpt = strOption (long "ipr" <> metavar "STRING" <> help "Path to the IPR executable")
-                    nomosCmdPathOpt = strOption (long "nomossa" <> metavar "STRING" <> help "Path to the nomossa executable")
-                    pathfinderCmdPathOpt = strOption (long "pathfinder" <> metavar "STRING" <> help "Path to the pathfinder executable")
+                    iprCmdPathOpt = optional $ strOption (long "ipr" <> metavar "STRING" <> help "Path to the IPR executable")
+                    nomosCmdPathOpt = optional $ strOption (long "nomossa" <> metavar "STRING" <> help "Path to the nomossa executable")
+                    pathfinderCmdPathOpt = optional $ strOption (long "pathfinder" <> metavar "STRING" <> help "Path to the pathfinder executable")
+                    iprEnabledOpt = not <$> (switch $ long "ipr-disabled" <> help "IPR scans will only be run if this flag is omitted and the ipr, nomossa and pathfinder options are passed in")
 
 -- org IDs are ints. project and revision IDs are strings
 syOpts :: Parser ScotlandYardOpts

--- a/src/App/VPSScan/Main.hs
+++ b/src/App/VPSScan/Main.hs
@@ -22,11 +22,12 @@ commands = hsubparser scanCommand
 
 
 vpsOpts :: Parser VPSOpts
-vpsOpts = VPSOpts <$> runSherlockOpts <*> runIPROpts <*> syOpts <*> organizationIDOpt <*> projectIDOpt <*> revisionIDOpt
+vpsOpts = VPSOpts <$> runSherlockOpts <*> iprOpts <*> syOpts <*> organizationIDOpt <*> projectIDOpt <*> revisionIDOpt
             where
               organizationIDOpt = option auto (long "organization" <> metavar "orgID" <> help "Organization ID")
               projectIDOpt = strOption (long "project" <> metavar "String" <> help "Project ID")
               revisionIDOpt = strOption (long "revision" <> metavar "String" <> help "Revision ID")
+              iprOpts = RunIPR.validateIprOpts <$> runIPROpts
 
 runSherlockOpts :: Parser SherlockOpts
 runSherlockOpts = SherlockOpts
@@ -40,17 +41,12 @@ runSherlockOpts = SherlockOpts
                     sherlockClientTokenOpt = strOption(long "client-token" <> metavar "STRING" <> help "Client token for authentication to Sherlock")
                     sherlockClientIDOpt = strOption(long "client-id" <> metavar "STRING" <> help "Client ID for authentication to Sherlock")
 
-runIPROpts :: Parser RunIPR.IPROpts
-runIPROpts = RunIPR.IPROpts
-                  <$> iprCmdPathOpt
-                  <*> nomosCmdPathOpt
-                  <*> pathfinderCmdPathOpt
-                  <*> iprEnabledOpt
-                where
-                    iprCmdPathOpt = optional $ strOption (long "ipr" <> metavar "STRING" <> help "Path to the IPR executable")
-                    nomosCmdPathOpt = optional $ strOption (long "nomossa" <> metavar "STRING" <> help "Path to the nomossa executable")
-                    pathfinderCmdPathOpt = optional $ strOption (long "pathfinder" <> metavar "STRING" <> help "Path to the pathfinder executable")
-                    iprEnabledOpt = not <$> (switch $ long "ipr-disabled" <> help "IPR scans will only be run if this flag is omitted and the ipr, nomossa and pathfinder options are passed in")
+runIPROpts :: Parser RunIPR.UnvalidatedIPROpts
+runIPROpts = RunIPR.UnvalidatedIPROpts <$> iprCmdPathOpt <*> nomossaCmdPathOpt <*> pathfinderCmdPathOpt
+  where
+    iprCmdPathOpt = optional (strOption (long "ipr" <> metavar "STRING" <> help "Path to the IPR executable"))
+    nomossaCmdPathOpt = optional (strOption (long "nomossa" <> metavar "STRING" <> help "Path to the nomossa executable"))
+    pathfinderCmdPathOpt = optional (strOption (long "pathfinder" <> metavar "STRING" <> help "Path to the pathfinder executable")) 
 
 -- org IDs are ints. project and revision IDs are strings
 syOpts :: Parser ScotlandYardOpts

--- a/src/App/VPSScan/Main.hs
+++ b/src/App/VPSScan/Main.hs
@@ -20,14 +20,12 @@ opts = info (commands <**> helper) (fullDesc <> header "vpscli -- FOSSA Vendored
 commands :: Parser (IO ())
 commands = hsubparser scanCommand
 
-
 vpsOpts :: Parser VPSOpts
-vpsOpts = VPSOpts <$> runSherlockOpts <*> iprOpts <*> syOpts <*> organizationIDOpt <*> projectIDOpt <*> revisionIDOpt
+vpsOpts = VPSOpts <$> runSherlockOpts <*> optional runIPROpts <*> syOpts <*> organizationIDOpt <*> projectIDOpt <*> revisionIDOpt
             where
               organizationIDOpt = option auto (long "organization" <> metavar "orgID" <> help "Organization ID")
               projectIDOpt = strOption (long "project" <> metavar "String" <> help "Project ID")
               revisionIDOpt = strOption (long "revision" <> metavar "String" <> help "Revision ID")
-              iprOpts = RunIPR.validateIprOpts <$> runIPROpts
 
 runSherlockOpts :: Parser SherlockOpts
 runSherlockOpts = SherlockOpts
@@ -41,12 +39,18 @@ runSherlockOpts = SherlockOpts
                     sherlockClientTokenOpt = strOption(long "client-token" <> metavar "STRING" <> help "Client token for authentication to Sherlock")
                     sherlockClientIDOpt = strOption(long "client-id" <> metavar "STRING" <> help "Client ID for authentication to Sherlock")
 
-runIPROpts :: Parser RunIPR.UnvalidatedIPROpts
-runIPROpts = RunIPR.UnvalidatedIPROpts <$> iprCmdPathOpt <*> nomossaCmdPathOpt <*> pathfinderCmdPathOpt
-  where
-    iprCmdPathOpt = optional (strOption (long "ipr" <> metavar "STRING" <> help "Path to the IPR executable"))
-    nomossaCmdPathOpt = optional (strOption (long "nomossa" <> metavar "STRING" <> help "Path to the nomossa executable"))
-    pathfinderCmdPathOpt = optional (strOption (long "pathfinder" <> metavar "STRING" <> help "Path to the pathfinder executable")) 
+-- If all three of these options are provided, then we run an IPR scan
+-- If none of them are provided, then we skip the IPR scan
+-- Providing just some of the arguments will result in an error
+runIPROpts :: Parser RunIPR.IPROpts
+runIPROpts = RunIPR.IPROpts
+                  <$> iprCmdPathOpt
+                  <*> nomosCmdPathOpt
+                  <*> pathfinderCmdPathOpt
+                where
+                    iprCmdPathOpt =  strOption (long "ipr" <> metavar "STRING" <> help "Path to the IPR executable")
+                    nomosCmdPathOpt = strOption (long "nomossa" <> metavar "STRING" <> help "Path to the nomossa executable")
+                    pathfinderCmdPathOpt = strOption (long "pathfinder" <> metavar "STRING" <> help "Path to the pathfinder executable")
 
 -- org IDs are ints. project and revision IDs are strings
 syOpts :: Parser ScotlandYardOpts

--- a/src/App/VPSScan/Scan.hs
+++ b/src/App/VPSScan/Scan.hs
@@ -59,10 +59,10 @@ vpsScan basedir ScanCmdOpts{..} = do
   trace $ "Scan ID from Scotland yard is " ++ show scanId
   trace "[All] Running IPR and Sherlock scans in parallel"
   trace "[Sherlock] Starting Sherlock scan"
-  if iprShouldRun vpsIpr
-    then trace "[IPR] Starting IPR scan"
-  else
-    trace "[IPR] IPR scan disabled"
+  case vpsIpr of
+    Just _ ->
+      trace "[IPR] Starting IPR scan"
+    Nothing -> trace "[IPR] IPR scan disabled"
 
   (iprResult, sherlockResult) <- liftIO $ concurrently
                 (runError @VPSError $ runIPR $ runScotlandYard $ runTrace $ runIPRScan basedir scanId vpsOpts)
@@ -88,7 +88,7 @@ runIPRScan ::
   , Has Trace sig m
   ) => Path Abs Dir ->  Text -> VPSOpts -> m ()
 runIPRScan basedir scanId vpsOpts@VPSOpts{..} =
-  case validateIPROpts vpsIpr of
+  case vpsIpr of
     Just iprOpts -> do
       iprResult <- tagError IPRFailed =<< execIPR basedir iprOpts
       trace "[IPR] IPR scan completed. Posting results to Scotland Yard"

--- a/src/App/VPSScan/Scan.hs
+++ b/src/App/VPSScan/Scan.hs
@@ -59,7 +59,11 @@ vpsScan basedir ScanCmdOpts{..} = do
   trace $ "Scan ID from Scotland yard is " ++ show scanId
   trace "[All] Running IPR and Sherlock scans in parallel"
   trace "[Sherlock] Starting Sherlock scan"
-  trace "[IPR] Starting IPR scan"
+  if iprShouldRun vpsIpr
+    then trace "[IPR] Starting IPR scan"
+  else
+    trace "[IPR] IPR scan disabled"
+
   (iprResult, sherlockResult) <- liftIO $ concurrently
                 (runError @VPSError $ runIPR $ runScotlandYard $ runTrace $ runIPRScan basedir scanId vpsOpts)
                 (runError @VPSError $ runSherlock $ runTrace $ runSherlockScan basedir scanId vpsOpts)
@@ -83,13 +87,18 @@ runIPRScan ::
   , Has (Error VPSError) sig m
   , Has Trace sig m
   ) => Path Abs Dir ->  Text -> VPSOpts -> m ()
-runIPRScan basedir scanId vpsOpts@VPSOpts{..} = do
-  iprResult <- tagError IPRFailed =<< execIPR basedir vpsIpr
-  trace "[IPR] IPR scan completed. Posting results to Scotland Yard"
+runIPRScan basedir scanId vpsOpts@VPSOpts{..} =
+  case validateIPROpts vpsIpr of
+    Just iprOpts -> do
+      iprResult <- tagError IPRFailed =<< execIPR basedir iprOpts
+      trace "[IPR] IPR scan completed. Posting results to Scotland Yard"
 
-  tagError Couldn'tUpload =<< uploadIPRResults vpsOpts scanId iprResult
-  trace "[IPR] Post to Scotland Yard complete"
-  trace "[IPR] IPR scan complete"
+      tagError Couldn'tUpload =<< uploadIPRResults vpsOpts scanId iprResult
+      trace "[IPR] Post to Scotland Yard complete"
+      trace "[IPR] IPR scan complete"
+    Nothing ->
+      trace "[IPR] IPR Scan disabled"
+
 
 validateDir :: FilePath -> IO (Path Abs Dir)
 validateDir dir = do

--- a/src/App/VPSScan/Scan.hs
+++ b/src/App/VPSScan/Scan.hs
@@ -60,8 +60,7 @@ vpsScan basedir ScanCmdOpts{..} = do
   trace "[All] Running IPR and Sherlock scans in parallel"
   trace "[Sherlock] Starting Sherlock scan"
   case vpsIpr of
-    Just _ ->
-      trace "[IPR] Starting IPR scan"
+    Just _ -> trace "[IPR] Starting IPR scan"
     Nothing -> trace "[IPR] IPR scan disabled"
 
   (iprResult, sherlockResult) <- liftIO $ concurrently

--- a/src/App/VPSScan/Scan/RunIPR.hs
+++ b/src/App/VPSScan/Scan/RunIPR.hs
@@ -6,8 +6,6 @@ module App.VPSScan.Scan.RunIPR
     IPRC (..),
     execIPR,
     IPRError (..),
-    UnvalidatedIPROpts (..),
-    validateIprOpts
   )
 where
 
@@ -18,26 +16,12 @@ import qualified Data.Vector as V
 import Prologue
 import Effect.Exec
 
-data UnvalidatedIPROpts = UnvalidatedIPROpts
-  { maybeIprCmdPath :: Maybe String,
-    maybeNomosCmdPath :: Maybe String,
-    maybePathfinderCmdPath :: Maybe String
-  }
-  deriving (Eq, Ord, Show, Generic)
-
 data IPROpts = IPROpts
   { iprCmdPath :: String,
     nomosCmdPath :: String,
     pathfinderCmdPath :: String
   }
   deriving (Eq, Ord, Show, Generic)
-
-validateIprOpts :: UnvalidatedIPROpts -> Maybe IPROpts
-validateIprOpts unvalidated =
-  case unvalidated of
-    (UnvalidatedIPROpts (Just iprPath) (Just nomosPath) (Just pathfinderPath)) ->
-      Just $ IPROpts iprPath nomosPath pathfinderPath
-    _ -> Nothing
 
 iprCmdArgs :: Path Abs Dir -> IPROpts -> [String]
 iprCmdArgs baseDir IPROpts {..} = ["-target", toFilePath baseDir, "-nomossa", nomosCmdPath, "-pathfinder", pathfinderCmdPath]

--- a/src/App/VPSScan/Scan/RunIPR.hs
+++ b/src/App/VPSScan/Scan/RunIPR.hs
@@ -95,11 +95,11 @@ instance (Algebra sig m, MonadIO m) => Algebra (IPR :+: sig) (IPRC m) where
 
       maybeValue <- runError @ExecErr $ runExecIO $ execJson basedir iprCommand $ iprCmdArgs basedir opts
       let result = case maybeValue of
-            Left err -> (Left (IPRCommandFailed (T.pack (show err))))
+            Left err -> Left (IPRCommandFailed (T.pack (show err)))
             Right value -> do
               let maybeExtracted = extractNonEmptyFiles value
               case maybeExtracted of
-                Nothing -> (Left NoFilesEntryInOutput)
-                Just extracted -> (Right extracted)
+                Nothing -> Left NoFilesEntryInOutput
+                Just extracted -> Right extracted
 
       pure (result <$ ctx)

--- a/src/App/VPSScan/Scan/RunIPR.hs
+++ b/src/App/VPSScan/Scan/RunIPR.hs
@@ -6,6 +6,9 @@ module App.VPSScan.Scan.RunIPR
     IPRC (..),
     execIPR,
     IPRError (..),
+    iprShouldRun,
+    validateIPROpts,
+    ValidatedIPROpts,
   )
 where
 
@@ -17,14 +20,34 @@ import Prologue
 import Effect.Exec
 
 data IPROpts = IPROpts
+  { maybeIprCmdPath :: Maybe String,
+    maybeNomosCmdPath :: Maybe String,
+    maybePathfinderCmdPath :: Maybe String,
+    iprEnabled :: Bool
+  }
+  deriving (Eq, Ord, Show, Generic)
+
+data ValidatedIPROpts = ValidatedIPROpts
   { iprCmdPath :: String,
     nomosCmdPath :: String,
     pathfinderCmdPath :: String
   }
   deriving (Eq, Ord, Show, Generic)
 
-iprCmdArgs :: Path Abs Dir -> IPROpts -> [String]
-iprCmdArgs baseDir IPROpts {..} = ["-target", toFilePath baseDir, "-nomossa", nomosCmdPath, "-pathfinder", pathfinderCmdPath]
+validateIPROpts :: IPROpts -> Maybe ValidatedIPROpts
+validateIPROpts IPROpts{..} =
+  case (maybeIprCmdPath, maybeNomosCmdPath, maybePathfinderCmdPath, iprEnabled) of
+    (Just iprPath, Just nomosPath, Just pathfinderPath, True) -> Just (ValidatedIPROpts iprPath nomosPath pathfinderPath)
+    _ -> Nothing
+
+iprShouldRun :: IPROpts -> Bool
+iprShouldRun iprOpts =
+  case validateIPROpts iprOpts of
+    Just _ -> True
+    Nothing -> False
+
+iprCmdArgs :: Path Abs Dir -> ValidatedIPROpts -> [String]
+iprCmdArgs baseDir ValidatedIPROpts {..} = ["-target", toFilePath baseDir, "-nomossa", nomosCmdPath, "-pathfinder", pathfinderCmdPath]
 
 extractNonEmptyFiles :: Value -> Maybe Value
 extractNonEmptyFiles (Object obj) = do
@@ -60,9 +83,9 @@ data IPRError
   deriving (Eq, Ord, Show, Generic)
 
 data IPR m k where
-  ExecIPR :: Path Abs Dir -> IPROpts -> IPR m (Either IPRError Value)
+  ExecIPR :: Path Abs Dir -> ValidatedIPROpts -> IPR m (Either IPRError Value)
 
-execIPR :: Has IPR sig m => Path Abs Dir -> IPROpts -> m (Either IPRError Value)
+execIPR :: Has IPR sig m => Path Abs Dir -> ValidatedIPROpts -> m (Either IPRError Value)
 execIPR basedir iprOpts = send (ExecIPR basedir iprOpts)
 
 ----- production ipr interpreter
@@ -73,7 +96,7 @@ newtype IPRC m a = IPRC {runIPR :: m a}
 instance (Algebra sig m, MonadIO m) => Algebra (IPR :+: sig) (IPRC m) where
   alg hdl sig ctx = IPRC $ case sig of
     R other -> alg (runIPR . hdl) other ctx
-    L (ExecIPR basedir opts@IPROpts {..}) -> do
+    L (ExecIPR basedir opts@ValidatedIPROpts {..}) -> do
       let iprCommand :: Command
           iprCommand = Command [iprCmdPath] [] Never
 

--- a/src/App/VPSScan/Scan/RunIPR.hs
+++ b/src/App/VPSScan/Scan/RunIPR.hs
@@ -6,9 +6,8 @@ module App.VPSScan.Scan.RunIPR
     IPRC (..),
     execIPR,
     IPRError (..),
-    iprShouldRun,
-    validateIPROpts,
-    ValidatedIPROpts,
+    UnvalidatedIPROpts (..),
+    validateIprOpts
   )
 where
 
@@ -19,35 +18,29 @@ import qualified Data.Vector as V
 import Prologue
 import Effect.Exec
 
-data IPROpts = IPROpts
+data UnvalidatedIPROpts = UnvalidatedIPROpts
   { maybeIprCmdPath :: Maybe String,
     maybeNomosCmdPath :: Maybe String,
-    maybePathfinderCmdPath :: Maybe String,
-    iprEnabled :: Bool
+    maybePathfinderCmdPath :: Maybe String
   }
   deriving (Eq, Ord, Show, Generic)
 
-data ValidatedIPROpts = ValidatedIPROpts
+data IPROpts = IPROpts
   { iprCmdPath :: String,
     nomosCmdPath :: String,
     pathfinderCmdPath :: String
   }
   deriving (Eq, Ord, Show, Generic)
 
-validateIPROpts :: IPROpts -> Maybe ValidatedIPROpts
-validateIPROpts IPROpts{..} =
-  case (maybeIprCmdPath, maybeNomosCmdPath, maybePathfinderCmdPath, iprEnabled) of
-    (Just iprPath, Just nomosPath, Just pathfinderPath, True) -> Just (ValidatedIPROpts iprPath nomosPath pathfinderPath)
+validateIprOpts :: UnvalidatedIPROpts -> Maybe IPROpts
+validateIprOpts unvalidated =
+  case unvalidated of
+    (UnvalidatedIPROpts (Just iprPath) (Just nomosPath) (Just pathfinderPath)) ->
+      Just $ IPROpts iprPath nomosPath pathfinderPath
     _ -> Nothing
 
-iprShouldRun :: IPROpts -> Bool
-iprShouldRun iprOpts =
-  case validateIPROpts iprOpts of
-    Just _ -> True
-    Nothing -> False
-
-iprCmdArgs :: Path Abs Dir -> ValidatedIPROpts -> [String]
-iprCmdArgs baseDir ValidatedIPROpts {..} = ["-target", toFilePath baseDir, "-nomossa", nomosCmdPath, "-pathfinder", pathfinderCmdPath]
+iprCmdArgs :: Path Abs Dir -> IPROpts -> [String]
+iprCmdArgs baseDir IPROpts {..} = ["-target", toFilePath baseDir, "-nomossa", nomosCmdPath, "-pathfinder", pathfinderCmdPath]
 
 extractNonEmptyFiles :: Value -> Maybe Value
 extractNonEmptyFiles (Object obj) = do
@@ -83,9 +76,9 @@ data IPRError
   deriving (Eq, Ord, Show, Generic)
 
 data IPR m k where
-  ExecIPR :: Path Abs Dir -> ValidatedIPROpts -> IPR m (Either IPRError Value)
+  ExecIPR :: Path Abs Dir -> IPROpts -> IPR m (Either IPRError Value)
 
-execIPR :: Has IPR sig m => Path Abs Dir -> ValidatedIPROpts -> m (Either IPRError Value)
+execIPR :: Has IPR sig m => Path Abs Dir -> IPROpts -> m (Either IPRError Value)
 execIPR basedir iprOpts = send (ExecIPR basedir iprOpts)
 
 ----- production ipr interpreter
@@ -96,7 +89,7 @@ newtype IPRC m a = IPRC {runIPR :: m a}
 instance (Algebra sig m, MonadIO m) => Algebra (IPR :+: sig) (IPRC m) where
   alg hdl sig ctx = IPRC $ case sig of
     R other -> alg (runIPR . hdl) other ctx
-    L (ExecIPR basedir opts@ValidatedIPROpts {..}) -> do
+    L (ExecIPR basedir opts@IPROpts {..}) -> do
       let iprCommand :: Command
           iprCommand = Command [iprCmdPath] [] Never
 

--- a/src/App/VPSScan/Types.hs
+++ b/src/App/VPSScan/Types.hs
@@ -20,7 +20,7 @@ data SherlockOpts = SherlockOpts
 
 data VPSOpts = VPSOpts
   { vpsSherlock :: SherlockOpts
-  , vpsIpr :: RunIPR.IPROpts
+  , vpsIpr :: Maybe RunIPR.IPROpts
   , vpsScotlandYard :: ScotlandYardOpts
   , organizationID :: Int
   , projectID :: Text


### PR DESCRIPTION
You can also forcibly disable the IPR scan using the `--ipr-disabled` command
line flag