### PR TITLE
Bump dependency versions

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,13 +1,1 @@
 packages: .
-
--- fused-effects
-source-repository-package
-    type: git
-    location: https://github.com/fused-effects/fused-effects.git
-    tag: 11498a404dd2d6c3f0eb361704b6d7c1623c0406
-
--- fused-effects-exceptions
-source-repository-package
-    type: git
-    location: https://github.com/cnr/fused-effects-exceptions.git
-    tag: e8dc78e00da50f99c427a8b324e367eaf8ad0555

--- a/cabal.project.ci.linux
+++ b/cabal.project.ci.linux
@@ -7,15 +7,3 @@ packages: .
 
 package spectrometer
   ghc-options: -Werror
-
--- fused-effects
-source-repository-package
-    type: git
-    location: https://github.com/fused-effects/fused-effects.git
-    tag: 11498a404dd2d6c3f0eb361704b6d7c1623c0406
-
--- fused-effects-exceptions
-source-repository-package
-    type: git
-    location: https://github.com/cnr/fused-effects-exceptions.git
-    tag: e8dc78e00da50f99c427a8b324e367eaf8ad0555

--- a/cabal.project.ci.macos
+++ b/cabal.project.ci.macos
@@ -5,15 +5,3 @@ packages: .
 
 package spectrometer
   ghc-options: -Werror
-
--- fused-effects
-source-repository-package
-    type: git
-    location: https://github.com/fused-effects/fused-effects.git
-    tag: 11498a404dd2d6c3f0eb361704b6d7c1623c0406
-
--- fused-effects-exceptions
-source-repository-package
-    type: git
-    location: https://github.com/cnr/fused-effects-exceptions.git
-    tag: e8dc78e00da50f99c427a8b324e367eaf8ad0555

--- a/cabal.project.ci.windows
+++ b/cabal.project.ci.windows
@@ -7,21 +7,3 @@ packages: .
 
 package spectrometer
   ghc-options: -Werror
-
-package fused-effects
-  tests: False
-
-package fused-effects-exceptions
-  tests: False
-
--- fused-effects
-source-repository-package
-    type: git
-    location: https://github.com/fused-effects/fused-effects.git
-    tag: 11498a404dd2d6c3f0eb361704b6d7c1623c0406
-
--- fused-effects-exceptions
-source-repository-package
-    type: git
-    location: https://github.com/cnr/fused-effects-exceptions.git
-    tag: e8dc78e00da50f99c427a8b324e367eaf8ad0555

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -1,4 +1,4 @@
-cabal-version:      2.4
+cabal-version:      2.2
 name:               spectrometer
 version:            0.1.0.0
 license:            MPL-2.0
