### PR TITLE
Chunked IPR uploads

### DIFF
--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -53,6 +53,7 @@ common deps
     , prettyprinter-ansi-terminal  ^>=1.1.1
     , req                          >=3.4      && <3.6
     , split                        ^>=0.2.3.4
+    , basement                     ^>=0.0.11
     , stm                          ^>=2.5.0
     , stm-chans                    ^>=3.0.0
     , tar                          ^>=0.5.1.1

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -53,7 +53,6 @@ common deps
     , prettyprinter-ansi-terminal  ^>=1.1.1
     , req                          >=3.4      && <3.6
     , split                        ^>=0.2.3.4
-    , basement                     ^>=0.0.11
     , stm                          ^>=2.5.0
     , stm-chans                    ^>=3.0.0
     , tar                          ^>=0.5.1.1

--- a/src/App/VPSScan/Scan.hs
+++ b/src/App/VPSScan/Scan.hs
@@ -21,10 +21,9 @@ import App.VPSScan.Scan.Core
 import App.VPSScan.EmbeddedBinary
 import App.Types (BaseDir (..))
 import App.Util (validateDir)
-import Data.Text (unpack)
+import Data.Text (unpack, Text)
 import Control.Effect.Exception (bracket)
 import Path
-import Data.Text (Text)
 import Data.Aeson
 
 data ScanCmdOpts = ScanCmdOpts
@@ -67,7 +66,7 @@ vpsScan basedir ScanCmdOpts{..} binaryPaths = do
   _ <- context "creating project in FOSSA" $ createCoreProject projectName projectRevision fossa
 
   -- Create scan in SY
-  trace $ "[All] Creating scan in Scotland Yard"
+  trace "[All] Creating scan in Scotland Yard"
   let syOpts = ScotlandYardOpts locator projectRevision sherlockOrgId vpsOpts
   response <- context "creating scan ID" $ createScotlandYardScan syOpts
   let scanId = responseScanId response
@@ -95,9 +94,9 @@ vpsScan basedir ScanCmdOpts{..} binaryPaths = do
       trace (show $ renderFailureBundle sherlockFailure)
       sendIO exitFailure
 
-  trace $ "[All] Completing scan in FOSSA"
+  trace "[All] Completing scan in FOSSA"
   _ <- context "completing project in FOSSA" $ completeCoreProject (unLocator revisionLocator) fossa
-  trace $ "[All] Project is ready to view in FOSSA (Sherlock forensics may still be pending)"
+  trace "[All] Project is ready to view in FOSSA (Sherlock forensics may still be pending)"
 
 runSherlockScan ::
   ( Has Exec sig m

--- a/src/App/VPSScan/Scan.hs
+++ b/src/App/VPSScan/Scan.hs
@@ -51,7 +51,7 @@ vpsScan ::
   ) => Path Abs Dir -> ScanCmdOpts -> BinaryPaths -> m ()
 vpsScan basedir ScanCmdOpts{..} binaryPaths = do
   let vpsOpts@VPSOpts{..} = scanVpsOpts
-  
+
   -- Build the revision
   projectRevision <- buildRevision userProvidedRevision
 
@@ -123,5 +123,6 @@ runIPRScan basedir scanId binaryPaths syOpts vpsOpts =
     iprResult <- execIPR binaryPaths $ IPROpts basedir vpsOpts
     trace "[IPR] IPR scan completed. Posting results to Scotland Yard"
     context "uploading scan results" $ uploadIPRResults scanId iprResult syOpts
+    trace ""
     trace "[IPR] Post to Scotland Yard complete"
     trace "[IPR] IPR scan complete"

--- a/src/App/VPSScan/Scan/ScotlandYard.hs
+++ b/src/App/VPSScan/Scan/ScotlandYard.hs
@@ -180,7 +180,7 @@ chunkJSON (Object obj) key chunkSize = do
     _ -> Nothing
   let chunked = chunksOf chunkSize $ V.toList arr
   let chunker :: [Value] -> Value
