### PR TITLE
Create internal text util w/ tests

### DIFF
--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -136,6 +136,7 @@ library
     Control.Effect.Path
     Control.Effect.TaskPool
     Data.FileEmbed.Extra
+    Data.Text.Extra
     DepTypes
     Discovery.Walk
     Effect.Exec
@@ -234,6 +235,7 @@ test-suite unit-tests
     Cocoapods.PodfileSpec
     Effect.ExecSpec
     Erlang.Rebar3TreeSpec
+    Extra.TextSpec
     Go.GlideLockSpec
     Go.GoListSpec
     Go.GomodSpec

--- a/src/Data/Text/Extra.hs
+++ b/src/Data/Text/Extra.hs
@@ -1,0 +1,22 @@
+module Data.Text.Extra
+  ( splitOnceOn,
+    splitOnceOnEnd,
+  )
+where
+
+import Data.Text (Text)
+import qualified Data.Text as T
+
+splitOnceOn :: Text -> Text -> (Text, Text)
+splitOnceOn needle haystack = (head, strippedTail)
+  where
+    len = T.length needle
+    (head, tail) = T.breakOn needle haystack
+    strippedTail = T.drop len tail
+
+splitOnceOnEnd :: Text -> Text -> (Text, Text)
+splitOnceOnEnd needle haystack = (strippedHead, tail)
+  where
+    len = T.length needle
+    (head, tail) = T.breakOnEnd needle haystack
+    strippedHead = T.dropEnd len head

--- a/src/Strategy/RPM.hs
+++ b/src/Strategy/RPM.hs
@@ -15,6 +15,7 @@ import Control.Effect.Diagnostics
 import qualified Data.Map.Strict as M
 import Data.Maybe (mapMaybe)
 import qualified Data.Text as T
+import Data.Text.Extra (splitOnceOn)
 import DepTypes
 import Discovery.Walk
 import Effect.ReadFS
@@ -99,13 +100,6 @@ buildConstraint tail = constraint
       "=" -> Just $ CEq version
       "==" -> Just $ CEq version
       _ -> Nothing
-
-splitOnceOn :: Text -> Text -> (Text, Text)
-splitOnceOn needle haystack = (head, strippedTail)
-  where
-    len = T.length needle
-    (head, tail) = T.breakOn needle haystack
-    strippedTail = T.drop len tail
 
 getTypeFromLine :: Text -> Maybe RequiresType
 getTypeFromLine line = safeReq

--- a/src/VCS/Git.hs
+++ b/src/VCS/Git.hs
@@ -11,6 +11,7 @@ import qualified Data.Map as M
 import Data.Maybe (mapMaybe)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
+import Data.Text.Extra (splitOnceOn)
 import Data.Time
 import Data.Time.Format.ISO8601 (iso8601Show)
 import Effect.Exec
@@ -50,10 +51,3 @@ fetchGitContributors basedir = do
       let (email, textDate) = splitOnceOn "|" entry
       date <- parseTimeM True defaultTimeLocale "%Y-%-m-%-d" $ T.unpack textDate
       Just (email, date)
-
-splitOnceOn :: Text -> Text -> (Text, Text)
-splitOnceOn needle haystack = (head, strippedTail)
-  where
-    len = T.length needle
-    (head, tail) = T.breakOn needle haystack
-    strippedTail = T.drop len tail

--- a/test/Extra/TextSpec.hs
+++ b/test/Extra/TextSpec.hs
@@ -1,0 +1,17 @@
+module Extra.TextSpec (
+    spec
+) where
+
+import qualified Test.Hspec as Test
+import Prelude
+import Data.Text.Extra
+
+spec :: Test.Spec
+spec = do
+  Test.describe "Text splitOnceOn" $
+    Test.it "should split a string once from the start" $
+      splitOnceOn "-" "1-2-3" `Test.shouldBe` ("1", "2-3")
+      
+  Test.describe "Text splitOnceonEnd" $
+    Test.it "should split a string once from the end" $
+      splitOnceOnEnd "-" "1-2-3" `Test.shouldBe` ("1-2", "3")


### PR DESCRIPTION
_scheduling notes: Working on Cabal analyzer, thought I would need this utility.   After some refactoring, didn't need it anymore, so I broke it out into a separate PR.  This is a simple, small, tech debt PR._

This PR adds the `splitOnceOn` and `splitOnceOnEnd` utilities, which are both of the type `Text -> Text -> (Text, Text)`