### PR TITLE
Chunked ninja uploads

### DIFF
--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -52,6 +52,7 @@ common deps
     , prettyprinter                >=1.6      && <1.8
     , prettyprinter-ansi-terminal  ^>=1.1.1
     , req                          >=3.4      && <3.6
+    , split                        ^>=0.2.3.4
     , stm                          ^>=2.5.0
     , stm-chans                    ^>=3.0.0
     , tar                          ^>=0.5.1.1

--- a/src/App/VPSScan/Main.hs
+++ b/src/App/VPSScan/Main.hs
@@ -32,7 +32,7 @@ ninjaGraphOpts = NinjaGraphOpts <$> fossaOpts <*> ninjaDepsOpt <*> lunchTargetOp
     lunchTargetOpt = optional $ strOption (long "lunchtarget" <> metavar "STRING" <> help "Build target name to pass to lunch. If you are running in an environment with envsetup and lunch already configured, then you don't need to pass this in")
     scanIdOpt = strOption (long "scan-id" <> metavar "STRING" <> help "The scan ID that this build applies to")
     buildNameOpt = strOption (long "build-name" <> metavar "STRING" <> help "Human readable name of this build. This will be shown on the FOSSA website.")
-    projectNameOpt = strOption (long "project-name" <> metavar "STRING" <> help "The name of the project to create in FOSSA")
+    projectNameOpt = strOption (long "project-name" <> metavar "STRING" <> help "The name of the project that this scan is part of")
 
 fossaOpts :: Parser FossaOpts
 fossaOpts = FossaOpts <$> urlOpt <*> apiKeyOpt

--- a/src/App/VPSScan/Main.hs
+++ b/src/App/VPSScan/Main.hs
@@ -26,11 +26,13 @@ vpsOpts = VPSOpts <$> fossaOpts <*> projectNameOpt <*> projectRevision <*> skipI
     skipIprScanOpt = switch (long "skip-ipr-scan" <> help "If specified, the scan directory will not be scanned for intellectual property rights information")
 
 ninjaGraphOpts :: Parser NinjaGraphOpts
-ninjaGraphOpts = NinjaGraphOpts <$> ninjaDepsOpt <*> lunchTargetOpt <*> scotlandYardUrlOpt
+ninjaGraphOpts = NinjaGraphOpts <$> fossaOpts <*> ninjaDepsOpt <*> lunchTargetOpt <*> scanIdOpt <*> projectNameOpt <*> buildNameOpt
   where
     ninjaDepsOpt = optional $ strOption (long "ninjadeps" <> metavar "STRING")
-    lunchTargetOpt = optional $ strOption (long "lunchtarget" <> metavar "STRING" <> help "build target name to pass to lunch. If you are running in an environment with envsetup and lunch already configured, then you don't need to pass this in")
-    scotlandYardUrlOpt = uriOption (long "scotland-yard-url" <> metavar "STRING" <> help "URL for Scotland Yard service")
+    lunchTargetOpt = optional $ strOption (long "lunchtarget" <> metavar "STRING" <> help "Build target name to pass to lunch. If you are running in an environment with envsetup and lunch already configured, then you don't need to pass this in")
+    scanIdOpt = strOption (long "scan-id" <> metavar "STRING" <> help "The scan ID that this build applies to")
+    buildNameOpt = strOption (long "build-name" <> metavar "STRING" <> help "Human readable name of this build. This will be shown on the FOSSA website.")
+    projectNameOpt = strOption (long "project-name" <> metavar "STRING" <> help "The name of the project to create in FOSSA")
 
 fossaOpts :: Parser FossaOpts
 fossaOpts = FossaOpts <$> urlOpt <*> apiKeyOpt

--- a/src/App/VPSScan/NinjaGraph.hs
+++ b/src/App/VPSScan/NinjaGraph.hs
@@ -10,14 +10,13 @@ module App.VPSScan.NinjaGraph
 ) where
 
 import App.Types (BaseDir (..))
-import App.Util (parseUri, validateDir)
+import App.Util (validateDir)
 import App.VPSScan.Types
 import App.VPSScan.Scan.Core
 import App.VPSScan.Scan.ScotlandYard
 import Control.Carrier.Diagnostics
 import Control.Carrier.Trace.Printing
 import Control.Effect.Lift (Lift, sendIO)
-import Data.Aeson (ToJSON)
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as BL
@@ -28,7 +27,6 @@ import Data.Text.Encoding (decodeUtf8)
 import Data.Text.Prettyprint.Doc (pretty)
 import Effect.Exec
 import Effect.ReadFS
-import Network.HTTP.Req
 import Path
 import System.Exit (exitFailure)
 import qualified System.FilePath as FP

--- a/src/App/VPSScan/NinjaGraph.hs
+++ b/src/App/VPSScan/NinjaGraph.hs
@@ -69,7 +69,7 @@ getAndParseNinjaDeps dir ninjaGraphOpts@NinjaGraphOpts{..} = do
   graph <- scanNinjaDeps ninjaDepsContents
   SherlockInfo{..} <- getSherlockInfo ninjaFossaOpts
   let locator = createLocator ninjaProjectName sherlockOrgId
