### PR TITLE
Ninja scans in main vpscli scan

### DIFF
--- a/src/App/VPSScan/Main.hs
+++ b/src/App/VPSScan/Main.hs
@@ -30,7 +30,7 @@ vpsOpts = VPSOpts <$> runSherlockOpts <*> optional runIPROpts <*> syOpts <*> nin
 ninjaGraphOpts :: Parser NinjaGraphOpts
 ninjaGraphOpts = NinjaGraphOpts <$> runNinjaOpt <*> ninjaDepsOpt <*> lunchTargetOpt
                  where
-                   runNinjaOpt = option auto (long "ninja" <> metavar "STRING" <> help "Run a Ninja dependency graph scan")
+                   runNinjaOpt = switch (long "ninja" <> help "Run a Ninja dependency graph scan")
                    ninjaDepsOpt = optional $ strOption (long "ninjadeps" <> metavar "STRING")
                    lunchTargetOpt = optional $ strOption (long "lunchtarget" <> metavar "STRING" <> help "build target name to pass to lunch. If you are running in an environment with envsetup and lunch already configured, then you don't need to pass this in")
 

--- a/src/App/VPSScan/Main.hs
+++ b/src/App/VPSScan/Main.hs
@@ -8,7 +8,6 @@ import Options.Applicative
 
 import App.OptionExtensions
 import App.VPSScan.Scan (ScanCmdOpts(..), scanMain)
-import App.VPSScan.NinjaGraph (NinjaGraphCmdOpts(..), ninjaGraphMain)
 import App.VPSScan.Types
 import qualified App.VPSScan.Scan.RunIPR as RunIPR
 
@@ -19,21 +18,21 @@ opts :: ParserInfo (IO ())
 opts = info (commands <**> helper) (fullDesc <> header "vpscli -- FOSSA Vendored Package Scan CLI")
 
 commands :: Parser (IO ())
-commands = hsubparser $ scanCommand <> ninjaGraphCommand
+commands = hsubparser $ scanCommand
 
 vpsOpts :: Parser VPSOpts
-vpsOpts = VPSOpts <$> runSherlockOpts <*> optional runIPROpts <*> syOpts <*> organizationIDOpt <*> projectIDOpt <*> revisionIDOpt <*> filterOpt
+vpsOpts = VPSOpts <$> runSherlockOpts <*> optional runIPROpts <*> syOpts <*> ninjaGraphOpts <*> organizationIDOpt <*> projectIDOpt <*> revisionIDOpt <*> filterOpt
             where
               organizationIDOpt = option auto (long "organization" <> metavar "orgID" <> help "Organization ID")
               projectIDOpt = strOption (long "project" <> metavar "String" <> help "Project ID")
               revisionIDOpt = strOption (long "revision" <> metavar "String" <> help "Revision ID")
 
 ninjaGraphOpts :: Parser NinjaGraphOpts
-ninjaGraphOpts = NinjaGraphOpts <$> ninjaDepsOpt <*> lunchTargetOpt <*> scotlandYardUrlOpt
+ninjaGraphOpts = NinjaGraphOpts <$> runNinjaOpt <*> ninjaDepsOpt <*> lunchTargetOpt
                  where
+                   runNinjaOpt = option auto (long "ninja" <> metavar "STRING" <> help "Run a Ninja dependency graph scan")
                    ninjaDepsOpt = optional $ strOption (long "ninjadeps" <> metavar "STRING")
                    lunchTargetOpt = optional $ strOption (long "lunchtarget" <> metavar "STRING" <> help "build target name to pass to lunch. If you are running in an environment with envsetup and lunch already configured, then you don't need to pass this in")
-                   scotlandYardUrlOpt = uriOption (long "scotland-yard-url" <> metavar "STRING" <> help "URL for Scotland Yard service")
 
 runSherlockOpts :: Parser SherlockOpts
 runSherlockOpts = SherlockOpts
