### PR TITLE
Composer analyzer support

### DIFF
--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -127,6 +127,7 @@ library
     Strategy.Clojure
     Strategy.Cocoapods.Podfile
     Strategy.Cocoapods.PodfileLock
+    Strategy.Composer
     Strategy.Erlang.Rebar3Tree
     Strategy.Go.GlideLock
     Strategy.Go.GoList
@@ -206,6 +207,7 @@ test-suite unit-tests
     Clojure.ClojureSpec
     Cocoapods.PodfileLockSpec
     Cocoapods.PodfileSpec
+    Composer.ComposerLockSpec
     Effect.ExecSpec
     Erlang.Rebar3TreeSpec
     Extra.TextSpec

--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -42,6 +42,7 @@ import qualified Strategy.Carthage as Carthage
 import qualified Strategy.Clojure as Clojure
 import qualified Strategy.Cocoapods.Podfile as Podfile
 import qualified Strategy.Cocoapods.PodfileLock as PodfileLock
+import qualified Strategy.Composer as Composer
 import qualified Strategy.Erlang.Rebar3Tree as Rebar3Tree
 import qualified Strategy.Go.GlideLock as GlideLock
 import qualified Strategy.Go.GoList as GoList
@@ -227,6 +228,8 @@ discoverFuncs =
 
   , Podfile.discover
   , PodfileLock.discover
+
+  , Composer.discover
 
   , Clojure.discover
   

--- a/src/DepTypes.hs
+++ b/src/DepTypes.hs
@@ -49,6 +49,7 @@ data DepEnvironment =
 -- | A Dependency type. This corresponds to a "fetcher" on the backend
 data DepType =
     SubprojectType -- ^ A first-party subproject
+  | ComposerType -- ^ Dependency found from the composer fetcher.  
   | GitType -- ^ Repository in Github
   | GemType    -- ^ Gem registry
   | GooglesourceType  -- ^ android.googlesource.com

--- a/src/Srclib/Converter.hs
+++ b/src/Srclib/Converter.hs
@@ -111,3 +111,4 @@ depTypeToFetcher = \case
   CargoType -> "cargo"
   RPMType -> "rpm"
   HaskellType -> "haskell"
+  ComposerType -> "comp"

