### PR TITLE
Catch IOExceptions in the Effect.Exec handler

### DIFF
--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -97,12 +97,12 @@ library
 
   -- cabal-fmt: expand src
   exposed-modules:
+    App.Fossa.API.BuildWait
     App.Fossa.Analyze
     App.Fossa.Analyze.Graph
     App.Fossa.Analyze.GraphBuilder
     App.Fossa.Analyze.GraphMangler
     App.Fossa.Analyze.Project
-    App.Fossa.API.BuildWait
     App.Fossa.FossaAPIV1
     App.Fossa.Main
     App.Fossa.ProjectInference
@@ -115,11 +115,11 @@ library
     App.Types
     App.Util
     App.VPSScan.Main
+    App.VPSScan.NinjaGraph
     App.VPSScan.Scan
     App.VPSScan.Scan.RunIPR
     App.VPSScan.Scan.RunSherlock
     App.VPSScan.Scan.ScotlandYard
-    App.VPSScan.NinjaGraph
     App.VPSScan.Types
     Control.Carrier.Diagnostics
     Control.Carrier.Finally
@@ -226,6 +226,7 @@ test-suite unit-tests
     Clojure.ClojureSpec
     Cocoapods.PodfileLockSpec
     Cocoapods.PodfileSpec
+    Effect.ExecSpec
     Erlang.Rebar3TreeSpec
     Go.GlideLockSpec
     Go.GoListSpec

--- a/test/Effect/ExecSpec.hs
+++ b/test/Effect/ExecSpec.hs
@@ -1,0 +1,18 @@
+module Effect.ExecSpec
+  ( spec,
+  )
+where
+
+import Data.Either (isLeft)
+import Effect.Exec
+import Path.IO (getCurrentDir)
+import Test.Hspec
+import Prelude
+
+spec :: Spec
+spec = do
+  describe "IO-based handler" $ do
+    it "should return Left, and not throw an exception, when a command is not found" $ do
+      dir <- getCurrentDir
+      res <- runExecIO $ exec dir (Command "lkajsdflkjasdlfkjas" [] Always)
+      res `shouldSatisfy` isLeft


### PR DESCRIPTION
Previously, errors like "command doesn't exist" would be an uncaught exception.