@@ -79,10 +78,3 @@ scanCommand = command "scan" (info (scanMain <$> scanOptsParser) (progDesc "Scan
   scanOptsParser = ScanCmdOpts
                    <$> basedirOpt
                    <*> vpsOpts
-
-ninjaGraphCommand :: Mod CommandFields (IO ())
-ninjaGraphCommand = command "ninja-graph" (info (ninjaGraphMain <$> ninjaGraphOptsParser) (progDesc "Get a dependency graph for a ninja build"))
-  where
-    ninjaGraphOptsParser = NinjaGraphCmdOpts
-                          <$> basedirOpt
-                          <*> ninjaGraphOpts

--- a/src/App/VPSScan/NinjaGraph.hs
+++ b/src/App/VPSScan/NinjaGraph.hs
@@ -45,7 +45,7 @@ getAndParseNinjaDeps :: (Has Diagnostics sig m, MonadIO m) => Path Abs Dir -> Te
 getAndParseNinjaDeps dir projectId scanId scotlandYardOpts ninjaGraphOpts = do
   ninjaDepsContents <- runTrace $ runReadFSIO $ runExecIO $ getNinjaDeps dir ninjaGraphOpts
   graph <- scanNinjaDeps ninjaGraphOpts ninjaDepsContents
-  _ <- runHTTP $ createDependencyGraph projectId scanId scotlandYardOpts graph
+  _ <- runHTTP $ createDependencyGraph projectId scanId scotlandYardOpts (object ["targets" .= graph])
   pure ()
 
 -- If the path to an already generated ninja_deps file was passed in (with the --ninjadeps arg), then

--- a/src/App/VPSScan/Scan.hs
+++ b/src/App/VPSScan/Scan.hs
@@ -112,7 +112,7 @@ runNinjaDepsGraphScan ::
   ) => Path Abs Dir -> Text -> VPSOpts -> m ()
 runNinjaDepsGraphScan basedir scanId VPSOpts{..} =
   if runNinja then do
-    getAndParseNinjaDeps basedir scanId vpsScotlandYard vpsNinja
+    getAndParseNinjaDeps basedir projectID scanId vpsScotlandYard vpsNinja
   else
     pure ()
   where

--- a/src/App/VPSScan/Types.hs
+++ b/src/App/VPSScan/Types.hs
@@ -33,6 +33,7 @@ data VPSOpts = VPSOpts
   { vpsSherlock :: SherlockOpts
   , vpsIpr :: Maybe RunIPR.IPROpts
   , vpsScotlandYard :: ScotlandYardOpts
+  , vpsNinja :: NinjaGraphOpts
   , organizationID :: Int
   , projectID :: Text
   , revisionID :: Text
@@ -69,9 +70,9 @@ instance ToJSON DepsDependency where
     ]
 
 data NinjaGraphOpts = NinjaGraphOpts
-  { ninjaGraphNinjaPath :: Maybe FilePath
+  { runNinja :: Bool
+  , ninjaGraphNinjaPath :: Maybe FilePath
   , lunchTarget :: Maybe Text
-  , depsGraphScotlandYardUrl :: URI
   } deriving Generic
 
 newtype HTTP m a = HTTP {unHTTP :: m a}

--- a/test/App/VPSScan/NinjaGraphSpec.hs
+++ b/test/App/VPSScan/NinjaGraphSpec.hs
@@ -12,8 +12,6 @@ import App.VPSScan.Types
 import Data.Text.Encoding
 import Test.Hspec
 import Control.Carrier.Diagnostics
-import Text.URI (emptyURI)
-
 
 -- out/target/product/coral/obj/STATIC_LIBRARIES/libgptutils_intermediates/gpt-utils.o: #deps 2, deps mtime 1583962189 (VALID)
 --     device/google/coral/gpt-utils/gpt-utils.cpp
@@ -126,10 +124,10 @@ spec :: Spec
 spec = do
   smallNinjaDeps <- runIO (TIO.readFile "test/App/VPSScan/testdata/small-ninja-deps")
   weirdNinjaDeps <- runIO (TIO.readFile "test/App/VPSScan/testdata/ninja-deps-with-weird-targets")
-  let ninjaGraphOpts = NinjaGraphOpts { ninjaGraphNinjaPath  = Nothing
-                                  , lunchTarget = Nothing
-                                  , depsGraphScotlandYardUrl = emptyURI
-                                  }
+  let ninjaGraphOpts = NinjaGraphOpts { runNinja = True
+                                      , ninjaGraphNinjaPath  = Nothing
+                                      , lunchTarget = Nothing
+                                      }
 
   describe "scanNinjaDeps for a standard ninja deps file" $
     it "parses a small ninja deps file and generates a dependency graph" $ do


### PR DESCRIPTION
We need to run dependency graph scans as part of a normal `vpscli` scan, so get rid of the `vpscli ninja-graph` command and add some params to `vpscli scan`

I think this will create some merge conflicts with #105 