### PR TITLE
Add stack analyzer, fix Deptypes

### DIFF
--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -138,6 +138,7 @@ library
     Strategy.Googlesource.RepoManifest
     Strategy.Gradle
     Strategy.Haskell.Cabal
+    Strategy.Haskell.Stack
     Strategy.Maven.Plugin
     Strategy.Maven.PluginStrategy
     Strategy.Maven.Pom
@@ -219,6 +220,7 @@ test-suite unit-tests
     GraphUtil
     GraphingSpec
     Haskell.CabalSpec
+    Haskell.StackSpec
     Maven.PluginStrategySpec
     Node.NpmLockSpec
     Node.PackageJsonSpec

--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -51,6 +51,7 @@ import qualified Strategy.Go.GopkgToml as GopkgToml
 import qualified Strategy.Googlesource.RepoManifest as RepoManifest
 import qualified Strategy.Gradle as Gradle
 import qualified Strategy.Haskell.Cabal as Cabal
+import qualified Strategy.Haskell.Stack as Stack
 import qualified Strategy.Maven.PluginStrategy as MavenPlugin
 import qualified Strategy.Maven.Pom as MavenPom
 import qualified Strategy.Node.NpmList as NpmList
@@ -237,6 +238,8 @@ discoverFuncs =
   , Scala.discover
 
   , Cabal.discover
+
+  , Stack.discover
   ]
 
 updateProgress :: Has Logger sig m => Progress -> m ()

--- a/src/DepTypes.hs
+++ b/src/DepTypes.hs
@@ -61,7 +61,7 @@ data DepType =
   | GoType -- ^ Go dependency
   | CargoType -- ^ Rust Cargo Dependency
   | RPMType -- ^ RPM dependency
-  | HaskellType -- ^ Hackage Registry
+  | HackageType -- ^ Hackage Registry
   -- TODO: does this break the "location" abstraction?
   | CarthageType -- ^ A Carthage dependency -- effectively a "git" dependency. Name is repo path and version is tag/branch/hash
   deriving (Eq, Ord, Show, Generic)

--- a/src/Srclib/Converter.hs
+++ b/src/Srclib/Converter.hs
@@ -110,4 +110,4 @@ depTypeToFetcher = \case
   CarthageType -> "cart"
   CargoType -> "cargo"
   RPMType -> "rpm"
-  HaskellType -> "haskell"
+  HackageType -> "hackage"

--- a/src/Strategy/Haskell/Cabal.hs
+++ b/src/Strategy/Haskell/Cabal.hs
@@ -166,7 +166,7 @@ buildGraph plan = do
 toDependency :: InstallPlan -> Dependency
 toDependency plan =
   Dependency