-      chunker v = object ["Files" .= v]
+      chunker v = object [key .= v]
   Just $ map chunker chunked
 
 chunkJSON _ _ _ = Nothing

--- a/src/App/VPSScan/Scan/ScotlandYard.hs
+++ b/src/App/VPSScan/Scan/ScotlandYard.hs
@@ -118,7 +118,7 @@ createBuildGraphEndpoint baseurl projectId scanId = coreProxyPrefix baseurl /: "
 
 -- /projects/{projectID}/scans/{scanID}/build-graphs/{buildGraphID}/rules
 uploadBuildGraphChunkEndpoint :: Url 'Https -> Text -> Text -> Text ->  Url 'Https
-uploadBuildGraphChunkEndpoint baseurl projectId scanId buildGraphId = coreProxyPrefix baseurl /: "projects" /: projectId /: "scans" /: scanId /: "build-graphs" /: buildGraphId /: "rules"
+uploadBuildGraphChunkEndpoint baseurl projectId scanId buildGraphId = coreProxyPrefix baseurl /: "projects" /: projectId /: "scans" /: scanId /: "build-graphs" /: buildGraphId /: "rules" /: "partial"
 
 -- /projects/{projectID}/scans/{scanID}/build-graphs/{buildGraphID}/rules/complete
 uploadBuildGraphCompleteEndpoint :: Url 'Https -> Text -> Text -> Text ->  Url 'Https

--- a/src/App/VPSScan/Scan/ScotlandYard.hs
+++ b/src/App/VPSScan/Scan/ScotlandYard.hs
@@ -118,7 +118,7 @@ createBuildGraphEndpoint baseurl projectId scanId = coreProxyPrefix baseurl /: "
 
 -- /projects/{projectID}/scans/{scanID}/build-graphs/{buildGraphID}/rules
 uploadBuildGraphChunkEndpoint :: Url 'Https -> Text -> Text -> Text ->  Url 'Https
-uploadBuildGraphChunkEndpoint baseurl projectId scanId buildGraphId = coreProxyPrefix baseurl /: "projects" /: projectId /: "scans" /: scanId /: "build-graphs" /: buildGraphId /: "rules" /: "partial"
+uploadBuildGraphChunkEndpoint baseurl projectId scanId buildGraphId = coreProxyPrefix baseurl /: "projects" /: projectId /: "scans" /: scanId /: "build-graphs" /: buildGraphId /: "rules"
 
 -- /projects/{projectID}/scans/{scanID}/build-graphs/{buildGraphID}/rules/complete
 uploadBuildGraphCompleteEndpoint :: Url 'Https -> Text -> Text -> Text ->  Url 'Https

--- a/src/App/VPSScan/Scan/ScotlandYard.hs
+++ b/src/App/VPSScan/Scan/ScotlandYard.hs
@@ -50,7 +50,7 @@ coreProxyPrefix baseurl = baseurl /: "api" /: "proxy" /: "scotland-yard"
 createScanEndpoint :: Url 'Https -> Text -> Url 'Https
 createScanEndpoint baseurl projectId = coreProxyPrefix baseurl /: "projects" /: projectId /: "scans"
 
--- /projects/{projectID}/scans/{scanID}/discovered_licenses
+-- /projects/{projectID}/scans/{scanID}/discovered_licenses/partial
 uploadIPRChunkEndpoint :: Url 'Https -> Text -> Text -> Url 'Https
 uploadIPRChunkEndpoint baseurl projectId scanId = coreProxyPrefix baseurl /: "projects" /: projectId /: "scans" /: scanId /: "discovered_licenses" /: "partial"
 
@@ -89,7 +89,7 @@ createScotlandYardScan ScotlandYardOpts {..} = runHTTP $ do
   pure (responseBody resp)
 
 -- Given the results from a run of IPR, a scan ID and a URL for Scotland Yard,
