### PR TITLE
Pass filter option to `ramjet-cli-ipr` and `sherlock-cli`

### DIFF
--- a/src/App/VPSScan/Main.hs
+++ b/src/App/VPSScan/Main.hs
@@ -71,7 +71,7 @@ basedirOpt :: Parser FilePath
 basedirOpt = strOption (long "basedir" <> short 'd' <> metavar "DIR" <> help "Base directory for scanning" <> value ".")
 
 filterOpt :: Parser RunIPR.FilterExpressions
-filterOpt = option auto (long "ignore-file-regex" <> short 'i' <> metavar "REGEXPS" <> help "JSON encoded array of regular expressions used to filter scanned paths" <> value (RunIPR.FilterExpressions "[]"))
+filterOpt = RunIPR.FilterExpressions <$> strOption (long "ignore-file-regex" <> short 'i' <> metavar "REGEXPS" <> help "JSON encoded array of regular expressions used to filter scanned paths" <> value "[]")
 
 scanCommand :: Mod CommandFields (IO ())
 scanCommand = command "scan" (info (scanMain <$> scanOptsParser) (progDesc "Scan for projects and their dependencies"))

--- a/src/App/VPSScan/Main.hs
+++ b/src/App/VPSScan/Main.hs
@@ -70,8 +70,8 @@ syOpts = ScotlandYardOpts
 basedirOpt :: Parser FilePath
 basedirOpt = strOption (long "basedir" <> short 'd' <> metavar "DIR" <> help "Base directory for scanning" <> value ".")
 
-filterOpt :: Parser String
-filterOpt = strOption (long "ignore-file-regex" <> short 'i' <> metavar "REGEXPS" <> help "JSON encoded array of regular expressions used to filter scanned paths" <> value "[]")
+filterOpt :: Parser RunIPR.FilterExpressions
+filterOpt = option auto (long "ignore-file-regex" <> short 'i' <> metavar "REGEXPS" <> help "JSON encoded array of regular expressions used to filter scanned paths" <> value (RunIPR.FilterExpressions "[]"))
 
 scanCommand :: Mod CommandFields (IO ())
 scanCommand = command "scan" (info (scanMain <$> scanOptsParser) (progDesc "Scan for projects and their dependencies"))

--- a/src/App/VPSScan/Main.hs
+++ b/src/App/VPSScan/Main.hs
@@ -22,7 +22,7 @@ commands :: Parser (IO ())
 commands = hsubparser $ scanCommand <> ninjaGraphCommand
 
 vpsOpts :: Parser VPSOpts
-vpsOpts = VPSOpts <$> runSherlockOpts <*> optional runIPROpts <*> syOpts <*> organizationIDOpt <*> projectIDOpt <*> revisionIDOpt
+vpsOpts = VPSOpts <$> runSherlockOpts <*> optional runIPROpts <*> syOpts <*> organizationIDOpt <*> projectIDOpt <*> revisionIDOpt <*> filterOpt
             where
               organizationIDOpt = option auto (long "organization" <> metavar "orgID" <> help "Organization ID")
               projectIDOpt = strOption (long "project" <> metavar "String" <> help "Project ID")
@@ -69,6 +69,9 @@ syOpts = ScotlandYardOpts
 
 basedirOpt :: Parser FilePath
 basedirOpt = strOption (long "basedir" <> short 'd' <> metavar "DIR" <> help "Base directory for scanning" <> value ".")
+
+filterOpt :: Parser String
+filterOpt = strOption (long "ignore-file-regex" <> short 'i' <> metavar "REGEXPS" <> help "JSON encoded array of regular expressions used to filter scanned paths" <> value "[]")
 
 scanCommand :: Mod CommandFields (IO ())
 scanCommand = command "scan" (info (scanMain <$> scanOptsParser) (progDesc "Scan for projects and their dependencies"))

--- a/src/App/VPSScan/Scan.hs
+++ b/src/App/VPSScan/Scan.hs
@@ -87,7 +87,7 @@ runIPRScan ::
 runIPRScan basedir scanId vpsOpts@VPSOpts{..} =
   case vpsIpr of
     Just iprOpts -> do
-      iprResult <- execIPR basedir iprOpts
+      iprResult <- execIPR basedir filterExpressions iprOpts
       trace "[IPR] IPR scan completed. Posting results to Scotland Yard"
 
       context "uploading scan results" $ uploadIPRResults vpsOpts scanId iprResult

--- a/src/App/VPSScan/Scan/RunIPR.hs
+++ b/src/App/VPSScan/Scan/RunIPR.hs
@@ -55,9 +55,9 @@ data IPRError = NoFilesEntryInOutput
 instance ToDiagnostic IPRError where
   renderDiagnostic NoFilesEntryInOutput = "No \"Files\" entry in the IPR output"
 
+type FilterExpressions = String
 
-
-execIPR :: (Has Exec sig m, Has Diagnostics sig m) => Path Abs Dir -> String -> IPROpts -> m Value
+execIPR :: (Has Exec sig m, Has Diagnostics sig m) => Path Abs Dir -> FilterExpressions -> IPROpts -> m Value
 execIPR basedir filterExpressions iprOpts = do
   value <- execJson basedir (iprCommand filterExpressions iprOpts)
   let maybeExtracted = extractNonEmptyFiles value

--- a/src/App/VPSScan/Scan/RunIPR.hs
+++ b/src/App/VPSScan/Scan/RunIPR.hs
@@ -59,7 +59,7 @@ instance ToDiagnostic IPRError where
 newtype FilterExpressions = FilterExpressions String
 
 instance Show FilterExpressions where
