### PR TITLE
Log the best strategy name + dependency count for projects we find

### DIFF
--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -7,7 +7,7 @@ module App.Fossa.Analyze
   , ScanDestination(..)
   ) where
 
-import App.Fossa.Analyze.Project (Project, mkProjects)
+import App.Fossa.Analyze.Project (Project(..), mkProjects)
 import App.Fossa.FossaAPIV1 (ProjectMetadata, UploadResponse (..), uploadAnalysis, uploadContributors)
 import App.Fossa.ProjectInference (inferProject, mergeOverride)
 import App.Types
@@ -169,7 +169,7 @@ buildResult :: [Project] -> [ProjectFailure] -> Aeson.Value
 buildResult projects failures = Aeson.object
   [ "projects" .= projects
   , "failures" .= map renderFailure failures
-  , "sourceUnits" .= fromMaybe [] (traverse Srclib.toSourceUnit projects)
+  , "sourceUnits" .= map Srclib.toSourceUnit projects
   ]
 
 renderFailure :: ProjectFailure -> Aeson.Value

--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -7,7 +7,7 @@ module App.Fossa.Analyze
   , ScanDestination(..)
   ) where
 
-import App.Fossa.Analyze.Project (Project(..), ProjectStrategy(..), mkProjects)
+import App.Fossa.Analyze.Project (BestStrategy(..), Project(..), mkProjects)
 import App.Fossa.FossaAPIV1 (ProjectMetadata, UploadResponse (..), uploadAnalysis, uploadContributors)
 import App.Fossa.ProjectInference (inferProject, mergeOverride)
 import App.Types
@@ -22,8 +22,7 @@ import Control.Monad.IO.Class (MonadIO)
 import Data.Aeson ((.=))
 import qualified Data.Aeson as Aeson
 import Data.ByteString (ByteString)
-import Data.Foldable (for_, traverse_)
-import qualified Data.List.NonEmpty as NE
+import Data.Foldable (traverse_)
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import qualified Data.Text.Encoding as TE
@@ -33,7 +32,6 @@ import Data.Text.Prettyprint.Doc.Render.Terminal
 import Effect.Exec
 import Effect.Logger
 import Effect.ReadFS
-import qualified Graphing
 import Network.HTTP.Types (urlEncode)
 import Path
 import qualified Srclib.Converter as Srclib
@@ -111,23 +109,7 @@ analyze basedir destination override unpackArchives = runFinally $ do
   let projects = mkProjects closures
       result = buildResult projects failures
 
-  for_ projects $ \project -> do
-    let bestStrategy :: ProjectStrategy
-        bestStrategy = NE.head . projectStrategies $ project
-
-        bestStrategyName :: Text
-        bestStrategyName = projStrategyName $ bestStrategy
-
-        bestStrategyDepCount :: Int
-        bestStrategyDepCount = Graphing.size . projStrategyGraph $ bestStrategy
-
-    logInfo $
-      "Found " <> pretty bestStrategyName
-        <> " project at "
-        <> pretty (fromAbsDir (projectPath project))
-        <> " with "
-        <> pretty bestStrategyDepCount
-        <> " dependencies"
+  traverse_ (logInfo . ("Found " <>) . pretty . BestStrategy) projects
 
   case destination of
     OutputStdout -> logStdout $ pretty (decodeUtf8 (Aeson.encode result))

--- a/src/App/Fossa/Analyze/Project.hs
+++ b/src/App/Fossa/Analyze/Project.hs
@@ -4,6 +4,8 @@ module App.Fossa.Analyze.Project
   ( Project(..)
   , ProjectStrategy(..)
 
+  , BestStrategy(..)
+
   , mkProjects
   ) where
 
@@ -17,8 +19,10 @@ import qualified Data.Map.Strict as M
 import Data.Ord
 import Data.Text (Text)
 import DepTypes
-import Graphing
+import Graphing (Graphing)
+import qualified Graphing
 import Path
+import Prettyprinter (Pretty(..))
 import Types
 
 data Project = Project
