### PR TITLE
Implement contributor tracking

### DIFF
--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -184,6 +184,7 @@ library
     Strategy.Ruby.BundleShow
     Strategy.Ruby.GemfileLock
     Types
+    VCS.Git
 
   hs-source-dirs:  src
 

--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -11,15 +11,22 @@ import qualified Control.Carrier.Diagnostics as Diag
 import Control.Carrier.Output.IO
 import Control.Concurrent
 
+import App.Fossa.CliTypes
+import App.Fossa.FossaAPIV1 (ProjectMetadata, uploadAnalysis, UploadResponse(..), Contributors(..), uploadContributors)
 import App.Fossa.Analyze.Project (Project, mkProjects)
-import App.Fossa.FossaAPIV1 (ProjectMetadata, uploadAnalysis, UploadResponse(..))
 import App.Fossa.ProjectInference (mergeOverride, inferProject)
 import App.Types
 import Control.Carrier.Finally
 import Control.Carrier.TaskPool
+import Data.ByteString.Lazy (toStrict)
+import qualified Data.Map as M
+import qualified Data.Text as T
 import Data.Text.Lazy.Encoding (decodeUtf8)
 import Data.Text.Prettyprint.Doc
 import Data.Text.Prettyprint.Doc.Render.Terminal
+import Data.Time
+import Data.Time.Format.ISO8601 (iso8601Show)
+import Effect.Exec
 import Effect.Logger
 import Network.HTTP.Types (urlEncode)
 import qualified Srclib.Converter as Srclib
@@ -119,6 +126,60 @@ analyze basedir destination override unpackArchives = runFinally $ do
             , "============================================================"
             ]
           traverse_ (\err -> logError $ "FOSSA error: " <> viaShow err) (uploadError resp)
+
+          contribResult <- Diag.runDiagnostics $ runExecIO $ tryUploadContributors basedir baseurl apiKey $ uploadLocator resp
+          case contribResult of
+            Left failure -> logDebug (Diag.renderFailureBundle failure)
+            Right _ -> pure ()
+
+tryUploadContributors ::
+  ( Has Diag.Diagnostics sig m
+  , Has Exec sig m
+  , MonadIO m
+  ) => Path x Dir
+  -> URI
+  -> ApiKey
+  -> Text -- ^ Locator
+  -> m ()
+tryUploadContributors baseDir baseUrl apiKey locator = do
+  contributors <- fetchGitContributors baseDir
+  uploadContributors baseUrl apiKey locator contributors
+
+
+fetchGitContributors :: 
+  ( Has Diag.Diagnostics sig m
+  , Has Exec sig m
+  , MonadIO m
+  ) => Path x Dir -> m Contributors
+fetchGitContributors basedir = do
+  now <- liftIO getCurrentTime
+  rawContrib <- execThrow basedir $ gitLogCmd now
+  textContrib <- Diag.fromEitherShow . TE.decodeUtf8' $ toStrict rawContrib
+  pure . Contributors . M.map (T.pack . iso8601Show) $ foldr updateMap M.empty $ T.lines textContrib
+  where
+    updateMap :: Text -> Map Text Day -> Map Text Day
+    updateMap entry oldMap = case readLine entry of
+      Nothing -> oldMap
+      Just (email, date) -> 
+        if M.findWithDefault minimumDay email oldMap < date
+          then M.insert email date oldMap
+          else oldMap
+
+    readLine :: Text -> Maybe (Text, Day)
+    readLine entry = do
+      let (email, textDate) = splitOnceOn "|" entry
+      date <- parseTimeM True defaultTimeLocale "%Y-%-m-%-d" $ T.unpack textDate
+      Just (email, date)
+
+    minimumDay :: Day
+    minimumDay = ModifiedJulianDay 0
+
+splitOnceOn :: Text -> Text -> (Text, Text)
+splitOnceOn needle haystack = (head, strippedTail)
+  where
+    len = T.length needle
+    (head, tail) = T.breakOn needle haystack
+    strippedTail = T.drop len tail
 
 fossaProjectUrl :: URI -> Text -> Text -> Text
 fossaProjectUrl baseUrl rawLocator branch = URI.render baseUrl <> "projects/" <> encodedProject <> "/refs/branch/" <> branch <> "/" <> encodedRevision

