### PR TITLE
Create newtype for the basedir

### DIFF
--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -103,15 +103,16 @@ library
     App.Fossa.Analyze.GraphMangler
     App.Fossa.Analyze.Project
     App.Fossa.API.BuildWait
-    App.Fossa.CliTypes
     App.Fossa.FossaAPIV1
     App.Fossa.Main
     App.Fossa.ProjectInference
     App.Fossa.Report
     App.Fossa.Report.Attribution
     App.Fossa.Test
+    App.OptionExtensions
     App.Pathfinder.Main
     App.Pathfinder.Scan
+    App.Types
     App.Util
     App.VPSScan.Main
     App.VPSScan.Scan
@@ -137,7 +138,6 @@ library
     Effect.Logger
     Effect.ReadFS
     Graphing
-    OptionExtensions
     Parse.XML
     Prologue
     Srclib.Converter

--- a/src/App/Fossa/API/BuildWait.hs
+++ b/src/App/Fossa/API/BuildWait.hs
@@ -5,7 +5,7 @@ module App.Fossa.API.BuildWait (
 
 import Prologue
 
-import App.Fossa.CliTypes
+import App.Types
 import qualified App.Fossa.FossaAPIV1 as Fossa
 import Control.Carrier.Diagnostics
 import Control.Concurrent (threadDelay)

--- a/src/App/Fossa/FossaAPIV1.hs
+++ b/src/App/Fossa/FossaAPIV1.hs
@@ -20,7 +20,7 @@ module App.Fossa.FossaAPIV1
   , getAttribution
   ) where
 
-import App.Fossa.CliTypes
+import App.Types
 import App.Fossa.Analyze.Project
 import qualified App.Fossa.Report.Attribution as Attr
 import Control.Effect.Diagnostics
@@ -126,7 +126,7 @@ data ProjectMetadata = ProjectMetadata
 
 uploadAnalysis
   :: (Has Diagnostics sig m, MonadIO m)
-  => Path Abs Dir -- ^ root directory for analysis
+  => BaseDir -- ^ root directory for analysis
   -> URI -- ^ base url
   -> ApiKey -- ^ api key
   -> ProjectRevision
@@ -139,7 +139,7 @@ uploadAnalysis rootDir baseUri key ProjectRevision{..} metadata projects = fossa
   -- For each of the projects, we need to strip the root directory path from the prefix of the project path.
   -- We don't want parent directories of the scan root affecting "production path" filtering -- e.g., if we're
   -- running in a directory called "tmp", we still want results.
-  let rootPath = fromAbsDir rootDir
+  let rootPath = fromAbsDir $ unBaseDir rootDir
       dropPrefix :: String -> String -> String
       dropPrefix prefix str = fromMaybe prefix (stripPrefix prefix str)
       filteredProjects = filter (isProductionPath . dropPrefix rootPath . fromAbsDir . projectPath) projects

--- a/src/App/Fossa/ProjectInference.hs
+++ b/src/App/Fossa/ProjectInference.hs
@@ -7,7 +7,7 @@ module App.Fossa.ProjectInference
   )
 where
 
-import App.Fossa.CliTypes
+import App.Types
 import Control.Algebra
 import Control.Carrier.Diagnostics
 import qualified Data.ByteString.Lazy as BL

--- a/src/App/Fossa/Test.hs
+++ b/src/App/Fossa/Test.hs
@@ -8,7 +8,7 @@ import Prologue
 import qualified Prelude as Unsafe
 
 import App.Fossa.API.BuildWait
-import App.Fossa.CliTypes
+import App.Types
 import qualified App.Fossa.FossaAPIV1 as Fossa
 import App.Fossa.ProjectInference
 import Control.Carrier.Diagnostics
@@ -19,7 +19,6 @@ import qualified Data.Map as M
 import qualified Data.Text as T
 import Data.Text.IO (hPutStrLn)
 import Effect.Logger
-import Path.IO
 import System.IO (stderr)
 import System.Exit (exitSuccess, exitFailure)
 import Text.URI (URI)
@@ -32,18 +31,17 @@ data TestOutputType
 
 testMain
   :: URI -- ^ api base url
+  -> BaseDir
   -> ApiKey -- ^ api key
   -> Severity
   -> Int -- ^ timeout (seconds)
   -> TestOutputType
   -> OverrideProject
   -> IO ()
-testMain baseurl apiKey logSeverity timeoutSeconds outputType override = do
-  basedir <- getCurrentDir
-
+testMain baseurl basedir apiKey logSeverity timeoutSeconds outputType override = do
   void $ timeout timeoutSeconds $ withLogger logSeverity $ do
     result <- runDiagnostics $ do
-      revision <- mergeOverride override <$> inferProject basedir
+      revision <- mergeOverride override <$> inferProject (unBaseDir basedir)
 
       logInfo ""
       logInfo ("Using project name: `" <> pretty (projectName revision) <> "`")

--- a/src/App/OptionExtensions.hs
+++ b/src/App/OptionExtensions.hs
@@ -1,8 +1,9 @@
-module OptionExtensions (uriOption) where
+module App.OptionExtensions (uriOption) where
 
-import Options.Applicative
 import Prologue
+
 import qualified Data.Text as T
+import Options.Applicative
 import Text.URI (URI, mkURI)
 
 uriOption :: Mod OptionFields URI -> Parser URI

--- a/src/App/Pathfinder/Main.hs
+++ b/src/App/Pathfinder/Main.hs
@@ -9,6 +9,7 @@ import Options.Applicative
 import Path.IO
 
 import App.Pathfinder.Scan (scanMain)