@@ -8,7 +8,7 @@ extra-source-files:
   scripts/*.gradle
 
 common lang
-  build-depends:      base >=4.12 && <4.14
+  build-depends:      base >=4.12 && <4.15
   default-language:   Haskell2010
   default-extensions:
     NoImplicitPrelude
@@ -48,7 +48,7 @@ common lang
 
 common deps
   build-depends:
-    , aeson                        ^>=1.4.5
+    , aeson                        ^>=1.5.2.0
     , algebraic-graphs             ^>=0.5
     , async                        ^>=2.2.2
     , attoparsec                   ^>=0.13.2.3
@@ -61,27 +61,27 @@ common deps
     , exceptions                   ^>=0.10.4
     , file-embed                   ^>=0.0.11
     , filepath                     ^>=1.4.2.1
-    , fused-effects                ^>=1.0.2.0
-    , fused-effects-exceptions     ^>=1.0.0.0
+    , fused-effects                ^>=1.1.0.0
+    , fused-effects-exceptions     ^>=1.1.0.0
     , git-config                   ^>=0.1.2
     , hedn                         ^>=0.3.0.1
-    , http-client                  ^>=0.6.4.1
+    , http-client                  ^>=0.7.1
     , http-types                   ^>=0.12.3
     , megaparsec                   ^>=8.0
     , modern-uri                   ^>=0.3.1
     , mtl                          ^>=2.2.2
     , optparse-applicative         ^>=0.15.1
-    , path                         ^>=0.7
+    , path                         ^>=0.8
     , path-io                      ^>=1.6.0
     , prettyprinter                ^>=1.6
     , prettyprinter-ansi-terminal  ^>=1.1.1
-    , req                          ^>=3.1.0
+    , req                          ^>=3.4.0
     , stm                          ^>=2.5.0
     , stm-chans                    ^>=3.0.0
     , tar                          ^>=0.5.1.1
     , text                         ^>=1.2.3
     , time                         ^>=1.9.3
-    , tomland                      ^>=1.2.0
+    , tomland                      ^>=1.3.0.0
     , typed-process                ^>=0.2.6
     , unordered-containers         ^>=0.2.10
     , vector                       ^>=0.12.0.3

--- a/src/App/Fossa/FossaAPIV1.hs
+++ b/src/App/Fossa/FossaAPIV1.hs
@@ -21,10 +21,10 @@ module App.Fossa.FossaAPIV1
   ) where
 
 import App.Types
+import App.Util (parseUri)
 import App.Fossa.Analyze.Project
 import qualified App.Fossa.Report.Attribution as Attr
 import Control.Effect.Diagnostics
-import Data.Coerce (coerce)
 import Data.Maybe (catMaybes, fromMaybe)
 import Data.List (isInfixOf, stripPrefix)
 import Data.Text (Text)
@@ -48,13 +48,6 @@ newtype FossaReq m a = FossaReq { unFossaReq :: m a }
 
 instance (MonadIO m, Has Diagnostics sig m) => MonadHttp (FossaReq m) where
   handleHttpException = FossaReq . fatal . mangleError
-
--- parse a URI for use as a (base) Url, along with some default Options (e.g., port)
-parseUri :: Has Diagnostics sig m => URI -> m (Url 'Https, Option 'Https)
-parseUri uri = case useURI uri of
-  Nothing -> fatalText ("Invalid URL: " <> URI.render uri)
-  Just (Left (url, options)) -> pure (coerce url, coerce options)
-  Just (Right (url, options)) -> pure (url, options)
 
 fossaReq :: FossaReq m a -> m a
 fossaReq = unFossaReq

--- a/src/Discovery/Walk.hs
+++ b/src/Discovery/Walk.hs
@@ -1,22 +1,29 @@
 module Discovery.Walk
   ( -- * Walking the filetree
-    walk
-  , WalkStep(..)
+    walk,
+    WalkStep (..),
+    dirName,
+    fileName,
+  )
+where
 
-  , dirName
-  , fileName
-  ) where
-
-import Prologue
-
+import Control.Monad.IO.Class (MonadIO)
+import Data.Text (Text)
+import qualified Data.Text as T
+import Path
+import Prelude
 import Path.IO
 
 data WalkStep
-  = WalkContinue -- ^ Continue walking subdirectories
-  | WalkSkipSome [Path Abs Dir] -- ^ Skip some subdirectories
-  | WalkSkipAll -- ^ Skip all subdirectories
-  | WalkStop -- ^ Stop walking the filetree entirely
-  deriving (Eq, Ord, Show, Generic)
+  = -- | Continue walking subdirectories
+    WalkContinue
+  | -- | Skip some subdirectories
+    WalkSkipSome [Text]
+  | -- | Skip all subdirectories
+    WalkSkipAll
+  | -- | Stop walking the filetree entirely
+    WalkStop
+  deriving (Eq, Ord, Show)
 
 -- | Walk the filetree, rooted at an absolute directory. The passed-in function
 -- takes the @currentdir@ @subdirs@ and @files@, and produces a WalkStep
@@ -24,23 +31,23 @@ data WalkStep
 --
 -- You can inspect the names of files and directories with 'dirName' and
 -- 'fileName'
-walk
-  :: MonadIO m
-  => (Path Abs Dir -> [Path Abs Dir] -> [Path Abs File] -> m WalkStep)
-  -> Path Abs Dir
-  -> m ()
+walk ::
+  MonadIO m =>
+  (Path Abs Dir -> [Path Abs Dir] -> [Path Abs File] -> m WalkStep) ->
+  Path Abs Dir ->
+  m ()
 walk f = walkDir $ \dir subdirs files -> do
   -- normally, subdirs and files are _relative to dir_. We want them to be
   -- relative to the filetree walk
   step <- f dir subdirs files
   case step of
-    WalkContinue -> pure (WalkExclude [])
-    WalkSkipSome dirs -> pure (WalkExclude dirs)
-    WalkSkipAll -> pure (WalkExclude subdirs)
+    WalkContinue -> pure $ WalkExclude []
+    WalkSkipSome dirs -> pure . WalkExclude . filter (not . (`elem` dirs) . dirName) $ subdirs
+    WalkSkipAll -> pure $ WalkExclude subdirs
     WalkStop -> pure WalkFinish
 
-dirName :: Path a Dir -> String
-dirName = toFilePath . dirname
+dirName :: Path a Dir -> Text
+dirName = T.pack . toFilePath . dirname
 
 fileName :: Path a File -> String
 fileName = toFilePath . filename

--- a/src/Prologue.hs
+++ b/src/Prologue.hs
@@ -33,10 +33,3 @@ import Path as X
 
 import Data.Typeable as X (Typeable)
 import GHC.Generics as X (Generic, Generic1)
-
--- TODO: stolen from path-0.8.0. We're waiting on path-io to bump version bounds
--- so we can use it. Until then, we define it ourselves.
-data SomeBase t
-  = Abs (Path Abs t)
-  | Rel (Path Rel t)
-  deriving (Eq, Ord, Show, Generic)

--- a/src/Strategy/Go/GoList.hs
+++ b/src/Strategy/Go/GoList.hs
@@ -30,7 +30,7 @@ discover = walk $ \_ _ files -> do
     Nothing -> pure ()
     Just file  -> runSimpleStrategy "golang-golist" GolangGroup $ analyze (parent file)
 
-  pure $ WalkSkipSome [$(mkRelDir "vendor")]
+  pure $ WalkSkipSome ["vendor"]
 
 data Require = Require
   { reqPackage :: Text

--- a/src/Strategy/Go/Gomod.hs
+++ b/src/Strategy/Go/Gomod.hs
@@ -37,7 +37,7 @@ discover = walk $ \_ _ files -> do
     Nothing -> pure ()
     Just file -> runSimpleStrategy "golang-gomod" GolangGroup $ analyze file
 
-  pure $ WalkSkipSome [$(mkRelDir "vendor")]
+  pure $ WalkSkipSome ["vendor"]
 
 data Statement =
     RequireStatement Text Text -- ^ package, version

--- a/src/Strategy/Node/NpmList.hs
+++ b/src/Strategy/Node/NpmList.hs
@@ -21,7 +21,7 @@ discover = walk $ \dir _ files -> do
     Nothing -> pure ()
     Just _ -> runSimpleStrategy "nodejs-npmlist" NodejsGroup $ analyze dir
 
-  pure (WalkSkipSome [$(mkRelDir "node_modules")])
+  pure $ WalkSkipSome ["node_modules"]
 
 npmListCmd :: Command
 npmListCmd = Command

--- a/src/Strategy/Node/NpmLock.hs
+++ b/src/Strategy/Node/NpmLock.hs
@@ -27,7 +27,7 @@ discover = walk $ \_ _ files -> do
     Nothing -> pure ()
     Just file -> runSimpleStrategy "npm-packagelock" NodejsGroup $ analyze file
 
-  pure (WalkSkipSome [$(mkRelDir "node_modules")])
+  pure $ WalkSkipSome ["node_modules"]
 
 data NpmPackageJson = NpmPackageJson
   { packageName         :: Text

--- a/src/Strategy/Node/PackageJson.hs
+++ b/src/Strategy/Node/PackageJson.hs
@@ -24,7 +24,7 @@ discover = walk $ \_ _ files -> do
     Nothing -> pure ()
     Just file -> runSimpleStrategy "nodejs-packagejson" NodejsGroup $ analyze file
 
-  pure (WalkSkipSome [$(mkRelDir "node_modules")])
+  pure $ WalkSkipSome ["node_modules"]
 
 data PackageJson = PackageJson
   { packageDeps    :: Map Text Text

--- a/src/Strategy/Node/YarnLock.hs
+++ b/src/Strategy/Node/YarnLock.hs
@@ -27,7 +27,7 @@ discover = walk $ \_ _ files -> do
     Nothing -> pure ()
     Just file -> runSimpleStrategy "nodejs-yarnlock" NodejsGroup $ analyze file
 
-  pure (WalkSkipSome [$(mkRelDir "node_modules")])
+  pure (WalkSkipSome ["node_modules"])
 
 analyze :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs File -> m ProjectClosureBody
 analyze lockfile = do

--- a/test/Googlesource/RepoManifestSpec.hs
+++ b/test/Googlesource/RepoManifestSpec.hs
@@ -18,6 +18,7 @@ import Test.Hspec
 import Text.URI.QQ
 import Effect.ReadFS
 import Control.Carrier.Diagnostics
+import Path.IO (getCurrentDir)
 
 -- <remote name="aosp" fetch="https://android.googlesource.com" />
 remoteOne :: ManifestRemote
@@ -176,6 +177,7 @@ validatedProjectList = [validatedProjectOne, validatedProjectTwo, validatedProje
 spec :: Spec
 spec = do
   let runIt = runIO . runDiagnostics . runReadFSIO
+  currentDir <- runIO $ getCurrentDir
   basicManifest <- runIO (TIO.readFile "test/Googlesource/testdata/manifest.xml")
   noDefaultRemoteManifest <- runIO (TIO.readFile "test/Googlesource/testdata/manifest-no-default-remote.xml")
   noDefaultRevisionManifest <- runIO (TIO.readFile "test/Googlesource/testdata/manifest-no-default-revision.xml")
@@ -243,16 +245,16 @@ spec = do
             Right res -> f (resultValue res)
 
     describe "for a manifest with an include tag" $ do
-      projectsForManifestWithIncludes <- runIt $ nestedValidatedProjects $(mkRelDir "test/Googlesource/testdata") $(mkRelFile "test/Googlesource/testdata/manifest-with-include.xml")
+      projectsForManifestWithIncludes <- runIt $ nestedValidatedProjects (currentDir </> $(mkRelDir "test/Googlesource/testdata")) (currentDir </> $(mkRelFile "test/Googlesource/testdata/manifest-with-include.xml"))
       it "reads both files and gets the dependencies from the included file" $
         withResult projectsForManifestWithIncludes (`shouldMatchList` validatedProjectList)
 
     describe "for a manifest with a relative remote and no include" $ do
-      projectsForManifestWithRelativeRemoteNoInclude <- runIt $ nestedValidatedProjects $(mkRelDir "test/Googlesource/testdata/manifest-with-relative-remote-url") $(mkRelFile "test/Googlesource/testdata/manifest-with-relative-remote-url/manifest-without-include.xml")
+      projectsForManifestWithRelativeRemoteNoInclude <- runIt $ nestedValidatedProjects (currentDir </> $(mkRelDir "test/Googlesource/testdata/manifest-with-relative-remote-url")) (currentDir </> $(mkRelFile "test/Googlesource/testdata/manifest-with-relative-remote-url/manifest-without-include.xml"))
       it "gets the remote from the git config" $
         withResult projectsForManifestWithRelativeRemoteNoInclude (`shouldMatchList` validatedProjectList)
 
     describe "for a manifest with a relative remote and an include" $ do
-      projectsForManifestWithRelativeRemoteWithInclude <- runIt $ nestedValidatedProjects $(mkRelDir "test/Googlesource/testdata/manifest-with-relative-remote-url") $(mkRelFile "test/Googlesource/testdata/manifest-with-relative-remote-url/manifest-without-include.xml")
+      projectsForManifestWithRelativeRemoteWithInclude <- runIt $ nestedValidatedProjects (currentDir </> $(mkRelDir "test/Googlesource/testdata/manifest-with-relative-remote-url")) (currentDir </> $(mkRelFile "test/Googlesource/testdata/manifest-with-relative-remote-url/manifest-without-include.xml"))
       it "gets the remote from the git config" $
         withResult projectsForManifestWithRelativeRemoteWithInclude (`shouldMatchList` validatedProjectList)


### PR DESCRIPTION
This removes our dependency on the prerelease `fused-effects` / my fork of `fused-effects-exceptions`. There are a few propagating changes, but most suspiciously, `WalkSkipSome` is now causing compile errors where it wasn't before, but should have.