### PR TITLE
Use better types from the CLI handlers to the internals.

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -1,1 +1,1 @@
-- arguments: [-XTypeApplications]
+- arguments: [-XTypeApplications, -XNumericUnderscores]

--- a/docs/strategies.md
+++ b/docs/strategies.md
@@ -7,5 +7,6 @@ We support dependency analysis for the following languages/ecosystems:
 - [maven](strategies/maven.md)
 - [nodejs](strategies/nodejs.md) (yarn, npmcli)
 - [python](strategies/python.md) (pipenv, setuptools)
+- [rpm](strategies/rpm.md) (spec files)
 - [ruby](strategies/ruby.md) (bundler)
 - [rust](strategies/rust.md) (cargo)

--- a/docs/strategies/rpm.md
+++ b/docs/strategies/rpm.md
@@ -1,0 +1,36 @@
+# RPM analysis
+
+RPM packages managed by system package managers like `dnf` and `yum` are built
+using SPEC files.  We are able to analyze these files to determine build-time
+dependencies.
+
+| Strategy | Direct Deps | Deep Deps | Edges | Tags         |
+| ---      | ---         | ---       | ---   | ---          |
+| rpm-spec | ✅          | ❌        | ❌    | Environment  |
+
+## Project Discovery
+
+RPM SPEC files have strict naming conventions.  They must be in the form of
+`<package-name>.spec`, e.g.: `binutils.spec`.  We scan any file with a `.spec`
+file extension.
+
+## Analysis
+
+Currently, we scan for lines which start with `BuildRequires:`, followed by at
+least one space.  On this line we extract EXACTLY ONE package, which may
+optionally specify a single version constraint.  This package and its
+constraint are considered a single, direct, build-time dependency.
+
+## Limitations
+
+The SPEC file format is simple, yet robust.  We currently do not support all of
+its features yet.  Notably, we do not support the following:
+
+* Combinatoric version constraints, such as `(>= 1.2 and != 1.4) or = 0.9`
+  * Parentheses, as well as the `and` and `or` constructs are not supported yet.
+* Runtime requirements
+  * This is easy to implement, but may not be relevant or necessary for real-life
+    analysis.
+* Macros, such as `xxxxxx-%{?_isa}`, or `xxxxx = %{version}-%{release}`
+  * SPEC files allow for a few macros to dynamically determine package names/versions.
+    We do not yet support this, although we may support it in the future.

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -95,6 +95,7 @@ library
     App.Fossa.Analyze.GraphBuilder
     App.Fossa.Analyze.GraphMangler
     App.Fossa.Analyze.Project
+    App.Fossa.API.BuildWait
     App.Fossa.CliTypes
     App.Fossa.FossaAPIV1
     App.Fossa.Main
@@ -165,6 +166,7 @@ library
     Strategy.Python.ReqTxt
     Strategy.Python.SetupPy
     Strategy.Python.Util
+    Strategy.RPM
     Strategy.Ruby.BundleShow
     Strategy.Ruby.GemfileLock
     Types
@@ -232,6 +234,7 @@ test-suite unit-tests
     Python.ReqTxtSpec
     Python.RequirementsSpec
     Python.SetupPySpec
+    RPM.SpecFileSpec
     Ruby.BundleShowSpec
     Ruby.GemfileLockSpec
 

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -95,6 +95,7 @@ library
     App.Fossa.Analyze.GraphBuilder
     App.Fossa.Analyze.GraphMangler
     App.Fossa.Analyze.Project
+    App.Fossa.CliTypes
     App.Fossa.FossaAPIV1
     App.Fossa.Main
     App.Fossa.ProjectInference

--- a/src/App/Fossa/API/BuildWait.hs
+++ b/src/App/Fossa/API/BuildWait.hs
@@ -1,0 +1,53 @@
+module App.Fossa.API.BuildWait (
+    waitForBuild,
+    waitForIssues
+) where
+
+import Prologue
+
+import App.Fossa.CliTypes
+import qualified App.Fossa.FossaAPIV1 as Fossa
+import Control.Carrier.Diagnostics
+import Control.Concurrent (threadDelay)
+import Effect.Logger
+import Text.URI (URI)
+
+pollDelaySeconds :: Int
+pollDelaySeconds = 8
+
+data WaitError = BuildFailed -- ^ we encountered the FAILED status on a build
+  deriving (Show, Generic)
+
+instance ToDiagnostic WaitError where
+  renderDiagnostic BuildFailed = "The build failed. Check the FOSSA webapp for more details."
+
+waitForBuild
+  :: (Has Diagnostics sig m, MonadIO m, Has Logger sig m)
+  => URI
+  -> ApiKey -- ^ api key
+  -> ProjectRevision
+  -> m ()
+waitForBuild baseurl key revision = do
+  build <- Fossa.getLatestBuild baseurl key revision
+ 
+  case Fossa.buildTaskStatus (Fossa.buildTask build) of
+    Fossa.StatusSucceeded -> pure ()
+    Fossa.StatusFailed -> fatal BuildFailed
+    otherStatus -> do
+      logSticky $ "[ Waiting for build completion... last status: " <> viaShow otherStatus <> " ]"
+      liftIO $ threadDelay (pollDelaySeconds * 1_000_000)
+      waitForBuild baseurl key revision
+
+waitForIssues
+  :: (Has Diagnostics sig m, MonadIO m, Has Logger sig m)
+  => URI
+  -> ApiKey -- ^ api key
+  -> ProjectRevision
+  -> m Fossa.Issues
+waitForIssues baseurl key revision = do
+  issues <- Fossa.getIssues baseurl key revision
+  case Fossa.issuesStatus issues of
+    "WAITING" -> do
+      liftIO $ threadDelay (pollDelaySeconds * 1_000_000)
+      waitForIssues baseurl key revision
+    _ -> pure issues

