### PR TITLE
Use Text for Effect.Exec arguments

### DIFF
--- a/src/App/VPSScan/Scan/RunIPR.hs
+++ b/src/App/VPSScan/Scan/RunIPR.hs
@@ -13,13 +13,14 @@ import qualified Data.HashMap.Strict as HM
 import qualified Data.Vector as V
 import Effect.Exec
 import Data.Aeson
+import Data.Text
 import Path
 import Prelude
 
 data IPROpts = IPROpts
-  { iprCmdPath :: String,
-    nomosCmdPath :: String,
-    pathfinderCmdPath :: String
+  { iprCmdPath :: Text,
+    nomosCmdPath :: Text,
+    pathfinderCmdPath :: Text
   }
   deriving (Eq, Ord, Show)
 

--- a/src/App/VPSScan/Scan/RunIPR.hs
+++ b/src/App/VPSScan/Scan/RunIPR.hs
@@ -14,7 +14,8 @@ import qualified Data.HashMap.Strict as HM
 import qualified Data.Vector as V
 import Effect.Exec
 import Data.Aeson
-import Data.Text
+import Data.Text (Text)
+import qualified Data.Text as T
 import Path
 import Prelude
 
@@ -74,6 +75,6 @@ iprCommand :: FilterExpressions -> IPROpts -> Command
 iprCommand filterExpressions IPROpts {..} =
   Command
     { cmdName = iprCmdPath,
-      cmdArgs = ["-target", ".", "-nomossa", nomosCmdPath, "-pathfinder", pathfinderCmdPath, "-filter-expressions", pack (show filterExpressions)],
+      cmdArgs = ["-target", ".", "-nomossa", nomosCmdPath, "-pathfinder", pathfinderCmdPath, "-filter-expressions", T.pack (show filterExpressions)],
       cmdAllowErr = Never
     }

--- a/src/App/VPSScan/Scan/RunIPR.hs
+++ b/src/App/VPSScan/Scan/RunIPR.hs
@@ -64,17 +64,16 @@ instance Show FilterExpressions where
 
 execIPR :: (Has Exec sig m, Has Diagnostics sig m) => Path Abs Dir -> FilterExpressions -> IPROpts -> m Value
 execIPR basedir filterExpressions iprOpts = do
-  let filters = show filterExpressions
-  value <- execJson basedir (iprCommand filters iprOpts)
+  value <- execJson basedir (iprCommand filterExpressions iprOpts)
   let maybeExtracted = extractNonEmptyFiles value
   case maybeExtracted of
     Nothing -> fatal NoFilesEntryInOutput
     Just extracted -> pure extracted
 
-iprCommand :: String -> IPROpts -> Command
+iprCommand :: FilterExpressions -> IPROpts -> Command
 iprCommand filterExpressions IPROpts {..} =
   Command
     { cmdName = iprCmdPath,
-      cmdArgs = ["-target", ".", "-nomossa", nomosCmdPath, "-pathfinder", pathfinderCmdPath, "-filter-expressions", filterExpressions],
+      cmdArgs = ["-target", ".", "-nomossa", nomosCmdPath, "-pathfinder", pathfinderCmdPath, "-filter-expressions", pack (show filterExpressions)],
       cmdAllowErr = Never
     }

--- a/src/App/VPSScan/Scan/RunSherlock.hs
+++ b/src/App/VPSScan/Scan/RunSherlock.hs
@@ -19,9 +19,9 @@ sherlockCommand basedir scanId VPSOpts {..} =
     { cmdName = sherlockCmdPath,
       cmdArgs =
         [ "scan",
-          fromAbsDir basedir,
+          T.pack (fromAbsDir basedir),
           "--scan-id",
-          T.unpack scanId,
+          scanId,
           "--sherlock-api-secret-key",
           sherlockClientToken,
           "--sherlock-api-client-id",
@@ -29,11 +29,11 @@ sherlockCommand basedir scanId VPSOpts {..} =
           "--sherlock-api-host",
           sherlockUrl,
           "--organization-id",
-          show organizationID,
+          T.pack (show organizationID),
           "--project-id",
-          T.unpack projectID,
+          projectID,
           "--revision-id",
-          T.unpack revisionID
+          revisionID
         ],
       cmdAllowErr = Never
     }

--- a/src/App/VPSScan/Scan/RunSherlock.hs
+++ b/src/App/VPSScan/Scan/RunSherlock.hs
@@ -35,7 +35,7 @@ sherlockCommand basedir scanId VPSOpts {..} =
           "--revision-id",
           revisionID,
           "--filter-expressions",
-          show filterExpressions
+          T.pack (show filterExpressions)
         ],
       cmdAllowErr = Never
     }

