### PR TITLE
infer "master" if detached HEAD

### DIFF
--- a/src/App/Fossa/ProjectInference.hs
+++ b/src/App/Fossa/ProjectInference.hs
@@ -184,11 +184,8 @@ parseGitProjectRevision dir = do
     Nothing -> fatal (InvalidBranchName rawPath)
     Just path -> do
       branchExists <- doesFileExist (dir </> path)
-
-      unless branchExists (fatal (MissingBranch rawPath))
-
       revision <- removeNewlines <$> readContentsText (dir </> path)
-      let branch = dropPrefix "refs/heads/" rawPath
+      let branch = if branchExists then dropPrefix "refs/heads/" rawPath else "master"
       pure (branch, revision)
 
 removeNewlines :: Text -> Text


### PR DESCRIPTION
## Base Issue
We do not currently support git repositories in "detached HEAD" mode.  We require that a branch is present at all times, but there are several states where that would not be the case, including during dogfood builds.

## This PR
This PR is the "less correct" way of solving the problem, by not correcting the assumption of an always existing branch.  This immediately sets the default branch name of `master` in the case that we infer the branch name, but it is not found (due to detached HEAD).  This makes the assumption that Core will always default to `master` if not given a branch (which it does and seems to intend to continue doing), and re-uses that assumption locally.

## Alternatives
#141 - The "more correct" way.  Note that if this PR is merged, it may not stay in line with Core's assumptions.  However, this is generally agreed to be unlikely.  The primary benefit of #141 is that Core can make its own decision about the default branch, and require no input from us in the missing branch case.