### PR TITLE
Deduplicate the build/issue flow

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -1,1 +1,1 @@
-- arguments: [-XTypeApplications]
+- arguments: [-XTypeApplications, -XNumericUnderscores]

--- a/docs/strategies.md
+++ b/docs/strategies.md
@@ -7,5 +7,6 @@ We support dependency analysis for the following languages/ecosystems:
 - [maven](strategies/maven.md)
 - [nodejs](strategies/nodejs.md) (yarn, npmcli)
 - [python](strategies/python.md) (pipenv, setuptools)
+- [rpm](strategies/rpm.md) (spec files)
 - [ruby](strategies/ruby.md) (bundler)
 - [rust](strategies/rust.md) (cargo)

--- a/docs/strategies/rpm.md
+++ b/docs/strategies/rpm.md
@@ -1,0 +1,36 @@
+# RPM analysis
+
+RPM packages managed by system package managers like `dnf` and `yum` are built
+using SPEC files.  We are able to analyze these files to determine build-time
+dependencies.
+
+| Strategy | Direct Deps | Deep Deps | Edges | Tags         |
+| ---      | ---         | ---       | ---   | ---          |
+| rpm-spec | ✅          | ❌        | ❌    | Environment  |
+
+## Project Discovery
+
+RPM SPEC files have strict naming conventions.  They must be in the form of
+`<package-name>.spec`, e.g.: `binutils.spec`.  We scan any file with a `.spec`
+file extension.
+
+## Analysis
+
+Currently, we scan for lines which start with `BuildRequires:`, followed by at
+least one space.  On this line we extract EXACTLY ONE package, which may
+optionally specify a single version constraint.  This package and its
+constraint are considered a single, direct, build-time dependency.
+
+## Limitations
+
+The SPEC file format is simple, yet robust.  We currently do not support all of
+its features yet.  Notably, we do not support the following:
+
+* Combinatoric version constraints, such as `(>= 1.2 and != 1.4) or = 0.9`
+  * Parentheses, as well as the `and` and `or` constructs are not supported yet.
+* Runtime requirements
+  * This is easy to implement, but may not be relevant or necessary for real-life
+    analysis.
+* Macros, such as `xxxxxx-%{?_isa}`, or `xxxxx = %{version}-%{release}`
+  * SPEC files allow for a few macros to dynamically determine package names/versions.
+    We do not yet support this, although we may support it in the future.

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -165,6 +165,7 @@ library
     Strategy.Python.ReqTxt
     Strategy.Python.SetupPy
     Strategy.Python.Util
+    Strategy.RPM
     Strategy.Ruby.BundleShow
     Strategy.Ruby.GemfileLock
     Types
@@ -232,6 +233,7 @@ test-suite unit-tests
     Python.ReqTxtSpec
     Python.RequirementsSpec
     Python.SetupPySpec
+    RPM.SpecFileSpec
     Ruby.BundleShowSpec
     Ruby.GemfileLockSpec
 

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -95,6 +95,7 @@ library
     App.Fossa.Analyze.GraphBuilder
     App.Fossa.Analyze.GraphMangler
     App.Fossa.Analyze.Project
+    App.Fossa.BuildWait
     App.Fossa.CliTypes
     App.Fossa.FossaAPIV1
     App.Fossa.Main

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -95,7 +95,7 @@ library
     App.Fossa.Analyze.GraphBuilder
     App.Fossa.Analyze.GraphMangler
     App.Fossa.Analyze.Project
-    App.Fossa.BuildWait
+    App.Fossa.API.BuildWait
     App.Fossa.CliTypes
     App.Fossa.FossaAPIV1
     App.Fossa.Main

