### PR TITLE
Move vpscli extract folder to tmp

### DIFF
--- a/src/App/VPSScan/EmbeddedBinary.hs
+++ b/src/App/VPSScan/EmbeddedBinary.hs
@@ -58,8 +58,8 @@ extractedPath name = do
 
 extractDir :: MonadIO m => m (Path Abs Dir)
 extractDir = do
-  wd <- liftIO getCurrentDir
-  pure (wd </> $(mkRelDir ".vendor"))
+  wd <- liftIO getTempDir
+  pure (wd </> $(mkRelDir "vpscli-vendor"))
 
 makeExecutable :: Path Abs File -> IO ()
 makeExecutable path = do


### PR DESCRIPTION
I accidentally left `vpscli` extracting files to its CWD rather than `tmp`. This causes issues in docker deployments, in which only `tmp` is writable.