### PR TITLE
Handle multiple spec files in one directory

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,6 @@
 # v2.3.1
 
+- RPM: Merge spec file results in the analyzer. ([#138](https://github.com/fossas/spectrometer/pull/138))
 - Gradle: Accept and tag all build configuration names. ([#134](https://github.com/fossas/spectrometer/pull/134))
 
 # v2.3.0


### PR DESCRIPTION
When we find multiple `*.spec` files in a directory we correctly detect and scan them, but in the process of converting them to a srclib friendly format, we only select one of the strategies. This PR adjusts the RPM discovery and analysis functions to aggregate spec file dependencies.

This was heavily influenced by the work done for the requirements.txt parser. https://github.com/fossas/spectrometer/blob/master/src/Strategy/Python/ReqTxt.hs#L41