### PR TITLE
Use spectrometer to scan spectrometer

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,21 +9,6 @@ on: push
 
 jobs:
 
-  dependency-scan:
-    name: dependency-scan
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Install spectrometer from github
-        run: |
-          curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/spectrometer/master/install.sh | bash
-
-      - name: Run dependency scan
-        run: |
-          fossa analyze --filter cabal@.
-        env:
-          FOSSA_API_TOKEN: ${{ secrets.FOSSA_API_TOKEN }}
-
   build-all:
     name: ${{ matrix.os-name }}-build
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,19 @@ on: push
 
 jobs:
 
+  dependency-scan:
+    name: dependency-scan
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Install spectrometer from github
+        run: |
+          curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/spectrometer/master/install.sh | bash
+
+      - name: Run dependency scan
+        run: |
+          fossa analyze --filter cabal@.
+
   build-all:
     name: ${{ matrix.os-name }}-build
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,8 @@ jobs:
       - name: Run dependency scan
         run: |
           fossa analyze --filter cabal@.
+        env:
+          FOSSA_API_TOKEN: ${{ secrets.FOSSA_API_TOKEN }}
 
   build-all:
     name: ${{ matrix.os-name }}-build

--- a/.github/workflows/dependency-scan.yml
+++ b/.github/workflows/dependency-scan.yml
@@ -9,6 +9,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Update cabal cache for spectrometer run
+        run: |
+          cabal update
+
       - name: Install spectrometer from github
         run: |
           curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/spectrometer/master/install.sh | bash
@@ -18,3 +22,9 @@ jobs:
           FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
         run: |
           fossa analyze --filter cabal@.
+
+      - name: Check for scan results
+        env:
+          FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
+        run: |
+          fossa test

--- a/.github/workflows/dependency-scan.yml
+++ b/.github/workflows/dependency-scan.yml
@@ -7,6 +7,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - uses: actions/checkout@v2
+
       - name: Install spectrometer from github
         run: |
           curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/spectrometer/master/install.sh | bash

--- a/.github/workflows/dependency-scan.yml
+++ b/.github/workflows/dependency-scan.yml
@@ -1,0 +1,18 @@
+name: Dependency scan
+on: push
+
+jobs:
+  dependency-scan:
+    name: dependency-scan
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Install spectrometer from github
+        run: |
+          curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/spectrometer/master/install.sh | bash
+
+      - name: Run dependency scan
+        env:
+          FOSSA_API_TOKEN: ${{ secrets.FOSSA_API_TOKEN }}
+        run: |
+          fossa analyze --filter cabal@.

--- a/.github/workflows/dependency-scan.yml
+++ b/.github/workflows/dependency-scan.yml
@@ -13,6 +13,6 @@ jobs:
 
       - name: Run dependency scan
         env:
-          FOSSA_API_TOKEN: ${{ secrets.FOSSA_API_TOKEN }}
+          FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
         run: |
           fossa analyze --filter cabal@.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Spectrometer
 
+[![FOSSA Status](https://app.fossa.com/api/projects/custom%2B1%2Fgithub.com%2Ffossas%2Fspectrometer.svg?type=shield)](https://app.fossa.com/projects/custom%2B1%2Fgithub.com%2Ffossas%2Fspectrometer?ref=badge_shield)
+
 Spectrometer is a minimal-configuration dependency analysis tool. It supports a wide array of languages and buildtools.
 
 Spectrometer extracts dependency graphs from your projects and reports them to [FOSSA](https://fossa.com) for license scanning, vulnerability scanning, and more.

--- a/src/App/Fossa/FossaAPIV1.hs
+++ b/src/App/Fossa/FossaAPIV1.hs
@@ -319,7 +319,7 @@ newtype IssueRule = IssueRule
 instance FromJSON Issues where
   parseJSON = withObject "Issues" $ \obj ->
     Issues <$> obj .: "count"
-           <*> obj .: "issues"
+           <*> obj .:? "issues" .!= []
            <*> obj .: "status"
 
 instance ToJSON Issues where


### PR DESCRIPTION
This uses the latest release of spectrometer to do our fossa scan. It also adds a license scan badge to our README

The `dependency-scan` task is failing for two reasons:
1. the json deserializer for the issues endpoint was too strict; if an issue scan isn't complete yet, it won't contain an `issues` key (fixed in this PR)
2. our policy doesn't allow for MPL

Otherwise this looks to be working as intended.