### PR TITLE
Re-enable deep dependency retrieval for golang projects

### DIFF
--- a/src/Strategy/Go/GoList.hs
+++ b/src/Strategy/Go/GoList.hs
@@ -20,6 +20,7 @@ import Discovery.Walk
 import Effect.Exec
 import Effect.Grapher
 import Graphing (Graphing)
+import Strategy.Go.Transitive (fillInTransitive)
 import Strategy.Go.Types
 import Types
 
@@ -62,8 +63,7 @@ analyze dir = fmap (mkProjectClosure dir) . graphingGolang $ do
 
   buildGraph requires
 
-  -- TODO: diagnostics?
-  -- _ <- try @ExecErr (fillInTransitive dir)
+  _ <- recover (fillInTransitive dir)
   pure ()
 
 mkProjectClosure :: Path Abs Dir -> Graphing Dependency -> ProjectClosureBody

--- a/src/Strategy/Go/Gomod.hs
+++ b/src/Strategy/Go/Gomod.hs
@@ -23,9 +23,11 @@ import qualified Text.Megaparsec.Char.Lexer as L
 
 import DepTypes
 import Discovery.Walk
+import Effect.Exec
 import Effect.Grapher
 import Effect.ReadFS
 import Graphing (Graphing)
+import Strategy.Go.Transitive (fillInTransitive)
 import Strategy.Go.Types
 import Types
 
@@ -177,6 +179,7 @@ resolve gomod = map resolveReplace (modRequires gomod)
 
 analyze ::
   ( Has ReadFS sig m
+  , Has Exec sig m
   , Has Diagnostics sig m
   )
   => Path Abs File -> m ProjectClosureBody
@@ -185,8 +188,7 @@ analyze file = fmap (mkProjectClosure file) . graphingGolang $ do
 
   buildGraph gomod
 
-  -- TODO: diagnostics?
-  -- _ <- runError @ExecErr (fillInTransitive (parent file))
+  _ <- recover (fillInTransitive (parent file))
   pure ()
 
 mkProjectClosure :: Path Abs File -> Graphing Dependency -> ProjectClosureBody

--- a/src/Strategy/Go/GopkgLock.hs
+++ b/src/Strategy/Go/GopkgLock.hs
@@ -17,9 +17,11 @@ import Prologue hiding ((.=))
 import Control.Effect.Diagnostics
 import DepTypes
 import Discovery.Walk
+import Effect.Exec
 import Effect.Grapher
 import Effect.ReadFS
 import Graphing (Graphing)
+import Strategy.Go.Transitive (fillInTransitive)
 import Strategy.Go.Types
 import qualified Toml
 import Toml (TomlCodec, (.=))
@@ -55,6 +57,7 @@ data Project = Project
 
 analyze ::
   ( Has ReadFS sig m
+  , Has Exec sig m
   , Has Diagnostics sig m
   )
   => Path Abs File -> m ProjectClosureBody
@@ -65,8 +68,7 @@ analyze file = fmap (mkProjectClosure file) . graphingGolang $ do
     Right golock -> do
       buildGraph (lockProjects golock)
 
-      -- TODO: diagnostics?
-      -- _ <- runError @ExecErr (fillInTransitive (parent file))
+      _ <- recover (fillInTransitive (parent file))
       pure ()
 
 mkProjectClosure :: Path Abs File -> Graphing Dependency -> ProjectClosureBody

--- a/src/Strategy/Go/GopkgToml.hs
+++ b/src/Strategy/Go/GopkgToml.hs
@@ -22,9 +22,11 @@ import qualified Toml
 
 import DepTypes
 import Discovery.Walk
+import Effect.Exec
 import Effect.Grapher
 import Effect.ReadFS
 import Graphing (Graphing)
+import Strategy.Go.Transitive (fillInTransitive)
 import Strategy.Go.Types
 import Types
 
@@ -65,6 +67,7 @@ data PkgConstraint = PkgConstraint
 
 analyze ::
   ( Has ReadFS sig m
+  , Has Exec sig m
   , Has Diagnostics sig m
   )
   => Path Abs File -> m ProjectClosureBody
@@ -75,8 +78,7 @@ analyze file = fmap (mkProjectClosure file) . graphingGolang $ do
     Right gopkg -> do
       buildGraph gopkg
 
-      -- TODO: diagnostics?
-      -- _ <- runError @ExecErr (fillInTransitive (parent file))
+      _ <- recover (fillInTransitive (parent file))
       pure ()
 
 mkProjectClosure :: Path Abs File -> Graphing Dependency -> ProjectClosureBody

--- a/src/Strategy/Go/Transitive.hs
+++ b/src/Strategy/Go/Transitive.hs
@@ -96,7 +96,7 @@ fillInTransitive ::
   , Has Exec sig m
   , Has Diagnostics sig m
   )
-  => Path Rel Dir -> m ()
+  => Path x Dir -> m ()
 fillInTransitive dir = do
   goListOutput <- execThrow dir goListCmd
   case decodeMany goListOutput of


### PR DESCRIPTION
This was disabled for use in v1 results comparison

Additionally: now that we have `Diagnostics`, we no longer outright ignore the warnings if transitive dependency retrieval fails