--- a/src/App/Fossa/API/BuildWait.hs
+++ b/src/App/Fossa/API/BuildWait.hs
@@ -1,4 +1,4 @@
-module App.Fossa.BuildWait (
+module App.Fossa.API.BuildWait (
     waitForBuild,
     waitForIssues
 ) where

--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -52,6 +52,7 @@ import qualified Strategy.NuGet.Nuspec as Nuspec
 import qualified Strategy.Python.Pipenv as Pipenv
 import qualified Strategy.Python.ReqTxt as ReqTxt
 import qualified Strategy.Python.SetupPy as SetupPy
+import qualified Strategy.RPM as RPM
 import qualified Strategy.Ruby.BundleShow as BundleShow
 import qualified Strategy.Ruby.GemfileLock as GemfileLock
 import Text.URI (URI)
@@ -183,6 +184,8 @@ discoverFuncs =
   , Clojure.discover
   
   , Cargo.discover
+
+  , RPM.discover
   ]
 
 updateProgress :: Has Logger sig m => Progress -> m ()

--- a/src/App/Fossa/BuildWait.hs
+++ b/src/App/Fossa/BuildWait.hs
@@ -1,0 +1,53 @@
+module App.Fossa.BuildWait (
+    waitForBuild,
+    waitForIssues
+) where
+
+import Prologue
+
+import App.Fossa.CliTypes
+import qualified App.Fossa.FossaAPIV1 as Fossa
+import Control.Carrier.Diagnostics
+import Control.Concurrent (threadDelay)
+import Effect.Logger
+import Text.URI (URI)
+
+pollDelaySeconds :: Int
+pollDelaySeconds = 8
+
+data WaitError = BuildFailed -- ^ we encountered the FAILED status on a build
+  deriving (Show, Generic)
+
+instance ToDiagnostic WaitError where
+  renderDiagnostic BuildFailed = "The build failed. Check the FOSSA webapp for more details."
+
+waitForBuild
+  :: (Has Diagnostics sig m, MonadIO m, Has Logger sig m)
+  => URI
+  -> ApiKey -- ^ api key
+  -> ProjectRevision
+  -> m ()
+waitForBuild baseurl key revision = do
+  build <- Fossa.getLatestBuild baseurl key revision
+ 
+  case Fossa.buildTaskStatus (Fossa.buildTask build) of
+    Fossa.StatusSucceeded -> pure ()
+    Fossa.StatusFailed -> fatal BuildFailed
+    otherStatus -> do
+      logSticky $ "[ Waiting for build completion... last status: " <> viaShow otherStatus <> " ]"
+      liftIO $ threadDelay (pollDelaySeconds * 1_000_000)
+      waitForBuild baseurl key revision
+
+waitForIssues
+  :: (Has Diagnostics sig m, MonadIO m, Has Logger sig m)
+  => URI
+  -> ApiKey -- ^ api key
+  -> ProjectRevision
+  -> m Fossa.Issues
+waitForIssues baseurl key revision = do
+  issues <- Fossa.getIssues baseurl key revision
+  case Fossa.issuesStatus issues of
+    "WAITING" -> do
+      liftIO $ threadDelay (pollDelaySeconds * 1_000_000)
+      waitForIssues baseurl key revision
+    _ -> pure issues

--- a/src/App/Fossa/Report.hs
+++ b/src/App/Fossa/Report.hs
@@ -6,7 +6,7 @@ module App.Fossa.Report
 import Prologue
 
 import App.Fossa.CliTypes
-import App.Fossa.BuildWait
+import App.Fossa.API.BuildWait
 import qualified App.Fossa.FossaAPIV1 as Fossa
 import App.Fossa.ProjectInference
 import Control.Concurrent (threadDelay)

--- a/src/App/Fossa/Test.hs
+++ b/src/App/Fossa/Test.hs
@@ -7,7 +7,7 @@ module App.Fossa.Test
 import Prologue
 import qualified Prelude as Unsafe
 
-import App.Fossa.BuildWait
+import App.Fossa.API.BuildWait
 import App.Fossa.CliTypes
 import qualified App.Fossa.FossaAPIV1 as Fossa
 import App.Fossa.ProjectInference

