### PR TITLE
ghc 8.10

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
 
           - os: ubuntu-latest
             os-name: Linux
-            container: docker.pkg.github.com/fossas/haskell-static-alpine/haskell-static-alpine:ghc-8.10
+            container: quay.io/fossa/haskell-static-alpine:ghc-8.10
             project-file: cabal.project.ci.linux
 
           - os: macos-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,17 +29,18 @@ jobs:
             os-name: Linux
             container: quay.io/fossa/haskell-static-alpine:ghc-8.10
             project-file: cabal.project.ci.linux
-            ghc: 8.10
+            # note: the real version is the one bundled in the docker image
+            ghc: '8.10'
 
           - os: macos-latest
             os-name: macOS
             project-file: cabal.project.ci.macos
-            ghc: 8.8
+            ghc: '8.10.1'
 
           - os: windows-latest
             os-name: Windows
             project-file: cabal.project.ci.windows
-            ghc: 8.8
+            ghc: '8.8'
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
 
           - os: ubuntu-latest
             os-name: Linux
-            container: quay.io/fossa/haskell-static-alpine
+            container: docker.pkg.github.com/fossas/haskell-static-alpine/haskell-static-alpine:ghc-8.10
             project-file: cabal.project.ci.linux
 
           - os: macos-latest
@@ -57,7 +57,7 @@ jobs:
       name: Setup ghc/cabal (non-alpine)
       if: ${{ !contains(matrix.os, 'ubuntu') }}
       with:
-        ghc-version: '8.8.2'
+        ghc-version: '8.10.2'
 
     - uses: actions/cache@v1
       name: Cache cabal store

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
           - os: windows-latest
             os-name: Windows
             project-file: cabal.project.ci.windows
-            ghc: '8.8'
+            ghc: '8.10.1'
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,21 +23,23 @@ jobs:
       fail-fast: false
       matrix:
         os: ['windows-latest', 'ubuntu-latest', 'macos-latest']
-        ghc: ['8.10.2']
         include:
 
           - os: ubuntu-latest
             os-name: Linux
             container: quay.io/fossa/haskell-static-alpine:ghc-8.10
             project-file: cabal.project.ci.linux
+            ghc: 8.10
 
           - os: macos-latest
             os-name: macOS
             project-file: cabal.project.ci.macos
+            ghc: 8.8
 
           - os: windows-latest
             os-name: Windows
             project-file: cabal.project.ci.windows
+            ghc: 8.8
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['windows-latest', 'ubuntu-latest', 'macos-latest']
+        ghc: ['8.10.2']
         include:
 
           - os: ubuntu-latest
@@ -57,13 +58,17 @@ jobs:
       name: Setup ghc/cabal (non-alpine)
       if: ${{ !contains(matrix.os, 'ubuntu') }}
       with:
-        ghc-version: '8.10.2'
+        ghc-version: ${{ matrix.ghc }}
 
     - uses: actions/cache@v1
       name: Cache cabal store
       with:
         path: ${{ steps.setup-haskell.outputs.cabal-store || '~/.cabal/store' }}
-        key: ${{ runner.os }}-v5-cabal-store
+        key: ${{ runner.os }}-${{ matrix.ghc }}-cabal-cache-${{ hashFiles('**/*.cabal') }}
+        restore-keys: |
+          ${{ runner.os }}-${{ matrix.ghc }}-cabal-cache-
+          ${{ runner.os }}-${{ matrix.ghc }}-
+          ${{ runner.os }}-
 
     - name: Build
       run: |

--- a/cabal.project
+++ b/cabal.project
@@ -1,3 +1,8 @@
 packages: .
 tests: True
 optimization: False
+
+source-repository-package
+  type: git
+  location: https://github.com/fossas/yarn-lock.git
+  tag: master

--- a/cabal.project.ci.linux
+++ b/cabal.project.ci.linux
@@ -7,3 +7,8 @@ packages: .
 
 package spectrometer
   ghc-options: -Werror
+
+source-repository-package
+  type: git
+  location: https://github.com/fossas/yarn-lock.git
+  tag: master

