### PR TITLE
Infer detached head

### DIFF
--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -132,7 +132,7 @@ analyze basedir destination override unpackArchives = runFinally $ do
             [ "============================================================"
             , ""
             , "    View FOSSA Report:"
-            , "    " <> pretty (fossaProjectUrl baseurl (uploadLocator resp) (projectBranch revision))
+            , "    " <> pretty (fossaProjectUrl baseurl (uploadLocator resp) revision)
             , ""
             , "============================================================"
             ]
@@ -158,14 +158,15 @@ tryUploadContributors baseDir baseUrl apiKey locator = do
   contributors <- fetchGitContributors baseDir
   uploadContributors baseUrl apiKey locator contributors
 
-fossaProjectUrl :: URI -> Text -> Text -> Text
-fossaProjectUrl baseUrl rawLocator branch = URI.render baseUrl <> "projects/" <> encodedProject <> "/refs/branch/" <> branch <> "/" <> encodedRevision
+fossaProjectUrl :: URI -> Text -> ProjectRevision -> Text
+fossaProjectUrl baseUrl rawLocator revision = URI.render baseUrl <> "projects/" <> encodedProject <> "/refs/branch/" <> branch <> "/" <> encodedRevision
   where
     Locator{locatorFetcher, locatorProject, locatorRevision} = parseLocator rawLocator
 
     underBS :: (ByteString -> ByteString) -> Text -> Text
     underBS f = TE.decodeUtf8 . f . TE.encodeUtf8
 
+    branch = underBS (urlEncode True) (fromMaybe undefined (projectBranch revision))
     encodedProject = underBS (urlEncode True) (locatorFetcher <> "+" <> locatorProject)
     encodedRevision = underBS (urlEncode True) (fromMaybe "" locatorRevision)
 

--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -121,7 +121,8 @@ analyze basedir destination override unpackArchives = runFinally $ do
       logInfo ""
       logInfo ("Using project name: `" <> pretty (projectName revision) <> "`")
       logInfo ("Using revision: `" <> pretty (projectRevision revision) <> "`")
-      logInfo ("Using branch: `" <> pretty (projectBranch revision) <> "`")
+      let branchText = fromMaybe "No branch (detached HEAD)" $ projectBranch revision
+      logInfo ("Using branch: `" <> pretty branchText <> "`")
 
       uploadResult <- Diag.runDiagnostics $ uploadAnalysis basedir baseurl apiKey revision metadata projects
       case uploadResult of

--- a/src/App/Fossa/FossaAPIV1.hs
+++ b/src/App/Fossa/FossaAPIV1.hs
@@ -156,9 +156,8 @@ uploadAnalysis rootDir baseUri key ProjectRevision{..} metadata projects = fossa
           <> "title" =: fromMaybe projectName (projectTitle metadata)
           <> apiHeader key
           <> mkMetadataOpts metadata
-          <> case projectBranch of
-            Just x -> "branch" =: x
-            Nothing -> mempty
+          -- Don't include branch if it doesn't exist, core may not handle empty string properly.
+          <> maybe mempty ("branch" =:) projectBranch
   resp <- req POST (uploadUrl baseUrl) (ReqBodyJson sourceUnits) jsonResponse (baseOptions <> opts)
   pure (responseBody resp)
 

--- a/src/App/Fossa/FossaAPIV1.hs
+++ b/src/App/Fossa/FossaAPIV1.hs
@@ -154,9 +154,11 @@ uploadAnalysis rootDir baseUri key ProjectRevision{..} metadata projects = fossa
           <> "v" =: cliVersion
           <> "managedBuild" =: True
           <> "title" =: fromMaybe projectName (projectTitle metadata)
-          <> "branch" =: projectBranch
           <> apiHeader key
           <> mkMetadataOpts metadata
+          <> case projectBranch of
+            Just x -> "branch" =: x
+            Nothing -> mempty
   resp <- req POST (uploadUrl baseUrl) (ReqBodyJson sourceUnits) jsonResponse (baseOptions <> opts)
   pure (responseBody resp)
 

--- a/src/App/Fossa/ProjectInference.hs
+++ b/src/App/Fossa/ProjectInference.hs
@@ -183,7 +183,7 @@ parseGitProjectRevision dir = do
 
   if "ref: " `T.isPrefixOf` headText
     then do
-      rawPath <- removeNewlines . dropPrefix "ref: " <$> readContentsText (dir </> relHead)
+      let rawPath = removeNewlines . dropPrefix "ref: " $ headText
 
       case parseRelFile (T.unpack rawPath) of
         Nothing -> fatal (InvalidBranchName rawPath)

--- a/src/App/Fossa/ProjectInference.hs
+++ b/src/App/Fossa/ProjectInference.hs
@@ -105,7 +105,7 @@ inferDefault dir = sendIO $ do
   tmp <- getTempDir
   writeFile (fromAbsDir tmp FP.</> ".fossa.revision") (show time)
 
-  pure (InferredProject (T.pack name) (T.pack (show time)) (Just "master"))
+  pure (InferredProject (T.pack name) (T.pack (show time)) Nothing)
 
 -- like Text.stripPrefix, but with a non-Maybe result (defaults to the original text)
 dropPrefix :: Text -> Text -> Text

--- a/src/App/Fossa/ProjectInference.hs
+++ b/src/App/Fossa/ProjectInference.hs
@@ -79,7 +79,7 @@ inferSVN dir = do
               . dropPrefix rootRelativeToUrl
               . dropPrefix "^" $ relUrl
 