--- a/src/DepTypes.hs
+++ b/src/DepTypes.hs
@@ -53,6 +53,7 @@ data DepType =
   | PodType    -- ^ Cocoapods registry
   | GoType -- ^ Go dependency
   | CargoType -- ^ Rust Cargo Dependency
+  | RPMType -- ^ RPM dependency
   -- TODO: does this break the "location" abstraction?
   | CarthageType -- ^ A Carthage dependency -- effectively a "git" dependency. Name is repo path and version is tag/branch/hash
   deriving (Eq, Ord, Show, Generic)

--- a/src/Srclib/Converter.hs
+++ b/src/Srclib/Converter.hs
@@ -104,3 +104,4 @@ depTypeToFetcher = \case
   GoType -> "go"
   CarthageType -> "cart"
   CargoType -> "cargo"
+  RPMType -> "rpm"

--- a/src/Strategy/RPM.hs
+++ b/src/Strategy/RPM.hs
@@ -1,0 +1,138 @@
+module Strategy.RPM
+  ( buildGraph,
+    discover,
+    getSpecDeps,
+    getTypeFromLine,
+    toDependency,
+    RPMDependency (..),
+    RequiresType (..),
+    Dependencies (..),
+  )
+where
+
+import Control.Effect.Error
+import Control.Effect.Diagnostics
+import qualified Data.Map.Strict as M
+import Data.Maybe (mapMaybe)
+import qualified Data.Text as T
+import DepTypes
+import Discovery.Walk
+import Effect.ReadFS
+import Graphing (Graphing)
+import qualified Graphing as G
+import Prologue
+import Types
+
+newtype SpecFileLabel
+  = RequiresType DepEnvironment
+  deriving (Eq, Ord, Show, Generic)
+
+data RPMDependency
+  = RPMDependency
+      { rpmDepName :: Text,
+        rpmConstraint :: Maybe VerConstraint
+      }
+  deriving (Eq, Ord, Show, Generic)
+
+data RequiresType
+  = BuildRequires RPMDependency
+  | RuntimeRequires RPMDependency
+  deriving (Eq, Ord, Show, Generic)
+
+data Dependencies
+  = Dependencies
+      { depBuildRequires :: [RPMDependency],
+        depRuntimeRequires :: [RPMDependency]
+      }
+  deriving (Eq, Ord, Show, Generic)
+
+discover :: HasDiscover sig m => Path Abs Dir -> m ()
+discover = walk $ \dir _ files ->
+  let specs = find (\f -> ".spec" `isSuffixOf` fileName f) files
+      analzyeFile specFile = runSimpleStrategy "rpm-spec" RPMGroup $ fmap (mkProjectClosure dir) (analyze specFile)
+   in traverse_ analzyeFile specs >> pure WalkSkipAll
+
+analyze :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Rel File -> m (Graphing Dependency)
+analyze specFile = do
+  specFileText <- readContentsText specFile
+  pure . buildGraph $ getSpecDeps specFileText
+
+mkProjectClosure :: Path Rel Dir -> Graphing Dependency -> ProjectClosureBody
+mkProjectClosure dir graph =
+  ProjectClosureBody
+    { bodyModuleDir = dir,
+      bodyDependencies = dependencies,
+      bodyLicenses = []
+    }
+  where
+    dependencies =
+      ProjectDependencies
+        { dependenciesGraph = graph,
+          dependenciesOptimal = Optimal,
+          dependenciesComplete = NotComplete
+        }
+
+toDependency :: RPMDependency -> Dependency
+toDependency pkg =
+    Dependency
+      { dependencyType = RPMType,
+        dependencyName = rpmDepName pkg,
+        dependencyVersion = rpmConstraint pkg,
+        dependencyLocations = [],
+        dependencyEnvironments = [],
+        dependencyTags = M.empty
+      }
+
+buildGraph :: Dependencies -> Graphing Dependency
+buildGraph Dependencies {..} = G.gmap toDependency $ G.fromList depBuildRequires
+
+buildConstraint :: Text -> Maybe VerConstraint
+buildConstraint tail = constraint
+  where
+    (comparatorStr, rawVersion) = splitOnceOn " " $ T.strip tail
+    version = T.strip rawVersion
+    constraint = case T.strip comparatorStr of
+      "<=" -> Just $ CLessOrEq version
+      "<" -> Just $ CLess version
+      ">=" -> Just $ CGreaterOrEq version
+      ">" -> Just $ CGreater version
+      "=" -> Just $ CEq version
+      "==" -> Just $ CEq version
+      _ -> Nothing
+
+splitOnceOn :: Text -> Text -> (Text, Text)
+splitOnceOn needle haystack = (head, strippedTail)
+  where
+    len = T.length needle
+    (head, tail) = T.breakOn needle haystack
+    strippedTail = T.drop len tail
+
+getTypeFromLine :: Text -> Maybe RequiresType
+getTypeFromLine line = safeReq
+  where
+    (header, value) = splitOnceOn ": " line
+    (pkgName, rawConstraint) = splitOnceOn " " $ T.strip value
+    --
+    isSafeName :: Text -> Bool
+    isSafeName name = not $ "%{" `T.isInfixOf` name
+    -- TODO: temporarily ignore names with macros, until we support expansion
+    safeReq :: Maybe RequiresType
+    safeReq = if isSafeName pkgName then req else Nothing
+    --
+    req :: Maybe RequiresType
+    req = case header of
+      "BuildRequires" -> Just . BuildRequires . RPMDependency pkgName $ buildConstraint rawConstraint
+      "Requires" -> Just . RuntimeRequires . RPMDependency pkgName $ buildConstraint rawConstraint
+      _ -> Nothing
+
+buildDependencies :: [RequiresType] -> Dependencies
+buildDependencies = foldr addDep blankDeps
+  where
+    addDep :: RequiresType -> Dependencies -> Dependencies
+    addDep req deps = case req of
+      BuildRequires dep -> deps {depBuildRequires = dep : depBuildRequires deps}
+      RuntimeRequires dep -> deps {depRuntimeRequires = dep : depRuntimeRequires deps}
+    blankDeps = Dependencies [] []
+
+getSpecDeps :: Text -> Dependencies
+getSpecDeps = buildDependencies . mapMaybe getTypeFromLine . T.lines

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -145,6 +145,7 @@ data StrategyGroup =
   | CocoapodsGroup
   | ClojureGroup
   | RustGroup
