### PR TITLE
Allow unknown gradle configurations

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+# v2.3.1
+
+- Gradle: Accept and tag all build configuration names. ([#134](https://github.com/fossas/spectrometer/pull/134))
+
 # v2.3.0
 
 - Adds a user guide

--- a/src/Srclib/Converter.hs
+++ b/src/Srclib/Converter.hs
@@ -65,12 +65,11 @@ mkSourceUnitDependency gr locator = SourceUnitDependency
 
 shouldPublishDep :: Dependency -> Bool
 shouldPublishDep Dependency{dependencyEnvironments} =
-  null dependencyEnvironments || EnvProduction `elem` dependencyEnvironments || hasOtherEnv dependencyEnvironments
+  null dependencyEnvironments || EnvProduction `elem` dependencyEnvironments || any isOtherEnv dependencyEnvironments
 
-hasOtherEnv :: [DepEnvironment] -> Bool
-hasOtherEnv [] = False
-hasOtherEnv ((EnvOther _) : _) = True
-hasOtherEnv (_ : xs) = hasOtherEnv xs
+isOtherEnv :: DepEnvironment -> Bool
+isOtherEnv (EnvOther _) = True
+isOtherEnv _ = False
 
 -- core can't handle subprojects
 isSupportedType :: Dependency -> Bool

--- a/src/Srclib/Converter.hs
+++ b/src/Srclib/Converter.hs
@@ -43,7 +43,7 @@ toSourceUnit Project {..} =
     graph = projStrategyGraph bestStrategy
 
     filteredGraph :: Graphing Dependency
-    filteredGraph = Graphing.filter (\d -> isProdDep d && isSupportedType d) graph
+    filteredGraph = Graphing.filter (\d -> shouldPublishDep d && isSupportedType d) graph
 
     locatorGraph :: Graphing Locator
     locatorGraph = Graphing.gmap toLocator filteredGraph
@@ -63,9 +63,14 @@ mkSourceUnitDependency gr locator = SourceUnitDependency
   , sourceDepImports = Set.toList $ AM.postSet locator gr
   }
 
-isProdDep :: Dependency -> Bool
-isProdDep Dependency{dependencyEnvironments} =
-  null dependencyEnvironments || EnvProduction `elem` dependencyEnvironments
+shouldPublishDep :: Dependency -> Bool
+shouldPublishDep Dependency{dependencyEnvironments} =
+  null dependencyEnvironments || EnvProduction `elem` dependencyEnvironments || hasOtherEnv dependencyEnvironments
+
+hasOtherEnv :: [DepEnvironment] -> Bool
+hasOtherEnv [] = False
+hasOtherEnv ((EnvOther _) : _) = True
+hasOtherEnv (_ : xs) = hasOtherEnv xs
 
 -- core can't handle subprojects
 isSupportedType :: Dependency -> Bool

--- a/src/Strategy/Gradle.hs
+++ b/src/Strategy/Gradle.hs
@@ -22,6 +22,7 @@ import Data.Foldable (find, for_)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as M
 import Data.Maybe (mapMaybe)
+import qualified Data.Set as S
 import Data.Text (Text)
 import qualified Data.Text as T
 import Data.Text.Encoding (decodeUtf8, encodeUtf8)
@@ -33,6 +34,8 @@ import Graphing (Graphing)
 import Path
 import qualified System.FilePath as FP
 import Types
+
+newtype GradleLabel = Env DepEnvironment deriving (Eq, Ord, Show)
 
 gradleJsonDepsCmd :: Text -> FP.FilePath -> Command
 gradleJsonDepsCmd baseCmd initScriptFilepath = Command
@@ -76,17 +79,22 @@ analyze dir = withSystemTempDir "fossa-gradle" $ \tmpDir -> do
       packagePathsWithJson :: [(Text,Text)]
       packagePathsWithJson = map (\line -> let (x,y) = T.breakOn "_" line in (x, T.drop 1 y {- drop the underscore; break doesn't remove it -})) jsonDepsLines
 
-      packagePathsWithDecoded :: [(Text, [JsonDep])]
-      packagePathsWithDecoded = [(name, deps) | (name, outJson) <- packagePathsWithJson
-                                              , Just configs <- [decodeStrict (encodeUtf8 outJson) :: Maybe (Map Text [JsonDep])]
-                                              , Just deps <- [M.lookup "default" configs]] -- FUTURE: use more than default?
+      packagePathsWithDecoded :: [((Text, Text), [JsonDep])]
+      packagePathsWithDecoded = do
+        (name, outJson) <- packagePathsWithJson
+        let Just configMap = decodeStrict $ encodeUtf8 outJson
+        (configName, deps) <- M.toList configMap
+        pure ((name, configName), deps)
+      -- packagePathsWithDecoded = [(name, deps) | (name, outJson) <- packagePathsWithJson
+      --                                         , Just configs <- [decodeStrict (encodeUtf8 outJson) :: Maybe (Map Text [JsonDep])]
+      --                                         , Just deps <- [M.lookup "default" configs]] -- FUTURE: use more than default?
 
-      packagesToOutput :: Map Text [JsonDep]
+      packagesToOutput :: Map (Text, Text) [JsonDep]
       packagesToOutput = M.fromList packagePathsWithDecoded
 
   pure (mkProjectClosure dir packagesToOutput)
 
-mkProjectClosure :: Path Abs Dir -> Map Text [JsonDep] -> ProjectClosureBody
+mkProjectClosure :: Path Abs Dir -> Map (Text, Text) [JsonDep] -> ProjectClosureBody
 mkProjectClosure dir deps = ProjectClosureBody
   { bodyModuleDir    = dir
   , bodyDependencies = dependencies
@@ -100,26 +108,41 @@ mkProjectClosure dir deps = ProjectClosureBody
     }
 
 -- TODO: use LabeledGraphing to add labels for environments
-buildGraph :: Map Text [JsonDep] -> Graphing Dependency
-buildGraph projectsAndDeps = run . evalGrapher $ M.traverseWithKey addProject projectsAndDeps
+buildGraph :: Map (Text, Text) [JsonDep] -> Graphing Dependency
+buildGraph projectsAndDeps = run . withLabeling toDependency $ M.traverseWithKey addProject projectsAndDeps
   where
   -- add top-level projects from the output
-  addProject :: Has (Grapher Dependency) sig m => Text -> [JsonDep] -> m ()
-  addProject projName projDeps = do
-    let projAsDep = projectToDep projName
+  addProject :: Has (LabeledGrapher JsonDep GradleLabel) sig m => (Text, Text) -> [JsonDep] -> m ()
+  addProject (projName, configName) projDeps = do
+    let projAsDep = projectToJsonDep projName
+        envLabel = configNameToLabel configName
     direct projAsDep
+    label projAsDep envLabel
     for_ projDeps $ \dep -> do
-      edge projAsDep (jsonDepToDep dep)
-      mkRecursiveEdges dep
+      edge projAsDep dep
+      mkRecursiveEdges dep envLabel
+    
+  configNameToLabel :: Text -> GradleLabel
+  configNameToLabel txt = case txt of
+    "compileOnly" -> Env EnvDevelopment
+    x | x `elem` ["testImplementation", "testCompileOnly", "testRuntimeOnly"] -> Env EnvTesting
+    x -> Env $ EnvOther x
+
+  toDependency :: JsonDep -> S.Set GradleLabel -> Dependency
+  toDependency dep = foldr applyLabel $ jsonDepToDep dep
+
+  applyLabel :: GradleLabel -> Dependency -> Dependency
+  applyLabel lbl dep = case lbl of
+    Env env -> dep { dependencyEnvironments = env : dependencyEnvironments dep }
 
   -- build edges between deps, recursively
-  mkRecursiveEdges :: Has (Grapher Dependency) sig m => JsonDep -> m ()
-  mkRecursiveEdges (ProjectDep _) = pure ()
-  mkRecursiveEdges jsondep@(PackageDep _ _ deps) = do
-    let packageAsDep = jsonDepToDep jsondep
+  mkRecursiveEdges :: Has (LabeledGrapher JsonDep GradleLabel) sig m => JsonDep -> GradleLabel -> m ()
+  mkRecursiveEdges (ProjectDep _) _ = pure ()
+  mkRecursiveEdges jsondep@(PackageDep _ _ deps) envLabel = do
+    label jsondep envLabel
     for_ deps $ \child -> do
-      edge packageAsDep (jsonDepToDep child)
-      mkRecursiveEdges child
+      edge jsondep child
+      mkRecursiveEdges child envLabel
 
   jsonDepToDep :: JsonDep -> Dependency
   jsonDepToDep (ProjectDep name) = projectToDep name
@@ -132,6 +155,8 @@ buildGraph projectsAndDeps = run . evalGrapher $ M.traverseWithKey addProject pr
       , dependencyEnvironments = []
       , dependencyTags = M.empty
       }
+
+  projectToJsonDep = ProjectDep
 
   projectToDep name = Dependency
     { dependencyType = SubprojectType

--- a/src/Strategy/Gradle.hs
+++ b/src/Strategy/Gradle.hs
@@ -21,7 +21,7 @@ import Data.FileEmbed (embedFile)
 import Data.Foldable (find, for_)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as M
-import Data.Maybe (mapMaybe)
+import Data.Maybe (mapMaybe, fromMaybe)
 import qualified Data.Set as S
 import Data.Text (Text)
 import qualified Data.Text as T
@@ -137,7 +137,7 @@ buildGraph projectsAndDeps = run . withLabeling toDependency $ M.traverseWithKey
 
   -- build edges between deps, recursively
   mkRecursiveEdges :: Has (LabeledGrapher JsonDep GradleLabel) sig m => JsonDep -> GradleLabel -> m ()
-  mkRecursiveEdges (ProjectDep _) _ = pure ()
+  mkRecursiveEdges (ProjectDep x) envLabel = label (ProjectDep x) envLabel
   mkRecursiveEdges jsondep@(PackageDep _ _ deps) envLabel = do
     label jsondep envLabel
     for_ deps $ \child -> do

--- a/src/Strategy/Gradle.hs
+++ b/src/Strategy/Gradle.hs
@@ -82,7 +82,7 @@ analyze dir = withSystemTempDir "fossa-gradle" $ \tmpDir -> do
       packagePathsWithDecoded :: [((Text, Text), [JsonDep])]
       packagePathsWithDecoded = do
         (name, outJson) <- packagePathsWithJson
-        let Just configMap = decodeStrict $ encodeUtf8 outJson
+        let configMap = fromMaybe mempty . decodeStrict $ encodeUtf8 outJson
         (configName, deps) <- M.toList configMap
         pure ((name, configName), deps)
       -- packagePathsWithDecoded = [(name, deps) | (name, outJson) <- packagePathsWithJson

--- a/src/Strategy/Gradle.hs
+++ b/src/Strategy/Gradle.hs
@@ -6,6 +6,8 @@ module Strategy.Gradle
 
   , buildGraph
   , JsonDep(..)
+  , PackageName (..)
+  , ConfigName (..)
   ) where
 
 import Control.Carrier.Error.Either

--- a/test/Gradle/GradleSpec.hs
+++ b/test/Gradle/GradleSpec.hs
@@ -27,7 +27,7 @@ projectTwo = Dependency
   , dependencyName = ":projectTwo"
   , dependencyVersion = Nothing
   , dependencyLocations = []
-  , dependencyEnvironments = [EnvDevelopment]
+  , dependencyEnvironments = [EnvDevelopment, EnvOther "config"]
   , dependencyTags = M.empty
   }
 
@@ -37,7 +37,7 @@ projectThree = Dependency
   , dependencyName = ":projectThree"
   , dependencyVersion = Nothing
   , dependencyLocations = []
-  , dependencyEnvironments = [EnvTesting]
+  , dependencyEnvironments = [EnvDevelopment, EnvTesting]
   , dependencyTags = M.empty
   }
 

--- a/test/Gradle/GradleSpec.hs
+++ b/test/Gradle/GradleSpec.hs
@@ -8,7 +8,7 @@ import Data.Text (Text)
 import DepTypes
 import GraphUtil
 import Graphing (Graphing, empty)
-import Strategy.Gradle (JsonDep (..), buildGraph)
+import Strategy.Gradle (JsonDep (..), buildGraph, PackageName(..), ConfigName(..))
 import Test.Hspec
 
 projectOne :: Dependency
@@ -68,6 +68,9 @@ gradleOutput = M.fromList
   , ((":projectThree", "testCompileOnly"), [PackageDep "mygroup:packageTwo" "2.0.0" []])
   ]
 
+wrapKeys :: (Text, Text) -> (PackageName, ConfigName)
+wrapKeys (a, b) = (PackageName a, ConfigName b)
+
 spec :: Spec
 spec = do
   describe "buildGraph" $ do
@@ -76,7 +79,7 @@ spec = do
       graph `shouldBe` (empty :: Graphing Dependency)
 
     it "should produce expected output" $ do
-      let graph = buildGraph gradleOutput
+      let graph = buildGraph $ M.mapKeys wrapKeys gradleOutput
       expectDeps [projectOne, projectTwo, projectThree, packageOne, packageTwo] graph
       expectDirect [projectOne, projectTwo, projectThree] graph
       expectEdges [ (projectOne, projectTwo)

--- a/test/Gradle/GradleSpec.hs
+++ b/test/Gradle/GradleSpec.hs
@@ -17,7 +17,7 @@ projectOne = Dependency
   , dependencyName = ":projectOne"
   , dependencyVersion = Nothing
   , dependencyLocations = []
-  , dependencyEnvironments = []
+  , dependencyEnvironments = [EnvOther "config"]
   , dependencyTags = M.empty
   }
 
@@ -27,7 +27,7 @@ projectTwo = Dependency
   , dependencyName = ":projectTwo"
   , dependencyVersion = Nothing
   , dependencyLocations = []
-  , dependencyEnvironments = []
+  , dependencyEnvironments = [EnvDevelopment]
   , dependencyTags = M.empty
   }
 