@@ -26,6 +30,27 @@ data Project = Project
   , projectStrategies :: NE.NonEmpty ProjectStrategy
   }
   deriving (Eq, Ord, Show)
+
+-- | Newtype used exclusively for a 'Pretty' instance on project
+newtype BestStrategy = BestStrategy {unBestStrategy :: Project}
+
+instance Pretty BestStrategy where
+  pretty (BestStrategy project) =
+    pretty bestStrategyName
+      <> " project at "
+      <> pretty (fromAbsDir (projectPath project))
+      <> " with "
+      <> pretty bestStrategyDepCount
+      <> " dependencies"
+    where
+      bestStrategy :: ProjectStrategy
+      bestStrategy = NE.head . projectStrategies $ project
+
+      bestStrategyName :: Text
+      bestStrategyName = projStrategyName $ bestStrategy
+
+      bestStrategyDepCount :: Int
+      bestStrategyDepCount = Graphing.size . projStrategyGraph $ bestStrategy
 
 data ProjectStrategy = ProjectStrategy
   { projStrategyName     :: Text

--- a/src/App/Fossa/FossaAPIV1.hs
+++ b/src/App/Fossa/FossaAPIV1.hs
@@ -149,7 +149,7 @@ uploadAnalysis rootDir baseUri key ProjectRevision{..} metadata projects = fossa
       dropPrefix prefix str = fromMaybe prefix (stripPrefix prefix str)
       filteredProjects = filter (isProductionPath . dropPrefix rootPath . fromAbsDir . projectPath) projects
      
-      sourceUnits = fromMaybe [] $ traverse toSourceUnit filteredProjects
+      sourceUnits = map toSourceUnit filteredProjects
       opts = "locator" =: renderLocator (Locator "custom" projectName (Just projectRevision))
           <> "v" =: cliVersion
           <> "managedBuild" =: True

--- a/src/Graphing.hs
+++ b/src/Graphing.hs
@@ -13,6 +13,7 @@ module Graphing
   ( -- * Graphing type
     Graphing(..)
   , empty
+  , size
   , direct
   , edge
 
@@ -91,6 +92,10 @@ filter f gr = gr { graphingDirect = direct', graphingAdjacent = adjacent' }
 -- | The empty Graphing
 empty :: Graphing ty
 empty = Graphing S.empty AM.empty
+
+-- | Determines the number of nodes in the graph ("reachable" or not)
+size :: Graphing ty -> Int
+size = AM.vertexCount . graphingAdjacent
 
 -- | Strip all items from the direct set, promote their immediate children to direct items
 stripRoot :: Ord ty => Graphing ty -> Graphing ty


### PR DESCRIPTION
The output ends up looking like this:

```
Found python-requirements project at /Users/connor/Desktop/tmp5/home-assistant/ with 668 dependencies
Found python-requirements project at /Users/connor/Desktop/tmp5/home-assistant/homeassistant/ with 0 dependencies
Found python-requirements project at /Users/connor/Desktop/tmp5/home-assistant/homeassistant/components/device_tracker/ with 0 dependencies
Found python-requirements project at /Users/connor/Desktop/tmp5/imagededup/ with 0 dependencies
Found python-pipenv project at /Users/connor/Desktop/tmp5/streamlit/lib/ with 106 dependencies
Found python-pipenv project at /Users/connor/Desktop/tmp5/theHarvester/ with 46 dependencies
Found python-requirements project at /Users/connor/Desktop/tmp5/youtube-dl/ with 0 dependencies
```

We could definitely use more color in our output 🤔

---

minor refactor along the way (the first commit): projects always contain a non-empty list of related strategies. Using the proper type here -- `NonEmpty` from `Data.List.NonEmpty`, rather than the normal list type -- has a couple of advantages:

1. Things like sourceunit conversion are simplified (`toSourceUnit` no longer produces a `Maybe` type), meaning we can just `map` instead of `traverse`
2. Projects are much more "correct by construction" -- i.e. we can now expect that _every_ project has _at least_ one associated strategy