--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -13,9 +13,10 @@ import Control.Carrier.Output.IO
 import Control.Concurrent
 import Path.IO
 
-import App.Fossa.FossaAPIV1 (ProjectRevision(..), ProjectMetadata, uploadAnalysis, UploadResponse(..))
+import App.Fossa.CliTypes
+import App.Fossa.FossaAPIV1 (ProjectMetadata, uploadAnalysis, UploadResponse(..))
 import App.Fossa.Analyze.Project (Project, mkProjects)
-import App.Fossa.ProjectInference (InferredProject(..), inferProject)
+import App.Fossa.ProjectInference (mergeOverride, inferProject)
 import Control.Carrier.TaskPool
 import Data.Text.Lazy.Encoding (decodeUtf8)
 import Data.Text.Prettyprint.Doc
@@ -59,14 +60,14 @@ import Types
 import qualified Data.Text.Encoding as TE
 
 data ScanDestination
-  = UploadScan URI Text ProjectMetadata -- ^ upload to fossa with provided api key and base url
+  = UploadScan URI ApiKey ProjectMetadata -- ^ upload to fossa with provided api key and base url
   | OutputStdout
   deriving (Generic)
  
-analyzeMain :: Severity -> ScanDestination -> Maybe Text -> Maybe Text -> Maybe Text -> IO ()
-analyzeMain logSeverity destination name revision branch = do
+analyzeMain :: Severity -> ScanDestination -> OverrideProject -> IO ()
+analyzeMain logSeverity destination project = do
   basedir <- getCurrentDir
-  withLogger logSeverity $ analyze basedir destination name revision branch
+  withLogger logSeverity $ analyze basedir destination project
 
 analyze ::
   ( Has (Lift IO) sig m
@@ -75,11 +76,9 @@ analyze ::
   )
   => Path Abs Dir
   -> ScanDestination
-  -> Maybe Text -- ^ cli override for name
-  -> Maybe Text -- ^ cli override for revision
-  -> Maybe Text -- ^ cli override for branch
+  -> OverrideProject
   -> m ()
-analyze basedir destination overrideName overrideRevision overrideBranch = do
+analyze basedir destination override = do
   capabilities <- liftIO getNumCapabilities
 
   (closures,(failures,())) <- runOutput @ProjectClosure $ runOutput @ProjectFailure $
@@ -95,11 +94,7 @@ analyze basedir destination overrideName overrideRevision overrideBranch = do
   case destination of
     OutputStdout -> logStdout $ pretty (decodeUtf8 (encode result))
     UploadScan baseurl apiKey metadata -> do
-      inferred <- inferProject basedir
-      let revision = ProjectRevision
-            (fromMaybe (inferredName inferred) overrideName)
-            (fromMaybe (inferredRevision inferred) overrideRevision)
-            (fromMaybe (inferredBranch inferred) overrideBranch)
+      revision <- mergeOverride override <$> inferProject basedir
 
       logInfo ""
       logInfo ("Using project name: `" <> pretty (projectName revision) <> "`")

--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -52,6 +52,7 @@ import qualified Strategy.NuGet.Nuspec as Nuspec
 import qualified Strategy.Python.Pipenv as Pipenv
 import qualified Strategy.Python.ReqTxt as ReqTxt
 import qualified Strategy.Python.SetupPy as SetupPy
+import qualified Strategy.RPM as RPM
 import qualified Strategy.Ruby.BundleShow as BundleShow
 import qualified Strategy.Ruby.GemfileLock as GemfileLock
 import Text.URI (URI)
@@ -183,6 +184,8 @@ discoverFuncs =
   , Clojure.discover
   
   , Cargo.discover
+
+  , RPM.discover
   ]
 
 updateProgress :: Has Logger sig m => Progress -> m ()

