### PR TITLE
Include orphan poms in the global closure graph; match on ".pom" file extensions the same as ".pom.xml"

### DIFF
--- a/src/Strategy/Maven/Pom/Closure.hs
+++ b/src/Strategy/Maven/Pom/Closure.hs
@@ -29,9 +29,8 @@ findPomFiles :: (Has ReadFS sig m, MonadIO m) => Path Abs Dir -> m [Path Abs Fil
 findPomFiles dir = do
   relPaths <- execState @[Path Rel File] [] $
     flip walk dir $ \_ _ files -> do
-      case find (\file -> fileName file == "pom.xml" || ".pom" `isSuffixOf` fileName file) files of
-        Just file -> modify @[Path Rel File] (file:)
-        Nothing -> pure ()
+      let poms = filter (\file -> "pom.xml" `isSuffixOf` fileName file || ".pom" `isSuffixOf` fileName file) files
+      traverse_ (modify . (:)) poms
 
       pure WalkContinue
 

--- a/src/Strategy/Maven/Pom/Closure.hs
+++ b/src/Strategy/Maven/Pom/Closure.hs
@@ -29,7 +29,7 @@ findPomFiles :: (Has ReadFS sig m, MonadIO m) => Path Abs Dir -> m [Path Abs Fil
 findPomFiles dir = do
   relPaths <- execState @[Path Rel File] [] $
     flip walk dir $ \_ _ files -> do
-      case find ((== "pom.xml") . fileName) files of
+      case find (\file -> fileName file == "pom.xml" || ".pom" `isSuffixOf` fileName file) files of
         Just file -> modify @[Path Rel File] (file:)
         Nothing -> pure ()
 

--- a/src/Strategy/Maven/Pom/Resolver.hs
+++ b/src/Strategy/Maven/Pom/Resolver.hs
@@ -40,7 +40,7 @@ buildGlobalClosure files = do
   -- Because the group/artifact/version are required to match, we can just build edges between _coordinates_, rather than between _pom files_
   buildClosure :: Map (Path Abs File) Pom -> GlobalClosure
   buildClosure cache = GlobalClosure
-    { globalGraph = AM.overlays
+    { globalGraph = AM.vertices (map pomCoord (M.elems cache)) `AM.overlay` AM.overlays
         [AM.edge parentCoord (pomCoord pom)
           | pom <- M.elems cache
           , Just parentCoord <- [pomParentCoord pom]]


### PR DESCRIPTION
If a pom isn't related to any other poms, it wasn't included in the global closure graph -- and as such, it wouldn't be included as a project