### PR TITLE
Allow `fossa vps analyze` metadata

### DIFF
--- a/src/App/Fossa/FossaAPIV1.hs
+++ b/src/App/Fossa/FossaAPIV1.hs
@@ -8,7 +8,6 @@ module App.Fossa.FossaAPIV1
   ( uploadAnalysis
   , uploadContributors
   , UploadResponse(..)
-  , ProjectMetadata(..)
   , mkMetadataOpts
   , FossaError(..)
   , FossaReq(..)
@@ -120,15 +119,6 @@ instance ToDiagnostic FossaError where
     JsonDeserializeError err -> "An error occurred when deserializing a response from the FOSSA API: " <> pretty err
     OtherError err -> "An unknown error occurred when accessing the FOSSA API: " <> viaShow err
     BadURI uri -> "Invalid FOSSA URL: " <> pretty (URI.render uri)
-
-data ProjectMetadata = ProjectMetadata
-  { projectTitle :: Maybe Text
-  , projectUrl :: Maybe Text
-  , projectJiraKey :: Maybe Text
-  , projectLink :: Maybe Text
-  , projectTeam :: Maybe Text
-  , projectPolicy :: Maybe Text
-  } deriving (Eq, Ord, Show)
 
 uploadAnalysis
   :: (Has (Lift IO) sig m, Has Diagnostics sig m)

--- a/src/App/Fossa/FossaAPIV1.hs
+++ b/src/App/Fossa/FossaAPIV1.hs
@@ -9,6 +9,7 @@ module App.Fossa.FossaAPIV1
   , uploadContributors
   , UploadResponse(..)
   , ProjectMetadata(..)
+  , mkMetadataOpts
   , FossaError(..)
   , FossaReq(..)
   , Contributors(..)
@@ -153,7 +154,6 @@ uploadAnalysis rootDir baseUri key ProjectRevision{..} metadata projects = fossa
       opts = "locator" =: renderLocator (Locator "custom" projectName (Just projectRevision))
           <> "v" =: cliVersion
           <> "managedBuild" =: True
-          <> "title" =: fromMaybe projectName (projectTitle metadata)
           <> apiHeader key
           <> mkMetadataOpts metadata
           -- Don't include branch if it doesn't exist, core may not handle empty string properly.
@@ -168,6 +168,7 @@ mkMetadataOpts ProjectMetadata{..} = mconcat $ catMaybes
   , ("link" =:) <$> projectLink
   , ("team" =:) <$> projectTeam
   , ("policy" =:) <$> projectPolicy
+  , ("title" =:) <$> projectTitle
   ]
 
 mangleError :: HttpException -> FossaError

--- a/src/App/Fossa/Main.hs
+++ b/src/App/Fossa/Main.hs
@@ -7,7 +7,6 @@ module App.Fossa.Main
 where
 
 import App.Fossa.Analyze (ScanDestination (..), analyzeMain)
-import App.Fossa.FossaAPIV1 (ProjectMetadata (..))
 import App.Fossa.ListTargets (listTargetsMain)
 import App.Fossa.Report (ReportType (..), reportMain)
 import App.Fossa.Test (TestOutputType (..), testMain)
@@ -59,7 +58,7 @@ appMain = do
         then analyzeMain baseDir logSeverity OutputStdout analyzeOverride analyzeUnpackArchives analyzeBuildTargetFilters
         else do
           key <- requireKey maybeApiKey
-          analyzeMain baseDir logSeverity (UploadScan optBaseUrl key analyzeMetadata) analyzeOverride analyzeUnpackArchives analyzeBuildTargetFilters
+          analyzeMain baseDir logSeverity (UploadScan $ UploadInfo optBaseUrl key analyzeMetadata) analyzeOverride analyzeUnpackArchives analyzeBuildTargetFilters
 
     TestCommand TestOptions {..} -> do
       baseDir <- validateDir testBaseDir
