### PR TITLE
Copy binaries to release instead of moving

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,15 +83,15 @@ jobs:
       if: ${{ contains(matrix.os, 'windows') }}
       run: |
         mkdir release
-        find . -type f -path '*/fossa/fossa.exe' -exec mv {} release \;
-        find . -type f -path '*/pathfinder/pathfinder.exe' -exec mv {} release \;
+        find . -type f -path '*/fossa/fossa.exe' -exec cp {} release \;
+        find . -type f -path '*/pathfinder/pathfinder.exe' -exec cp {} release \;
   
     - name: Find and move binaries (non-windows)
       if: ${{ !contains(matrix.os, 'windows') }}
       run: |
         mkdir release
-        find . -type f -path '*/fossa/fossa' -exec mv {} release \;
-        find . -type f -path '*/pathfinder/pathfinder' -exec mv {} release \;
+        find . -type f -path '*/fossa/fossa' -exec cp {} release \;
+        find . -type f -path '*/pathfinder/pathfinder' -exec cp {} release \;
 
     - name: Update vendored binaries
       if: ${{ !contains(matrix.os, 'windows') }}


### PR DESCRIPTION
My merge yesterday was premature: an issue appeared to be network related, but was actually build script related.
This PR fixes it.