+  | RPMGroup
   deriving (Eq, Ord, Show, Generic)
 
 -- FIXME: we also need to annotate dep graphs with Path Rel File -- merge these somehow?

--- a/test/RPM/SpecFileSpec.hs
+++ b/test/RPM/SpecFileSpec.hs
@@ -1,0 +1,90 @@
+module RPM.SpecFileSpec
+  ( spec,
+  )
+where
+
+import Data.Maybe (listToMaybe)
+import qualified Data.Text.IO as TIO
+import DepTypes
+import GraphUtil
+import Prologue
+import Strategy.RPM
+import qualified Test.Hspec as Test
+
+mkUnVerDep :: Text -> RPMDependency
+mkUnVerDep name = RPMDependency name Nothing
+
+mkVerDep :: Text -> VerConstraint -> RPMDependency
+mkVerDep name ver = RPMDependency name $ Just ver
+
+boostDep :: RPMDependency
+boostDep = mkUnVerDep "boost"
+
+cmakeDep :: RPMDependency
+cmakeDep = mkVerDep "cmake" $ CGreaterOrEq "2.8"
+
+jsoncppDep :: RPMDependency
+jsoncppDep = mkVerDep "jsoncpp" $ CLessOrEq "0.10.5"
+
+gtestDep :: RPMDependency
+gtestDep = mkVerDep "gtest" $ CGreater "6.4"
+
+libeventDep :: RPMDependency
+libeventDep = mkVerDep "libevent" $ CLess "9.8.1"
+
+libvirtDep :: RPMDependency
+libvirtDep = mkVerDep "libvirt" $ CEq "3.9.0"
+
+opensslDep :: RPMDependency
+opensslDep = mkVerDep "openssl" $ CEq "1.23.45"
+
+xzDep :: RPMDependency
+xzDep = mkUnVerDep "xz"
+
+libxml2Dep :: RPMDependency
+libxml2Dep = mkVerDep "libxml2" $ CGreaterOrEq "5.4.98"
+
+gmockDep :: RPMDependency
+gmockDep = mkVerDep "gmock" $ CEq "1.6.0-1.aapps.el7"
+
+tacpDep :: RPMDependency
+tacpDep = mkUnVerDep "tacp"
+
+buildDeps :: [RPMDependency]
+buildDeps =
+  [ boostDep,
+    cmakeDep,
+    jsoncppDep,
+    gtestDep,
+    libeventDep,
+    libvirtDep,
+    opensslDep,
+    libxml2Dep,
+    xzDep,
+    gmockDep
+  ]
+
+spec :: Test.Spec
+spec = do
+  Test.describe "rpm specfile parser" $ do
+    contents <- Test.runIO $ TIO.readFile "test/RPM/testdata/simple-test.spec"
+    Test.it "should list all BuildRequires and Requires" $ do
+      let deps = getSpecDeps contents
+      depBuildRequires deps `Test.shouldMatchList` buildDeps
+      listToMaybe (depRuntimeRequires deps) `Test.shouldBe` Just tacpDep
+  --
+  Test.describe "line parser"
+    $ Test.it "should parse single lines correctly"
+    $ do
+      getTypeFromLine "BuildRequires: xz = 1" `Test.shouldBe` Just (BuildRequires $ mkVerDep "xz" $ CEq "1")
+      getTypeFromLine "Requires: xz = 1" `Test.shouldBe` Just (RuntimeRequires $ mkVerDep "xz" $ CEq "1")
+  --
+  Test.describe "rpm dependency grapher" $
+    Test.it "should produce flat BuildRequires" $ do
+      let deps = Dependencies [boostDep, xzDep] [tacpDep, jsoncppDep]
+          gr = buildGraph deps
+
+      expectDeps (map toDependency [boostDep, xzDep]) gr
+      expectDirect (map toDependency [boostDep, xzDep]) gr
+      expectEdges [] gr
+

