### PR TITLE
Don't upx binary deps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,7 @@ jobs:
       if: ${{ contains(matrix.os, 'ubuntu') }}
       shell: sh
       run: |
-        apk add bash xz-dev bzip2-dev bzip2-static upx curl jq
+        apk add bash xz-dev bzip2-dev bzip2-static curl jq
 
     - name: Install MacOS binary dependencies
       if: ${{ contains(matrix.os, 'macos') }}

--- a/vendor_download.sh
+++ b/vendor_download.sh
@@ -6,7 +6,6 @@
 # Requires binary dependencies in $PATH:
 #   jq              Parse and manipulate json structures.
 #   curl            Download data over HTTP(s)
-#   upx             Compress binaries
 #
 
 set -e
@@ -62,9 +61,6 @@ done
 
 echo "Marking binaries executable"
 chmod +x vendor/*
-
-echo "Compressing binaries"
-upx vendor/*
 
 echo "Vendored binaries are ready for use"
 ls -lh vendor/


### PR DESCRIPTION
Now that we're building wth `ghc-8.10`, hopefully we won't need to UPX deps to get them to build- and therefore maybe we'll resolve the strange "file busy" errors we've been getting with extracted binaries.