### PR TITLE
Force unzip to overwrite previous fossa binaries

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -46,7 +46,7 @@ execute() {
   # http_download "${tmpdir}/${CHECKSUM}" "${CHECKSUM_URL}"
   # hash_sha256_verify "${tmpdir}/${TARBALL}" "${tmpdir}/${CHECKSUM}"
   srcdir="${tmpdir}"
-  (cd "${tmpdir}" && unzip "${TARBALL}")
+  (cd "${tmpdir}" && unzip -o "${TARBALL}")
   install -d -m 775 "${BINDIR}" 2> /dev/null || install -d "${BINDIR}"
   for binexe in "fossa" ; do
     if [ "$OS" = "windows" ]; then


### PR DESCRIPTION
This update forces the unzip command inside of the install script to overwrite the existing fossa binary. This was not necessary for cli v1 because the contents were distributed as tars which were handled by `tar` instead of `unzip`.