### PR TITLE
Fix contributors URL

### DIFF
--- a/src/App/Fossa/FossaAPIV1.hs
+++ b/src/App/Fossa/FossaAPIV1.hs
@@ -416,7 +416,7 @@ newtype Contributors = Contributors
   deriving (Eq, Ord, Show, ToJSON)
 
 contributorsEndpoint :: Url scheme -> Url scheme
-contributorsEndpoint baseurl = baseurl /: "api" /: "organization"
+contributorsEndpoint baseurl = baseurl /: "api" /: "contributors"
 
 uploadContributors :: (Has (Lift IO) sig m, Has Diagnostics sig m) => URI -> ApiKey -> Text -> Contributors -> m ()
 uploadContributors baseUri apiKey locator contributors = fossaReq $ do


### PR DESCRIPTION
Pointing to [this route.](https://github.com/fossas/FOSSA/blob/21e33ff92b29d1b201817c947062a6aad29d3011/routes/contributors.ts#L122)