### PR TITLE
Update to use reverse proxy to communicate with SY

### DIFF
--- a/src/App/VPSScan/Main.hs
+++ b/src/App/VPSScan/Main.hs
@@ -22,7 +22,7 @@ commands :: Parser (IO ())
 commands = hsubparser $ scanCommand <> ninjaGraphCommand
 
 vpsOpts :: Parser VPSOpts
-vpsOpts = VPSOpts <$> runSherlockOpts <*> optional runIPROpts <*> syOpts <*> organizationIDOpt <*> projectIDOpt <*> revisionIDOpt <*> filterOpt
+vpsOpts = VPSOpts <$> runSherlockOpts <*> optional runIPROpts <*> coreOpts <*> organizationIDOpt <*> projectIDOpt <*> revisionIDOpt <*> filterOpt
             where
               organizationIDOpt = option auto (long "organization" <> metavar "orgID" <> help "Organization ID")
               projectIDOpt = strOption (long "project" <> metavar "String" <> help "Project ID")
@@ -61,11 +61,12 @@ runIPROpts = RunIPR.IPROpts
                     pathfinderCmdPathOpt = strOption (long "pathfinder" <> metavar "STRING" <> help "Path to the pathfinder executable")
 
 -- org IDs are ints. project and revision IDs are strings
-syOpts :: Parser ScotlandYardOpts
-syOpts = ScotlandYardOpts
-                     <$> scotlandYardUrlOpt
+coreOpts :: Parser CoreServerOpts
+coreOpts = CoreServerOpts
+                     <$> urlOpt <*> apiKeyOpt
                   where
-                    scotlandYardUrlOpt = uriOption (long "scotland-yard-url" <> metavar "STRING" <> help "URL for Scotland Yard service")
+                    urlOpt = uriOption (long "fossa-url" <> metavar "STRING" <> help "URL for FOSSA service")
+                    apiKeyOpt =  strOption (long "fossa-api-key" <> metavar "STRING" <> help "API key for FOSSA service")
 
 basedirOpt :: Parser FilePath
 basedirOpt = strOption (long "basedir" <> short 'd' <> metavar "DIR" <> help "Base directory for scanning" <> value ".")

--- a/src/App/VPSScan/Main.hs
+++ b/src/App/VPSScan/Main.hs
@@ -22,7 +22,7 @@ commands :: Parser (IO ())
 commands = hsubparser $ scanCommand <> ninjaGraphCommand
 
 vpsOpts :: Parser VPSOpts
-vpsOpts = VPSOpts <$> runSherlockOpts <*> optional runIPROpts <*> coreOpts <*> organizationIDOpt <*> projectIDOpt <*> revisionIDOpt <*> filterOpt
+vpsOpts = VPSOpts <$> runSherlockOpts <*> optional runIPROpts <*> fossaOpts <*> organizationIDOpt <*> projectIDOpt <*> revisionIDOpt <*> filterOpt
             where
               organizationIDOpt = option auto (long "organization" <> metavar "orgID" <> help "Organization ID")
               projectIDOpt = strOption (long "project" <> metavar "String" <> help "Project ID")
@@ -61,8 +61,8 @@ runIPROpts = RunIPR.IPROpts
                     pathfinderCmdPathOpt = strOption (long "pathfinder" <> metavar "STRING" <> help "Path to the pathfinder executable")
 
 -- org IDs are ints. project and revision IDs are strings
-coreOpts :: Parser CoreServerOpts
-coreOpts = CoreServerOpts
+fossaOpts :: Parser FossaOpts
+fossaOpts = FossaOpts
                      <$> urlOpt <*> apiKeyOpt
                   where
                     urlOpt = uriOption (long "fossa-url" <> metavar "STRING" <> help "URL for FOSSA service")