+import App.Types (BaseDir (..))
 import App.Util (validateDir)
 
 appMain :: IO ()
@@ -23,7 +24,7 @@ appMain = do
         Nothing -> scanMain currentDir debug
         Just dir -> do
           resolved <- validateDir dir
-          scanMain resolved debug
+          scanMain (unBaseDir resolved) debug
 
 data CommandOpts = LicenseScan (Maybe FilePath) Bool
   deriving Show

--- a/src/App/Types.hs
+++ b/src/App/Types.hs
@@ -1,5 +1,6 @@
-module App.Fossa.CliTypes
+module App.Types
   ( ApiKey (..),
+    BaseDir (..),
     OverrideProject (..),
     ProjectRevision (..)
   )
@@ -8,6 +9,7 @@ where
 import Prologue
 
 newtype ApiKey = ApiKey {unApiKey :: Text} deriving (Eq, Ord, Show)
+newtype BaseDir = BaseDir {unBaseDir :: Path Abs Dir} deriving (Eq, Ord, Show)
 
 data OverrideProject = OverrideProject
   { overrideName :: Maybe Text,

--- a/src/App/Util.hs
+++ b/src/App/Util.hs
@@ -5,6 +5,7 @@ module App.Util
 
 import Prologue
 
+import App.Types
 import Control.Carrier.Diagnostics
 import qualified Path.IO as P
 import System.Exit (die)
@@ -12,13 +13,13 @@ import Text.URI (URI, render)
 import Network.HTTP.Req
 
 -- | Validate that a filepath points to a directory and the directory exists
-validateDir :: FilePath -> IO (Path Abs Dir)
+validateDir :: FilePath -> IO BaseDir
 validateDir dir = do
   absolute <- P.resolveDir' dir
   exists <- P.doesDirExist absolute
 
   unless exists (die $ "ERROR: Directory " <> show absolute <> " does not exist")
-  pure absolute
+  pure $ BaseDir absolute
 
 -- parse a URI for use as a (base) Url, along with some default Options (e.g., port)
 parseUri :: Has Diagnostics sig m => URI -> m (Url 'Https, Option 'Https)

--- a/src/App/VPSScan/Main.hs
+++ b/src/App/VPSScan/Main.hs
@@ -6,11 +6,11 @@ import Prologue
 
 import Options.Applicative
 
+import App.OptionExtensions
 import App.VPSScan.Scan (ScanCmdOpts(..), scanMain)
 import App.VPSScan.NinjaGraph (NinjaGraphCmdOpts(..), ninjaGraphMain)
 import App.VPSScan.Types
 import qualified App.VPSScan.Scan.RunIPR as RunIPR
-import OptionExtensions
 
 appMain :: IO ()
 appMain = join (customExecParser (prefs showHelpOnEmpty) opts)

--- a/src/App/VPSScan/NinjaGraph.hs
+++ b/src/App/VPSScan/NinjaGraph.hs
@@ -22,6 +22,7 @@ import Network.HTTP.Req
 import qualified System.FilePath as FP
 
 import App.VPSScan.Types
+import App.Types (BaseDir (..))
 import App.Util (validateDir, parseUri)
 
 -- end of copy-paste
@@ -49,7 +50,7 @@ data NinjaParseState = Starting | Parsing | Complete | Error
 ninjaGraphMain :: NinjaGraphCmdOpts -> IO ()
 ninjaGraphMain NinjaGraphCmdOpts{..} = do
   dir <- validateDir ninjaCmdBasedir
-  result <- runDiagnostics $ getAndParseNinjaDeps dir ninjaCmdNinjaGraphOpts
+  result <- runDiagnostics $ getAndParseNinjaDeps (unBaseDir dir) ninjaCmdNinjaGraphOpts
   case result of
     Left failure -> do
       print $ renderFailureBundle failure

--- a/src/App/VPSScan/Scan.hs
+++ b/src/App/VPSScan/Scan.hs
@@ -16,6 +16,7 @@ import App.VPSScan.Types
 import App.VPSScan.Scan.RunSherlock
 import App.VPSScan.Scan.ScotlandYard
 import App.VPSScan.Scan.RunIPR
+import App.Types (BaseDir (..))
 import App.Util (validateDir)
 
 data ScanCmdOpts = ScanCmdOpts
@@ -26,7 +27,7 @@ data ScanCmdOpts = ScanCmdOpts
 scanMain :: ScanCmdOpts -> IO ()
 scanMain opts@ScanCmdOpts{..} = do
   basedir <- validateDir cmdBasedir
-  result <- runDiagnostics $ runTrace $ vpsScan basedir opts
+  result <- runDiagnostics $ runTrace $ vpsScan (unBaseDir basedir) opts
   case result of
     Left failure -> do
       print $ renderFailureBundle failure


### PR DESCRIPTION
This PR serves two purposes:

- Create a newtype that tells us when we are dealing with the "current working directory or cli-provided override directory", rather than "some absolute path", though the two may be related or even identical.  The points at which we should unwrap the type comes when a different path does not break the very idea of the function using it.  Therefore, this is primarily only helpful for top-level dispatch.
- This should also clear out any use of the "set working directory, then fetch it from the process later" pattern from the `fossa` executable.  This is a purity change, which can have very real, tangible effects during multi-threaded code.
  - Currently, it appears there are no bugs related to changing directory, but that is an effect of good implementation, rather than type-system guarantees.  This should make it difficult to introduce these bugs, 