--- a/src/App/VPSScan/Types.hs
+++ b/src/App/VPSScan/Types.hs
@@ -22,10 +22,10 @@ data ScotlandYardOpts = ScotlandYardOpts
   deriving (Generic)
 
 data SherlockOpts = SherlockOpts
-  { sherlockCmdPath :: String,
-    sherlockUrl :: String,
-    sherlockClientToken :: String,
-    sherlockClientID :: String
+  { sherlockCmdPath :: Text,
+    sherlockUrl :: Text,
+    sherlockClientToken :: Text,
+    sherlockClientID :: Text
   }
   deriving (Eq, Ord, Show, Generic)
 

--- a/src/Strategy/Gradle.hs
+++ b/src/Strategy/Gradle.hs
@@ -30,10 +30,10 @@ import Effect.Grapher
 import Graphing (Graphing)
 import Types
 
-gradleJsonDepsCmd :: String -> FP.FilePath -> Command
+gradleJsonDepsCmd :: Text -> FP.FilePath -> Command
 gradleJsonDepsCmd baseCmd initScriptFilepath = Command
-  { cmdName = baseCmd -- ["./gradlew", "gradlew.bat", "gradle"]
-  , cmdArgs = ["jsonDeps", "-I", initScriptFilepath]
+  { cmdName = baseCmd
+  , cmdArgs = ["jsonDeps", "-I", T.pack initScriptFilepath]
   , cmdAllowErr = Never
   }
 

--- a/src/Strategy/Maven/Plugin.hs
+++ b/src/Strategy/Maven/Plugin.hs
@@ -18,19 +18,20 @@ import Control.Effect.Diagnostics
 import Control.Effect.Exception
 import qualified Data.ByteString as BS
 import Data.FileEmbed (embedFile)
+import qualified Data.Text as T
 import Path.IO (createTempDir, getTempDir, removeDirRecur)
 import qualified System.FilePath as FP
 
 import Effect.Exec
 import Effect.ReadFS
 
-pluginGroup :: String
+pluginGroup :: Text
 pluginGroup = "com.github.ferstl"
 
-pluginArtifact :: String
+pluginArtifact :: Text
 pluginArtifact = "depgraph-maven-plugin"
 
-pluginVersion :: String
+pluginVersion :: Text
 pluginVersion = "3.3.0"
 
 pluginJar :: ByteString
@@ -75,7 +76,7 @@ mavenInstallPluginCmd pluginFilePath = Command
     , "-DartifactId=" <> pluginArtifact
     , "-Dversion=" <> pluginVersion
     , "-Dpackaging=jar"
-    , "-Dfile=" <> pluginFilePath
+    , "-Dfile=" <> T.pack pluginFilePath
     ]
   , cmdAllowErr = Never
   }

--- a/src/Strategy/Python/PipList.hs
+++ b/src/Strategy/Python/PipList.hs
@@ -27,7 +27,7 @@ discover = walk $ \dir _ files -> do
 
   pure WalkContinue
 
-pipListCmd :: String -> Command
+pipListCmd :: Text -> Command
 pipListCmd baseCmd = Command
   { cmdName = baseCmd
   , cmdArgs = ["list", "--format=json"]

--- a/src/VCS/Git.hs
+++ b/src/VCS/Git.hs
@@ -24,7 +24,7 @@ gitLogCmd now =
       cmdAllowErr = Never
     }
   where
-    sinceArg = iso8601Show $ utctDay wayBack
+    sinceArg = T.pack . iso8601Show $ utctDay wayBack
     delta = nominalDay * (-90)
     wayBack = addUTCTime delta now
 


### PR DESCRIPTION
We previously had to use `String` in a bunch of places, because our `Effect.Exec` operations took `String`s as arguments instead of `Text`. This migrates `Effect.Exec` and its callsites