--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -12,7 +12,6 @@ import Control.Carrier.Output.IO
 import Control.Concurrent
 
 import App.Fossa.Analyze.Project (Project, mkProjects)
-import App.Fossa.CliTypes
 import App.Fossa.FossaAPIV1 (ProjectMetadata, uploadAnalysis, UploadResponse(..), uploadContributors)
 import App.Fossa.ProjectInference (mergeOverride, inferProject)
 import App.Types
@@ -123,7 +122,7 @@ analyze basedir destination override unpackArchives = runFinally $ do
             ]
           traverse_ (\err -> logError $ "FOSSA error: " <> viaShow err) (uploadError resp)
 
-          contribResult <- Diag.runDiagnostics $ runExecIO $ tryUploadContributors basedir baseurl apiKey $ uploadLocator resp
+          contribResult <- Diag.runDiagnostics $ runExecIO $ tryUploadContributors (unBaseDir basedir) baseurl apiKey $ uploadLocator resp
           case contribResult of
             Left failure -> logDebug (Diag.renderFailureBundle failure)
             Right _ -> pure ()

--- a/src/VCS/Git.hs
+++ b/src/VCS/Git.hs
@@ -1,0 +1,59 @@
+module VCS.Git
+  ( gitLogCmd,
+    fetchGitContributors,
+  )
+where
+
+import App.Fossa.FossaAPIV1 (Contributors (..))
+import qualified Control.Carrier.Diagnostics as Diag
+import Data.ByteString.Lazy (toStrict)
+import qualified Data.Map as M
+import Data.Maybe (mapMaybe)
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as TE
+import Data.Time
+import Data.Time.Format.ISO8601 (iso8601Show)
+import Effect.Exec
+import Prologue
+
+gitLogCmd :: UTCTime -> Command
+gitLogCmd now =
+  Command
+    { cmdName = "git",
+      cmdArgs = ["log", "--since", sinceArg, "--date=short", "--format=%ae|%cd"],
+      cmdAllowErr = Never
+    }
+  where
+    sinceArg = iso8601Show $ utctDay wayBack
+    delta = nominalDay * (-90)
+    wayBack = addUTCTime delta now
+
+fetchGitContributors ::
+  ( Has Diag.Diagnostics sig m,
+    Has Exec sig m,
+    MonadIO m
+  ) =>
+  Path x Dir ->
+  m Contributors
+fetchGitContributors basedir = do
+  now <- liftIO getCurrentTime
+  rawContrib <- execThrow basedir $ gitLogCmd now
+  textContrib <- Diag.fromEitherShow . TE.decodeUtf8' $ toStrict rawContrib
+  pure . Contributors
+    . M.map (T.pack . iso8601Show)
+    . M.fromListWith max
+    . mapMaybe readLine
+    $ T.lines textContrib
+  where
+    readLine :: Text -> Maybe (Text, Day)
+    readLine entry = do
+      let (email, textDate) = splitOnceOn "|" entry
+      date <- parseTimeM True defaultTimeLocale "%Y-%-m-%-d" $ T.unpack textDate
+      Just (email, date)
+
+splitOnceOn :: Text -> Text -> (Text, Text)
+splitOnceOn needle haystack = (head, strippedTail)
+  where
+    len = T.length needle
+    (head, tail) = T.breakOn needle haystack
+    strippedTail = T.drop len tail


### PR DESCRIPTION
Basic outline:

- If upload analysis has been successful (meaning we successfully called the API, not that we didn't receive any errors), try to upload contributor tracking data.
- Data takes the shape of `{"<authorEmail>": "<latest contribution date: YYYY-MM-DD>", ...}`
- Once contributor tracking phase is started, we do not fail the analysis or process for any reason within our control, including errors.
- Errors are reported as debug messages, but otherwise ignored.  This includes all three instances of `IO`:
  - Retrieving the current date
  - Invoking and reading the `git log ...` output
  - Uploading the contribution data to the core endpoint
- Malformed output lines from `git log ...` are ignored, since git should be taking care of that.  We can add protection here later if needed.
- No response is needed from the API, but we may want to check for an error message.  We can add this once the core endpoint has been implemented.