--- a/src/Strategy/Composer.hs
+++ b/src/Strategy/Composer.hs
@@ -1,17 +1,14 @@
-{-# language TemplateHaskell #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 module Strategy.Composer
-  ( discover
-  , analyze
-  , buildGraph
-
-  , ComposerLock(..)
-  , CompDep(..)
-  , Source(..)
+  ( discover,
+    analyze,
+    buildGraph,
+    ComposerLock (..),
+    CompDep (..),
+    Source (..),
   )
-  where
-
-import Prologue
+where
 
 import Control.Effect.Diagnostics
 import qualified Data.Map.Strict as M
@@ -31,100 +28,105 @@ discover = walk $ \_ _ files -> do
   pure WalkContinue
 
 data ComposerLock = ComposerLock
-  { packages    :: [CompDep]
-  , packagesDev :: [CompDep]
-  } deriving (Eq, Ord, Show, Generic)
+  { packages :: [CompDep],
+    packagesDev :: [CompDep]
+  }
+  deriving (Eq, Ord, Show, Generic)
 
 data CompDep = CompDep
-  { name         :: Text
-  , version      :: Text
-  , source       :: Source
-  , require      :: Maybe (Map Text Text) -- ^ name to version spec
-  , requireDev   :: Maybe (Map Text Text)
-  } deriving (Eq, Ord, Show, Generic)
+  { name :: Text,
+    version :: Text,
+    source :: Source,
+    -- | name to version spec
+    require :: Maybe (Map Text Text),
+    requireDev :: Maybe (Map Text Text)
+  }
+  deriving (Eq, Ord, Show, Generic)
 
 data Source = Source
-  { sourceType  :: Text
-  , url         :: Text
-  , reference   :: Text
-  } deriving (Eq, Ord, Show, Generic)
+  { sourceType :: Text,
+    url :: Text,
+    reference :: Text
+  }
+  deriving (Eq, Ord, Show, Generic)
 
 instance FromJSON ComposerLock where
   parseJSON = withObject "ComposerLock" $ \obj ->
     ComposerLock <$> obj .: "packages"
-                 <*> obj .: "packages-dev"
+      <*> obj .: "packages-dev"
 
 instance FromJSON CompDep where
   parseJSON = withObject "CompDep" $ \obj ->
-    CompDep <$> obj .:  "name"
-            <*> obj .:  "version"
-            <*> obj .:  "source"
-            <*> obj .:? "require"
-            <*> obj .:? "require-dev"
+    CompDep <$> obj .: "name"
+      <*> obj .: "version"
+      <*> obj .: "source"
+      <*> obj .:? "require"
+      <*> obj .:? "require-dev"
 
 instance FromJSON Source where
   parseJSON = withObject "Source" $ \obj ->
     Source <$> obj .: "type"
-           <*> obj .: "url"
-           <*> obj .: "reference"
+      <*> obj .: "url"
+      <*> obj .: "reference"
 
 analyze :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs File -> m ProjectClosureBody
 analyze file = mkProjectClosure file <$> readContentsJson @ComposerLock file
 
 mkProjectClosure :: Path Abs File -> ComposerLock -> ProjectClosureBody
-mkProjectClosure file lock = ProjectClosureBody
-  { bodyModuleDir    = parent file
-  , bodyDependencies = dependencies
-  , bodyLicenses     = []
-  }
-  where
-  dependencies = ProjectDependencies
-    { dependenciesGraph    = buildGraph lock
-    , dependenciesOptimal  = Optimal
-    , dependenciesComplete = Complete
+mkProjectClosure file lock =
+  ProjectClosureBody
+    { bodyModuleDir = parent file,
+      bodyDependencies = dependencies,
+      bodyLicenses = []
     }
+  where
+    dependencies =
+      ProjectDependencies
+        { dependenciesGraph = buildGraph lock,
+          dependenciesOptimal = Optimal,
+          dependenciesComplete = Complete
+        }
 
-newtype CompPkg = CompPkg { pkgName :: Text }
+newtype CompPkg = CompPkg {pkgName :: Text}
   deriving (Eq, Ord, Show, Generic)
 
 type CompGrapher = LabeledGrapher CompPkg CompLabel
 
-data CompLabel =
-    CompVersion Text
-    | CompEnv DepEnvironment
+data CompLabel
+  = CompVersion Text
+  | CompEnv DepEnvironment
   deriving (Eq, Ord, Show, Generic)
 
 buildGraph :: ComposerLock -> Graphing Dependency
 buildGraph composerLock = run . withLabeling toDependency $ do
-      traverse_ (addDeps EnvProduction) $ packages composerLock
-      traverse_ (addDeps EnvDevelopment) $ packagesDev composerLock
-
+  traverse_ (addDeps EnvProduction) $ packages composerLock
+  traverse_ (addDeps EnvDevelopment) $ packagesDev composerLock
   where
-  addDeps :: Has CompGrapher sig m => DepEnvironment -> CompDep -> m ()
-  addDeps env dep = do
-        let pkg = CompPkg (name dep)
-        _ <- M.traverseWithKey (addEdge pkg) (fromMaybe (M.fromList []) $ require dep) 
-        label pkg (CompVersion $ version dep)
-        label pkg (CompEnv env)
-        direct pkg
-  
-  addEdge :: Has CompGrapher sig m => CompPkg -> Text -> Text -> m ()
-  addEdge pkg name _ = do
-        edge pkg (CompPkg name)
+    addDeps :: Has CompGrapher sig m => DepEnvironment -> CompDep -> m ()
+    addDeps env dep = do
+      let pkg = CompPkg (name dep)
+      _ <- M.traverseWithKey (addEdge pkg) (fromMaybe (M.fromList []) $ require dep)
+      label pkg (CompVersion $ version dep)
+      label pkg (CompEnv env)
+      direct pkg
 
-  toDependency :: CompPkg -> Set CompLabel -> Dependency
-  toDependency pkg = foldr addLabel (start pkg)
+    addEdge :: Has CompGrapher sig m => CompPkg -> Text -> Text -> m ()
+    addEdge pkg name _ = edge pkg (CompPkg name)
 
-  addLabel :: CompLabel -> Dependency -> Dependency
-  addLabel (CompVersion ver) dep = dep { dependencyVersion = Just (CEq ver) }
-  addLabel (CompEnv env) dep = dep { dependencyEnvironments = env : dependencyEnvironments dep }
+    toDependency :: CompPkg -> Set CompLabel -> Dependency
+    toDependency pkg = foldr addLabel (start pkg)
 
-  start :: CompPkg -> Dependency
-  start CompPkg{..} = Dependency
-    { dependencyType = ComposerType
-    , dependencyName = pkgName
-    , dependencyVersion = Nothing
-    , dependencyLocations = []
-    , dependencyEnvironments = []
-    , dependencyTags = M.empty
-    }
+    addLabel :: CompLabel -> Dependency -> Dependency
+    addLabel (CompVersion ver) dep = dep {dependencyVersion = Just (CEq ver)}
+    addLabel (CompEnv env) dep = dep {dependencyEnvironments = env : dependencyEnvironments dep}
+
+    start :: CompPkg -> Dependency
+    start CompPkg {..} =
+      Dependency
+        { dependencyType = ComposerType,
+          dependencyName = pkgName,
+          dependencyVersion = Nothing,
+          dependencyLocations = [],
+          dependencyEnvironments = [],
+          dependencyTags = M.empty
+        }

--- a/src/Strategy/Composer.hs
+++ b/src/Strategy/Composer.hs
@@ -1,0 +1,130 @@
+{-# language TemplateHaskell #-}
+
+module Strategy.Composer
+  ( discover
+  , analyze
+  , buildGraph
+
+  , ComposerLock(..)
+  , CompDep(..)
+  , Source(..)
+  )
+  where
+
+import Prologue
+
+import Control.Effect.Diagnostics
+import qualified Data.Map.Strict as M
+import DepTypes
+import Discovery.Walk
+import Effect.Grapher
+import Effect.ReadFS
+import Graphing (Graphing)
+import Types
+
+discover :: HasDiscover sig m => Path Abs Dir -> m ()
+discover = walk $ \_ _ files -> do
+  case find (\f -> fileName f == "composer.lock") files of
+    Nothing -> pure ()
+    Just file -> runSimpleStrategy "php-composerlock" PHPGroup $ analyze file
+
+  pure WalkContinue
+
+data ComposerLock = ComposerLock
+  { packages    :: [CompDep]
+  , packagesDev :: [CompDep]
+  } deriving (Eq, Ord, Show, Generic)
+
+data CompDep = CompDep
+  { name         :: Text
+  , version      :: Text
+  , source       :: Source
+  , require      :: Maybe (Map Text Text) -- ^ name to version spec
+  , requireDev   :: Maybe (Map Text Text)
+  } deriving (Eq, Ord, Show, Generic)
+
+data Source = Source
+  { sourceType  :: Text
+  , url         :: Text
+  , reference   :: Text
+  } deriving (Eq, Ord, Show, Generic)
+
+instance FromJSON ComposerLock where
+  parseJSON = withObject "ComposerLock" $ \obj ->
+    ComposerLock <$> obj .: "packages"
+                 <*> obj .: "packages-dev"
+
+instance FromJSON CompDep where
+  parseJSON = withObject "CompDep" $ \obj ->
+    CompDep <$> obj .:  "name"
+            <*> obj .:  "version"
+            <*> obj .:  "source"
+            <*> obj .:? "require"
+            <*> obj .:? "require-dev"
+
+instance FromJSON Source where
+  parseJSON = withObject "Source" $ \obj ->
+    Source <$> obj .: "type"
+           <*> obj .: "url"
+           <*> obj .: "reference"
+
+analyze :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs File -> m ProjectClosureBody
+analyze file = mkProjectClosure file <$> readContentsJson @ComposerLock file
+
+mkProjectClosure :: Path Abs File -> ComposerLock -> ProjectClosureBody
+mkProjectClosure file lock = ProjectClosureBody
+  { bodyModuleDir    = parent file
+  , bodyDependencies = dependencies
+  , bodyLicenses     = []
+  }
+  where
+  dependencies = ProjectDependencies
+    { dependenciesGraph    = buildGraph lock
+    , dependenciesOptimal  = Optimal
+    , dependenciesComplete = Complete
+    }
+
+newtype CompPkg = CompPkg { pkgName :: Text }
+  deriving (Eq, Ord, Show, Generic)
+
+type CompGrapher = LabeledGrapher CompPkg CompLabel
+
+data CompLabel =
+    CompVersion Text
+    | CompEnv DepEnvironment
+  deriving (Eq, Ord, Show, Generic)
+
+buildGraph :: ComposerLock -> Graphing Dependency
+buildGraph composerLock = run . withLabeling toDependency $ do
+      traverse_ (addDeps EnvProduction) $ packages composerLock
+      traverse_ (addDeps EnvDevelopment) $ packagesDev composerLock
+
+  where
+  addDeps :: Has CompGrapher sig m => DepEnvironment -> CompDep -> m ()
+  addDeps env dep = do
+        let pkg = CompPkg (name dep)
+        _ <- M.traverseWithKey (addEdge pkg) (fromMaybe (M.fromList []) $ require dep) 
+        label pkg (CompVersion $ version dep)
+        label pkg (CompEnv env)
+        direct pkg
+  
+  addEdge :: Has CompGrapher sig m => CompPkg -> Text -> Text -> m ()
+  addEdge pkg name _ = do
+        edge pkg (CompPkg name)
+
+  toDependency :: CompPkg -> Set CompLabel -> Dependency
+  toDependency pkg = foldr addLabel (start pkg)
+
+  addLabel :: CompLabel -> Dependency -> Dependency
+  addLabel (CompVersion ver) dep = dep { dependencyVersion = Just (CEq ver) }
+  addLabel (CompEnv env) dep = dep { dependencyEnvironments = env : dependencyEnvironments dep }
+
+  start :: CompPkg -> Dependency
+  start CompPkg{..} = Dependency
+    { dependencyType = ComposerType
+    , dependencyName = pkgName
+    , dependencyVersion = Nothing
+    , dependencyLocations = []
+    , dependencyEnvironments = []
+    , dependencyTags = M.empty
+    }

--- a/src/Strategy/Composer.hs
+++ b/src/Strategy/Composer.hs
@@ -17,6 +17,7 @@ import Discovery.Walk
 import Effect.Grapher
 import Effect.ReadFS
 import Graphing (Graphing)
+import Prologue
 import Types
 
 discover :: HasDiscover sig m => Path Abs Dir -> m ()

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -148,6 +148,7 @@ data StrategyGroup =
   | GradleGroup
   | MavenGroup
   | NodejsGroup
+  | PHPGroup
   | PythonGroup
   | RubyGroup
   | CocoapodsGroup

--- a/test/Composer/ComposerLockSpec.hs
+++ b/test/Composer/ComposerLockSpec.hs
@@ -1,75 +1,80 @@
-{-# language TemplateHaskell #-}
-
 module Composer.ComposerLockSpec
-  ( spec
-  ) where
+  ( spec,
+  )
+where
 
-import Prologue
-
-import qualified Data.Map.Strict as M
 import qualified Data.ByteString as BS
-
+import qualified Data.Map.Strict as M
+import Data.Aeson
 import DepTypes
 import GraphUtil
-
 import Strategy.Composer
-
 import Test.Hspec
 
 dependencyOne :: Dependency
-dependencyOne = Dependency { dependencyType = ComposerType
-                        , dependencyName = "one"
-                        , dependencyVersion = Just (CEq "1.0.0")
-                        , dependencyLocations = []
-                        , dependencyEnvironments = [EnvProduction]
-                        , dependencyTags = M.empty
-                        }
+dependencyOne =
+  Dependency
+    { dependencyType = ComposerType,
+      dependencyName = "one",
+      dependencyVersion = Just (CEq "1.0.0"),
+      dependencyLocations = [],
+      dependencyEnvironments = [EnvProduction],
+      dependencyTags = M.empty
+    }
 
 dependencyTwo :: Dependency
-dependencyTwo = Dependency { dependencyType = ComposerType
-                        , dependencyName = "two"
-                        , dependencyVersion = Just (CEq "2.0.0")
-                        , dependencyLocations = []
-                        , dependencyEnvironments = [EnvProduction]
-                        , dependencyTags = M.empty
-                        }
+dependencyTwo =
+  Dependency
+    { dependencyType = ComposerType,
+      dependencyName = "two",
+      dependencyVersion = Just (CEq "2.0.0"),
+      dependencyLocations = [],
+      dependencyEnvironments = [EnvProduction],
+      dependencyTags = M.empty
+    }
 
 dependencyThree :: Dependency
-dependencyThree = Dependency { dependencyType = ComposerType
-                        , dependencyName = "three"
-                        , dependencyVersion = Just (CEq "3.0.0")
-                        , dependencyLocations = []
-                        , dependencyEnvironments = [EnvProduction]
-                        , dependencyTags = M.empty
-                        }
+dependencyThree =
+  Dependency
+    { dependencyType = ComposerType,
+      dependencyName = "three",
+      dependencyVersion = Just (CEq "3.0.0"),
+      dependencyLocations = [],
+      dependencyEnvironments = [EnvProduction],
+      dependencyTags = M.empty
+    }
 
 dependencyFour :: Dependency
-dependencyFour = Dependency { dependencyType = ComposerType
-                        , dependencyName = "four"
-                        , dependencyVersion = Just (CEq "4.0.0")
-                        , dependencyLocations = []
-                        , dependencyEnvironments = [EnvProduction]
-                        , dependencyTags = M.empty
-                        }
+dependencyFour =
+  Dependency
+    { dependencyType = ComposerType,
+      dependencyName = "four",
+      dependencyVersion = Just (CEq "4.0.0"),
+      dependencyLocations = [],
+      dependencyEnvironments = [EnvProduction],
+      dependencyTags = M.empty
+    }
 
 dependencyFive :: Dependency
-dependencyFive = Dependency { dependencyType = ComposerType
-                        , dependencyName = "five"
-                        , dependencyVersion = Just (CEq "5.0.0")
-                        , dependencyLocations = []
-                        , dependencyEnvironments = [EnvDevelopment]
-                        , dependencyTags = M.empty
-                        }
+dependencyFive =
+  Dependency
+    { dependencyType = ComposerType,
+      dependencyName = "five",
+      dependencyVersion = Just (CEq "5.0.0"),
+      dependencyLocations = [],
+      dependencyEnvironments = [EnvDevelopment],
+      dependencyTags = M.empty
+    }
 
 spec :: Spec
 spec = do
   testFile <- runIO (BS.readFile "test/Composer/testdata/composer.lock")
   describe "composer.lock analyzer" $
-    it "reads a file and constructs an accurate graph" $ 
+    it "reads a file and constructs an accurate graph" $
       case eitherDecodeStrict testFile of
         Right res -> do
-              let graph = buildGraph res
-              expectDeps [dependencyOne, dependencyTwo, dependencyThree, dependencyFour, dependencyFive] graph
-              expectDirect [dependencyOne, dependencyTwo, dependencyThree, dependencyFour, dependencyFive] graph
-              expectEdges [ (dependencyOne, dependencyTwo), (dependencyOne, dependencyTwo), (dependencyTwo, dependencyFour)]  graph
+          let graph = buildGraph res
+          expectDeps [dependencyOne, dependencyTwo, dependencyThree, dependencyFour, dependencyFive] graph
+          expectDirect [dependencyOne, dependencyTwo, dependencyThree, dependencyFour, dependencyFive] graph
+          expectEdges [(dependencyOne, dependencyTwo), (dependencyOne, dependencyTwo), (dependencyTwo, dependencyFour)] graph
         Left err -> expectationFailure $ show err

--- a/test/Composer/ComposerLockSpec.hs
+++ b/test/Composer/ComposerLockSpec.hs
@@ -64,8 +64,8 @@ dependencyFive = Dependency { dependencyType = ComposerType
 spec :: Spec
 spec = do
   testFile <- runIO (BS.readFile "test/Composer/testdata/composer.lock")
-  describe "composer.lock analyzer" $ do
-    it "reads a file and constructs an accurate graph" $ do
+  describe "composer.lock analyzer" $
+    it "reads a file and constructs an accurate graph" $ 
       case eitherDecodeStrict testFile of
         Right res -> do
               let graph = buildGraph res

--- a/test/Composer/ComposerLockSpec.hs
+++ b/test/Composer/ComposerLockSpec.hs
@@ -1,0 +1,75 @@
+{-# language TemplateHaskell #-}
+
+module Composer.ComposerLockSpec
+  ( spec
+  ) where
+
+import Prologue
+
+import qualified Data.Map.Strict as M
+import qualified Data.ByteString as BS
+
+import DepTypes
+import GraphUtil
+
+import Strategy.Composer
+
+import Test.Hspec
+
+dependencyOne :: Dependency
+dependencyOne = Dependency { dependencyType = ComposerType
+                        , dependencyName = "one"
+                        , dependencyVersion = Just (CEq "1.0.0")
+                        , dependencyLocations = []
+                        , dependencyEnvironments = [EnvProduction]
+                        , dependencyTags = M.empty
+                        }
+
+dependencyTwo :: Dependency
+dependencyTwo = Dependency { dependencyType = ComposerType
+                        , dependencyName = "two"
+                        , dependencyVersion = Just (CEq "2.0.0")
+                        , dependencyLocations = []
+                        , dependencyEnvironments = [EnvProduction]
+                        , dependencyTags = M.empty
+                        }
+
+dependencyThree :: Dependency
+dependencyThree = Dependency { dependencyType = ComposerType
+                        , dependencyName = "three"
+                        , dependencyVersion = Just (CEq "3.0.0")
+                        , dependencyLocations = []
+                        , dependencyEnvironments = [EnvProduction]
+                        , dependencyTags = M.empty
+                        }
+
+dependencyFour :: Dependency
+dependencyFour = Dependency { dependencyType = ComposerType
+                        , dependencyName = "four"
+                        , dependencyVersion = Just (CEq "4.0.0")
+                        , dependencyLocations = []
+                        , dependencyEnvironments = [EnvProduction]
+                        , dependencyTags = M.empty
+                        }
+
+dependencyFive :: Dependency
+dependencyFive = Dependency { dependencyType = ComposerType
+                        , dependencyName = "five"
+                        , dependencyVersion = Just (CEq "5.0.0")
+                        , dependencyLocations = []
+                        , dependencyEnvironments = [EnvDevelopment]
+                        , dependencyTags = M.empty
+                        }
+
+spec :: Spec
+spec = do
+  testFile <- runIO (BS.readFile "test/Composer/testdata/composer.lock")
+  describe "composer.lock analyzer" $ do
+    it "reads a file and constructs an accurate graph" $ do
+      case eitherDecodeStrict testFile of
+        Right res -> do
+              let graph = buildGraph res
+              expectDeps [dependencyOne, dependencyTwo, dependencyThree, dependencyFour, dependencyFive] graph
+              expectDirect [dependencyOne, dependencyTwo, dependencyThree, dependencyFour, dependencyFive] graph
+              expectEdges [ (dependencyOne, dependencyTwo), (dependencyOne, dependencyTwo), (dependencyTwo, dependencyFour)]  graph
+        Left err -> expectationFailure $ show err

--- a/test/Composer/testdata/composer.lock
+++ b/test/Composer/testdata/composer.lock
@@ -1,0 +1,131 @@
+{
+    "_readme": [
+        "This test file stores a dep graph",
+        "The first package has all available fields for testing",
+        "and all subsequent pacakges are trimmed"
+    ],
+    "content-hash": "9b94ece2895724239b36aec399e5321a",
+    "packages": [
+        {
+            "name": "one",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/one.git",
+                "reference": "1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/95c63ab2117a72f48f5a55da9740a3273d45b7fd",
+                "reference": "95c63ab2117a72f48f5a55da9740a3273d45b7fd",
+                "shasum": ""
+            },
+            "require": {
+                "two": "*",
+                "three": "*"
+            },
+            "require-dev": {
+                "five": "^4.8.35 || ^5.7 || 6.5 - 8"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "ComposerCaBundle": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mr. Code",
+                    "email": "mrcode@coding.com",
+                    "homepage": "http://theinternet.com"
+                }
+            ],
+            "description": "description",
+            "keywords": [
+                "cabundle"
+            ],
+            "support": {
+                "irc": "irc://irc.freenode.org/composer",
+                "issues": "https://github.com/composer/ca-bundle/issues",
+                "source": "https://github.com/composer/ca-bundle/tree/1.2.7"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "github.com",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-04-08T08:27:21+00:00"
+        },
+        {
+            "name": "two",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/two",
+                "reference": "2"
+            },
+            "require": {
+                "four": "^5.3.2 || ^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "five": "^0.12.19"
+            }
+        },
+        {
+            "name": "three",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/three",
+                "reference": "3"
+            }
+        },
+        {
+            "name": "four",
+            "version": "4.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/four",
+                "reference": "4"
+            }
+        }
+    ],
+    "packages-dev": [
+        {
+            "name": "five",
+            "version": "5.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/five",
+                "reference": "5"
+            }
+      }
+    ],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {
+        "php": "^5.3.2 || ^7.0 || ^8.0"
+    },
+    "platform-dev": [],
+    "platform-overrides": {
+        "php": "5.3.9"
+    },
+    "plugin-api-version": "2.0.0"
+}

--- a/test/Composer/testdata/composer.lock
+++ b/test/Composer/testdata/composer.lock
@@ -1,10 +1,4 @@
 {
-    "_readme": [
-        "This test file stores a dep graph",
-        "The first package has all available fields for testing",
-        "and all subsequent pacakges are trimmed"
-    ],
-    "content-hash": "9b94ece2895724239b36aec399e5321a",
     "packages": [
         {
             "name": "one",
@@ -14,61 +8,13 @@
                 "url": "https://github.com/composer/one.git",
                 "reference": "1"
             },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/95c63ab2117a72f48f5a55da9740a3273d45b7fd",
-                "reference": "95c63ab2117a72f48f5a55da9740a3273d45b7fd",
-                "shasum": ""
-            },
             "require": {
                 "two": "*",
                 "three": "*"
             },
             "require-dev": {
                 "five": "^4.8.35 || ^5.7 || 6.5 - 8"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "ComposerCaBundle": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Mr. Code",
-                    "email": "mrcode@coding.com",
-                    "homepage": "http://theinternet.com"
-                }
-            ],
-            "description": "description",
-            "keywords": [
-                "cabundle"
-            ],
-            "support": {
-                "irc": "irc://irc.freenode.org/composer",
-                "issues": "https://github.com/composer/ca-bundle/issues",
-                "source": "https://github.com/composer/ca-bundle/tree/1.2.7"
-            },
-            "funding": [
-                {
-                    "url": "https://packagist.com",
-                    "type": "custom"
-                },
-                {
-                    "url": "github.com",
-                    "type": "github"
-                }
-            ],
-            "time": "2020-04-08T08:27:21+00:00"
+            }
         },
         {
             "name": "two",
@@ -114,18 +60,5 @@
                 "reference": "5"
             }
       }
-    ],
-    "aliases": [],
-    "minimum-stability": "stable",
-    "stability-flags": [],
-    "prefer-stable": false,
-    "prefer-lowest": false,
-    "platform": {
-        "php": "^5.3.2 || ^7.0 || ^8.0"
-    },
-    "platform-dev": [],
-    "platform-overrides": {
-        "php": "5.3.9"
-    },
-    "plugin-api-version": "2.0.0"
+    ]
 }


### PR DESCRIPTION
This PR creates support for the Composer package manager used most commonly by PHP developers.

Composer support in this analyzer relies on parsing the `composer.lock` file. This analyzer is capable of constructing an accurate dependency graph with pinned versions and differentiating between production and development dependencies.

Future work might include support for parsing `composer` command line output or the `composer.json` manifest file to accurately determine which dependencies are direct dependencies. This is unnecessary for the initial support and can be added once more work has. been done to make merging strategies feasible.