-        pure $ InferredProject root revision (Just $ if T.null trimmedRelative then "trunk" else trimmedRelative)
+        pure . InferredProject root revision $ if T.null trimmedRelative then Nothing else Just trimmedRelative
 
   case maybeProject of
     Nothing -> fatal (CommandParseError svnCommand "Invalid output (missing Repository Root or Revision)")

--- a/src/App/Fossa/ProjectInference.hs
+++ b/src/App/Fossa/ProjectInference.hs
@@ -11,6 +11,7 @@ where
 
 import App.Types
 import Control.Algebra
+import Control.Applicative ((<|>))
 import Control.Carrier.Diagnostics
 import Control.Effect.Lift (Lift, sendIO)
 import Control.Monad (unless)
@@ -37,7 +38,7 @@ mergeOverride OverrideProject {..} InferredProject {..} = ProjectRevision name r
   where
     name = fromMaybe inferredName overrideName
     revision = fromMaybe inferredRevision overrideRevision
-    branch = fromMaybe inferredBranch overrideBranch
+    branch = overrideBranch <|> inferredBranch
 
 inferProject :: (Has Logger sig m, Has (Lift IO) sig m) => Path Abs Dir -> m InferredProject
 inferProject current = do
@@ -78,7 +79,7 @@ inferSVN dir = do
               . dropPrefix rootRelativeToUrl
               . dropPrefix "^" $ relUrl
 
-        pure $ InferredProject root revision (if T.null trimmedRelative then "trunk" else trimmedRelative)
+        pure $ InferredProject root revision (Just $ if T.null trimmedRelative then "trunk" else trimmedRelative)
 
   case maybeProject of
     Nothing -> fatal (CommandParseError svnCommand "Invalid output (missing Repository Root or Revision)")
@@ -104,7 +105,7 @@ inferDefault dir = sendIO $ do
   tmp <- getTempDir
   writeFile (fromAbsDir tmp FP.</> ".fossa.revision") (show time)
 
-  pure (InferredProject (T.pack name) (T.pack (show time)) "master")
+  pure (InferredProject (T.pack name) (T.pack (show time)) (Just "master"))
 
 -- like Text.stripPrefix, but with a non-Maybe result (defaults to the original text)
 dropPrefix :: Text -> Text -> Text
@@ -170,7 +171,7 @@ parseGitProjectRevision ::
   ( Has ReadFS sig m
   , Has Diagnostics sig m
   )
-  => Path Abs Dir -> m (Text, Text) -- branch, revision
+  => Path Abs Dir -> m (Maybe Text, Text) -- branch, revision
 parseGitProjectRevision dir = do
   let relHead = [relfile|HEAD|]
 
@@ -178,18 +179,23 @@ parseGitProjectRevision dir = do
 
   unless headExists (fatal MissingGitHead)
 
-  rawPath <- removeNewlines . dropPrefix "ref: " <$> readContentsText (dir </> relHead)
+  headText <- readContentsText (dir </> relHead)
 
-  case parseRelFile (T.unpack rawPath) of
-    Nothing -> fatal (InvalidBranchName rawPath)
-    Just path -> do
-      branchExists <- doesFileExist (dir </> path)
+  if "ref: " `T.isPrefixOf` headText
+    then do
+      rawPath <- removeNewlines . dropPrefix "ref: " <$> readContentsText (dir </> relHead)
 
-      unless branchExists (fatal (MissingBranch rawPath))
+      case parseRelFile (T.unpack rawPath) of
+        Nothing -> fatal (InvalidBranchName rawPath)
+        Just path -> do
+          branchExists <- doesFileExist (dir </> path)
 
-      revision <- removeNewlines <$> readContentsText (dir </> path)
-      let branch = dropPrefix "refs/heads/" rawPath
-      pure (branch, revision)
+          unless branchExists (fatal (MissingBranch rawPath))
+
+          revision <- removeNewlines <$> readContentsText (dir </> path)
+          let branch = dropPrefix "refs/heads/" rawPath
+          pure (Just branch, revision)
+    else pure (Nothing, T.strip headText)
 
 removeNewlines :: Text -> Text
 removeNewlines = T.replace "\r" "" . T.replace "\n" ""
@@ -217,6 +223,6 @@ instance ToDiagnostic InferenceError where
 data InferredProject = InferredProject
   { inferredName :: Text,
     inferredRevision :: Text,
-    inferredBranch :: Text
+    inferredBranch :: Maybe Text
   }
   deriving (Eq, Ord, Show)

--- a/src/App/Types.hs
+++ b/src/App/Types.hs
@@ -21,5 +21,5 @@ data OverrideProject = OverrideProject
 data ProjectRevision = ProjectRevision
   { projectName :: Text
   , projectRevision :: Text
-  , projectBranch :: Text
+  , projectBranch :: Maybe Text
   } deriving (Eq, Ord, Show)


### PR DESCRIPTION
## Base Issue
We do not currently support git repositories in "detached HEAD" mode.  We require that a branch is present at all times, but there are several states where that would not be the case, including during dogfood builds.

## This PR
This PR is the "more correct" way of solving the problem, by populating the lack of branch all the way out to FOSSA Core.
The relevant types have been changed, and all breaking areas have been fixed.  Analysis Upload API call has been updated with the relevant information.  There are several known issues, which will be outlined in the comments, each matching the overall theme: **"Can we execute our entire process without a branch name?"**

## Alternatives
~#142 - The "less correct", but much simpler way.  Note that this PR needs some questions answered, and it may preclude the possibility of this method entirely.  The other PR is working and ready.~
^ closed since this one worked and is more correct.