--- a/test/RPM/testdata/simple-test.spec
+++ b/test/RPM/testdata/simple-test.spec
@@ -1,0 +1,31 @@
+# A haiku showing how permissive our current parser is.
+To prove our parser
+This is not in a comment
+No hashtag needed
+
+# Basic parsing
+BuildRequires: boost
+
+# Simple version text
+BuildRequires: cmake >= 2.8
+BuildRequires: jsoncpp <= 0.10.5
+BuildRequires: gtest > 6.4
+BuildRequires: libevent < 9.8.1
+BuildRequires: libvirt == 3.9.0
+BuildRequires: openssl = 1.23.45
+
+# Bad operator, will ignore version
+BuildRequires: xz >> 1.2.3
+
+# Lots of spaces, should be fine
+BuildRequires:   libxml2     >=   5.4.98
+
+# Complex version text (shouldn't change behavior)
+BuildRequires:  gmock = 1.6.0-1.aapps.el7
+
+# We also handle "Requires" headers
+Requires:   tacp
+
+# Ignored due to macro use
+BuildRequires:  cloudistics-core%{?_isa} = %{version}-%{release}
+


### PR DESCRIPTION
When `fossa report` was created, there was a development time constraint.  To meet this constraint, some of the logic from `App.Fossa.Test` was duplicated to `App.Fossa.Report`.  The two biggest copies were `waitForBuild` and `waitForIssues`, which can be easily abstracted.

Marked as draft until #83 is merged, because we're losing some type refactoring.