--- post the IPR result in chunks of 1000 entries to the "Upload IPR Data" endpoint on Scotland Yard.
+-- post the IPR result in chunks of ~ 1 MB to the "Upload IPR Data" endpoint on Scotland Yard.
 -- once all of the chunks are complete, PUT to the "upload IPR data complete" endpoint,
 uploadIPRResults :: (Has (Lift IO) sig m, Has Diagnostics sig m) => Text -> Value -> ScotlandYardOpts -> m ()
 uploadIPRResults scanId value ScotlandYardOpts {..} = runHTTP $ do
@@ -124,7 +124,7 @@ uploadBuildGraphChunkEndpoint baseurl projectId scanId buildGraphId = coreProxyP
 uploadBuildGraphCompleteEndpoint :: Url 'Https -> Text -> Text -> Text ->  Url 'Https
 uploadBuildGraphCompleteEndpoint baseurl projectId scanId buildGraphId = coreProxyPrefix baseurl /: "projects" /: projectId /: "scans" /: scanId /: "build-graphs" /: buildGraphId /: "rules" /: "complete"
 
--- create the build graph in SY, upload it in chunks and then complete it.
+-- create the build graph in SY, upload it in chunks of ~ 1 MB and then complete it.
 uploadBuildGraph :: (Has (Lift IO) sig m, Has Diagnostics sig m) => ScotlandYardNinjaOpts -> [DepsTarget] -> m ()
 uploadBuildGraph syOpts@ScotlandYardNinjaOpts {..} targets = runHTTP $ do
   let NinjaGraphOpts{..} = syNinjaOpts

--- a/src/App/VPSScan/Scan/ScotlandYard.hs
+++ b/src/App/VPSScan/Scan/ScotlandYard.hs
@@ -17,7 +17,10 @@ import Control.Monad.IO.Class
 import Control.Effect.Lift
 import App.VPSScan.Types
 import Data.Foldable (traverse_)
+import qualified Data.HashMap.Strict as HM
 import Data.List.Split
+import Data.Maybe (fromMaybe)
+import qualified Data.Vector as V
 import Effect.Logger
 import GHC.Conc.Sync (getNumCapabilities)
 import App.VPSScan.Scan.Core
@@ -48,8 +51,12 @@ createScanEndpoint :: Url 'Https -> Text -> Url 'Https
 createScanEndpoint baseurl projectId = coreProxyPrefix baseurl /: "projects" /: projectId /: "scans"
 
 -- /projects/{projectID}/scans/{scanID}/discovered_licenses