-  show (FilterExpressions x) = show x
+  show (FilterExpressions x) = x :: String
 
 execIPR :: (Has Exec sig m, Has Diagnostics sig m) => Path Abs Dir -> FilterExpressions -> IPROpts -> m Value
 execIPR basedir filterExpressions iprOpts = do

--- a/src/App/VPSScan/Scan/RunIPR.hs
+++ b/src/App/VPSScan/Scan/RunIPR.hs
@@ -3,6 +3,7 @@
 module App.VPSScan.Scan.RunIPR
   ( IPROpts (..),
     execIPR,
+    FilterExpressions (..),
     IPRError (..),
   )
 where
@@ -55,11 +56,12 @@ data IPRError = NoFilesEntryInOutput
 instance ToDiagnostic IPRError where
   renderDiagnostic NoFilesEntryInOutput = "No \"Files\" entry in the IPR output"
 
-type FilterExpressions = String
+newtype FilterExpressions = FilterExpressions String deriving (Show, Read)
 
 execIPR :: (Has Exec sig m, Has Diagnostics sig m) => Path Abs Dir -> FilterExpressions -> IPROpts -> m Value
 execIPR basedir filterExpressions iprOpts = do
-  value <- execJson basedir (iprCommand filterExpressions iprOpts)
+  let filters = show filterExpressions
+  value <- execJson basedir (iprCommand filters iprOpts)
   let maybeExtracted = extractNonEmptyFiles value
   case maybeExtracted of
     Nothing -> fatal NoFilesEntryInOutput

--- a/src/App/VPSScan/Scan/RunIPR.hs
+++ b/src/App/VPSScan/Scan/RunIPR.hs
@@ -56,18 +56,19 @@ instance ToDiagnostic IPRError where
   renderDiagnostic NoFilesEntryInOutput = "No \"Files\" entry in the IPR output"
 
 
-execIPR :: (Has Exec sig m, Has Diagnostics sig m) => Path Abs Dir -> IPROpts -> m Value
-execIPR basedir iprOpts = do
-  value <- execJson basedir (iprCommand iprOpts)
+
+execIPR :: (Has Exec sig m, Has Diagnostics sig m) => Path Abs Dir -> String -> IPROpts -> m Value
+execIPR basedir filterExpressions iprOpts = do
+  value <- execJson basedir (iprCommand filterExpressions iprOpts)
   let maybeExtracted = extractNonEmptyFiles value
   case maybeExtracted of
     Nothing -> fatal NoFilesEntryInOutput
     Just extracted -> pure extracted
 
-iprCommand :: IPROpts -> Command
-iprCommand IPROpts {..} =
+iprCommand :: String -> IPROpts -> Command
+iprCommand filterExpressions IPROpts {..} =
   Command
     { cmdName = iprCmdPath,
-      cmdArgs = ["-target", ".", "-nomossa", nomosCmdPath, "-pathfinder", pathfinderCmdPath],
+      cmdArgs = ["-target", ".", "-nomossa", nomosCmdPath, "-pathfinder", pathfinderCmdPath, "-filter-expressions", filterExpressions],
       cmdAllowErr = Never
     }

--- a/src/App/VPSScan/Scan/RunIPR.hs
+++ b/src/App/VPSScan/Scan/RunIPR.hs
@@ -56,7 +56,10 @@ data IPRError = NoFilesEntryInOutput
 instance ToDiagnostic IPRError where
   renderDiagnostic NoFilesEntryInOutput = "No \"Files\" entry in the IPR output"
 
-newtype FilterExpressions = FilterExpressions String deriving (Show, Read)
+newtype FilterExpressions = FilterExpressions String
+
+instance Show FilterExpressions where
+  show (FilterExpressions x) = show x
 
 execIPR :: (Has Exec sig m, Has Diagnostics sig m) => Path Abs Dir -> FilterExpressions -> IPROpts -> m Value
 execIPR basedir filterExpressions iprOpts = do

--- a/src/App/VPSScan/Scan/RunSherlock.hs
+++ b/src/App/VPSScan/Scan/RunSherlock.hs
@@ -35,7 +35,7 @@ sherlockCommand basedir scanId VPSOpts {..} =
           "--revision-id",
           T.unpack revisionID,
           "--filter-expressions",
-          filterExpressions
+          show filterExpressions
         ],
       cmdAllowErr = Never
     }

--- a/src/App/VPSScan/Scan/RunSherlock.hs
+++ b/src/App/VPSScan/Scan/RunSherlock.hs
@@ -33,7 +33,9 @@ sherlockCommand basedir scanId VPSOpts {..} =
           "--project-id",
           T.unpack projectID,
           "--revision-id",
-          T.unpack revisionID
+          T.unpack revisionID,
+          "--filter-expressions",
+          filterExpressions
         ],
       cmdAllowErr = Never
     }

--- a/src/App/VPSScan/Types.hs
+++ b/src/App/VPSScan/Types.hs
@@ -36,7 +36,7 @@ data VPSOpts = VPSOpts
   , organizationID :: Int
   , projectID :: Text
   , revisionID :: Text
-  , filterExpressions :: String
+  , filterExpressions :: RunIPR.FilterExpressions
   } deriving (Generic)
 
 data DepsTarget = DepsTarget

--- a/src/App/VPSScan/Types.hs
+++ b/src/App/VPSScan/Types.hs
@@ -36,6 +36,7 @@ data VPSOpts = VPSOpts
   , organizationID :: Int
   , projectID :: Text
   , revisionID :: Text
+  , filterExpressions :: String
   } deriving (Generic)
 
 data DepsTarget = DepsTarget


### PR DESCRIPTION
* Accept filter options as a text blob, but specify in the option help text that the value provided should be a JSON encoded string array.
* Pass filter options blob to `ramjet-cli-ipr` and `sherlock-cli` as is.

Note: won't be merged until support for this has been merged into downstream CLIs.