--- a/src/App/Fossa/CliTypes.hs
+++ b/src/App/Fossa/CliTypes.hs
@@ -1,0 +1,22 @@
+module App.Fossa.CliTypes
+  ( ApiKey (..),
+    OverrideProject (..),
+    ProjectRevision (..)
+  )
+where
+
+import Prologue
+
+newtype ApiKey = ApiKey {unApiKey :: Text} deriving (Eq, Ord, Show)
+
+data OverrideProject = OverrideProject
+  { overrideName :: Maybe Text,
+    overrideRevision :: Maybe Text,
+    overrideBranch :: Maybe Text
+  }
+
+data ProjectRevision = ProjectRevision
+  { projectName :: Text
+  , projectRevision :: Text
+  , projectBranch :: Text
+  } deriving (Eq, Ord, Show)

--- a/src/App/Fossa/FossaAPIV1.hs
+++ b/src/App/Fossa/FossaAPIV1.hs
@@ -1,7 +1,6 @@
 module App.Fossa.FossaAPIV1
   ( uploadAnalysis
   , UploadResponse(..)
-  , ProjectRevision(..)
   , ProjectMetadata(..)
   , FossaError(..)
   , FossaReq(..)
@@ -21,12 +20,13 @@ module App.Fossa.FossaAPIV1
   , getAttribution
   ) where
 
+import App.Fossa.CliTypes
 import App.Fossa.Analyze.Project
 import qualified App.Fossa.Report.Attribution as Attr
 import Control.Effect.Diagnostics
 import Data.Coerce (coerce)
 import Data.List (isInfixOf)
-import Data.Maybe (fromMaybe)
+import Data.Maybe (catMaybes, fromMaybe)
 import Data.Text (Text)
 import Data.Aeson
 import Prelude
@@ -42,7 +42,6 @@ import Srclib.Converter (toSourceUnit)
 import Srclib.Types
 import Text.URI (URI)
 import qualified Text.URI as URI
-import Data.Maybe (catMaybes)
 
 newtype FossaReq m a = FossaReq { unFossaReq :: m a }
   deriving (Functor, Applicative, Monad, MonadIO, Algebra sig)
@@ -74,6 +73,9 @@ renderLocatorUrl :: Int -> Locator -> Text
 renderLocatorUrl orgId Locator{..} =
   locatorFetcher <> "+" <> T.pack (show orgId) <> "/" <> locatorProject <> "$" <> fromMaybe "" locatorRevision
 