--- a/cabal.project.ci.macos
+++ b/cabal.project.ci.macos
@@ -5,3 +5,8 @@ packages: .
 
 package spectrometer
   ghc-options: -Werror
+
+source-repository-package
+  type: git
+  location: https://github.com/fossas/yarn-lock.git
+  tag: master

--- a/cabal.project.ci.windows
+++ b/cabal.project.ci.windows
@@ -7,3 +7,8 @@ packages: .
 
 package spectrometer
   ghc-options: -Werror
+
+source-repository-package
+  type: git
+  location: https://github.com/fossas/yarn-lock.git
+  tag: master

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -71,18 +71,18 @@ common deps
     , megaparsec                   ^>=8.0
     , modern-uri                   ^>=0.3.1
     , mtl                          ^>=2.2.2
-    , optparse-applicative         ^>=0.15.1
+    , optparse-applicative         >=0.15     && <0.17
     , path                         ^>=0.8
     , path-io                      ^>=1.6.0
-    , prettyprinter                ^>=1.6
+    , prettyprinter                >=1.6      && <1.8
     , prettyprinter-ansi-terminal  ^>=1.1.1
-    , req                          ^>=3.4.0
+    , req                          >=3.4      && <3.6
     , stm                          ^>=2.5.0
     , stm-chans                    ^>=3.0.0
     , tar                          ^>=0.5.1.1
-    , template-haskell             ^>=2.15
+    , template-haskell             >=2.15     && <2.17
     , text                         ^>=1.2.3
-    , time                         ^>=1.9.3
+    , time                         >=1.9      && <1.11
     , tomland                      ^>=1.3.0.0
     , typed-process                ^>=0.2.6
     , unordered-containers         ^>=0.2.10
@@ -116,15 +116,15 @@ library
     App.Pathfinder.Scan
     App.Types
     App.Util
+    App.VPSScan.EmbeddedBinary
     App.VPSScan.Main
     App.VPSScan.NinjaGraph
     App.VPSScan.Scan
+    App.VPSScan.Scan.Core
     App.VPSScan.Scan.RunIPR
     App.VPSScan.Scan.RunSherlock
     App.VPSScan.Scan.ScotlandYard
-    App.VPSScan.Scan.Core
     App.VPSScan.Types
-    App.VPSScan.EmbeddedBinary
     Control.Carrier.Diagnostics
     Control.Carrier.Finally
     Control.Carrier.Output.IO
@@ -135,8 +135,8 @@ library
     Control.Effect.Output
     Control.Effect.Path
     Control.Effect.TaskPool
-    DepTypes
     Data.FileEmbed.Extra
+    DepTypes
     Discovery.Walk
     Effect.Exec
     Effect.Grapher
@@ -268,4 +268,3 @@ test-suite unit-tests
     , hspec-hedgehog    ^>=0.0.1.2
     , hspec-megaparsec  ^>=2.1
     , spectrometer
- 

--- a/src/App/VPSScan/NinjaGraph.hs
+++ b/src/App/VPSScan/NinjaGraph.hs
@@ -61,7 +61,7 @@ ninjaGraphMain NinjaGraphCmdOpts{..} = do
 getAndParseNinjaDeps :: (Has Diagnostics sig m, MonadIO m) => Path Abs Dir -> NinjaGraphOpts -> m ()
 getAndParseNinjaDeps dir ninjaGraphOpts = do
   ninjaDepsContents <- runTrace $ runReadFSIO $ runExecIO $ getNinjaDeps dir ninjaGraphOpts
-  graph <- scanNinjaDeps ninjaGraphOpts ninjaDepsContents
+  graph <- scanNinjaDeps ninjaDepsContents
   _ <- runHTTP $ postDepsGraphResults ninjaGraphOpts graph
   pure ()
 
@@ -74,9 +74,8 @@ getNinjaDeps baseDir opts@NinjaGraphOpts{..} =
     Nothing -> BL.toStrict <$> generateNinjaDeps baseDir opts
     Just ninjaPath -> readNinjaDepsFile ninjaPath
 