@@ -37,7 +37,7 @@ projectThree = Dependency
   , dependencyName = ":projectThree"
   , dependencyVersion = Nothing
   , dependencyLocations = []
-  , dependencyEnvironments = []
+  , dependencyEnvironments = [EnvTesting]
   , dependencyTags = M.empty
   }
 
@@ -47,7 +47,7 @@ packageOne = Dependency
   , dependencyName = "mygroup:packageOne"
   , dependencyVersion = Just (CEq "1.0.0")
   , dependencyLocations = []
-  , dependencyEnvironments = []
+  , dependencyEnvironments = [EnvDevelopment]
   , dependencyTags = M.empty
   }
 
@@ -57,15 +57,15 @@ packageTwo = Dependency
   , dependencyName = "mygroup:packageTwo"
   , dependencyVersion = Just (CEq "2.0.0")
   , dependencyLocations = []
-  , dependencyEnvironments = []
+  , dependencyEnvironments = [EnvTesting]
   , dependencyTags = M.empty
   }
 
-gradleOutput :: Map Text [JsonDep]
+gradleOutput :: Map (Text, Text) [JsonDep]
 gradleOutput = M.fromList
-  [ (":projectOne", [ProjectDep ":projectTwo"])
-  , (":projectTwo", [ProjectDep ":projectThree", PackageDep "mygroup:packageOne" "1.0.0" []])
-  , (":projectThree", [PackageDep "mygroup:packageTwo" "2.0.0" []])
+  [ ((":projectOne", "config"), [ProjectDep ":projectTwo"])
+  , ((":projectTwo", "compileOnly"), [ProjectDep ":projectThree", PackageDep "mygroup:packageOne" "1.0.0" []])
+  , ((":projectThree", "testCompileOnly"), [PackageDep "mygroup:packageTwo" "2.0.0" []])
   ]
 
 spec :: Spec


### PR DESCRIPTION
Major changes:

* Move from `Grapher Dependency` to `LabeledGrapher JsonDep GradleLabel`
* Pick up env tags from configuration name
* Flow env tags to children recursively
* Don't remove `EnvOther` deps from output graph.