@@ -85,7 +84,8 @@ appMain = do
       case vpsCommand of
         VPSAnalyzeCommand VPSAnalyzeOptions {..} -> do
           baseDir <- validateDir vpsAnalyzeBaseDir
-          scanMain optBaseUrl baseDir apikey logSeverity override vpsFileFilter (SkipIPRScan skipIprScan)
+          let uploadInfo = UploadInfo optBaseUrl apikey vpsAnalyzeMeta
+          scanMain baseDir logSeverity uploadInfo override vpsFileFilter (SkipIPRScan skipIprScan)
         NinjaGraphCommand ninjaGraphOptions -> do
           ninjaGraphMain optBaseUrl apikey logSeverity override ninjaGraphOptions
           

--- a/src/App/Fossa/Main.hs
+++ b/src/App/Fossa/Main.hs
@@ -219,7 +219,7 @@ vpsOpts = VPSOptions <$> skipIprScanOpt <*> fileFilterOpt <*> vpsCommands
     fileFilterOpt = FilterExpressions <$> jsonOption (long "ignore-file-regex" <> short 'i' <> metavar "REGEXPS" <> help "JSON encoded array of regular expressions used to filter scanned paths" <> value [])
 
 vpsAnalyzeOpts :: Parser VPSAnalyzeOptions
-vpsAnalyzeOpts = VPSAnalyzeOptions <$> baseDirArg
+vpsAnalyzeOpts = VPSAnalyzeOptions <$> baseDirArg <*> metadataOpts
 
 ninjaGraphOpts :: Parser NinjaGraphCLIOptions
 ninjaGraphOpts = NinjaGraphCLIOptions <$> baseDirArg <*> ninjaDepsOpt <*> lunchTargetOpt <*> scanIdOpt <*> buildNameOpt
@@ -294,5 +294,7 @@ data VPSOptions = VPSOptions
     vpsCommand :: VPSCommand
   }
 
-newtype VPSAnalyzeOptions = VPSAnalyzeOptions
-  { vpsAnalyzeBaseDir :: FilePath }
+data VPSAnalyzeOptions = VPSAnalyzeOptions
+  { vpsAnalyzeBaseDir :: FilePath,
+    vpsAnalyzeMeta :: ProjectMetadata
+  }

--- a/src/App/Fossa/VPS/Scan/Core.hs
+++ b/src/App/Fossa/VPS/Scan/Core.hs
@@ -18,8 +18,9 @@ module App.Fossa.VPS.Scan.Core
 where
 
 -- I REALLY don't like mixing these modules together.
-import App.Fossa.FossaAPIV1 (mkMetadataOpts, ProjectMetadata)
+import App.Fossa.FossaAPIV1 (mkMetadataOpts)
 import App.Fossa.VPS.Types
+import App.Types (ProjectMetadata)
 import App.Util (parseUri)
 import Data.Text (pack, Text)
 import Prelude

--- a/src/App/Fossa/VPS/Scan/Core.hs
+++ b/src/App/Fossa/VPS/Scan/Core.hs
@@ -17,6 +17,8 @@ module App.Fossa.VPS.Scan.Core
   )
 where
 
+-- I REALLY don't like mixing these modules together.
+import App.Fossa.FossaAPIV1 (mkMetadataOpts, ProjectMetadata)
 import App.Fossa.VPS.Types
 import App.Util (parseUri)
 import Data.Text (pack, Text)
@@ -84,13 +86,14 @@ projectScanFiltersEndpoint baseurl locator = baseurl /: "api" /: "vendored-packa
   FIXME: Every function below this line is using a data structure designed for the CLI.
   This tightly couples us to our CLI API, and is very tedious to change with the merge of `vpscli` and `fossa` exe's.
 -}
