### PR TITLE
Pin base16-bytestring version

### DIFF
--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -26,6 +26,8 @@ common deps
     , algebraic-graphs             ^>=0.5
     , async                        ^>=2.2.2
     , attoparsec                   ^>=0.13.2.3
+    -- TODO: This fixes a bug in cpio-conduit that prevents it from compiling. Remove this once we fix or bump cpio-conduit
+    , base16-bytestring            ^>=0.1.1.7
     , bytestring                   ^>=0.10.8
     , codec-rpm                    ^>=0.2.2
     , conduit                      ^>=1.3.2


### PR DESCRIPTION
Fix a bug where `cpio-conduit` is unable to build.