-  let syOpts = ScotlandYardNinjaOpts locator sherlockOrgId ninjaGraphOpts
+      syOpts = ScotlandYardNinjaOpts locator sherlockOrgId ninjaGraphOpts
   _ <- uploadBuildGraph syOpts graph
   pure ()
 

--- a/src/App/VPSScan/Scan/ScotlandYard.hs
+++ b/src/App/VPSScan/Scan/ScotlandYard.hs
@@ -73,11 +73,10 @@ instance FromJSON CreateBuildGraphResponse where
 createScotlandYardScan :: (Has (Lift IO) sig m, Has Diagnostics sig m) => ScotlandYardOpts -> m ScanResponse
 createScotlandYardScan ScotlandYardOpts {..} = runHTTP $ do
   let VPSOpts{..} = syVpsOpts
-  let FossaOpts{..} = fossa
-
-  let body = object ["revisionId" .= projectRevision, "organizationId" .= organizationId]
-  let auth = coreAuthHeader fossaApiKey
-  let locator = unLocator projectId
+      FossaOpts{..} = fossa
+      body = object ["revisionId" .= projectRevision, "organizationId" .= organizationId]
+      auth = coreAuthHeader fossaApiKey
+      locator = unLocator projectId
 
   (baseUrl, baseOptions) <- parseUri fossaUrl
   resp <- req POST (createScanEndpoint baseUrl locator) (ReqBodyJson body) jsonResponse (baseOptions <> header "Content-Type" "application/json" <> auth)
@@ -89,9 +88,9 @@ createScotlandYardScan ScotlandYardOpts {..} = runHTTP $ do
 uploadIPRResults :: (ToJSON a, Has (Lift IO) sig m, Has Diagnostics sig m) => Text -> a -> ScotlandYardOpts -> m ()
 uploadIPRResults scanId value ScotlandYardOpts {..} = runHTTP $ do
   let VPSOpts{..} = syVpsOpts
-  let FossaOpts{..} = fossa
-  let auth = coreAuthHeader fossaApiKey
-  let locator = unLocator projectId
+      FossaOpts{..} = fossa
+      auth = coreAuthHeader fossaApiKey
+      locator = unLocator projectId
 
   (baseUrl, baseOptions) <- parseUri fossaUrl
   _ <- req POST (scanDataEndpoint baseUrl locator scanId) (ReqBodyJson value) ignoreResponse (baseOptions <> header "Content-Type" "application/json" <> auth)
@@ -113,9 +112,9 @@ uploadBuildGraphCompleteEndpoint baseurl projectId scanId buildGraphId = corePro
 uploadBuildGraph :: (Has (Lift IO) sig m, Has Diagnostics sig m) => ScotlandYardNinjaOpts -> [DepsTarget] -> m ()
 uploadBuildGraph syOpts@ScotlandYardNinjaOpts {..} targets = runHTTP $ do
   let NinjaGraphOpts{..} = syNinjaOpts
-  let FossaOpts{..} = ninjaFossaOpts
-  let auth = coreAuthHeader fossaApiKey
-  let locator = unLocator syNinjaProjectId
+      FossaOpts{..} = ninjaFossaOpts
+      auth = coreAuthHeader fossaApiKey
+      locator = unLocator syNinjaProjectId
   (baseUrl, baseOptions) <- parseUri fossaUrl
   let authenticatedHttpOptions = baseOptions <> header "Content-Type" "application/json" <> auth
 

--- a/src/App/VPSScan/Scan/ScotlandYard.hs
+++ b/src/App/VPSScan/Scan/ScotlandYard.hs
@@ -4,8 +4,10 @@
 module App.VPSScan.Scan.ScotlandYard
   ( createScotlandYardScan
   , uploadIPRResults
+  , uploadBuildGraph
   , ScanResponse (..)
   , ScotlandYardOpts (..)
+  , ScotlandYardNinjaOpts (..)
   )
 where
 
@@ -23,6 +25,12 @@ data ScotlandYardOpts = ScotlandYardOpts
   , projectRevision :: Text
   , organizationId :: Int
   , syVpsOpts :: VPSOpts
+  }
+
+data ScotlandYardNinjaOpts = ScotlandYardNinjaOpts
+  { syNinjaProjectId :: Locator
+  , syNinjaOrganizationId :: Int
+  , syNinjaOpts :: NinjaGraphOpts
   }
 
 -- Prefix for Core's reverse proxy to SY
@@ -46,11 +54,20 @@ instance FromJSON ScanResponse where
   parseJSON = withObject "ScanResponse" $ \obj ->
     ScanResponse <$> obj .: "scanId"
 
