### PR TITLE
Create draft releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -134,5 +134,6 @@ jobs:
       uses: softprops/action-gh-release@v1
       with:
         files: release/*
+        draft: true
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
There are edge cases where we do not want to publish a release, or may
want to create a pre-release instead.  This adds a tiny overhead to
release creation, but prevents a few potential accidents.

Example we could have run into: we needed to push a spot fix, but doing so required including some untested changes.
If we forgot to mark it as a pre-release, sales eng or scripting customers could have pulled an untested
version and potentially broken their builds.  This was very unlikely here, and is even less likely in the future.
That said, safety first.