### PR TITLE
Merge dependencies found for *req*.txt files in the same directory

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,1 +1,3 @@
 packages: .
+tests: True
+optimization: False

--- a/src/Graphing.hs
+++ b/src/Graphing.hs
@@ -42,6 +42,15 @@ data Graphing ty = Graphing
   , graphingAdjacent :: AdjacencyMap ty
   } deriving (Eq, Ord, Show, Generic)
 
+instance Ord ty => Semigroup (Graphing ty) where
+  graphing <> graphing' =
+    Graphing
+      (graphingDirect graphing `S.union` graphingDirect graphing')
+      (graphingAdjacent graphing `AM.overlay` graphingAdjacent graphing')
+
+instance Ord ty => Monoid (Graphing ty) where
+  mempty = Graphing S.empty AM.empty
+
 -- | Transform a Graphing by applying a function to each of its vertices.
 --
 -- Graphing isn't a lawful 'Functor', so we don't provide an instance.


### PR DESCRIPTION
Analysis still succeeds if at least one `*req*.txt` file successfully parses. If they all fail, `--debug` gives really helpful output:

```
----------
A fatal error occurred:

    Analysis failed for all discovered *req*.txt files


>>>
Relevant warnings include:

    Error parsing file /Users/connor/Desktop/tmp24/req_two.txt : /Users/connor/Desktop/tmp24/req_two.txt:1:1:
      |
    1 | %@##$#@
      | ^
    unexpected '%'
    expecting "bzr+", "git+", "hg+", "http:", "https:", "svn+", '#', '-', '.', '/', end of input, end of line, or specification


    Error parsing file /Users/connor/Desktop/tmp24/req_one.txt : /Users/connor/Desktop/tmp24/req_one.txt:1:1:
      |
    1 | $#@%@%
      | ^
    unexpected '$'
    expecting "bzr+", "git+", "hg+", "http:", "https:", "svn+", '#', '-', '.', '/', end of input, end of line, or specification
```