### PR TITLE
Archive unpacking

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,12 +41,11 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Install bash & xz (alpine)
+    - name: Install bash & xz & bzip2 (alpine)
       if: ${{ contains(matrix.os, 'ubuntu') }}
       shell: sh
       run: |
-        apk add bash
-        apk add xz-dev
+        apk add bash xz-dev bzip2-dev bzip2-static
 
     - uses: actions/setup-haskell@v1.1
       id: setup-haskell

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,11 +41,12 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Install bash (alpine)
+    - name: Install bash & xz (alpine)
       if: ${{ contains(matrix.os, 'ubuntu') }}
       shell: sh
       run: |
         apk add bash
+        apk add xz-dev
 
     - uses: actions/setup-haskell@v1.1
       id: setup-haskell

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -85,6 +85,7 @@ common deps
     , yaml                         ^>=0.11.1
     , yarn-lock                    ^>=0.6.2
     , zlib                         ^>=0.6.2.1
+    , zip                          ^>=1.5.0
 
 library
   import:          lang

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -117,10 +117,12 @@ library
     App.VPSScan.Scan.ScotlandYard
     App.VPSScan.Types
     Control.Carrier.Diagnostics
+    Control.Carrier.Finally
     Control.Carrier.Output.IO
     Control.Carrier.TaskPool
     Control.Carrier.Threaded
     Control.Effect.Diagnostics
+    Control.Effect.Finally
     Control.Effect.Output
     Control.Effect.Path
     Control.Effect.TaskPool

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -74,6 +74,7 @@ common deps
     , req                          ^>=3.1.0
     , stm                          ^>=2.5.0
     , stm-chans                    ^>=3.0.0
+    , tar                          ^>=0.5.1.1
     , text                         ^>=1.2.3
     , time                         ^>=1.9.3
     , tomland                      ^>=1.2.0
@@ -83,6 +84,7 @@ common deps
     , xml                          ^>=1.3.14
     , yaml                         ^>=0.11.1
     , yarn-lock                    ^>=0.6.2
+    , zlib                         ^>=0.6.2.1
 
 library
   import:          lang
@@ -115,6 +117,7 @@ library
     Control.Carrier.Threaded
     Control.Effect.Diagnostics
     Control.Effect.Output
+    Control.Effect.Path
     Control.Effect.TaskPool
     DepTypes
     Discovery.Walk
@@ -128,6 +131,7 @@ library
     Prologue
     Srclib.Converter
     Srclib.Types
+    Strategy.Archive
     Strategy.Cargo
     Strategy.Carthage
     Strategy.Clojure

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -53,7 +53,11 @@ common deps
     , async                        ^>=2.2.2
     , attoparsec                   ^>=0.13.2.3
     , bytestring                   ^>=0.10.8
+    , codec-rpm                    ^>=0.2.2
+    , conduit                      ^>=1.3.2
+    , conduit-extra                ^>=1.3.5
     , containers                   ^>=0.6.0
+    , cpio-conduit                 ^>=0.7.0
     , exceptions                   ^>=0.10.4
     , file-embed                   ^>=0.0.11
     , filepath                     ^>=1.4.2.1
@@ -84,8 +88,8 @@ common deps
     , xml                          ^>=1.3.14
     , yaml                         ^>=0.11.1
     , yarn-lock                    ^>=0.6.2
-    , zlib                         ^>=0.6.2.1
     , zip                          ^>=1.5.0
+    , zlib                         ^>=0.6.2.1
 
 library
   import:          lang
@@ -133,6 +137,7 @@ library
     Srclib.Converter
     Srclib.Types
     Strategy.Archive
+    Strategy.Archive.RPM
     Strategy.Cargo
     Strategy.Carthage
     Strategy.Clojure

--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -107,7 +107,7 @@ analyze basedir destination overrideName overrideRevision overrideBranch = do
       logInfo ("Using revision: `" <> pretty (projectRevision revision) <> "`")
       logInfo ("Using branch: `" <> pretty (projectBranch revision) <> "`")
 
-      uploadResult <- Diag.runDiagnostics $ uploadAnalysis baseurl apiKey revision metadata projects
+      uploadResult <- Diag.runDiagnostics $ uploadAnalysis basedir baseurl apiKey revision metadata projects
       case uploadResult of
         Left failure -> logError (Diag.renderFailureBundle failure)
         Right success -> do

--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -16,6 +16,7 @@ import Path.IO
 import App.Fossa.FossaAPIV1 (ProjectRevision(..), ProjectMetadata, uploadAnalysis, UploadResponse(..))
 import App.Fossa.Analyze.Project (Project, mkProjects)
 import App.Fossa.ProjectInference (InferredProject(..), inferProject)
+import Control.Carrier.Finally
 import Control.Carrier.TaskPool
 import Data.Text.Lazy.Encoding (decodeUtf8)
 import Data.Text.Prettyprint.Doc
@@ -81,7 +82,7 @@ analyze ::
   -> Maybe Text -- ^ cli override for revision
   -> Maybe Text -- ^ cli override for branch
   -> m ()
-analyze basedir destination overrideName overrideRevision overrideBranch = do
+analyze basedir destination overrideName overrideRevision overrideBranch = runFinally $ do
   capabilities <- liftIO getNumCapabilities
 
   (closures,(failures,())) <- runOutput @ProjectClosure $ runOutput @ProjectFailure $

--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -24,6 +24,7 @@ import Effect.Logger
 import Network.HTTP.Types (urlEncode)
 import qualified Srclib.Converter as Srclib
 import Srclib.Types (Locator(..), parseLocator)
+import qualified Strategy.Archive as Archive
 import qualified Strategy.Cargo as Cargo
 import qualified Strategy.Carthage as Carthage
 import qualified Strategy.Clojure as Clojure
@@ -194,6 +195,8 @@ discoverFuncs =
   , Cargo.discover
 
   , RPM.discover
+
+  , Archive.discover discover
   ]
 
 updateProgress :: Has Logger sig m => Progress -> m ()

--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -84,7 +84,7 @@ analyze basedir destination overrideName overrideRevision overrideBranch = do
   capabilities <- liftIO getNumCapabilities
 
   (closures,(failures,())) <- runOutput @ProjectClosure $ runOutput @ProjectFailure $
-    withTaskPool capabilities updateProgress (traverse_ ($ basedir) discoverFuncs)
+    withTaskPool capabilities updateProgress (discover basedir)
 
   traverse_ (logDebug . Diag.renderFailureBundle . projectFailureCause) failures
 
@@ -145,6 +145,9 @@ renderFailure failure = object
   [ "name" .= projectFailureName failure
   , "cause" .= show (Diag.renderFailureBundle (projectFailureCause failure))
   ]
+
+discover :: HasDiscover sig m => Path Abs Dir -> m ()
+discover dir = traverse_ ($ dir) discoverFuncs
 
 discoverFuncs :: HasDiscover sig m => [Path Abs Dir -> m ()]
 discoverFuncs =

--- a/src/App/Fossa/Analyze/Project.hs
+++ b/src/App/Fossa/Analyze/Project.hs
@@ -19,7 +19,7 @@ import Graphing
 import Types
 
 data Project = Project
