### PR TITLE
SPEC file parsing with focus on requires dependencies

### DIFF
--- a/src/Strategy/RPM.hs
+++ b/src/Strategy/RPM.hs
@@ -84,7 +84,7 @@ toDependency pkg =
       }
 
 buildGraph :: Dependencies -> Graphing Dependency
-buildGraph Dependencies {..} = G.gmap toDependency $ G.fromList depBuildRequires
+buildGraph Dependencies {..} = G.gmap toDependency $ G.fromList depRuntimeRequires
 
 buildConstraint :: Text -> Maybe VerConstraint
 buildConstraint tail = constraint

--- a/test/RPM/SpecFileSpec.hs
+++ b/test/RPM/SpecFileSpec.hs
@@ -80,11 +80,11 @@ spec = do
       getTypeFromLine "Requires: xz = 1" `Test.shouldBe` Just (RuntimeRequires $ mkVerDep "xz" $ CEq "1")
   --
   Test.describe "rpm dependency grapher" $
-    Test.it "should produce flat BuildRequires" $ do
+    Test.it "should produce flat RuntimeRequires" $ do
       let deps = Dependencies [boostDep, xzDep] [tacpDep, jsoncppDep]
           gr = buildGraph deps
 
-      expectDeps (map toDependency [boostDep, xzDep]) gr
-      expectDirect (map toDependency [boostDep, xzDep]) gr
+      expectDeps [toDependency tacpDep] gr
+      expectDirect [toDependency tacp] gr
       expectEdges [] gr
 

--- a/test/RPM/SpecFileSpec.hs
+++ b/test/RPM/SpecFileSpec.hs
@@ -84,7 +84,6 @@ spec = do
       let deps = Dependencies [boostDep, xzDep] [tacpDep, jsoncppDep]
           gr = buildGraph deps
 
-      expectDeps [toDependency tacpDep] gr
-      expectDirect [toDependency tacp] gr
+      expectDeps (map toDependency [tacpDep, jsoncppDep]) gr
+      expectDirect (map toDependency [tacpDep, jsoncppDep]) gr
       expectEdges [] gr
-


### PR DESCRIPTION
After customer feedback we have determined that focusing on the `requires` lines in the rpm spec file is more important than the `buildrequires` lines. This will be mitigated in the future by introducing package tagging, but at the moment the best solution is only uploading `requires` deps.