-createCoreProject :: (Has (Lift IO) sig m, Has Diagnostics sig m) => Text -> Text -> FossaOpts -> m ()
-createCoreProject name revision FossaOpts{..} = runHTTP $ do
+createCoreProject :: (Has (Lift IO) sig m, Has Diagnostics sig m) => Text -> Text -> ProjectMetadata -> FossaOpts -> m ()
+createCoreProject name revision metadata FossaOpts{..} = runHTTP $ do
   let auth = coreAuthHeader fossaApiKey
+  let metaOpts = mkMetadataOpts metadata
   let body = object ["name" .= name, "revision" .= revision]
 
   (baseUrl, baseOptions) <- parseUri fossaUrl
-  _ <- req POST (createProjectEndpoint baseUrl) (ReqBodyJson body) ignoreResponse (baseOptions <> header "Content-Type" "application/json" <> auth)
+  _ <- req POST (createProjectEndpoint baseUrl) (ReqBodyJson body) ignoreResponse (baseOptions <> header "Content-Type" "application/json" <> auth <> metaOpts)
   pure ()
 
 completeCoreProject :: (Has (Lift IO) sig m, Has Diagnostics sig m) => RevisionLocator -> FossaOpts -> m ()

--- a/src/App/Fossa/VPS/Types.hs
+++ b/src/App/Fossa/VPS/Types.hs
@@ -40,7 +40,7 @@ instance ToJSON FilterExpressions where
 
 -- FIXME: replace these with non-CLI types
 -- VPSOpts in particular is used as a God type, and is very unwieldy in the merged CLI form.
-data FossaOpts = FossaOpts
+data FossaOpts = FossaOpts  -- FIXME: remove this type, use App.Types.UploadInfo instead.
   { fossaUrl :: URI
   , fossaApiKey :: Text
   }
@@ -53,7 +53,7 @@ data PartialVPSOpts
     }
 
 data VPSOpts = VPSOpts
-  { fossa :: FossaOpts
+  { fossa :: FossaOpts  -- FIXME: remove this field, keep upload info separate.
   , vpsProjectName :: Text
   , userProvidedRevision :: Maybe Text  -- FIXME: Since we can now infer a revision, we should rename this field.
   , skipIprScan :: Bool

--- a/src/App/Types.hs
+++ b/src/App/Types.hs
@@ -3,21 +3,39 @@ module App.Types
     BaseDir (..),
     NinjaGraphCLIOptions (..),
     OverrideProject (..),
+    ProjectMetadata (..),
     ProjectRevision (..),
+    UploadInfo (..),
   )
 where
 
 import Data.Text (Text)
+import Text.URI
 import Path
 
 newtype ApiKey = ApiKey {unApiKey :: Text} deriving (Eq, Ord, Show)
 newtype BaseDir = BaseDir {unBaseDir :: Path Abs Dir} deriving (Eq, Ord, Show)
+
+data UploadInfo = UploadInfo
+  { uploadUri :: URI,
+    uploadApiKey :: ApiKey,
+    uploadMetadata :: ProjectMetadata
+  }
 
 data OverrideProject = OverrideProject
   { overrideName :: Maybe Text,
     overrideRevision :: Maybe Text,
     overrideBranch :: Maybe Text
   }
+
+data ProjectMetadata = ProjectMetadata
+  { projectTitle :: Maybe Text
+  , projectUrl :: Maybe Text
+  , projectJiraKey :: Maybe Text
+  , projectLink :: Maybe Text
+  , projectTeam :: Maybe Text
+  , projectPolicy :: Maybe Text
+  } deriving (Eq, Ord, Show)
 
 data ProjectRevision = ProjectRevision
   { projectName :: Text


### PR DESCRIPTION
*Doc changes will be added soon.*

* Separate `App.Types.UploadInfo` out of `ScanDestination`
* Move `ProjectMetadata` to common types module.
* Move `title || projectName` logic to core, simplify CLI logic. (See note)
* Add metadata opts to command-line.  Flow those opts through API.

***NOTE:** it is unsafe to merge this until fossas/FOSSA#5147 is merged.*