+data CreateBuildGraphResponse = CreateBuildGraphResponse
+  { responseBuildGraphId :: Text
+  }
+  deriving (Eq, Ord, Show)
+
+instance FromJSON CreateBuildGraphResponse where
+  parseJSON = withObject "CreateBuildGraphResponse" $ \obj ->
+    CreateBuildGraphResponse <$> obj .: "ID"
+
 createScotlandYardScan :: (Has (Lift IO) sig m, Has Diagnostics sig m) => ScotlandYardOpts -> m ScanResponse
 createScotlandYardScan ScotlandYardOpts {..} = runHTTP $ do
   let VPSOpts{..} = syVpsOpts
   let FossaOpts{..} = fossa
-  
+
   let body = object ["revisionId" .= projectRevision, "organizationId" .= organizationId]
   let auth = coreAuthHeader fossaApiKey
   let locator = unLocator projectId
@@ -71,4 +88,31 @@ uploadIPRResults scanId value ScotlandYardOpts {..} = runHTTP $ do
 
   (baseUrl, baseOptions) <- parseUri fossaUrl
   _ <- req POST (scanDataEndpoint baseUrl locator scanId) (ReqBodyJson value) ignoreResponse (baseOptions <> header "Content-Type" "application/json" <> auth)
+  pure ()
+
+-- /projects/{projectID}/scans/{scanID}/build-graphs
+createBuildGraphEndpoint :: Url 'Https -> Text -> Text -> Url 'Https
+createBuildGraphEndpoint baseurl projectId scanId = coreProxyPrefix baseurl /: "projects" /: projectId /: "scans" /: scanId /: "build-graphs"
+
+-- /projects/{projectID}/scans/{scanID}/build-graphs/{buildGraphID}/rules
+uploadBuildGraphChunkEndpoint :: Url 'Https -> Text -> Text -> Text ->  Url 'Https
+uploadBuildGraphChunkEndpoint baseurl projectId scanId buildGraphId = coreProxyPrefix baseurl /: "projects" /: projectId /: "scans" /: scanId /: "build-graphs" /: buildGraphId /: "rules"
+
+-- /projects/{projectID}/scans/{scanID}/build-graphs/{buildGraphID}/rules/complete
+uploadBuildGraphCompleteEndpoint :: Url 'Https -> Text -> Text -> Text ->  Url 'Https
+uploadBuildGraphCompleteEndpoint baseurl projectId scanId buildGraphId = coreProxyPrefix baseurl /: "projects" /: projectId /: "scans" /: scanId /: "build-graphs" /: buildGraphId /: "rules" /: "complete"
+
+-- create the build graph in SY, upload it in chunks and then complete it.
+uploadBuildGraph :: (Has (Lift IO) sig m, Has Diagnostics sig m) => ScotlandYardNinjaOpts -> [DepsTarget] -> m ()
+uploadBuildGraph ScotlandYardNinjaOpts {..} graph = runHTTP $ do
+  let NinjaGraphOpts{..} = syNinjaOpts
+  let FossaOpts{..} = ninjaFossaOpts
+  let auth = coreAuthHeader fossaApiKey
+  let locator = unLocator syNinjaProjectId
+  let body = object ["display_name" .= buildName]
+  (baseUrl, baseOptions) <- parseUri fossaUrl
+  resp <- req POST (createBuildGraphEndpoint baseUrl locator scanId) (ReqBodyJson body) jsonResponse (baseOptions <> header "Content-Type" "application/json" <> auth)
+  let buildGraphId = CreateBuildGraphResponse $ responseBody resp
+  _ <- req POST (uploadBuildGraphChunkEndpoint baseUrl locator scanId (responseBuildGraphId buildGraphId)) (ReqBodyJson graph) ignoreResponse (baseOptions <> header "Content-Type" "application/json" <> auth)
+  _ <- req POST (uploadBuildGraphCompleteEndpoint baseUrl locator scanId (responseBuildGraphId buildGraphId)) (ReqBodyJson $ object []) ignoreResponse (baseOptions <> header "Content-Type" "application/json" <> auth)
   pure ()

--- a/src/App/VPSScan/Types.hs
+++ b/src/App/VPSScan/Types.hs
@@ -67,9 +67,12 @@ instance ToJSON DepsDependency where
     ]
 
 data NinjaGraphOpts = NinjaGraphOpts
-  { ninjaGraphNinjaPath :: Maybe FilePath
+  { ninjaFossaOpts :: FossaOpts
+  , ninjaGraphNinjaPath :: Maybe FilePath
   , lunchTarget :: Maybe Text
-  , depsGraphScotlandYardUrl :: URI
+  , scanId :: Text
+  , ninjaProjectName :: Text
+  , buildName :: Text
   }
 
 newtype HTTP m a = HTTP {unHTTP :: m a}


### PR DESCRIPTION
This PR does two things:

* It updates `vpscli ninja-graph` to post to Fossa Core instead of SY. I attempted to follow the patterns Kit used when doing this for `vpscli scan`.
* It does a chunked upload of ninja-graph scans. This requires three different stages:

1. Create the build graph
2. Upload chunks of build graph data
3. Mark the build graph as completed