-  { projectPath       :: Path Rel Dir
+  { projectPath       :: Path Abs Dir
   , projectStrategies :: [ProjectStrategy]
   }
   deriving (Eq, Ord, Show, Generic)
@@ -34,10 +34,10 @@ data ProjectStrategy = ProjectStrategy
 mkProjects :: [ProjectClosure] -> [Project]
 mkProjects = toProjects . grouping
   where
-  toProjects :: Map (StrategyGroup, Path Rel Dir) [ProjectClosure] -> [Project]
+  toProjects :: Map (StrategyGroup, Path Abs Dir) [ProjectClosure] -> [Project]
   toProjects = fmap toProject . M.toList
 
-  toProject :: ((StrategyGroup, Path Rel Dir), [ProjectClosure]) -> Project
+  toProject :: ((StrategyGroup, Path Abs Dir), [ProjectClosure]) -> Project
   toProject ((_, dir), closures) = Project
     { projectPath = dir
     , projectStrategies = fmap toProjectStrategy $
@@ -55,7 +55,7 @@ mkProjects = toProjects . grouping
                     , projStrategyComplete = dependenciesComplete closureDependencies
                     }
 
-  grouping :: [ProjectClosure] -> Map (StrategyGroup, Path Rel Dir) [ProjectClosure]
+  grouping :: [ProjectClosure] -> Map (StrategyGroup, Path Abs Dir) [ProjectClosure]
   grouping closures = M.fromListWith (<>) $ toList $ do
     closure <- closures
     let strategyGroup = closureStrategyGroup closure

--- a/src/App/Fossa/FossaAPIV1.hs
+++ b/src/App/Fossa/FossaAPIV1.hs
@@ -25,7 +25,7 @@ import App.Fossa.Analyze.Project
 import qualified App.Fossa.Report.Attribution as Attr
 import Control.Effect.Diagnostics
 import Data.Coerce (coerce)
-import Data.List (isInfixOf)
+import Data.List (isInfixOf, stripPrefix)
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import Data.Aeson
@@ -117,16 +117,24 @@ data ProjectMetadata = ProjectMetadata
 
 uploadAnalysis
   :: (Has Diagnostics sig m, MonadIO m)
-  => URI -- ^ base url
+  => Path Abs Dir -- ^ root directory for analysis
+  -> URI -- ^ base url
   -> Text -- ^ api key
   -> ProjectRevision
   -> ProjectMetadata
   -> [Project]
   -> m UploadResponse
-uploadAnalysis baseUri key ProjectRevision{..} metadata projects = fossaReq $ do
+uploadAnalysis rootDir baseUri key ProjectRevision{..} metadata projects = fossaReq $ do
   (baseUrl, baseOptions) <- parseUri baseUri
 
-  let filteredProjects = filter (isProductionPath . projectPath) projects
+  -- For each of the projects, we need to strip the root directory path from the prefix of the project path.
+  -- We don't want parent directories of the scan root affecting "production path" filtering -- e.g., if we're
+  -- running in a directory called "tmp", we still want results.
+  let rootPath = fromAbsDir rootDir
+      dropPrefix :: String -> String -> String
+      dropPrefix prefix str = fromMaybe prefix (stripPrefix prefix str)
+      filteredProjects = filter (isProductionPath . dropPrefix rootPath . fromAbsDir . projectPath) projects
+     
       sourceUnits = fromMaybe [] $ traverse toSourceUnit filteredProjects
       opts = "locator" =: renderLocator (Locator "custom" projectName (Just projectRevision))
           <> "v" =: cliVersion
@@ -159,8 +167,8 @@ mangleError err = case err of
 
 -- we specifically want Rel paths here: parent directories shouldn't affect path
 -- filtering
-isProductionPath :: Path Rel fd -> Bool
-isProductionPath path = not $ any (`isInfixOf` toFilePath path)
+isProductionPath :: FilePath -> Bool
+isProductionPath path = not $ any (`isInfixOf` path)
   [ "doc/"
   , "docs/"
   , "test/"

--- a/src/App/Fossa/FossaAPIV1.hs
+++ b/src/App/Fossa/FossaAPIV1.hs
@@ -165,8 +165,6 @@ mangleError err = case err of
   JsonHttpException msg -> JsonDeserializeError msg
   _ -> OtherError err
 
--- we specifically want Rel paths here: parent directories shouldn't affect path
--- filtering
 isProductionPath :: FilePath -> Bool
 isProductionPath path = not $ any (`isInfixOf` path)
   [ "doc/"
@@ -183,7 +181,6 @@ isProductionPath path = not $ any (`isInfixOf` path)
   , "bower_components/"
   , "third_party/"
   , "third-party/"
-  , "tmp/"
   , "Carthage/"
   , "Checkouts/"
   ]

--- a/src/App/Fossa/Main.hs
+++ b/src/App/Fossa/Main.hs
@@ -31,10 +31,10 @@ appMain = do
     AnalyzeCommand AnalyzeOptions {..} -> do
       changeDir analyzeBaseDir
       if analyzeOutput
-        then analyzeMain logSeverity OutputStdout optProjectName optProjectRevision analyzeBranch
+        then analyzeMain logSeverity OutputStdout optProjectName optProjectRevision analyzeBranch analyzeUnpackArchives
         else do
           key <- requireKey maybeApiKey
-          analyzeMain logSeverity (UploadScan optBaseUrl key analyzeMetadata) optProjectName optProjectRevision analyzeBranch
+          analyzeMain logSeverity (UploadScan optBaseUrl key analyzeMetadata) optProjectName optProjectRevision analyzeBranch analyzeUnpackArchives
     TestCommand TestOptions {..} -> do
       changeDir testBaseDir
       key <- requireKey maybeApiKey
@@ -117,6 +117,7 @@ analyzeOpts :: Parser AnalyzeOptions
 analyzeOpts =
   AnalyzeOptions
     <$> switch (long "output" <> short 'o' <> help "Output results to stdout instead of uploading to fossa")
+    <*> switch (long "unpack-archives" <> help "Recursively unpack and analyze discovered archives")
     <*> optional (strOption (long "branch" <> help "this repository's current branch (default: current VCS branch)"))
     <*> metadataOpts
     <*> baseDirArg
@@ -175,6 +176,7 @@ data ReportOptions = ReportOptions
 
 data AnalyzeOptions = AnalyzeOptions
   { analyzeOutput :: Bool,
+    analyzeUnpackArchives :: Bool,
     analyzeBranch :: Maybe Text,
     analyzeMetadata :: ProjectMetadata,
     analyzeBaseDir :: FilePath

--- a/src/App/Pathfinder/Scan.hs
+++ b/src/App/Pathfinder/Scan.hs
@@ -8,6 +8,7 @@ import Prologue
 import qualified Data.ByteString.Lazy as BL
 import qualified Data.Text as T
 import Control.Carrier.Error.Either
+import Control.Carrier.Finally
 import Control.Effect.Exception as Exc
 import Control.Carrier.Output.IO
 import Control.Concurrent
@@ -39,7 +40,7 @@ scan ::
   , MonadIO m
   )
   => Path Abs Dir -> m ()
-scan basedir = do
+scan basedir = runFinally $ do
   setCurrentDir basedir
   capabilities <- liftIO getNumCapabilities
 

--- a/src/Control/Carrier/Finally.hs
+++ b/src/Control/Carrier/Finally.hs
@@ -9,26 +9,27 @@ module Control.Carrier.Finally
 where
 
 import Control.Carrier.Reader
-import Control.Monad.IO.Class (MonadIO)
 import Control.Effect.Exception (finally)
 import Control.Effect.Finally as X
 import Control.Effect.Lift
+import Control.Monad.IO.Class (MonadIO)
+import Data.Foldable (traverse_)
 import Data.Functor (void)
 import Data.IORef
 import Prelude
 
-newtype FinallyC m a = FinallyC {runFinallyC :: ReaderC (IORef (FinallyC m ())) m a}
+newtype FinallyC m a = FinallyC {runFinallyC :: ReaderC (IORef [FinallyC m ()]) m a}
   deriving (Functor, Applicative, Monad, MonadIO)
 
 runFinally :: Has (Lift IO) sig m => FinallyC m a -> m a
 runFinally (FinallyC go) = do
-  ref <- sendIO $ newIORef (pure ())
-  runReader ref go `finally` (runFinally =<< sendIO (readIORef ref))
+  ref <- sendIO $ newIORef []
+  runReader ref go `finally` (traverse_ runFinally =<< sendIO (readIORef ref))
 
 instance (Has (Lift IO) sig m, Algebra sig m) => Algebra (Finally :+: sig) (FinallyC m) where
   alg hdl sig ctx = FinallyC $ case sig of
     L (OnExit go) -> do
       ref <- ask
-      sendIO $ atomicModifyIORef ref (\cur -> (cur *> void (hdl (go <$ ctx)), ()))
+      sendIO $ atomicModifyIORef' ref (\cur -> (void (hdl (go <$ ctx)) : cur, ()))
       pure ctx
     R other -> alg (runFinallyC . hdl) (R other) ctx

--- a/src/Control/Carrier/Finally.hs
+++ b/src/Control/Carrier/Finally.hs
@@ -1,0 +1,34 @@
+module Control.Carrier.Finally
+  ( -- * Finally carrier
+    FinallyC (..),
+    runFinally,
+
+    -- * Re-exports
+    module X,
+  )
+where
+
+import Control.Carrier.Reader
+import Control.Monad.IO.Class (MonadIO)
+import Control.Effect.Exception (finally)
+import Control.Effect.Finally as X
+import Control.Effect.Lift
+import Data.Functor (void)
+import Data.IORef
+import Prelude
+
+newtype FinallyC m a = FinallyC {runFinallyC :: ReaderC (IORef (FinallyC m ())) m a}
+  deriving (Functor, Applicative, Monad, MonadIO)
+
+runFinally :: Has (Lift IO) sig m => FinallyC m a -> m a
+runFinally (FinallyC go) = do
+  ref <- sendIO $ newIORef (pure ())
+  runReader ref go `finally` (runFinally =<< sendIO (readIORef ref))
+
+instance (Has (Lift IO) sig m, Algebra sig m) => Algebra (Finally :+: sig) (FinallyC m) where
+  alg hdl sig ctx = FinallyC $ case sig of
+    L (OnExit go) -> do
+      ref <- ask
+      sendIO $ atomicModifyIORef ref (\cur -> (cur *> void (hdl (go <$ ctx)), ()))
+      pure ctx
+    R other -> alg (runFinallyC . hdl) (R other) ctx

--- a/src/Control/Effect/Finally.hs
+++ b/src/Control/Effect/Finally.hs
@@ -1,0 +1,18 @@
+module Control.Effect.Finally
+  ( -- * Finally effect
+    Finally (..),
+    onExit,
+
+    -- * Re-exports
+    module X,
+  )
+where
+
+import Control.Algebra as X
+import Prelude
+
+data Finally m k where
+  OnExit :: m a -> Finally m ()
+
+onExit :: Has Finally sig m => m a -> m ()
+onExit = send . OnExit

--- a/src/Control/Effect/Path.hs
+++ b/src/Control/Effect/Path.hs
@@ -1,0 +1,20 @@
+-- | Fused-effects wrapped functions from Path.IO
+module Control.Effect.Path
+  ( withSystemTempDir,
+  )
+where
+
+import Control.Effect.Lift
+import Path
+import qualified Path.IO as PIO
+import Prelude
+
+withSystemTempDir ::
+  Has (Lift IO) sig m =>
+  -- | Directory name template
+  String ->
+  -- | Callback that can use the directory
+  (Path Abs Dir -> m a) ->
+  m a
+withSystemTempDir name f = liftWith @IO $ \hdl ctx ->
+  PIO.withSystemTempDir name (hdl . (<$ ctx) . f)

--- a/src/Discovery/Walk.hs
+++ b/src/Discovery/Walk.hs
@@ -13,7 +13,7 @@ import Path.IO
 
 data WalkStep
   = WalkContinue -- ^ Continue walking subdirectories
-  | WalkSkipSome [Path Rel Dir] -- ^ Skip some subdirectories
+  | WalkSkipSome [Path Abs Dir] -- ^ Skip some subdirectories
   | WalkSkipAll -- ^ Skip all subdirectories
   | WalkStop -- ^ Stop walking the filetree entirely
   deriving (Eq, Ord, Show, Generic)
@@ -26,13 +26,13 @@ data WalkStep
 -- 'fileName'
 walk
   :: MonadIO m
-  => (Path Rel Dir -> [Path Rel Dir] -> [Path Rel File] -> m WalkStep)
+  => (Path Abs Dir -> [Path Abs Dir] -> [Path Abs File] -> m WalkStep)
   -> Path Abs Dir
   -> m ()
-walk f = walkDirRel $ \dir subdirs files -> do
+walk f = walkDir $ \dir subdirs files -> do
   -- normally, subdirs and files are _relative to dir_. We want them to be
   -- relative to the filetree walk
-  step <- f dir (map (dir </>) subdirs) (map (dir </>) files)
+  step <- f dir subdirs files
   case step of
     WalkContinue -> pure (WalkExclude [])
     WalkSkipSome dirs -> pure (WalkExclude dirs)

--- a/src/Strategy/Archive.hs
+++ b/src/Strategy/Archive.hs
@@ -18,6 +18,7 @@ import Data.Foldable (traverse_)
 import Data.List (isSuffixOf)
 import Discovery.Walk
 import Path
+import Strategy.Archive.RPM (extractRpm)
 import Types
 import Prelude hiding (zip)
 
@@ -32,6 +33,9 @@ discover go = walk $ \_ _ files -> do
 
   let zips = filter (\file -> ".zip" `isSuffixOf` fileName file) files
   traverse_ (\file -> forkArchiveDiscover $ withArchive zip file go) zips
+
+  let rpms = filter (\file -> ".rpm" `isSuffixOf` fileName file) files
+  traverse_ (\file -> forkArchiveDiscover $ withArchive extractRpm file go) rpms
 
   pure WalkContinue
 

--- a/src/Strategy/Archive.hs
+++ b/src/Strategy/Archive.hs
@@ -7,7 +7,6 @@ import qualified Codec.Archive.Tar as Tar
 import qualified Codec.Archive.Zip as Zip
 import qualified Codec.Compression.GZip as GZip
 import Control.Carrier.Diagnostics (FailureBundle (..), SomeDiagnostic (..))
-import Control.Carrier.Interpret
 import Control.Effect.Exception (SomeException, try)
 import Control.Effect.Exception (mask)
 import Control.Effect.Lift

--- a/src/Strategy/Archive.hs
+++ b/src/Strategy/Archive.hs
@@ -1,0 +1,52 @@
+module Strategy.Archive
+  ( discover,
+  )
+where
+
+import qualified Codec.Archive.Tar as Tar
+import qualified Codec.Compression.GZip as GZip
+import Control.Effect.Lift
+import Control.Effect.Path (withSystemTempDir)
+import qualified Data.ByteString.Lazy as BL
+import Data.Foldable (traverse_)
+import Discovery.Walk
+import Data.List (isSuffixOf)
+import Path
+import Types
+import Prelude
+
+-- Given a discover function to run over unarchived contents, discover projects
+discover :: HasDiscover sig m => (Path Abs Dir -> m ()) -> Path Abs Dir -> m ()
+discover go = walk $ \_ _ files -> do
+  let tars = filter (\file -> ".tar.gz" `isSuffixOf` fileName file) files
+  traverse_ (\file -> withTar file go) tars
+
+  let tarGzs = filter (\file -> ".tar.gz" `isSuffixOf` fileName file) files
+  traverse_ (\file -> withTarGz file go) tarGzs
+ 
+  pure WalkContinue
+
+-- TODO: exceptions?
+withTar :: Has (Lift IO) sig m => Path Abs File -> (Path Abs Dir -> m ()) -> m ()
+withTar = withArchive (\dir file -> sendIO $ Tar.extract (fromAbsDir dir) (fromAbsFile file))
+
+withTarGz :: Has (Lift IO) sig m => Path Abs File -> (Path Abs Dir -> m ()) -> m ()
+withTarGz =
+  withArchive
+    ( \dir file ->
+        sendIO $
+          Tar.unpack (fromAbsDir dir) . Tar.read . GZip.decompress =<< BL.readFile (fromAbsFile file)
+    )
+
+withArchive ::
+  Has (Lift IO) sig m =>
+  -- | Archive extraction function
+  (Path Abs Dir -> Path Abs File -> m ()) ->
+  -- | Path to archive
+  Path Abs File ->
+  -- | Callback
+  (Path Abs Dir -> m ()) ->
+  m ()
+withArchive extract file go = withSystemTempDir (fileName file) $ \tmpDir -> do
+  extract tmpDir file
+  go tmpDir

--- a/src/Strategy/Archive.hs
+++ b/src/Strategy/Archive.hs
@@ -34,6 +34,9 @@ discover go = walk $ \_ _ files -> do
   let zips = filter (\file -> ".zip" `isSuffixOf` fileName file) files
   traverse_ (\file -> forkArchiveDiscover $ withArchive zip file go) zips
 
+  let jars = filter (\file -> ".jar" `isSuffixOf` fileName file) files
+  traverse_ (\file -> forkArchiveDiscover $ withArchive zip file go) jars
+
   let rpms = filter (\file -> ".rpm" `isSuffixOf` fileName file) files
   traverse_ (\file -> forkArchiveDiscover $ withArchive extractRpm file go) rpms
 

--- a/src/Strategy/Archive.hs
+++ b/src/Strategy/Archive.hs
@@ -21,7 +21,6 @@ import Path
 import Types
 import Prelude
 
--- FIXME: module paths include the tmp directory
 -- Given a discover function to run over unarchived contents, discover projects
 discover :: HasDiscover sig m => (Path Abs Dir -> m ()) -> Path Abs Dir -> m ()
 discover go = walk $ \_ _ files -> do

--- a/src/Strategy/Archive/RPM.hs
+++ b/src/Strategy/Archive/RPM.hs
@@ -1,0 +1,41 @@
+module Strategy.Archive.RPM
+  ( extractRpm
+  )
+where
+
+import qualified Codec.RPM.Conduit as RPM
+import Conduit
+import Control.Effect.Lift
+import Control.Exception (throwIO)
+import Control.Monad.Except
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Char8 as BS8
+import qualified Data.ByteString.Lazy as BL
+import qualified Data.CPIO as CPIO
+import Path
+import Prelude
+import qualified Path.IO as PIO
+
+extractRpm :: Has (Lift IO) sig m => Path Abs Dir -> Path Abs File -> m ()
+extractRpm dir rpmFile = do
+  res <-
+    sendIO . runResourceT . runExceptT . runConduit $
+      readRPMEntries rpmFile .| filterC (not . CPIO.isEntryDirectory) .| sinkDir
+  case res of
+    Left parseErr -> sendIO . throwIO $ parseErr
+    Right () -> pure ()
+  where
+    -- morally: :: Path b File -> ConduitT i CPIO.Entry m ()
+    -- (has a couple of additional constraints, e.g., MonadError for attoparsec ParseError)
+    readRPMEntries file = sourceFileBS (toFilePath file) .| RPM.parseRPMC .| RPM.payloadContentsC
+    --
+    sinkDir :: MonadIO m => ConduitT CPIO.Entry o m ()
+    sinkDir = mapM_C $ \entry -> do
+      let filepath = BS8.unpack $ CPIO.cpioFileName entry
+
+      -- explicitly ignore absolute paths
+      case parseRelFile filepath of
+        Nothing -> pure ()
+        Just filepath' -> do
+          liftIO . PIO.ensureDir $ (dir </> parent filepath')
+          liftIO . BS.writeFile (fromAbsFile (dir </> filepath')) . BL.toStrict $ CPIO.cpioFileData entry

--- a/src/Strategy/Cargo.hs
+++ b/src/Strategy/Cargo.hs
@@ -138,7 +138,7 @@ cargoMetadataCmd = Command
   , cmdAllowErr = Never
   }
 
-mkProjectClosure :: Path Rel Dir ->  Graphing Dependency -> ProjectClosureBody
+mkProjectClosure :: Path Abs Dir ->  Graphing Dependency -> ProjectClosureBody
 mkProjectClosure dir graph = ProjectClosureBody
   { bodyModuleDir    = dir
   , bodyDependencies = dependencies
@@ -152,7 +152,7 @@ mkProjectClosure dir graph = ProjectClosureBody
     }
 
 analyze :: (Has Exec sig m, Has Diagnostics sig m)
-  => Path Rel Dir -> m (Graphing Dependency)
+  => Path Abs Dir -> m (Graphing Dependency)
 analyze manifestDir = do
   _ <- execThrow manifestDir cargoGenLockfileCmd
   meta <- execJson @CargoMetadata manifestDir cargoMetadataCmd

--- a/src/Strategy/Clojure.hs
+++ b/src/Strategy/Clojure.hs
@@ -48,7 +48,7 @@ discover = walk $ \dir _ files -> do
       runSimpleStrategy "clojure-lein" ClojureGroup $ mkProjectClosure dir <$> analyze file
       pure WalkSkipAll
 
-mkProjectClosure :: Path Rel Dir -> Graphing Dependency -> ProjectClosureBody
+mkProjectClosure :: Path Abs Dir -> Graphing Dependency -> ProjectClosureBody
 mkProjectClosure dir deps =
   ProjectClosureBody
     { bodyModuleDir = dir,
@@ -61,7 +61,7 @@ mkProjectClosure dir deps =
       bodyLicenses = []
     }
 
-analyze :: (Has Exec sig m, Has Diagnostics sig m) => Path Rel File -> m (Graphing Dependency)
+analyze :: (Has Exec sig m, Has Diagnostics sig m) => Path Abs File -> m (Graphing Dependency)
 analyze file = do
   stdoutBL <- execThrow (parent file) leinDepsCmd
   let stdoutTL = decodeUtf8 stdoutBL

--- a/src/Strategy/Cocoapods/Podfile.hs
+++ b/src/Strategy/Cocoapods/Podfile.hs
@@ -33,10 +33,10 @@ discover = walk $ \_ _ files -> do
 
   pure WalkContinue
 
-analyze :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Rel File -> m ProjectClosureBody
+analyze :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs File -> m ProjectClosureBody
 analyze file = mkProjectClosure file <$> readContentsParser parsePodfile file
 
-mkProjectClosure :: Path Rel File -> Podfile -> ProjectClosureBody
+mkProjectClosure :: Path Abs File -> Podfile -> ProjectClosureBody
 mkProjectClosure file podfile = ProjectClosureBody
   { bodyModuleDir    = parent file
   , bodyDependencies = dependencies

--- a/src/Strategy/Cocoapods/PodfileLock.hs
+++ b/src/Strategy/Cocoapods/PodfileLock.hs
@@ -35,10 +35,10 @@ discover = walk $ \_ _ files -> do
 
   pure WalkContinue
 
-analyze :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Rel File -> m ProjectClosureBody
+analyze :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs File -> m ProjectClosureBody
 analyze file = mkProjectClosure file <$> readContentsParser findSections file
 
-mkProjectClosure :: Path Rel File -> [Section] -> ProjectClosureBody
+mkProjectClosure :: Path Abs File -> [Section] -> ProjectClosureBody
 mkProjectClosure file sections = ProjectClosureBody
   { bodyModuleDir    = parent file
   , bodyDependencies = dependencies

--- a/src/Strategy/Erlang/Rebar3Tree.hs
+++ b/src/Strategy/Erlang/Rebar3Tree.hs
@@ -37,10 +37,10 @@ rebar3TreeCmd = Command
   , cmdAllowErr = Never
   }
 
-analyze :: (Has Exec sig m, Has Diagnostics sig m) => Path Rel Dir -> m ProjectClosureBody
+analyze :: (Has Exec sig m, Has Diagnostics sig m) => Path Abs Dir -> m ProjectClosureBody
 analyze dir = mkProjectClosure dir <$> execParser rebar3TreeParser dir rebar3TreeCmd
 
-mkProjectClosure :: Path Rel Dir -> [Rebar3Dep] -> ProjectClosureBody
+mkProjectClosure :: Path Abs Dir -> [Rebar3Dep] -> ProjectClosureBody
 mkProjectClosure dir deps = ProjectClosureBody
   { bodyModuleDir    = dir
   , bodyDependencies = dependencies

--- a/src/Strategy/Go/GlideLock.hs
+++ b/src/Strategy/Go/GlideLock.hs
@@ -29,10 +29,10 @@ discover = walk $ \_ _ files -> do
 
   pure WalkContinue
 
-analyze :: ( Has ReadFS sig m , Has Diagnostics sig m) => Path Rel File -> m ProjectClosureBody
+analyze :: ( Has ReadFS sig m , Has Diagnostics sig m) => Path Abs File -> m ProjectClosureBody
 analyze file = mkProjectClosure file <$> readContentsYaml @GlideLockfile file
 
-mkProjectClosure :: Path Rel File -> GlideLockfile -> ProjectClosureBody
+mkProjectClosure :: Path Abs File -> GlideLockfile -> ProjectClosureBody
 mkProjectClosure file lock = ProjectClosureBody
   { bodyModuleDir    = parent file
   , bodyDependencies = dependencies

--- a/src/Strategy/Go/GoList.hs
+++ b/src/Strategy/Go/GoList.hs
@@ -47,7 +47,7 @@ analyze ::
   ( Has Exec sig m
   , Has Diagnostics sig m
   )
-  => Path Rel Dir -> m ProjectClosureBody
+  => Path Abs Dir -> m ProjectClosureBody
 analyze dir = fmap (mkProjectClosure dir) . graphingGolang $ do
   stdout <- execThrow dir golistCmd
 
@@ -66,7 +66,7 @@ analyze dir = fmap (mkProjectClosure dir) . graphingGolang $ do
   -- _ <- try @ExecErr (fillInTransitive dir)
   pure ()
 
-mkProjectClosure :: Path Rel Dir -> Graphing Dependency -> ProjectClosureBody
+mkProjectClosure :: Path Abs Dir -> Graphing Dependency -> ProjectClosureBody
 mkProjectClosure dir graph = ProjectClosureBody
   { bodyModuleDir    = dir
   , bodyDependencies = dependencies

--- a/src/Strategy/Go/Gomod.hs
+++ b/src/Strategy/Go/Gomod.hs
@@ -179,7 +179,7 @@ analyze ::
   ( Has ReadFS sig m
   , Has Diagnostics sig m
   )
-  => Path Rel File -> m ProjectClosureBody
+  => Path Abs File -> m ProjectClosureBody
 analyze file = fmap (mkProjectClosure file) . graphingGolang $ do
   gomod <- readContentsParser gomodParser file
 
@@ -189,7 +189,7 @@ analyze file = fmap (mkProjectClosure file) . graphingGolang $ do
   -- _ <- runError @ExecErr (fillInTransitive (parent file))
   pure ()
 
-mkProjectClosure :: Path Rel File -> Graphing Dependency -> ProjectClosureBody
+mkProjectClosure :: Path Abs File -> Graphing Dependency -> ProjectClosureBody
 mkProjectClosure file graph = ProjectClosureBody
   { bodyModuleDir    = parent file
   , bodyDependencies = dependencies

--- a/src/Strategy/Go/GopkgLock.hs
+++ b/src/Strategy/Go/GopkgLock.hs
@@ -57,11 +57,11 @@ analyze ::
   ( Has ReadFS sig m
   , Has Diagnostics sig m
   )
-  => Path Rel File -> m ProjectClosureBody
+  => Path Abs File -> m ProjectClosureBody
 analyze file = fmap (mkProjectClosure file) . graphingGolang $ do
   contents <- readContentsText file
   case Toml.decode golockCodec contents of
-    Left err -> fatal (FileParseError (fromRelFile file) (Toml.prettyException err))
+    Left err -> fatal (FileParseError (fromAbsFile file) (Toml.prettyException err))
     Right golock -> do
       buildGraph (lockProjects golock)
 
@@ -69,7 +69,7 @@ analyze file = fmap (mkProjectClosure file) . graphingGolang $ do
       -- _ <- runError @ExecErr (fillInTransitive (parent file))
       pure ()
 
-mkProjectClosure :: Path Rel File -> Graphing Dependency -> ProjectClosureBody
+mkProjectClosure :: Path Abs File -> Graphing Dependency -> ProjectClosureBody
 mkProjectClosure file graph = ProjectClosureBody
   { bodyModuleDir    = parent file
   , bodyDependencies = dependencies

--- a/src/Strategy/Go/GopkgToml.hs
+++ b/src/Strategy/Go/GopkgToml.hs
@@ -67,11 +67,11 @@ analyze ::
   ( Has ReadFS sig m
   , Has Diagnostics sig m
   )
-  => Path Rel File -> m ProjectClosureBody
+  => Path Abs File -> m ProjectClosureBody
 analyze file = fmap (mkProjectClosure file) . graphingGolang $ do
   contents <- readContentsText file
   case Toml.decode gopkgCodec contents of
-    Left err -> fatal (FileParseError (fromRelFile file) (Toml.prettyException err))
+    Left err -> fatal (FileParseError (fromAbsFile file) (Toml.prettyException err))
     Right gopkg -> do
       buildGraph gopkg
 
@@ -79,7 +79,7 @@ analyze file = fmap (mkProjectClosure file) . graphingGolang $ do
       -- _ <- runError @ExecErr (fillInTransitive (parent file))
       pure ()
 
-mkProjectClosure :: Path Rel File -> Graphing Dependency -> ProjectClosureBody
+mkProjectClosure :: Path Abs File -> Graphing Dependency -> ProjectClosureBody
 mkProjectClosure file graph = ProjectClosureBody
   { bodyModuleDir     = parent file
   , bodyDependencies  = dependencies

--- a/src/Strategy/Gradle.hs
+++ b/src/Strategy/Gradle.hs
@@ -13,6 +13,7 @@ import Data.Aeson.Types (Parser, unexpected)
 import Control.Carrier.Error.Either
 import Control.Effect.Diagnostics
 import Control.Effect.Exception
+import Control.Effect.Path (withSystemTempDir)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as BL
 import Data.FileEmbed (embedFile)
@@ -20,7 +21,6 @@ import qualified Data.Map.Strict as M
 import Data.Maybe (mapMaybe)
 import qualified Data.Text as T
 import Data.Text.Encoding (decodeUtf8, encodeUtf8)
-import Path.IO (createTempDir, getTempDir, removeDirRecur)
 import qualified System.FilePath as FP
 
 import DepTypes
@@ -55,40 +55,33 @@ analyze ::
   , MonadIO m
   )
   => Path Rel Dir -> m ProjectClosureBody
-analyze dir =
-  bracket (liftIO (getTempDir >>= \tmp -> createTempDir tmp "fossa-gradle"))
-          (liftIO . removeDirRecur)
-          act
+analyze dir = withSystemTempDir "fossa-gradle" $ \tmpDir -> do
+  let initScriptFilepath = fromAbsDir tmpDir FP.</> "jsondeps.gradle"
+  liftIO (BS.writeFile initScriptFilepath initScript)
+  stdout <- execThrow dir (gradleJsonDepsCmd "./gradlew" initScriptFilepath)
+              <||> execThrow dir (gradleJsonDepsCmd "gradlew.bat" initScriptFilepath)
+              <||> execThrow dir (gradleJsonDepsCmd "gradle" initScriptFilepath)
 
-  where
+  let text = decodeUtf8 $ BL.toStrict stdout
+      textLines :: [Text]
+      textLines = T.lines (T.filter (/= '\r') text)
+      -- jsonDeps lines look like:
+      -- JSONDEPS_:project-path_{"configName":[{"type":"package", ...}, ...], ...}
+      jsonDepsLines :: [Text]
+      jsonDepsLines = mapMaybe (T.stripPrefix "JSONDEPS_") textLines
 
-  act tmpDir = do
-    let initScriptFilepath = fromAbsDir tmpDir FP.</> "jsondeps.gradle"
-    liftIO (BS.writeFile initScriptFilepath initScript)
-    stdout <- execThrow dir (gradleJsonDepsCmd "./gradlew" initScriptFilepath)
-                <||> execThrow dir (gradleJsonDepsCmd "gradlew.bat" initScriptFilepath)
-                <||> execThrow dir (gradleJsonDepsCmd "gradle" initScriptFilepath)
+      packagePathsWithJson :: [(Text,Text)]
+      packagePathsWithJson = map (\line -> let (x,y) = T.breakOn "_" line in (x, T.drop 1 y {- drop the underscore; break doesn't remove it -})) jsonDepsLines
 
-    let text = decodeUtf8 $ BL.toStrict stdout
-        textLines :: [Text]
-        textLines = T.lines (T.filter (/= '\r') text)
-        -- jsonDeps lines look like:
-        -- JSONDEPS_:project-path_{"configName":[{"type":"package", ...}, ...], ...}
-        jsonDepsLines :: [Text]
-        jsonDepsLines = mapMaybe (T.stripPrefix "JSONDEPS_") textLines
+      packagePathsWithDecoded :: [(Text, [JsonDep])]
+      packagePathsWithDecoded = [(name, deps) | (name, json) <- packagePathsWithJson
+                                              , Just configs <- [decodeStrict (encodeUtf8 json) :: Maybe (Map Text [JsonDep])]
+                                              , Just deps <- [M.lookup "default" configs]] -- FUTURE: use more than default?
 
-        packagePathsWithJson :: [(Text,Text)]
-        packagePathsWithJson = map (\line -> let (x,y) = T.breakOn "_" line in (x, T.drop 1 y {- drop the underscore; break doesn't remove it -})) jsonDepsLines
+      packagesToOutput :: Map Text [JsonDep]
+      packagesToOutput = M.fromList packagePathsWithDecoded
 
-        packagePathsWithDecoded :: [(Text, [JsonDep])]
-        packagePathsWithDecoded = [(name, deps) | (name, json) <- packagePathsWithJson
-                                                , Just configs <- [decodeStrict (encodeUtf8 json) :: Maybe (Map Text [JsonDep])]
-                                                , Just deps <- [M.lookup "default" configs]] -- FUTURE: use more than default?
-
-        packagesToOutput :: Map Text [JsonDep]
-        packagesToOutput = M.fromList packagePathsWithDecoded
-
-    pure (mkProjectClosure dir packagesToOutput)
+  pure (mkProjectClosure dir packagesToOutput)
 
 mkProjectClosure :: Path Rel Dir -> Map Text [JsonDep] -> ProjectClosureBody
 mkProjectClosure dir deps = ProjectClosureBody

--- a/src/Strategy/Gradle.hs
+++ b/src/Strategy/Gradle.hs
@@ -54,7 +54,7 @@ analyze ::
   , Has Diagnostics sig m
   , MonadIO m
   )
-  => Path Rel Dir -> m ProjectClosureBody
+  => Path Abs Dir -> m ProjectClosureBody
 analyze dir = withSystemTempDir "fossa-gradle" $ \tmpDir -> do
   let initScriptFilepath = fromAbsDir tmpDir FP.</> "jsondeps.gradle"
   liftIO (BS.writeFile initScriptFilepath initScript)
@@ -83,7 +83,7 @@ analyze dir = withSystemTempDir "fossa-gradle" $ \tmpDir -> do
 
   pure (mkProjectClosure dir packagesToOutput)
 
-mkProjectClosure :: Path Rel Dir -> Map Text [JsonDep] -> ProjectClosureBody
+mkProjectClosure :: Path Abs Dir -> Map Text [JsonDep] -> ProjectClosureBody
 mkProjectClosure dir deps = ProjectClosureBody
   { bodyModuleDir    = dir
   , bodyDependencies = dependencies

--- a/src/Strategy/Maven/Plugin.hs
+++ b/src/Strategy/Maven/Plugin.hs
@@ -54,16 +54,16 @@ withUnpackedPlugin act =
 
     act pluginJarFilepath
 
-installPlugin :: (Has Exec sig m, Has Diagnostics sig m) => Path Rel Dir -> FP.FilePath -> m ()
+installPlugin :: (Has Exec sig m, Has Diagnostics sig m) => Path Abs Dir -> FP.FilePath -> m ()
 installPlugin dir path = void $ execThrow dir (mavenInstallPluginCmd path)
 
-execPlugin :: (Has Exec sig m, Has Diagnostics sig m) => Path Rel Dir -> m ()
+execPlugin :: (Has Exec sig m, Has Diagnostics sig m) => Path Abs Dir -> m ()
 execPlugin dir = void $ execThrow dir mavenPluginDependenciesCmd
 
 outputFile :: Path Rel File
 outputFile = $(mkRelFile "target/dependency-graph.json")
 
-parsePluginOutput :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Rel Dir -> m PluginOutput
+parsePluginOutput :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs Dir -> m PluginOutput
 parsePluginOutput dir = readContentsJson (dir </> outputFile)
 
 mavenInstallPluginCmd :: FP.FilePath -> Command

--- a/src/Strategy/Maven/PluginStrategy.hs
+++ b/src/Strategy/Maven/PluginStrategy.hs
@@ -33,14 +33,14 @@ analyze ::
   , Has Diagnostics sig m
   , MonadIO m
   )
-  => Path Rel Dir -> m ProjectClosureBody
+  => Path Abs Dir -> m ProjectClosureBody
 analyze dir = withUnpackedPlugin $ \filepath -> do
   installPlugin dir filepath
   execPlugin dir
   pluginOutput <- parsePluginOutput dir
   pure (mkProjectClosure dir pluginOutput)
 
-mkProjectClosure :: Path Rel Dir -> PluginOutput -> ProjectClosureBody
+mkProjectClosure :: Path Abs Dir -> PluginOutput -> ProjectClosureBody
 mkProjectClosure dir pluginOutput = ProjectClosureBody
   { bodyModuleDir    = dir
   , bodyDependencies = dependencies

--- a/src/Strategy/Maven/Pom/Closure.hs
+++ b/src/Strategy/Maven/Pom/Closure.hs
@@ -26,27 +26,23 @@ findProjects basedir = do
   pure (buildProjectClosures basedir globalClosure)
 
 findPomFiles :: (Has ReadFS sig m, MonadIO m) => Path Abs Dir -> m [Path Abs File]
-findPomFiles dir = do
-  relPaths <- execState @[Path Rel File] [] $
-    flip walk dir $ \_ _ files -> do
-      case find ((== "pom.xml") . fileName) files of
-        Just file -> modify @[Path Rel File] (file:)
-        Nothing -> pure ()
+findPomFiles dir = execState @[Path Abs File] [] $
+  flip walk dir $ \_ _ files -> do
+    case find ((== "pom.xml") . fileName) files of
+      Just file -> modify @[Path Abs File] (file:)
+      Nothing -> pure ()
 
-      pure WalkContinue
-
-  -- FIXME: exceptions
-  traverse (liftIO . PIO.makeAbsolute) relPaths
+    pure WalkContinue
 
 buildProjectClosures :: Path Abs Dir -> GlobalClosure -> [MavenProjectClosure]
 buildProjectClosures basedir global = closures
   where
   closures = map (\(path, (coord, pom)) -> toClosure path coord pom) (M.toList projectRoots)
 
-  toClosure :: Path Rel File -> MavenCoordinate -> Pom -> MavenProjectClosure
+  toClosure :: Path Abs File -> MavenCoordinate -> Pom -> MavenProjectClosure
   toClosure path coord pom = MavenProjectClosure path coord pom (globalGraph global) (globalPoms global)
 
-  projectRoots :: Map (Path Rel File) (MavenCoordinate, Pom)
+  projectRoots :: Map (Path Abs File) (MavenCoordinate, Pom)
   projectRoots = determineProjectRoots basedir global graphRoots
 
   graphRoots :: [MavenCoordinate]
@@ -55,20 +51,21 @@ buildProjectClosures basedir global = closures
 sourceVertices :: Ord a => AM.AdjacencyMap a -> [a]
 sourceVertices graph = [v | v <- AM.vertexList graph, S.null (AM.preSet v graph)]
 
-determineProjectRoots :: Path Abs Dir -> GlobalClosure -> [MavenCoordinate] -> Map (Path Rel File) (MavenCoordinate, Pom)
+determineProjectRoots :: Path Abs Dir -> GlobalClosure -> [MavenCoordinate] -> Map (Path Abs File) (MavenCoordinate, Pom)
 determineProjectRoots rootDir closure = go . S.fromList
   where
-  go :: Set MavenCoordinate -> Map (Path Rel File) (MavenCoordinate, Pom)
+  go :: Set MavenCoordinate -> Map (Path Abs File) (MavenCoordinate, Pom)
   go coordRoots
     | S.null coordRoots = M.empty
     | otherwise = M.union projects (go frontier)
     where
-    inRoot :: Set (MavenCoordinate, Path Rel File, Pom)
+    inRoot :: Set (MavenCoordinate, Path Abs File, Pom)
     inRoot = S.fromList $
       mapMaybe (\coord -> do
                    (abspath, pom) <- M.lookup coord (globalPoms closure)
-                   relpath <- PIO.makeRelative rootDir abspath
-                   pure (coord, relpath, pom)) (S.toList coordRoots)
+                   -- This ensures that the absolute path is relative to the root directory
+                   _ <- PIO.makeRelative rootDir abspath
+                   Just (coord, abspath, pom)) (S.toList coordRoots)
 
     inRootCoords :: Set MavenCoordinate
     inRootCoords = S.map (\(c,_,_) -> c) inRoot
@@ -76,7 +73,7 @@ determineProjectRoots rootDir closure = go . S.fromList
     remainingCoords :: Set MavenCoordinate
     remainingCoords = coordRoots S.\\ inRootCoords
 
-    projects :: Map (Path Rel File) (MavenCoordinate, Pom)
+    projects :: Map (Path Abs File) (MavenCoordinate, Pom)
     projects = M.fromList $ S.toList $ S.map (\(coord,path,pom) -> (path, (coord, pom))) inRoot
 
     frontier :: Set MavenCoordinate
@@ -84,7 +81,7 @@ determineProjectRoots rootDir closure = go . S.fromList
 
 
 data MavenProjectClosure = MavenProjectClosure
-  { closurePath      :: Path Rel File
+  { closurePath      :: Path Abs File
   , closureRootCoord :: MavenCoordinate
   , closureRootPom   :: Pom
   , closureGraph     :: AM.AdjacencyMap MavenCoordinate

--- a/src/Strategy/Node/NpmList.hs
+++ b/src/Strategy/Node/NpmList.hs
@@ -30,10 +30,10 @@ npmListCmd = Command
   , cmdAllowErr = NonEmptyStdout
   }
 
-analyze :: (Has Exec sig m, Has Diagnostics sig m) => Path Rel Dir -> m ProjectClosureBody
+analyze :: (Has Exec sig m, Has Diagnostics sig m) => Path Abs Dir -> m ProjectClosureBody
 analyze dir = mkProjectClosure dir <$> execJson @NpmOutput dir npmListCmd
 
-mkProjectClosure :: Path Rel Dir -> NpmOutput -> ProjectClosureBody
+mkProjectClosure :: Path Abs Dir -> NpmOutput -> ProjectClosureBody
 mkProjectClosure dir npmOutput = ProjectClosureBody
   { bodyModuleDir     = dir
   , bodyDependencies  = dependencies

--- a/src/Strategy/Node/NpmLock.hs
+++ b/src/Strategy/Node/NpmLock.hs
@@ -57,10 +57,10 @@ instance FromJSON NpmDep where
            <*> obj .:? "requires"
            <*> obj .:? "dependencies"
 
-analyze :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Rel File -> m ProjectClosureBody
+analyze :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs File -> m ProjectClosureBody
 analyze file = mkProjectClosure file <$> readContentsJson @NpmPackageJson file
 
-mkProjectClosure :: Path Rel File -> NpmPackageJson -> ProjectClosureBody
+mkProjectClosure :: Path Abs File -> NpmPackageJson -> ProjectClosureBody
 mkProjectClosure file lock = ProjectClosureBody
   { bodyModuleDir    = parent file
   , bodyDependencies = dependencies

--- a/src/Strategy/Node/PackageJson.hs
+++ b/src/Strategy/Node/PackageJson.hs
@@ -36,10 +36,10 @@ instance FromJSON PackageJson where
     PackageJson <$> obj .:? "dependencies"    .!= M.empty
                 <*> obj .:? "devDependencies" .!= M.empty
 
-analyze :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Rel File -> m ProjectClosureBody
+analyze :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs File -> m ProjectClosureBody
 analyze file = mkProjectClosure file <$> readContentsJson @PackageJson file
 
-mkProjectClosure :: Path Rel File -> PackageJson -> ProjectClosureBody
+mkProjectClosure :: Path Abs File -> PackageJson -> ProjectClosureBody
 mkProjectClosure file package = ProjectClosureBody
   { bodyModuleDir    = parent file
   , bodyDependencies = dependencies

--- a/src/Strategy/Node/YarnLock.hs
+++ b/src/Strategy/Node/YarnLock.hs
@@ -29,16 +29,16 @@ discover = walk $ \_ _ files -> do
 
   pure (WalkSkipSome [$(mkRelDir "node_modules")])
 
-analyze :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Rel File -> m ProjectClosureBody
+analyze :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs File -> m ProjectClosureBody
 analyze lockfile = do
-  let path = fromRelFile lockfile
+  let path = fromAbsFile lockfile
 
   contents <- readContentsText lockfile
   case YL.parse path contents of
     Left err -> fatal (FileParseError path (YL.prettyLockfileError err))
     Right a -> pure (mkProjectClosure lockfile a)
 
-mkProjectClosure :: Path Rel File -> YL.Lockfile -> ProjectClosureBody
+mkProjectClosure :: Path Abs File -> YL.Lockfile -> ProjectClosureBody
 mkProjectClosure file lock = ProjectClosureBody
   { bodyModuleDir    = parent file
   , bodyDependencies = dependencies

--- a/src/Strategy/NuGet/Nuspec.hs
+++ b/src/Strategy/NuGet/Nuspec.hs
@@ -34,10 +34,10 @@ discover = walk $ \_ _ files -> do
 
   pure WalkContinue
 
-analyze :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Rel File -> m ProjectClosureBody
+analyze :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs File -> m ProjectClosureBody
 analyze file = mkProjectClosure file <$> readContentsXML @Nuspec file
 
-mkProjectClosure :: Path Rel File -> Nuspec -> ProjectClosureBody
+mkProjectClosure :: Path Abs File -> Nuspec -> ProjectClosureBody
 mkProjectClosure file nuspec = ProjectClosureBody
   { bodyModuleDir    = parent file
   , bodyDependencies = dependencies

--- a/src/Strategy/NuGet/PackageReference.hs
+++ b/src/Strategy/NuGet/PackageReference.hs
@@ -31,13 +31,13 @@ discover = walk $ \_ _ files -> do
   pure WalkContinue
  
   where 
-      isPackageRefFile :: Path Rel File -> Bool
+      isPackageRefFile :: Path b File -> Bool
       isPackageRefFile file = any (\x -> L.isSuffixOf x (fileName file)) [".csproj", ".xproj", ".vbproj", ".dbproj", ".fsproj"]
 
-analyze :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Rel File -> m ProjectClosureBody
+analyze :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs File -> m ProjectClosureBody
 analyze file = mkProjectClosure file <$> readContentsXML @PackageReference file
 
-mkProjectClosure :: Path Rel File -> PackageReference -> ProjectClosureBody
+mkProjectClosure :: Path Abs File -> PackageReference -> ProjectClosureBody
 mkProjectClosure file package = ProjectClosureBody
   { bodyModuleDir    = parent file
   , bodyDependencies = dependencies

--- a/src/Strategy/NuGet/PackagesConfig.hs
+++ b/src/Strategy/NuGet/PackagesConfig.hs
@@ -39,10 +39,10 @@ newtype PackagesConfig = PackagesConfig
   { deps :: [NuGetDependency]
   } deriving (Eq, Ord, Show, Generic)
 
-analyze :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Rel File -> m ProjectClosureBody
+analyze :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs File -> m ProjectClosureBody
 analyze file = mkProjectClosure file <$> readContentsXML file
 
-mkProjectClosure :: Path Rel File -> PackagesConfig -> ProjectClosureBody
+mkProjectClosure :: Path Abs File -> PackagesConfig -> ProjectClosureBody
 mkProjectClosure file config = ProjectClosureBody
   { bodyModuleDir    = parent file
   , bodyDependencies = dependencies

--- a/src/Strategy/NuGet/Paket.hs
+++ b/src/Strategy/NuGet/Paket.hs
@@ -36,10 +36,10 @@ discover = walk $ \_ _ files -> do
 
   pure WalkContinue
 
-analyze :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Rel File -> m ProjectClosureBody
+analyze :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs File -> m ProjectClosureBody
 analyze file = mkProjectClosure file <$> readContentsParser findSections file
 
-mkProjectClosure :: Path Rel File -> [Section] -> ProjectClosureBody
+mkProjectClosure :: Path Abs File -> [Section] -> ProjectClosureBody
 mkProjectClosure file sections = ProjectClosureBody
   { bodyModuleDir    = parent file
   , bodyDependencies = dependencies

--- a/src/Strategy/NuGet/ProjectAssetsJson.hs
+++ b/src/Strategy/NuGet/ProjectAssetsJson.hs
@@ -45,10 +45,10 @@ instance FromJSON DependencyInfo where
     DependencyInfo <$> obj .: "type"
              <*> obj .:? "dependencies" .!= M.empty
 
-analyze :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Rel File -> m ProjectClosureBody
+analyze :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs File -> m ProjectClosureBody
 analyze file = mkProjectClosure file <$> readContentsJson @ProjectAssetsJson file
 
-mkProjectClosure :: Path Rel File -> ProjectAssetsJson -> ProjectClosureBody
+mkProjectClosure :: Path Abs File -> ProjectAssetsJson -> ProjectClosureBody
 mkProjectClosure file projectAssetsJson = ProjectClosureBody
   { bodyModuleDir    = parent file
   , bodyDependencies = dependencies

--- a/src/Strategy/NuGet/ProjectJson.hs
+++ b/src/Strategy/NuGet/ProjectJson.hs
@@ -53,10 +53,10 @@ instance FromJSON DependencyInfo where
     parseJSONText = withText "DependencyVersion" $ \text ->
         pure $ DependencyInfo text Nothing
 
-analyze :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Rel File -> m ProjectClosureBody
+analyze :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs File -> m ProjectClosureBody
 analyze file = mkProjectClosure file <$> readContentsJson @ProjectJson file
 
-mkProjectClosure :: Path Rel File -> ProjectJson -> ProjectClosureBody
+mkProjectClosure :: Path Abs File -> ProjectJson -> ProjectClosureBody
 mkProjectClosure file projectJson = ProjectClosureBody
   { bodyModuleDir    = parent file
   , bodyDependencies = dependencies

--- a/src/Strategy/Python/PipList.hs
+++ b/src/Strategy/Python/PipList.hs
@@ -34,13 +34,13 @@ pipListCmd baseCmd = Command
   , cmdAllowErr = Never
   }
 
-analyze :: (Has Exec sig m, Has Diagnostics sig m) => Path Rel Dir -> m ProjectClosureBody
+analyze :: (Has Exec sig m, Has Diagnostics sig m) => Path Abs Dir -> m ProjectClosureBody
 analyze dir = do
   deps <- execJson @[PipListDep] dir (pipListCmd "pip3")
             <||> execJson @[PipListDep] dir (pipListCmd "pip")
   pure (mkProjectClosure dir deps)
 
-mkProjectClosure :: Path Rel Dir -> [PipListDep] -> ProjectClosureBody
+mkProjectClosure :: Path Abs Dir -> [PipListDep] -> ProjectClosureBody
 mkProjectClosure dir deps = ProjectClosureBody
   { bodyModuleDir    = dir
   , bodyDependencies = dependencies

--- a/src/Strategy/Python/Pipenv.hs
+++ b/src/Strategy/Python/Pipenv.hs
@@ -45,14 +45,14 @@ analyze ::
   , Has Exec sig m
   , Has Diagnostics sig m
   )
-  => Path Rel File -> m ProjectClosureBody
+  => Path Abs File -> m ProjectClosureBody
 analyze lockfile = do
   lock <- readContentsJson lockfile
   maybeDeps <- recover (execJson (parent lockfile) pipenvGraphCmd)
 
   pure (mkProjectClosure lockfile lock maybeDeps)
 
-mkProjectClosure :: Path Rel File -> PipfileLock -> Maybe [PipenvGraphDep] -> ProjectClosureBody
+mkProjectClosure :: Path Abs File -> PipfileLock -> Maybe [PipenvGraphDep] -> ProjectClosureBody
 mkProjectClosure file lockfile maybeDeps = ProjectClosureBody
   { bodyModuleDir    = parent file
   , bodyDependencies = dependencies

--- a/src/Strategy/Python/ReqTxt.hs
+++ b/src/Strategy/Python/ReqTxt.hs
@@ -27,10 +27,10 @@ discover = walk $ \_ _ files -> do
 
   pure WalkContinue
 
-analyze :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Rel File -> m ProjectClosureBody
+analyze :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs File -> m ProjectClosureBody
 analyze file = mkProjectClosure file <$> readContentsParser requirementsTxtParser file
 
-mkProjectClosure :: Path Rel File -> [Req] -> ProjectClosureBody
+mkProjectClosure :: Path Abs File -> [Req] -> ProjectClosureBody
 mkProjectClosure file reqs = ProjectClosureBody
   { bodyModuleDir    = parent file
   , bodyDependencies = dependencies

--- a/src/Strategy/Python/SetupPy.hs
+++ b/src/Strategy/Python/SetupPy.hs
@@ -24,10 +24,10 @@ discover = walk $ \_ _ files -> do
 
   pure WalkContinue
 
-analyze :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Rel File -> m ProjectClosureBody
+analyze :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs File -> m ProjectClosureBody
 analyze file = mkProjectClosure file <$> readContentsParser installRequiresParser file
 
-mkProjectClosure :: Path Rel File -> [Req] -> ProjectClosureBody
+mkProjectClosure :: Path Abs File -> [Req] -> ProjectClosureBody
 mkProjectClosure file reqs = ProjectClosureBody
   { bodyModuleDir    = parent file
   , bodyDependencies = dependencies

--- a/src/Strategy/RPM.hs
+++ b/src/Strategy/RPM.hs
@@ -52,12 +52,12 @@ discover = walk $ \dir _ files ->
       analzyeFile specFile = runSimpleStrategy "rpm-spec" RPMGroup $ fmap (mkProjectClosure dir) (analyze specFile)
    in traverse_ analzyeFile specs >> pure WalkSkipAll
 
-analyze :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Rel File -> m (Graphing Dependency)
+analyze :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs File -> m (Graphing Dependency)
 analyze specFile = do
   specFileText <- readContentsText specFile
   pure . buildGraph $ getSpecDeps specFileText
 
-mkProjectClosure :: Path Rel Dir -> Graphing Dependency -> ProjectClosureBody
+mkProjectClosure :: Path Abs Dir -> Graphing Dependency -> ProjectClosureBody
 mkProjectClosure dir graph =
   ProjectClosureBody
     { bodyModuleDir = dir,

--- a/src/Strategy/Ruby/BundleShow.hs
+++ b/src/Strategy/Ruby/BundleShow.hs
@@ -37,10 +37,10 @@ bundleShowCmd = Command
   , cmdAllowErr = Never
   }
 
-analyze :: (Has Exec sig m, Has Diagnostics sig m) => Path Rel Dir -> m ProjectClosureBody
+analyze :: (Has Exec sig m, Has Diagnostics sig m) => Path Abs Dir -> m ProjectClosureBody
 analyze dir = mkProjectClosure dir <$> execParser bundleShowParser dir bundleShowCmd
 
-mkProjectClosure :: Path Rel Dir -> [BundleShowDep] -> ProjectClosureBody
+mkProjectClosure :: Path Abs Dir -> [BundleShowDep] -> ProjectClosureBody
 mkProjectClosure dir deps = ProjectClosureBody
   { bodyModuleDir    = dir
   , bodyDependencies = dependencies

--- a/src/Strategy/Ruby/GemfileLock.hs
+++ b/src/Strategy/Ruby/GemfileLock.hs
@@ -61,10 +61,10 @@ newtype DirectDep = DirectDep
       { directName :: Text
       } deriving (Eq, Ord, Show, Generic)
 
-analyze :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Rel File -> m ProjectClosureBody
+analyze :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs File -> m ProjectClosureBody
 analyze file = mkProjectClosure file <$> readContentsParser @[Section] findSections file
 
-mkProjectClosure :: Path Rel File -> [Section] -> ProjectClosureBody
+mkProjectClosure :: Path Abs File -> [Section] -> ProjectClosureBody
 mkProjectClosure file sections = ProjectClosureBody
   { bodyModuleDir    = parent file
   , bodyDependencies = dependencies

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -112,7 +112,7 @@ toProjectClosure strategyGroup name body = ProjectClosure
   }
 
 data ProjectClosureBody = ProjectClosureBody
-  { bodyModuleDir    :: Path Rel Dir
+  { bodyModuleDir    :: Path Abs Dir
   , bodyDependencies :: ProjectDependencies
   , bodyLicenses     :: [LicenseResult]
   } deriving (Eq, Ord, Show, Generic)
@@ -120,7 +120,7 @@ data ProjectClosureBody = ProjectClosureBody
 data ProjectClosure = ProjectClosure
   { closureStrategyGroup :: StrategyGroup
   , closureStrategyName  :: Text -- ^ e.g., "python-pipenv". This is temporary: ProjectClosures will eventually combine several strategies into one
-  , closureModuleDir     :: Path Rel Dir -- ^ the relative module directory (for grouping with other strategies)
+  , closureModuleDir     :: Path Abs Dir -- ^ the absolute module directory (for grouping with other strategies)
   , closureDependencies  :: ProjectDependencies
   , closureLicenses      :: [LicenseResult]
   } deriving (Eq, Ord, Show, Generic)

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -27,6 +27,7 @@ import Control.Algebra
 import Control.Carrier.TaskPool
 import Control.Carrier.Diagnostics
 import Control.Effect.Exception
+import Control.Effect.Finally
 import Control.Carrier.Output.IO
 import DepTypes
 import Effect.Exec
@@ -73,6 +74,7 @@ type TaskC m = ExecIOC (ReadFSIOC (DiagnosticsC m))
 
 type HasDiscover sig m =
   ( Has (Lift IO) sig m
+  , Has Finally sig m
   , Has Logger sig m
   , Has TaskPool sig m
   , Has (Output ProjectClosure) sig m

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -146,6 +146,7 @@ data StrategyGroup =
   | ClojureGroup
   | RustGroup
   | RPMGroup
+  | ArchiveGroup
   deriving (Eq, Ord, Show, Generic)
 
 -- FIXME: we also need to annotate dep graphs with Path Rel File -- merge these somehow?

--- a/test/Carthage/CarthageSpec.hs
+++ b/test/Carthage/CarthageSpec.hs
@@ -10,6 +10,7 @@ import Effect.ReadFS
 import qualified Graphing as G
 import GraphUtil
 import Strategy.Carthage
+import Path.IO (makeAbsolute)
 
 import Test.Hspec
 
@@ -25,8 +26,8 @@ spec = do
         & runReadFSIO
         & runDiagnostics
 
-  emptyResult <- runIO $ runIt testProjectEmpty
-  complexResult <- runIO $ runIt testProjectComplex
+  emptyResult <- runIO $ runIt =<< makeAbsolute testProjectEmpty
+  complexResult <- runIO $ runIt =<< makeAbsolute testProjectComplex
 
   describe "carthage analyze" $ do
     it "should work for empty projects" $ do

--- a/test/Go/GoListSpec.hs
+++ b/test/Go/GoListSpec.hs
@@ -17,6 +17,7 @@ import Effect.Exec
 import Effect.Grapher
 import Graphing (Graphing(..))
 import Strategy.Go.GoList
+import Path.IO (getCurrentDir)
 import Types
 
 import Test.Hspec
@@ -51,13 +52,11 @@ expected = run . evalGrapher $ do
                       , dependencyTags = M.empty
                       }
 
-testdir :: Path Rel Dir
-testdir = $(mkRelDir ".")
-
 spec :: Spec
 spec = do
   outputTrivial <- runIO (BL.readFile "test/Go/testdata/golist-stdout.trivial")
   outputComplex <- runIO (BL.readFile "test/Go/testdata/golist-stdout.complex")
+  testdir <- runIO getCurrentDir
 
   describe "golist analyze" $ do
     it "produces the expected output" $ do


### PR DESCRIPTION
This adds `--unpack-archives` as a command switch to `fossa analyze`. Discovered `.tar`, `.tar.gz`, `.zip`, `.jar`, and `.rpm` files will be recursively unarchived and analyzed.

This required using absolute filepaths in all strategies, so there are a bunch of "unrelated" changes in this PR. This is required because archives are unpacked in a temporary directory, and the current working directory is process-global -- so reading relative files/directories won't work if we want to run things in parallel.