-scanDataEndpoint :: Url 'Https -> Text -> Text -> Url 'Https
-scanDataEndpoint baseurl projectId scanId = coreProxyPrefix baseurl /: "projects" /: projectId /: "scans" /: scanId /: "discovered_licenses"
+uploadIPRChunkEndpoint :: Url 'Https -> Text -> Text -> Url 'Https
+uploadIPRChunkEndpoint baseurl projectId scanId = coreProxyPrefix baseurl /: "projects" /: projectId /: "scans" /: scanId /: "discovered_licenses"
+
+-- /projects/{projectID}/scans/{scanID}/discovered_licenses/complete
+uploadIPRCompleteEndpoint :: Url 'Https -> Text -> Text -> Url 'Https
+uploadIPRCompleteEndpoint baseurl projectId scanId = coreProxyPrefix baseurl /: "projects" /: projectId /: "scans" /: scanId /: "discovered_licenses" /: "complete"
 
 data ScanResponse = ScanResponse
   { responseScanId :: Text
@@ -82,9 +89,9 @@ createScotlandYardScan ScotlandYardOpts {..} = runHTTP $ do
   pure (responseBody resp)
 
 -- Given the results from a run of IPR, a scan ID and a URL for Scotland Yard,
--- post the IPR result to the "Upload Scan Data" endpoint on Scotland Yard
--- POST /scans/{scanID}/discovered_licenses
-uploadIPRResults :: (ToJSON a, Has (Lift IO) sig m, Has Diagnostics sig m) => Text -> a -> ScotlandYardOpts -> m ()
+-- post the IPR result in chunks of 1000 entries to the "Upload IPR Data" endpoint on Scotland Yard.
+-- once all of the chunks are complete, PUT to the "upload IPR data complete" endpoint,
+uploadIPRResults :: (Has (Lift IO) sig m, Has Diagnostics sig m) => Text -> Value -> ScotlandYardOpts -> m ()
 uploadIPRResults scanId value ScotlandYardOpts {..} = runHTTP $ do
   let VPSOpts{..} = syVpsOpts
       FossaOpts{..} = fossa
@@ -92,7 +99,17 @@ uploadIPRResults scanId value ScotlandYardOpts {..} = runHTTP $ do
       locator = unLocator projectId
 
   (baseUrl, baseOptions) <- parseUri fossaUrl
-  _ <- req POST (scanDataEndpoint baseUrl locator scanId) (ReqBodyJson value) ignoreResponse (baseOptions <> header "Content-Type" "application/json" <> auth)
+  let chunkedJSON = fromMaybe [] (chunkJSON value "Files" 1000)
+
+  capabilities <- liftIO getNumCapabilities
+  let url = uploadIPRChunkEndpoint baseUrl projectName scanId
+  _ <- liftIO $ withLogger SevTrace $ withTaskPool capabilities updateProgress $ traverse_ (forkTask . uploadIPRChunk url baseOptions) chunkedJSON
+  _ <- req PUT (uploadIPRCompleteEndpoint baseUrl locator scanId) (ReqBodyJson $ object []) ignoreResponse (baseOptions <> header "Content-Type" "application/json" <> auth)
+  pure ()
+
+uploadIPRChunk :: (Has (Lift IO) sig m) => Url 'Https -> Option 'Https -> Value -> m ()
+uploadIPRChunk url postOptions jsonChunk = do
+  _ <- sendIO $ runDiagnostics $ runHTTP $ req POST url (ReqBodyJson jsonChunk) ignoreResponse (postOptions <> header "Content-Type" "application/json")
   pure ()
 
 -- /projects/{projectID}/scans/{scanID}/build-graphs
@@ -154,3 +171,16 @@ updateProgress Progress{..} =
             <> annotate (color Green) (pretty pCompleted)
             <> " Completed"
             <> " ]" )
+
+chunkJSON :: Value -> Text -> Int -> Maybe [Value]
+chunkJSON (Object obj) key chunkSize = do
+  a <- HM.lookup key obj
+  arr <- case a of
+    Array aa -> Just aa
+    _ -> Nothing
+  let chunked = chunksOf chunkSize $ V.toList arr
+  let chunker :: [Value] -> Value
+      chunker v = object ["Files" .= v]
+  Just $ map chunker chunked
+
+chunkJSON _ _ _ = Nothing

--- a/src/App/VPSScan/Scan/ScotlandYard.hs
+++ b/src/App/VPSScan/Scan/ScotlandYard.hs
@@ -11,7 +11,6 @@ module App.VPSScan.Scan.ScotlandYard
   )
 where
 
-import Basement.IntegralConv
 import Control.Carrier.TaskPool
 import Control.Carrier.Diagnostics
 import Control.Monad.IO.Class
@@ -195,11 +194,11 @@ chunkedBySize d maxByteSize =
   where
     addToList :: (ToJSON a) => Int -> a -> [[a]] -> [[a]]
     addToList maxLength ele (first:rest) =
-      if currentLength + newLength > maxLength then
+      if (fromIntegral $ currentLength + newLength) > maxLength then
         [ele]:first:rest
       else
         (ele:first):rest
       where
-        currentLength = sum $ map (int64ToInt . BS.length . encode) first
-        newLength = int64ToInt $ BS.length $ encode ele
+        currentLength = sum $ map (BS.length . encode) first
+        newLength = BS.length $ encode ele
     addToList _ ele [] = [[ele]]


### PR DESCRIPTION
Upload IPR scan results in chunks of 1000 files (we're only uploading files with licenses), and post to the "IPR scan complete" endpoint once all IPR results have been posted

NOTE: This is dependent on the changes to SY in https://github.com/fossas/basis/pull/819

closes fossas/issues#190