### PR TITLE
Integration testing: prerequisites

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+- Fixes bug where the rebar3 strategy would incorrectly find dependencies as top-level projects ([#119](https://github.com/fossas/spectrometer/pull/119))
+- Fixes various issues in the setup.py parser ([#119](https://github.com/fossas/spectrometer/pull/119))
+
 # v2.2.1
 
 - Fixes bug where the req.txt strategy would run even when no relevant files were present ([#109](https://github.com/fossas/spectrometer/pull/109))

--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -22,6 +22,7 @@ import Data.Text.Prettyprint.Doc
 import Data.Text.Prettyprint.Doc.Render.Terminal
 import Effect.Exec
 import Effect.Logger
+import Effect.ReadFS
 import Network.HTTP.Types (urlEncode)
 import qualified Srclib.Converter as Srclib
 import Srclib.Types (Locator(..), parseLocator)
@@ -86,7 +87,7 @@ analyze ::
 analyze basedir destination override unpackArchives = runFinally $ do
   capabilities <- liftIO getNumCapabilities
 
-  (closures,(failures,())) <- runOutput @ProjectClosure $ runOutput @ProjectFailure $
+  (closures,(failures,())) <- runOutput @ProjectClosure . runOutput @ProjectFailure . runExecIO . runReadFSIO $
     withTaskPool capabilities updateProgress $
       if unpackArchives
         then discoverWithArchives $ unBaseDir basedir

--- a/src/Strategy/Erlang/Rebar3Tree.hs
+++ b/src/Strategy/Erlang/Rebar3Tree.hs
@@ -25,10 +25,10 @@ import Types
 discover :: HasDiscover sig m => Path Abs Dir -> m ()
 discover = walk $ \dir _ files -> do
   case find (\f -> (fileName f) == "rebar.config") files of
-    Nothing -> pure ()
-    Just _  -> runSimpleStrategy "erlang-rebar3tree" ErlangGroup $ analyze dir
-
-  pure WalkContinue
+    Nothing -> pure WalkContinue
+    Just _  -> do
+      runSimpleStrategy "erlang-rebar3tree" ErlangGroup $ analyze dir
+      pure WalkSkipAll
 
 rebar3TreeCmd :: Command
 rebar3TreeCmd = Command

--- a/src/Strategy/Maven/Pom.hs
+++ b/src/Strategy/Maven/Pom.hs
@@ -1,12 +1,12 @@
 module Strategy.Maven.Pom
-  ( discover
-  , mkProjectClosure
-  ) where
-
-import Prologue
+  ( discover,
+    analyze,
+    mkProjectClosure,
+  )
+where
 
 import qualified Algebra.Graph.AdjacencyMap as AM
-import Control.Carrier.Error.Either
+import Control.Effect.Diagnostics
 import Control.Effect.Output
 import qualified Data.Map.Strict as M
 import Data.Maybe (mapMaybe)
@@ -14,89 +14,106 @@ import qualified Data.Set as S
 import qualified Data.Text as T
 import DepTypes
 import Effect.Grapher
+import Effect.ReadFS
 import qualified Graphing as G
+import Prologue
 import qualified Path.IO as Path
 import Strategy.Maven.Pom.Closure
 import Strategy.Maven.Pom.PomFile
 import Types
 
 data MavenStrategyOpts = MavenStrategyOpts
-  { strategyPath  :: Path Rel File
-  , strategyGraph :: G.Graphing Dependency
-  } deriving (Eq, Ord, Show, Generic)
+  { strategyPath :: Path Rel File,
+    strategyGraph :: G.Graphing Dependency
+  }
+  deriving (Eq, Ord, Show, Generic)
 
 discover :: HasDiscover sig m => Path Abs Dir -> m ()
-discover dir = runStrategy "maven-pom" MavenGroup $ do
+discover = runStrategy "maven-pom" MavenGroup . analyze
+
+analyze ::
+  ( Has ReadFS sig m,
+    Has Diagnostics sig m,
+    Has (Output ProjectClosure) sig m,
+    MonadIO m
+  ) =>
+  Path Abs Dir ->
+  m ()
+analyze dir = do
   (mvnClosures :: [MavenProjectClosure]) <- findProjects dir
   traverse_ (output . mkProjectClosure dir) mvnClosures
 
 mkProjectClosure :: Path Abs Dir -> MavenProjectClosure -> ProjectClosure
-mkProjectClosure basedir mvnClosure = ProjectClosure
-  { closureStrategyGroup = MavenGroup
-  , closureStrategyName  = "maven-pom"
-  , closureModuleDir     = parent (closurePath mvnClosure)
-  , closureDependencies  = dependencies
-  , closureLicenses      = licenses
-  }
-  where
-  dependencies = ProjectDependencies
-    { dependenciesGraph    = buildProjectGraph mvnClosure
-    , dependenciesOptimal  = NotOptimal
-    , dependenciesComplete = NotComplete
+mkProjectClosure basedir mvnClosure =
+  ProjectClosure
+    { closureStrategyGroup = MavenGroup,
+      closureStrategyName = "maven-pom",
+      closureModuleDir = parent (closurePath mvnClosure),
+      closureDependencies = dependencies,
+      closureLicenses = licenses
     }
+  where
+    dependencies =
+      ProjectDependencies
+        { dependenciesGraph = buildProjectGraph mvnClosure,
+          dependenciesOptimal = NotOptimal,
+          dependenciesComplete = NotComplete
+        }
 
-  licenses :: [LicenseResult]
-  licenses = do
-    (abspath,pom) <- M.elems (closurePoms mvnClosure)
-    case Path.makeRelative basedir abspath of
-      Nothing -> []
-      Just relpath ->
-        let path = toFilePath relpath
-            validated = mapMaybe validateLicense (pomLicenses pom)
-         in pure (LicenseResult path validated)
+    licenses :: [LicenseResult]
+    licenses = do
+      (abspath, pom) <- M.elems (closurePoms mvnClosure)
+      case Path.makeRelative basedir abspath of
+        Nothing -> []
+        Just relpath ->
+          let path = toFilePath relpath
+              validated = mapMaybe validateLicense (pomLicenses pom)
+           in pure (LicenseResult path validated)
 
-  -- we prefer URLs over SPDX because name isn't guaranteed to be an SPDX expression
-  validateLicense :: PomLicense -> Maybe License
-  validateLicense license = licenseAsUrl <|> licenseAsSpdx
-    where
-      licenseAsUrl = License LicenseURL <$> pomLicenseUrl license
-      licenseAsSpdx = License LicenseSPDX <$> pomLicenseName license
+    -- we prefer URLs over SPDX because name isn't guaranteed to be an SPDX expression
+    validateLicense :: PomLicense -> Maybe License
+    validateLicense license = licenseAsUrl <|> licenseAsSpdx
+      where
+        licenseAsUrl = License LicenseURL <$> pomLicenseUrl license
+        licenseAsSpdx = License LicenseSPDX <$> pomLicenseName license
 
 type Version = Text
+
 data MavenPackage = MavenPackage Group Artifact (Maybe Version)
   deriving (Eq, Ord, Show, Generic)
 
 type MavenGrapher = LabeledGrapher MavenPackage MavenLabel
 
-data MavenLabel =
-    MavenLabelScope Text
+data MavenLabel
+  = MavenLabelScope Text
   | MavenLabelOptional Text
   deriving (Eq, Ord, Show, Generic)
 
 toDependency :: MavenPackage -> Set MavenLabel -> Dependency
 toDependency (MavenPackage group artifact version) = foldr applyLabel start
   where
-  start :: Dependency
-  start = Dependency
-    { dependencyType = MavenType
-    , dependencyName = group <> ":" <> artifact
-    , dependencyVersion = CEq <$> version
-    , dependencyLocations = []
-    , dependencyEnvironments = []
-    , dependencyTags = M.empty
-    }
+    start :: Dependency
+    start =
+      Dependency
+        { dependencyType = MavenType,
+          dependencyName = group <> ":" <> artifact,
+          dependencyVersion = CEq <$> version,
+          dependencyLocations = [],
+          dependencyEnvironments = [],
+          dependencyTags = M.empty
+        }
 
-  applyLabel :: MavenLabel -> Dependency -> Dependency
-  applyLabel lbl dep = case lbl of
-    MavenLabelScope scope ->
-      if scope == "test"
-        then dep { dependencyEnvironments = EnvTesting : dependencyEnvironments dep }
-        else addTag "scope" scope dep
-    MavenLabelOptional opt -> addTag "optional" opt dep
+    applyLabel :: MavenLabel -> Dependency -> Dependency
+    applyLabel lbl dep = case lbl of
+      MavenLabelScope scope ->
+        if scope == "test"
+          then dep {dependencyEnvironments = EnvTesting : dependencyEnvironments dep}
+          else addTag "scope" scope dep
+      MavenLabelOptional opt -> addTag "optional" opt dep
 
-  -- TODO: reuse this in other strategies
-  addTag :: Text -> Text -> Dependency -> Dependency
-  addTag key value dep = dep { dependencyTags = M.insertWith (++) key [value] (dependencyTags dep) }
+    -- TODO: reuse this in other strategies
+    addTag :: Text -> Text -> Dependency -> Dependency
+    addTag key value dep = dep {dependencyTags = M.insertWith (++) key [value] (dependencyTags dep)}
 
 -- TODO: set top-level direct deps as direct instead of the project?
 buildProjectGraph :: MavenProjectClosure -> G.Graphing Dependency
@@ -104,43 +121,43 @@ buildProjectGraph closure = run . withLabeling toDependency $ do
   direct (coordToPackage (closureRootCoord closure))
   go (closureRootCoord closure) (closureRootPom closure)
   where
-  go :: Has MavenGrapher sig m => MavenCoordinate -> Pom -> m ()
-  go coord incompletePom = do
-    _ <- M.traverseWithKey addDep deps
-    for_ childPoms $ \(childCoord,childPom) -> do
-      edge (coordToPackage coord) (coordToPackage childCoord)
-      go childCoord childPom
+    go :: Has MavenGrapher sig m => MavenCoordinate -> Pom -> m ()
+    go coord incompletePom = do
+      _ <- M.traverseWithKey addDep deps
+      for_ childPoms $ \(childCoord, childPom) -> do
+        edge (coordToPackage coord) (coordToPackage childCoord)
+        go childCoord childPom
+      where
+        completePom :: Pom
+        completePom = overlayParents incompletePom
 
-    where
-    completePom :: Pom
-    completePom = overlayParents incompletePom
+        overlayParents :: Pom -> Pom
+        overlayParents pom = fromMaybe pom $ do
+          parentCoord <- pomParentCoord pom
+          (_, parentPom) <- M.lookup parentCoord (closurePoms closure)
+          pure (pom <> overlayParents parentPom)
 
-    overlayParents :: Pom -> Pom
-    overlayParents pom = fromMaybe pom $ do
-      parentCoord <- pomParentCoord pom
-      (_,parentPom) <- M.lookup parentCoord (closurePoms closure)
-      pure (pom <> overlayParents parentPom)
+        deps :: Map (Group, Artifact) MvnDepBody
+        deps = reifyDeps completePom
 
-    deps :: Map (Group,Artifact) MvnDepBody
-    deps = reifyDeps completePom
+        addDep :: Has MavenGrapher sig m => (Group, Artifact) -> MvnDepBody -> m ()
+        addDep (group, artifact) body = do
+          let interpolatedVersion = classify . naiveInterpolate (pomProperties completePom) <$> depVersion body
+              -- maven classifiers are appended to the end of versions, e.g., 3.0.0 with a classifier
+              -- of "sources" would result in "3.0.0-sources"
+              classify version = case depClassifier body of
+                Nothing -> version
+                Just classifier -> version <> "-" <> classifier
+              depPackage = MavenPackage group artifact interpolatedVersion
 
-    addDep :: Has MavenGrapher sig m => (Group,Artifact) -> MvnDepBody -> m ()
-    addDep (group,artifact) body = do
-      let interpolatedVersion = classify . naiveInterpolate (pomProperties completePom) <$> depVersion body
-          -- maven classifiers are appended to the end of versions, e.g., 3.0.0 with a classifier
-          -- of "sources" would result in "3.0.0-sources"
-          classify version = case depClassifier body of
-            Nothing -> version
-            Just classifier -> version <> "-" <> classifier
-          depPackage = MavenPackage group artifact interpolatedVersion
+          edge (coordToPackage coord) depPackage
+          traverse_ (label depPackage . MavenLabelScope) (depScope body)
+          traverse_ (label depPackage . MavenLabelOptional) (depOptional body)
 
-      edge (coordToPackage coord) depPackage
-      traverse_ (label depPackage . MavenLabelScope) (depScope body)
-      traverse_ (label depPackage . MavenLabelOptional) (depOptional body)
-
-    childPoms :: [(MavenCoordinate,Pom)]
-    childPoms = [(childCoord,pom) | childCoord <- S.toList (AM.postSet coord (closureGraph closure))
-                                  , Just (_,pom) <- [M.lookup childCoord (closurePoms closure)]]
+        childPoms :: [(MavenCoordinate, Pom)]
+        childPoms =
+          [ (childCoord, pom) | childCoord <- S.toList (AM.postSet coord (closureGraph closure)), Just (_, pom) <- [M.lookup childCoord (closurePoms closure)]
+          ]
 
 coordToPackage :: MavenCoordinate -> MavenPackage
 coordToPackage coord = MavenPackage (coordGroup coord) (coordArtifact coord) (Just (coordVersion coord))
@@ -148,8 +165,8 @@ coordToPackage coord = MavenPackage (coordGroup coord) (coordArtifact coord) (Ju
 reifyDeps :: Pom -> Map (Group, Artifact) MvnDepBody
 reifyDeps pom = M.mapWithKey overlayDepManagement (pomDependencies pom)
   where
-  overlayDepManagement :: (Group,Artifact) -> MvnDepBody -> MvnDepBody
-  overlayDepManagement key body = maybe body (body <>) (M.lookup key (pomDependencyManagement pom))
+    overlayDepManagement :: (Group, Artifact) -> MvnDepBody -> MvnDepBody
+    overlayDepManagement key body = maybe body (body <>) (M.lookup key (pomDependencyManagement pom))
 
 -- Naively interpolate properties into a Text. This only interpolates Text that
 -- starts with "${" and ends with "}", e.g.,
@@ -159,8 +176,8 @@ reifyDeps pom = M.mapWithKey overlayDepManagement (pomDependencies pom)
 -- will not have its property interpolated
 naiveInterpolate :: Map Text Text -> Text -> Text
 naiveInterpolate properties text
-  | T.isPrefixOf "${" text
-  , T.isSuffixOf "}" text =
-      let stripped = T.drop 2 (T.init text)
-       in fromMaybe ("PROPERTY NOT FOUND: " <> text) (M.lookup stripped properties)
+  | T.isPrefixOf "${" text,
+    T.isSuffixOf "}" text =
+    let stripped = T.drop 2 (T.init text)
+     in fromMaybe ("PROPERTY NOT FOUND: " <> text) (M.lookup stripped properties)
   | otherwise = text

--- a/src/Strategy/Python/SetupPy.hs
+++ b/src/Strategy/Python/SetupPy.hs
@@ -45,7 +45,7 @@ type Parser = Parsec Void Text
 installRequiresParser :: Parser [Req]
 installRequiresParser = prefix *> entries <* end
   where
-  prefix  = skipManyTill anySingle (string "install_requires") *> space *> char '=' *> space *> char '['
+  prefix  = skipManyTill anySingle (string "install_requires") *> space *> char '=' *> space *> char '[' *> space
   entries = between quote quote requirementParser `sepBy` (space *> char ',' *> space)
   end     = char ']'
 

--- a/src/Strategy/Python/SetupPy.hs
+++ b/src/Strategy/Python/SetupPy.hs
@@ -46,7 +46,7 @@ installRequiresParser :: Parser [Req]
 installRequiresParser = prefix *> entries <* end
   where
   prefix  = skipManyTill anySingle (string "install_requires") *> space *> char '=' *> space *> char '[' *> space
-  entries = (between quote quote requirementParser *> space) `sepBy` (char ',' *> space)
+  entries = (between quote quote requirementParser <* space) `sepBy` (char ',' *> space)
   end     = char ']'
 
   quote   = char '\''

--- a/src/Strategy/Python/SetupPy.hs
+++ b/src/Strategy/Python/SetupPy.hs
@@ -49,4 +49,4 @@ installRequiresParser = prefix *> entries <* end
   entries = (between quote quote requirementParser <* space) `sepBy` (char ',' *> space)
   end     = char ']'
 
-  quote   = char '\''
+  quote   = char '\'' <|> char '\"'

--- a/src/Strategy/Python/SetupPy.hs
+++ b/src/Strategy/Python/SetupPy.hs
@@ -45,7 +45,7 @@ type Parser = Parsec Void Text
 installRequiresParser :: Parser [Req]
 installRequiresParser = prefix *> entries <* end
   where
-  prefix  = skipManyTill anySingle (string "install_requires=[")
+  prefix  = skipManyTill anySingle (string "install_requires") *> space *> char '=' *> space *> char '['
   entries = between quote quote requirementParser `sepBy` char ','
   end     = char ']'
 

--- a/src/Strategy/Python/SetupPy.hs
+++ b/src/Strategy/Python/SetupPy.hs
@@ -47,10 +47,12 @@ installRequiresParser :: Parser [Req]
 installRequiresParser = prefix *> entries <* end
   where
   prefix  = skipManyTill anySingle (symbol "install_requires") *> symbol "=" *> symbol "["
-  entries = (between quote quote requirementParser) `sepEndBy` symbol ","
-  end     = symbol "]"
+  entries = (requireSurroundedBy "\"" <|> requireSurroundedBy "\'") `sepEndBy` symbol ","
 
-  quote   = symbol "\'" <|> symbol "\""
+  requireSurroundedBy :: Text -> Parser Req
+  requireSurroundedBy quote = between (symbol quote) (symbol quote) requirementParser
+
+  end     = symbol "]"
 
   symbol :: Text -> Parser Text
   symbol = L.symbol space

--- a/src/Strategy/Python/SetupPy.hs
+++ b/src/Strategy/Python/SetupPy.hs
@@ -9,6 +9,7 @@ import Prologue
 import Control.Effect.Diagnostics
 import Text.Megaparsec
 import Text.Megaparsec.Char
+import qualified Text.Megaparsec.Char.Lexer as L
 
 import Discovery.Walk
 import Effect.ReadFS
@@ -45,8 +46,11 @@ type Parser = Parsec Void Text
 installRequiresParser :: Parser [Req]
 installRequiresParser = prefix *> entries <* end
   where
-  prefix  = skipManyTill anySingle (string "install_requires") *> space *> char '=' *> space *> char '[' *> space
-  entries = (between quote quote requirementParser <* space) `sepBy` (char ',' *> space)
-  end     = char ']'
+  prefix  = skipManyTill anySingle (symbol "install_requires") *> symbol "=" *> symbol "["
+  entries = (between quote quote requirementParser) `sepEndBy` symbol ","
+  end     = symbol "]"
 
-  quote   = char '\'' <|> char '\"'
+  quote   = symbol "\'" <|> symbol "\""
+
+  symbol :: Text -> Parser Text
+  symbol = L.symbol space

--- a/src/Strategy/Python/SetupPy.hs
+++ b/src/Strategy/Python/SetupPy.hs
@@ -46,7 +46,7 @@ installRequiresParser :: Parser [Req]
 installRequiresParser = prefix *> entries <* end
   where
   prefix  = skipManyTill anySingle (string "install_requires") *> space *> char '=' *> space *> char '['
-  entries = between quote quote requirementParser `sepBy` char ','
+  entries = between quote quote requirementParser `sepBy` (space *> char ',' *> space)
   end     = char ']'
 
   quote   = char '\''

--- a/src/Strategy/Python/SetupPy.hs
+++ b/src/Strategy/Python/SetupPy.hs
@@ -46,7 +46,7 @@ installRequiresParser :: Parser [Req]
 installRequiresParser = prefix *> entries <* end
   where
   prefix  = skipManyTill anySingle (string "install_requires") *> space *> char '=' *> space *> char '[' *> space
-  entries = between quote quote requirementParser `sepBy` (space *> char ',' *> space)
+  entries = (between quote quote requirementParser *> space) `sepBy` (char ',' *> space)
   end     = char ']'
 
   quote   = char '\''


### PR DESCRIPTION
For integration testing, we want to use a different interpreter of the `Exec` effect. As currently written, `discover` functions use `runStrategy` to internally interpret the `Exec` effect, which prevents us from doing so.

Instead, these changes force the `Has Exec`/`Has ReadFS` constraints upward, through the `discover`, so we can interpret `Exec` with a different interpreter in our tests.

---

This also fixes a few issues discovered while building integration tests:
- `rebar3tree` would treat dependencies as top-level projects
- the `setup.py` parser would horribly break if you even looked at it the wrong way (didn't allow double-quotes, was whitespace-sensitive, didn't allow trailing commas in the dependency list)