--- a/src/App/VPSScan/Scan/ScotlandYard.hs
+++ b/src/App/VPSScan/Scan/ScotlandYard.hs
@@ -22,7 +22,7 @@ coreProxyPrefix :: Url 'Https -> Url 'Https
 coreProxyPrefix baseurl = baseurl /: "api" /: "proxy" /: "scotland-yard"
 
 authHeader :: Text -> Option scheme
-authHeader apiKey = header "Authorization" (encodeUtf8 ("token " <> apiKey))
+authHeader apiKey = header "Authorization" (encodeUtf8 ("Bearer " <> apiKey))
 
 -- /projects/{projectID}/scans
 createScanEndpoint :: Url 'Https -> Text -> Url 'Https

--- a/src/App/VPSScan/Scan/ScotlandYard.hs
+++ b/src/App/VPSScan/Scan/ScotlandYard.hs
@@ -9,9 +9,9 @@ where
 
 import App.VPSScan.Types
 import Control.Effect.Diagnostics
-import Control.Monad.IO.Class
+import Control.Monad.IO.Class (MonadIO)
 import Data.Aeson
-import Data.Text
+import Data.Text (Text, append, pack)
 import Network.HTTP.Req
 import Prelude
 import App.Util (parseUri)
@@ -26,7 +26,7 @@ authHeader apiKey = header "Authorization" (encodeUtf8 (append (pack "token ") a
 
 -- /projects/{projectID}/scans
 createScanEndpoint :: Url 'Https -> Text -> Url 'Https
-createScanEndpoint baseurl projectId = (coreProxyPrefix baseurl) /: "projects" /: projectId /: "scans"
+createScanEndpoint baseurl projectId = coreProxyPrefix baseurl /: "projects" /: projectId /: "scans"
 
 -- /projects/{projectID}/scans/{scanID}/discovered_licenses
 scanDataEndpoint :: Url 'Https -> Text -> Text -> Url 'Https
@@ -43,8 +43,7 @@ instance FromJSON ScanResponse where
 
 createScotlandYardScan :: (MonadIO m, Has Diagnostics sig m) => VPSOpts -> m ScanResponse
 createScotlandYardScan VPSOpts {..} = runHTTP $ do
-  let body = object ["organizationId" .= organizationID, "revisionId" .= revisionID, "projectId" .= projectID]
-      CoreServerOpts {..} = coreInstance
+  let body = object ["organizationId" .= organizationID, "revisionId" .= revisionID, "projectId" .= projectID]; CoreServerOpts {..} = coreInstance
   let auth = authHeader fossaApiKey
 
   (baseUrl, baseOptions) <- parseUri fossaUrl

--- a/src/App/VPSScan/Scan/ScotlandYard.hs
+++ b/src/App/VPSScan/Scan/ScotlandYard.hs
@@ -43,7 +43,7 @@ instance FromJSON ScanResponse where
 
 createScotlandYardScan :: (MonadIO m, Has Diagnostics sig m) => VPSOpts -> m ScanResponse
 createScotlandYardScan VPSOpts {..} = runHTTP $ do
-  let body = object ["organizationId" .= organizationID, "revisionId" .= revisionID, "projectId" .= projectID]; CoreServerOpts {..} = coreInstance
+  let body = object ["organizationId" .= organizationID, "revisionId" .= revisionID, "projectId" .= projectID]; FossaOpts {..} = fossaInstance
   let auth = authHeader fossaApiKey
 
   (baseUrl, baseOptions) <- parseUri fossaUrl
@@ -55,7 +55,7 @@ createScotlandYardScan VPSOpts {..} = runHTTP $ do
 -- POST /scans/{scanID}/discovered_licenses
 uploadIPRResults :: (ToJSON a, MonadIO m, Has Diagnostics sig m) => VPSOpts -> Text -> a -> m ()
 uploadIPRResults VPSOpts {..} scanId value = runHTTP $ do
-  let CoreServerOpts {..} = coreInstance
+  let FossaOpts {..} = fossaInstance
   let auth = authHeader fossaApiKey
 
   (baseUrl, baseOptions) <- parseUri fossaUrl

--- a/src/App/VPSScan/Scan/ScotlandYard.hs
+++ b/src/App/VPSScan/Scan/ScotlandYard.hs
@@ -11,7 +11,7 @@ import App.VPSScan.Types
 import Control.Effect.Diagnostics
 import Control.Monad.IO.Class (MonadIO)
 import Data.Aeson
-import Data.Text (Text, append, pack)
+import Data.Text (Text)
 import Network.HTTP.Req
 import Prelude
 import App.Util (parseUri)
@@ -22,7 +22,7 @@ coreProxyPrefix :: Url 'Https -> Url 'Https
 coreProxyPrefix baseurl = baseurl /: "api" /: "proxy" /: "scotland-yard"
 
 authHeader :: Text -> Option scheme
-authHeader apiKey = header "Authorization" (encodeUtf8 (append (pack "token ") apiKey))
+authHeader apiKey = header "Authorization" (encodeUtf8 ("token " <> apiKey))
 
 -- /projects/{projectID}/scans
 createScanEndpoint :: Url 'Https -> Text -> Url 'Https

--- a/src/App/VPSScan/Types.hs
+++ b/src/App/VPSScan/Types.hs
@@ -1,7 +1,7 @@
 module App.VPSScan.Types
 ( VPSOpts(..)
 , SherlockOpts(..)
-, ScotlandYardOpts(..)
+, CoreServerOpts(..)
 , DepsTarget(..)
 , DepsDependency(..)
 , NinjaGraphOpts(..)
@@ -17,8 +17,8 @@ import Text.URI (URI)
 import Network.HTTP.Req
 import Data.Text.Prettyprint.Doc (viaShow)
 
-data ScotlandYardOpts = ScotlandYardOpts
-  {scotlandYardUrl :: URI}
+data CoreServerOpts = CoreServerOpts
+  {fossaUrl :: URI, fossaApiKey :: Text}
   deriving (Generic)
 
 data SherlockOpts = SherlockOpts
@@ -32,7 +32,7 @@ data SherlockOpts = SherlockOpts
 data VPSOpts = VPSOpts
   { vpsSherlock :: SherlockOpts
   , vpsIpr :: Maybe RunIPR.IPROpts
-  , vpsScotlandYard :: ScotlandYardOpts
+  , coreInstance :: CoreServerOpts
   , organizationID :: Int
   , projectID :: Text
   , revisionID :: Text

--- a/src/App/VPSScan/Types.hs
+++ b/src/App/VPSScan/Types.hs
@@ -1,7 +1,7 @@
 module App.VPSScan.Types
 ( VPSOpts(..)
 , SherlockOpts(..)
-, CoreServerOpts(..)
+, FossaOpts(..)
 , DepsTarget(..)
 , DepsDependency(..)
 , NinjaGraphOpts(..)
@@ -17,7 +17,7 @@ import Text.URI (URI)
 import Network.HTTP.Req
 import Data.Text.Prettyprint.Doc (viaShow)
 
-data CoreServerOpts = CoreServerOpts
+data FossaOpts = FossaOpts
   {fossaUrl :: URI, fossaApiKey :: Text}
   deriving (Generic)
 
@@ -32,7 +32,7 @@ data SherlockOpts = SherlockOpts
 data VPSOpts = VPSOpts
   { vpsSherlock :: SherlockOpts
   , vpsIpr :: Maybe RunIPR.IPROpts
-  , coreInstance :: CoreServerOpts
+  , fossaInstance :: FossaOpts
   , organizationID :: Int
   , projectID :: Text
   , revisionID :: Text


### PR DESCRIPTION
This PR updates `vpscli` to use the Core reverse proxy to communicate with SY instead of communicating directly.

_Note: this will not be merged until fossas/FOSSA#4858 is accepted._