-    { dependencyType = HaskellType,
+    { dependencyType = HackageType,
       dependencyName = planName plan,
       dependencyVersion = Just $ CEq $ planVersion plan,
       dependencyLocations = [],

--- a/src/Strategy/Haskell/Stack.hs
+++ b/src/Strategy/Haskell/Stack.hs
@@ -1,0 +1,127 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Strategy.Haskell.Stack
+  ( discover,
+    -- * Testing
+    buildGraph,
+    PackageName (..),
+    StackDep (..),
+    StackLocationType (..),
+  )
+where
+
+import Control.Effect.Diagnostics
+import Data.Aeson.Types
+import Data.Foldable (for_, find)
+import qualified Data.Map.Strict as M
+import Data.Text (Text)
+import qualified Data.Text as T
+import Discovery.Walk
+import Effect.Exec
+import Effect.Grapher
+import qualified Graphing as G
+import Path
+import Types
+import Prelude
+import Control.Monad (when)
+
+newtype PackageName = PackageName {unPackageName :: Text} deriving (FromJSON, Eq, Ord, Show)
+newtype StackLocation = StackLocation {unStackLocation :: StackLocationType} deriving (Eq, Ord, Show)
+
+data StackDep = StackDep
+  { stackName :: PackageName,
+    stackVersion :: Text,
+    stackDepNames :: [PackageName],
+    stackLocation :: StackLocationType
+  }
+  deriving (Eq, Ord, Show)
+
+data StackLocationType
+  = Local
+  | Remote
+  | BuiltIn
+  deriving (Eq, Ord, Show)
+
+instance FromJSON StackDep where
+  parseJSON = withObject "StackDep" $ \obj ->
+    StackDep <$> obj .: "name"
+      <*> obj .: "version"
+      <*> obj .:? "dependencies" .!= []
+      <*> fmap unStackLocation (obj .:? "location" .!= StackLocation BuiltIn)
+
+instance FromJSON StackLocation where
+  parseJSON = withObject "StackLocation" $ \obj ->
+    StackLocation <$> (obj .: "type" >>= parseLocationType)
+
+parseLocationType :: MonadFail m => Text -> m StackLocationType
+parseLocationType txt
+  | txt == "hackage" = pure Remote
+  | txt `elem` ["project package", "archive"] = pure Local
+  | otherwise = fail $ "Bad location type: " ++ T.unpack txt
+
+discover :: HasDiscover sig m => Path Abs Dir -> m ()
+discover = walk $ \dir _ files ->
+  case find (\f -> fileName f == "stack.yaml") files of
+    Nothing -> pure WalkContinue
+    Just _ -> do
+      runSimpleStrategy "haskell-stack" HaskellGroup $ fmap (mkProjectClosure dir) (analyze dir)
+      pure WalkSkipAll
+
+stackJSONDepsCmd :: Command
+stackJSONDepsCmd =
+  Command
+    { cmdName = "stack",
+      cmdArgs = ["ls", "dependencies", "json"],
+      cmdAllowErr = Never
+    }
+
+mkProjectClosure :: Path Abs Dir -> G.Graphing Dependency -> ProjectClosureBody
+mkProjectClosure dir graph =
+  ProjectClosureBody
+    { bodyModuleDir = dir,
+      bodyDependencies = dependencies,
+      bodyLicenses = []
+    }
+  where
+    dependencies =
+      ProjectDependencies
+        { dependenciesGraph = graph,
+          dependenciesOptimal = Optimal,
+          dependenciesComplete = Complete
+        }
+
+doGraph :: Has (MappedGrapher PackageName StackDep) sig m => StackDep -> m ()
+doGraph dep = do
+  let name = stackName dep
+  mapping name dep
+  for_ (stackDepNames dep) $ \child -> do
+    edge name child
+    when (stackLocation dep == Local) (direct child)
+
+ignorePackageName :: PackageName -> a -> a
+ignorePackageName = flip const
+
+shouldInclude :: StackDep -> Bool
+shouldInclude dep = Remote == stackLocation dep
+
+toDependency :: StackDep -> Dependency
+toDependency dep =
+  Dependency
+    { dependencyType = HackageType,
+      dependencyName = unPackageName $ stackName dep,
+      dependencyVersion = Just $ CEq $ stackVersion dep,
+      dependencyLocations = [],
+      dependencyEnvironments = [],
+      dependencyTags = M.empty
+    }
+
+buildGraph :: Has Diagnostics sig m => [StackDep] -> m (G.Graphing Dependency)
+buildGraph deps = do
+  result <- withMapping ignorePackageName $ traverse doGraph deps
+  case result of
+    Left err -> fatal err
+    Right gr -> pure . G.gmap toDependency $ G.filter shouldInclude gr
+
+analyze :: (Has Exec sig m, Has Diagnostics sig m) => Path Abs Dir -> m (G.Graphing Dependency)
+analyze dir = execJson @[StackDep] dir stackJSONDepsCmd >>= buildGraph

--- a/test/Haskell/StackSpec.hs
+++ b/test/Haskell/StackSpec.hs
@@ -1,0 +1,50 @@
+{-# LANGUAGE RecordWildCards #-}
+
+module Haskell.StackSpec
+  ( spec,
+  )
+where
+
+import Data.Aeson
+import qualified Data.ByteString.Lazy as BL
+import Data.Text (Text)
+import qualified Graphing as G
+import qualified Test.Hspec as Test
+import Prelude
+import Strategy.Haskell.Stack
+import Control.Carrier.Diagnostics
+import Types
+import GraphUtil
+
+allDeps :: [StackDep]
+allDeps = [builtinDep, deepDep, localDep, remoteDep]
+
+mkDep :: Text -> [Text] -> StackLocationType -> StackDep
+mkDep name deps = StackDep (PackageName name) (name <> "-ver") (map PackageName deps)
+
+builtinDep :: StackDep
+builtinDep = mkDep "builtin" [] BuiltIn
+deepDep :: StackDep
+deepDep = mkDep "deep" [] Remote
+localDep :: StackDep
+localDep = mkDep "local" ["remote", "builtin"] Local
+remoteDep :: StackDep
+remoteDep = mkDep "remote" ["deep"] Remote
+
+spec :: Test.Spec
+spec = do
+  Test.describe "Stack json deps parser" $ do
+    jsonBytes <- Test.runIO $ BL.readFile "test/Haskell/testdata/stack.json"
+    Test.it "should parse a json dependencies file" $
+      case eitherDecode jsonBytes of
+        Left err -> Test.expectationFailure $ "Failed to parse: " ++ err
+        Right deps -> deps `Test.shouldMatchList` allDeps
+
+  Test.describe "Stack graph builder" $ 
+    case run . runDiagnostics . buildGraph $ allDeps of
+      Left fbundle -> Test.it "should build a graph" $ Test.expectationFailure (show $ renderFailureBundle fbundle)
+      Right ResultBundle {..} -> do
+        let gr = G.gmap dependencyName resultValue
+        Test.it "should have the correct deps" $ expectDeps ["deep", "remote"] gr
+        Test.it "should have the correct direct deps" $ expectDirect ["remote"] gr
+        Test.it "should have the correct edges" $ expectEdges [("remote", "deep")] gr

--- a/test/Haskell/StackSpec.hs
+++ b/test/Haskell/StackSpec.hs
@@ -19,7 +19,7 @@ import GraphUtil
 allDeps :: [StackDep]
 allDeps = [builtinDep, deepDep, localDep, remoteDep]
 
-mkDep :: Text -> [Text] -> StackLocationType -> StackDep
+mkDep :: Text -> [Text] -> StackLocation -> StackDep
 mkDep name deps = StackDep (PackageName name) (name <> "-ver") (map PackageName deps)
 
 builtinDep :: StackDep

--- a/test/Haskell/testdata/stack.json
+++ b/test/Haskell/testdata/stack.json
@@ -1,0 +1,35 @@
+[
+    {
+        "location": {
+            "type": "hackage"
+        },
+        "name": "remote",
+        "version": "remote-ver",
+        "dependencies": [
+            "deep"
+        ]
+    },
+    {
+        "location": {
+            "type": "project package"
+        },
+        "name": "local",
+        "version": "local-ver",
+        "dependencies": [
+            "remote",
+            "builtin"
+        ]
+    },
+    {
+        "location": {
+            "type": "hackage"
+        },
+        "name": "deep",
+        "version": "deep-ver",
+        "dependencies": []
+    },
+    {
+        "name": "builtin",
+        "version": "builtin-ver"
+    }
+]


### PR DESCRIPTION
Very similar to #122 (Cabal analyzer), since stack wraps a lot of cabal-the-library functionality.

This ends up being much simpler than the associated analyzer in v1.x, because of the availability of `stack ls dependencies json`.