-scanNinjaDeps :: (Has Diagnostics sig m) => NinjaGraphOpts -> ByteString -> m [DepsTarget]
-scanNinjaDeps NinjaGraphOpts{..} ninjaDepsContents =
-  map correctedTarget <$> ninjaDeps
+scanNinjaDeps :: (Has Diagnostics sig m) => ByteString -> m [DepsTarget]
+scanNinjaDeps ninjaDepsContents = map correctedTarget <$> ninjaDeps
   where
     ninjaDeps = parseNinjaDeps ninjaDepsContents
 

--- a/test/App/VPSScan/NinjaGraphSpec.hs
+++ b/test/App/VPSScan/NinjaGraphSpec.hs
@@ -6,13 +6,12 @@ import Prologue
 
 import qualified Data.Text.IO as TIO
 import qualified Data.Text as T
-import Data.List
+import qualified Data.List as List
 import App.VPSScan.NinjaGraph
 import App.VPSScan.Types
 import Data.Text.Encoding
 import Test.Hspec
 import Control.Carrier.Diagnostics
-import Text.URI (emptyURI)
 
 
 -- out/target/product/coral/obj/STATIC_LIBRARIES/libgptutils_intermediates/gpt-utils.o: #deps 2, deps mtime 1583962189 (VALID)
@@ -126,26 +125,22 @@ spec :: Spec
 spec = do
   smallNinjaDeps <- runIO (TIO.readFile "test/App/VPSScan/testdata/small-ninja-deps")
   weirdNinjaDeps <- runIO (TIO.readFile "test/App/VPSScan/testdata/ninja-deps-with-weird-targets")
-  let ninjaGraphOpts = NinjaGraphOpts { ninjaGraphNinjaPath  = Nothing
-                                  , lunchTarget = Nothing
-                                  , depsGraphScotlandYardUrl = emptyURI
-                                  }
 
   describe "scanNinjaDeps for a standard ninja deps file" $
     it "parses a small ninja deps file and generates a dependency graph" $ do
-      eitherScanned <- runDiagnostics $ scanNinjaDeps ninjaGraphOpts (encodeUtf8 smallNinjaDeps)
+      eitherScanned <- runDiagnostics $ scanNinjaDeps (encodeUtf8 smallNinjaDeps)
       case eitherScanned of
         Left _ -> expectationFailure (T.unpack "could not parse ninja deps")
         Right scanned -> resultValue scanned `shouldMatchList` smallNinjaDepsTargets
 
   describe "scanNinjaDeps for a ninja deps file with weird targets" $ do
     it "finds the correct input for a target where the first dependency is a txt file" $ do
-      eitherScanned <- runDiagnostics $ scanNinjaDeps ninjaGraphOpts (encodeUtf8 weirdNinjaDeps)
+      eitherScanned <- runDiagnostics $ scanNinjaDeps (encodeUtf8 weirdNinjaDeps)
       case eitherScanned of
         Left _ -> expectationFailure (T.unpack "could not parse ninja deps")
-        Right scanned -> head (resultValue scanned) `shouldBe` targetWithFirstLevelWeirdnessFix
+        Right scanned -> List.head (resultValue scanned) `shouldBe` targetWithFirstLevelWeirdnessFix
     it "finds the correct input for a target where the first and second dependencies are txt files" $ do
-      eitherScanned <- runDiagnostics $ scanNinjaDeps ninjaGraphOpts (encodeUtf8 weirdNinjaDeps)
+      eitherScanned <- runDiagnostics $ scanNinjaDeps (encodeUtf8 weirdNinjaDeps)
       case eitherScanned of
         Left _ -> expectationFailure (T.unpack "could not parse ninja deps")
-        Right scanned -> (resultValue scanned !! 1) `shouldBe` targetWithSecondLevelWeirdnessFix
+        Right scanned -> (resultValue scanned List.!! 1) `shouldBe` targetWithSecondLevelWeirdnessFix


### PR DESCRIPTION
This PR includes changes required to build with ghc 8.10

unrelated: this adds fallback keys to the `cache` action, which improves how often we get a cache hit