+apiHeader :: ApiKey -> Option scheme
+apiHeader key = header "Authorization" ("token " <> encodeUtf8 (unApiKey key))
+
 data UploadResponse = UploadResponse
   { uploadLocator :: Text
   , uploadError   :: Maybe Text
@@ -100,12 +102,6 @@ instance ToDiagnostic FossaError where
     OtherError err -> "An unknown error occurred when accessing the FOSSA API: " <> viaShow err
     BadURI uri -> "Invalid FOSSA URL: " <> pretty (URI.render uri)
 
-data ProjectRevision = ProjectRevision
-  { projectName :: Text
-  , projectRevision :: Text
-  , projectBranch :: Text
-  } deriving (Eq, Ord, Show)
-
 data ProjectMetadata = ProjectMetadata
   { projectTitle :: Maybe Text
   , projectUrl :: Maybe Text
@@ -118,7 +114,7 @@ data ProjectMetadata = ProjectMetadata
 uploadAnalysis
   :: (Has Diagnostics sig m, MonadIO m)
   => URI -- ^ base url
-  -> Text -- ^ api key
+  -> ApiKey -- ^ api key
   -> ProjectRevision
   -> ProjectMetadata
   -> [Project]
@@ -133,7 +129,7 @@ uploadAnalysis baseUri key ProjectRevision{..} metadata projects = fossaReq $ do
           <> "managedBuild" =: True
           <> "title" =: fromMaybe projectName (projectTitle metadata)
           <> "branch" =: projectBranch
-          <> header "Authorization" ("token " <> encodeUtf8 key)
+          <> apiHeader key
           <> mkMetadataOpts metadata
   resp <- req POST (uploadUrl baseUrl) (ReqBodyJson sourceUnits) jsonResponse (baseOptions <> opts)
   pure (responseBody resp)
@@ -226,14 +222,13 @@ instance FromJSON BuildStatus where
 getLatestBuild
   :: (Has Diagnostics sig m, MonadIO m)
   => URI
-  -> Text -- ^ api key
-  -> Text -- ^ project name
-  -> Text -- ^ project revision
+  -> ApiKey -- ^ api key
+  -> ProjectRevision
   -> m Build
-getLatestBuild baseUri key projectName projectRevision = fossaReq $ do
+getLatestBuild baseUri key ProjectRevision {..} = fossaReq $ do
   (baseUrl, baseOptions) <- parseUri baseUri
 
-  let opts = baseOptions <> header "Authorization" ("token " <> encodeUtf8 key)
+  let opts = baseOptions <> apiHeader key
 
   Organization orgId <- responseBody <$> req GET (organizationEndpoint baseUrl) NoReqBody jsonResponse opts
  
@@ -248,14 +243,13 @@ issuesEndpoint baseUrl orgId locator = baseUrl /: "api" /: "cli" /: renderLocato
 getIssues
   :: (Has Diagnostics sig m, MonadIO m)
   => URI
-  -> Text -- ^ api key
-  -> Text -- ^ project name
-  -> Text -- ^ project revision
+  -> ApiKey -- ^ api key
+  -> ProjectRevision
   -> m Issues
-getIssues baseUri key projectName projectRevision = fossaReq $ do
+getIssues baseUri key ProjectRevision{..} = fossaReq $ do
   (baseUrl, baseOptions) <- parseUri baseUri
  
-  let opts = baseOptions <> header "Authorization" ("token " <> encodeUtf8 key)
+  let opts = baseOptions <> apiHeader key
 
   Organization orgId <- responseBody <$> req GET (organizationEndpoint baseUrl) NoReqBody jsonResponse opts
   response <- req GET (issuesEndpoint baseUrl orgId (Locator "custom" projectName (Just projectRevision))) NoReqBody jsonResponse opts
@@ -363,20 +357,19 @@ attributionEndpoint baseurl orgId locator = baseurl /: "api" /: "revisions" /: r
 getAttribution
   :: (Has Diagnostics sig m, MonadIO m)
   => URI
-  -> Text -- ^ api key
-  -> Text -- ^ project name
-  -> Text -- ^ project revision
+  -> ApiKey -- ^ api key
+  -> ProjectRevision
   -> m Attr.Attribution
-getAttribution baseUri key project revision = fossaReq $ do
+getAttribution baseUri key ProjectRevision{..} = fossaReq $ do
   (baseUrl, baseOptions) <- parseUri baseUri
 
   let opts = baseOptions
-        <> header "Authorization" ("token " <> encodeUtf8 key)
+        <> apiHeader key
         <> "includeDeepDependencies" =: True
         <> "includeHashAndVersionData" =: True
         <> "includeDownloadUrl" =: True
   Organization orgId <- responseBody <$> req GET (organizationEndpoint baseUrl) NoReqBody jsonResponse opts
-  response <- req GET (attributionEndpoint baseUrl orgId (Locator "custom" project (Just revision))) NoReqBody jsonResponse opts
+  response <- req GET (attributionEndpoint baseUrl orgId (Locator "custom" projectName (Just projectRevision))) NoReqBody jsonResponse opts
   pure (responseBody response)
 
 ----------

--- a/src/App/Fossa/Main.hs
+++ b/src/App/Fossa/Main.hs
@@ -1,4 +1,4 @@
-{-# language QuasiQuotes #-}
+{-# LANGUAGE QuasiQuotes #-}
 
 module App.Fossa.Main
   ( appMain,
@@ -11,8 +11,8 @@ import App.Fossa.FossaAPIV1 (ProjectMetadata (..))
 import App.Fossa.Report (ReportType (..), reportMain)
 import App.Fossa.Test (TestOutputType (..), testMain)
 import qualified Data.Text as T
-import OptionExtensions
 import Effect.Logger
+import OptionExtensions
 import Options.Applicative
 import Path.IO (doesDirExist, resolveDir', setCurrentDir)
 import Prologue
@@ -25,11 +25,15 @@ appMain :: IO ()
 appMain = do
   CmdOptions {..} <- customExecParser (prefs (showHelpOnError <> subparserInline)) (info (opts <**> helper) (fullDesc <> header "fossa-cli - Flexible, performant dependency analysis"))
   let logSeverity = bool SevInfo SevDebug optDebug
-
+  --
   maybeApiKey <- checkAPIKey optAPIKey
-
-  let override = OverrideProject { overrideName = optProjectName, overrideRevision = optProjectRevision, overrideBranch = Nothing }
-
+  let override =
+        OverrideProject
+          { overrideName = optProjectName,
+            overrideRevision = optProjectRevision,
+            overrideBranch = Nothing
+          }
+  --
   case optCommand of
     AnalyzeCommand AnalyzeOptions {..} -> do
       changeDir analyzeBaseDir
@@ -39,18 +43,20 @@ appMain = do
         else do
           key <- requireKey maybeApiKey
           analyzeMain logSeverity (UploadScan optBaseUrl key analyzeMetadata) analyzeOverride
+    --
     TestCommand TestOptions {..} -> do
       changeDir testBaseDir
       key <- requireKey maybeApiKey
       testMain optBaseUrl key logSeverity testTimeout testOutputType override
+    --
     InitCommand ->
       withLogger logSeverity $ logWarn "This command has been deprecated and is no longer needed.  It has no effect and may be safely removed."
+    --
     ReportCommand ReportOptions {..} -> do
       unless reportJsonOutput $ die "report command currently only supports JSON output.  Please try `fossa report --json REPORT_NAME`"
       changeDir reportBaseDir
       key <- requireKey maybeApiKey
       reportMain optBaseUrl key logSeverity reportTimeout reportType override
-      
 
 requireKey :: Maybe ApiKey -> IO ApiKey
 requireKey (Just key) = pure key
@@ -59,7 +65,8 @@ requireKey Nothing = die "A FOSSA API key is required to run this command"
 changeDir :: FilePath -> IO ()
 changeDir path = validateDir path >>= setCurrentDir
 
-infixr 1 <$$>
+infixl 4 <$$>
+
 (<$$>) :: (Functor f, Functor g) => (a -> b) -> f (g a) -> f (g b)
 (<$$>) = fmap . fmap
 
@@ -67,8 +74,7 @@ infixr 1 <$$>
 checkAPIKey :: Maybe Text -> IO (Maybe ApiKey)
 checkAPIKey key = case key of
   Just key' -> pure . Just $ ApiKey key'
-  Nothing -> ApiKey <$$> T.pack <$$> lookupEnv "FOSSA_API_KEY"
-    
+  Nothing -> ApiKey . T.pack <$$> lookupEnv "FOSSA_API_KEY"
 
 -- | Validate that a filepath points to a directory and the directory exists
 validateDir :: FilePath -> IO (Path Abs Dir)

--- a/src/App/Fossa/Report.hs
+++ b/src/App/Fossa/Report.hs
@@ -6,11 +6,13 @@ module App.Fossa.Report
 import Prologue
 
 import App.Fossa.CliTypes
+import App.Fossa.API.BuildWait
 import qualified App.Fossa.FossaAPIV1 as Fossa
 import App.Fossa.ProjectInference
 import Control.Concurrent (threadDelay)
 import Control.Carrier.Diagnostics
 import qualified Control.Concurrent.Async as Async
+import Data.Functor (($>))
 import Data.Text.IO (hPutStrLn)
 import Effect.Logger
 import Path.IO
@@ -83,48 +85,9 @@ reportMain baseUri apiKey logSeverity timeoutSeconds reportType override = do
   hPutStrLn stderr "Timed out while waiting for build/issues scan"
   exitFailure
 
-waitForBuild
-  :: (Has Diagnostics sig m, MonadIO m, Has Logger sig m)
-  => URI
-  -> ApiKey -- ^ api key
-  -> ProjectRevision
-  -> m ()
-waitForBuild baseUri key revision = do
-  build <- Fossa.getLatestBuild baseUri key revision
-  case Fossa.buildTaskStatus (Fossa.buildTask build) of
-    Fossa.StatusSucceeded -> pure ()
-    Fossa.StatusFailed -> fatal BuildFailed
-    otherStatus -> do
-      logSticky $ "[ Waiting for build completion... last status: " <> viaShow otherStatus <> " ]"
-      liftIO $ threadDelay (pollDelaySeconds * 1000000)
-      waitForBuild baseUri key revision
-
-waitForIssues
-  :: (Has Diagnostics sig m, MonadIO m, Has Logger sig m)
-  => URI
-  -> ApiKey -- ^ api key
-  -> ProjectRevision
-  -> m ()
-waitForIssues baseUri key revision = do
-  issues <- Fossa.getIssues baseUri key revision
-  case Fossa.issuesStatus issues of
-    "WAITING" -> do
-      liftIO $ threadDelay (pollDelaySeconds * 1000000)
-      waitForIssues baseUri key revision
-    _ -> pure ()
-
-pollDelaySeconds :: Int
-pollDelaySeconds = 8
-
 timeout
   :: Int -- ^ number of seconds before timeout
   -> IO a
   -> IO (Maybe a)
-timeout seconds act = either id id <$> Async.race (Just <$> act) (threadDelay (seconds * 1000000) *> pure Nothing)
-
-data WaitError
-  = BuildFailed -- ^ we encountered the FAILED status on a build
-  deriving (Show, Generic)
-
-instance ToDiagnostic WaitError where
-  renderDiagnostic BuildFailed = "The build failed. Check the FOSSA webapp for more details."
+-- timeout seconds act = either id id <$> Async.race (Just <$> act) (threadDelay (seconds * 1_000_000) *> pure Nothing)
+timeout seconds act = either id id <$> Async.race (Just <$> act) (threadDelay (seconds * 1_000_000) $> Nothing)

--- a/src/App/Fossa/Test.hs
+++ b/src/App/Fossa/Test.hs
@@ -7,12 +7,14 @@ module App.Fossa.Test
 import Prologue
 import qualified Prelude as Unsafe
 
+import App.Fossa.API.BuildWait
 import App.Fossa.CliTypes
 import qualified App.Fossa.FossaAPIV1 as Fossa
 import App.Fossa.ProjectInference
 import Control.Carrier.Diagnostics
 import Control.Concurrent (threadDelay)
 import qualified Control.Concurrent.Async as Async
+import Data.Functor (($>))
 import qualified Data.Map as M
 import qualified Data.Text as T
 import Data.Text.IO (hPutStrLn)
@@ -23,9 +25,6 @@ import System.Exit (exitSuccess, exitFailure)
 import Text.URI (URI)
 import qualified Data.Aeson as Aeson
 import Data.Text.Lazy.Encoding (decodeUtf8)
-
-pollDelaySeconds :: Int
-pollDelaySeconds = 8
 
 data TestOutputType
   = TestOutputPretty -- ^ pretty output format for issues
@@ -129,45 +128,8 @@ renderedIssues issues = rendered
           | length xs <= ix = Nothing
           | otherwise = Just (xs Unsafe.!! ix)
 
-data TestError = TestBuildFailed -- ^ we encountered the FAILED status on a build
-  deriving (Show, Generic)
-
-instance ToDiagnostic TestError where
-  renderDiagnostic TestBuildFailed = "The build failed. Check the FOSSA webapp for more details."
-
-waitForBuild
-  :: (Has Diagnostics sig m, MonadIO m, Has Logger sig m)
-  => URI
-  -> ApiKey -- ^ api key
-  -> ProjectRevision
-  -> m ()
-waitForBuild baseurl key revision = do
-  build <- Fossa.getLatestBuild baseurl key revision
- 
-  case Fossa.buildTaskStatus (Fossa.buildTask build) of
-    Fossa.StatusSucceeded -> pure ()
-    Fossa.StatusFailed -> fatal TestBuildFailed
-    otherStatus -> do
-      logSticky $ "[ Waiting for build completion... last status: " <> viaShow otherStatus <> " ]"
-      liftIO $ threadDelay (pollDelaySeconds * 1_000_000)
-      waitForBuild baseurl key revision
-
-waitForIssues
-  :: (Has Diagnostics sig m, MonadIO m, Has Logger sig m)
-  => URI
-  -> ApiKey -- ^ api key
-  -> ProjectRevision
-  -> m Fossa.Issues
-waitForIssues baseurl key revision = do
-  issues <- Fossa.getIssues baseurl key revision
-  case Fossa.issuesStatus issues of
-    "WAITING" -> do
-      liftIO $ threadDelay (pollDelaySeconds * 1_000_000)
-      waitForIssues baseurl key revision
-    _ -> pure issues
-
 timeout
   :: Int -- ^ number of seconds before timeout
   -> IO a
   -> IO (Maybe a)
-timeout seconds act = either id id <$> Async.race (Just <$> act) (threadDelay (seconds * 1_000_000) *> pure Nothing)
+timeout seconds act = either id id <$> Async.race (Just <$> act) (threadDelay (seconds * 1_000_000) $> Nothing)

--- a/src/DepTypes.hs
+++ b/src/DepTypes.hs
@@ -53,6 +53,7 @@ data DepType =
   | PodType    -- ^ Cocoapods registry
   | GoType -- ^ Go dependency
   | CargoType -- ^ Rust Cargo Dependency
+  | RPMType -- ^ RPM dependency
   -- TODO: does this break the "location" abstraction?
   | CarthageType -- ^ A Carthage dependency -- effectively a "git" dependency. Name is repo path and version is tag/branch/hash
   deriving (Eq, Ord, Show, Generic)

--- a/src/Srclib/Converter.hs
+++ b/src/Srclib/Converter.hs
@@ -104,3 +104,4 @@ depTypeToFetcher = \case
   GoType -> "go"
   CarthageType -> "cart"
   CargoType -> "cargo"
+  RPMType -> "rpm"

--- a/src/Strategy/RPM.hs
+++ b/src/Strategy/RPM.hs
@@ -1,0 +1,138 @@
+module Strategy.RPM
+  ( buildGraph,
+    discover,
+    getSpecDeps,
+    getTypeFromLine,
+    toDependency,
+    RPMDependency (..),
+    RequiresType (..),
+    Dependencies (..),
+  )
+where
+
+import Control.Effect.Error
+import Control.Effect.Diagnostics
+import qualified Data.Map.Strict as M
+import Data.Maybe (mapMaybe)
+import qualified Data.Text as T
+import DepTypes
+import Discovery.Walk
+import Effect.ReadFS
+import Graphing (Graphing)
+import qualified Graphing as G
+import Prologue
+import Types
+
+newtype SpecFileLabel
+  = RequiresType DepEnvironment
+  deriving (Eq, Ord, Show, Generic)
+
+data RPMDependency
+  = RPMDependency
+      { rpmDepName :: Text,
+        rpmConstraint :: Maybe VerConstraint
+      }
+  deriving (Eq, Ord, Show, Generic)
+
+data RequiresType
+  = BuildRequires RPMDependency
+  | RuntimeRequires RPMDependency
+  deriving (Eq, Ord, Show, Generic)
+
+data Dependencies
+  = Dependencies
+      { depBuildRequires :: [RPMDependency],
+        depRuntimeRequires :: [RPMDependency]
+      }
+  deriving (Eq, Ord, Show, Generic)
+
+discover :: HasDiscover sig m => Path Abs Dir -> m ()
+discover = walk $ \dir _ files ->
+  let specs = find (\f -> ".spec" `isSuffixOf` fileName f) files
+      analzyeFile specFile = runSimpleStrategy "rpm-spec" RPMGroup $ fmap (mkProjectClosure dir) (analyze specFile)
+   in traverse_ analzyeFile specs >> pure WalkSkipAll
+
+analyze :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Rel File -> m (Graphing Dependency)
+analyze specFile = do
+  specFileText <- readContentsText specFile
+  pure . buildGraph $ getSpecDeps specFileText
+
+mkProjectClosure :: Path Rel Dir -> Graphing Dependency -> ProjectClosureBody
+mkProjectClosure dir graph =
+  ProjectClosureBody
+    { bodyModuleDir = dir,
+      bodyDependencies = dependencies,
+      bodyLicenses = []
+    }
+  where
+    dependencies =
+      ProjectDependencies
+        { dependenciesGraph = graph,
+          dependenciesOptimal = Optimal,
+          dependenciesComplete = NotComplete
+        }
+
+toDependency :: RPMDependency -> Dependency
+toDependency pkg =
+    Dependency
+      { dependencyType = RPMType,
+        dependencyName = rpmDepName pkg,
+        dependencyVersion = rpmConstraint pkg,
+        dependencyLocations = [],
+        dependencyEnvironments = [],
+        dependencyTags = M.empty
+      }
+
+buildGraph :: Dependencies -> Graphing Dependency
+buildGraph Dependencies {..} = G.gmap toDependency $ G.fromList depBuildRequires
+
+buildConstraint :: Text -> Maybe VerConstraint
+buildConstraint tail = constraint
+  where
+    (comparatorStr, rawVersion) = splitOnceOn " " $ T.strip tail
+    version = T.strip rawVersion
+    constraint = case T.strip comparatorStr of
+      "<=" -> Just $ CLessOrEq version
+      "<" -> Just $ CLess version
+      ">=" -> Just $ CGreaterOrEq version
+      ">" -> Just $ CGreater version
+      "=" -> Just $ CEq version
+      "==" -> Just $ CEq version
+      _ -> Nothing
+
+splitOnceOn :: Text -> Text -> (Text, Text)
+splitOnceOn needle haystack = (head, strippedTail)
+  where
+    len = T.length needle
+    (head, tail) = T.breakOn needle haystack
+    strippedTail = T.drop len tail
+
+getTypeFromLine :: Text -> Maybe RequiresType
+getTypeFromLine line = safeReq
+  where
+    (header, value) = splitOnceOn ": " line
+    (pkgName, rawConstraint) = splitOnceOn " " $ T.strip value
+    --
+    isSafeName :: Text -> Bool
+    isSafeName name = not $ "%{" `T.isInfixOf` name
+    -- TODO: temporarily ignore names with macros, until we support expansion
+    safeReq :: Maybe RequiresType
+    safeReq = if isSafeName pkgName then req else Nothing
+    --
+    req :: Maybe RequiresType
+    req = case header of
+      "BuildRequires" -> Just . BuildRequires . RPMDependency pkgName $ buildConstraint rawConstraint
+      "Requires" -> Just . RuntimeRequires . RPMDependency pkgName $ buildConstraint rawConstraint
+      _ -> Nothing
+
+buildDependencies :: [RequiresType] -> Dependencies
+buildDependencies = foldr addDep blankDeps
+  where
+    addDep :: RequiresType -> Dependencies -> Dependencies
+    addDep req deps = case req of
+      BuildRequires dep -> deps {depBuildRequires = dep : depBuildRequires deps}
+      RuntimeRequires dep -> deps {depRuntimeRequires = dep : depRuntimeRequires deps}
+    blankDeps = Dependencies [] []
+
+getSpecDeps :: Text -> Dependencies
+getSpecDeps = buildDependencies . mapMaybe getTypeFromLine . T.lines

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -145,6 +145,7 @@ data StrategyGroup =
   | CocoapodsGroup
   | ClojureGroup
   | RustGroup
+  | RPMGroup
   deriving (Eq, Ord, Show, Generic)
 
 -- FIXME: we also need to annotate dep graphs with Path Rel File -- merge these somehow?

--- a/test/RPM/SpecFileSpec.hs
+++ b/test/RPM/SpecFileSpec.hs
@@ -1,0 +1,90 @@
+module RPM.SpecFileSpec
+  ( spec,
+  )
+where
+
+import Data.Maybe (listToMaybe)
+import qualified Data.Text.IO as TIO
+import DepTypes
+import GraphUtil
+import Prologue
+import Strategy.RPM
+import qualified Test.Hspec as Test
+
+mkUnVerDep :: Text -> RPMDependency
+mkUnVerDep name = RPMDependency name Nothing
+
+mkVerDep :: Text -> VerConstraint -> RPMDependency
+mkVerDep name ver = RPMDependency name $ Just ver
+
+boostDep :: RPMDependency
+boostDep = mkUnVerDep "boost"
+
+cmakeDep :: RPMDependency
+cmakeDep = mkVerDep "cmake" $ CGreaterOrEq "2.8"
+
+jsoncppDep :: RPMDependency
+jsoncppDep = mkVerDep "jsoncpp" $ CLessOrEq "0.10.5"
+
+gtestDep :: RPMDependency
+gtestDep = mkVerDep "gtest" $ CGreater "6.4"
+
+libeventDep :: RPMDependency
+libeventDep = mkVerDep "libevent" $ CLess "9.8.1"
+
+libvirtDep :: RPMDependency
+libvirtDep = mkVerDep "libvirt" $ CEq "3.9.0"
+
+opensslDep :: RPMDependency
+opensslDep = mkVerDep "openssl" $ CEq "1.23.45"
+
+xzDep :: RPMDependency
+xzDep = mkUnVerDep "xz"
+
+libxml2Dep :: RPMDependency
+libxml2Dep = mkVerDep "libxml2" $ CGreaterOrEq "5.4.98"
+
+gmockDep :: RPMDependency
+gmockDep = mkVerDep "gmock" $ CEq "1.6.0-1.aapps.el7"
+
+tacpDep :: RPMDependency
+tacpDep = mkUnVerDep "tacp"
+
+buildDeps :: [RPMDependency]
+buildDeps =
+  [ boostDep,
+    cmakeDep,
+    jsoncppDep,
+    gtestDep,
+    libeventDep,
+    libvirtDep,
+    opensslDep,
+    libxml2Dep,
+    xzDep,
+    gmockDep
+  ]
+
+spec :: Test.Spec
+spec = do
+  Test.describe "rpm specfile parser" $ do
+    contents <- Test.runIO $ TIO.readFile "test/RPM/testdata/simple-test.spec"
+    Test.it "should list all BuildRequires and Requires" $ do
+      let deps = getSpecDeps contents
+      depBuildRequires deps `Test.shouldMatchList` buildDeps
+      listToMaybe (depRuntimeRequires deps) `Test.shouldBe` Just tacpDep
+  --
+  Test.describe "line parser"
+    $ Test.it "should parse single lines correctly"
+    $ do
+      getTypeFromLine "BuildRequires: xz = 1" `Test.shouldBe` Just (BuildRequires $ mkVerDep "xz" $ CEq "1")
+      getTypeFromLine "Requires: xz = 1" `Test.shouldBe` Just (RuntimeRequires $ mkVerDep "xz" $ CEq "1")
+  --
+  Test.describe "rpm dependency grapher" $
+    Test.it "should produce flat BuildRequires" $ do
+      let deps = Dependencies [boostDep, xzDep] [tacpDep, jsoncppDep]
+          gr = buildGraph deps
+
+      expectDeps (map toDependency [boostDep, xzDep]) gr
+      expectDirect (map toDependency [boostDep, xzDep]) gr
+      expectEdges [] gr
+

--- a/test/RPM/testdata/simple-test.spec
+++ b/test/RPM/testdata/simple-test.spec
@@ -1,0 +1,31 @@
+# A haiku showing how permissive our current parser is.
+To prove our parser
+This is not in a comment
+No hashtag needed
+
+# Basic parsing
+BuildRequires: boost
+
+# Simple version text
+BuildRequires: cmake >= 2.8
+BuildRequires: jsoncpp <= 0.10.5
+BuildRequires: gtest > 6.4
+BuildRequires: libevent < 9.8.1
+BuildRequires: libvirt == 3.9.0
+BuildRequires: openssl = 1.23.45
+
+# Bad operator, will ignore version
+BuildRequires: xz >> 1.2.3
+
+# Lots of spaces, should be fine
+BuildRequires:   libxml2     >=   5.4.98
+
+# Complex version text (shouldn't change behavior)
+BuildRequires:  gmock = 1.6.0-1.aapps.el7
+
+# We also handle "Requires" headers
+Requires:   tacp
+
+# Ignored due to macro use
+BuildRequires:  cloudistics-core%{?_isa} = %{version}-%{release}
+


### PR DESCRIPTION
Summary:

* Wrap the `Text` of the API key as early as possible, unwrap it as late as possible.
* Abstract building the Authorization header (where we actually need the api key text)
* Collapse project {name, revision, branch} by leveraging the inferred project and an override project, and merging them, using the resulting merge type everywhere else.