### PR TITLE
fossa vps test

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,11 @@
+# v2.4
+
+- Integrates `vpscli scan` as `fossa vps analyze` ([#148](https://github.com/fossas/spectrometer/pull/148))
+- Removes `vpscli` binary ([#148](https://github.com/fossas/spectrometer/pull/148))
+- Adds support for `--team` and other metadata flags to vps analysis ([#149](https://github.com/fossas/spectrometer/pull/149))
+- Adds `fossa vps test` command, analogous to `fossa test` for vps projects ([#150](https://github.com/fossas/spectrometer/pull/150))
+- Adds `fossa vps report` command, analogous to `fossa report` for vps projects ([#150](https://github.com/fossas/spectrometer/pull/150))
+
 # v2.3.2
 
 - Adds `fossa list-targets` to list "analysis-targets" (projects and subprojects) available for analysis ([#140](https://github.com/fossas/spectrometer/pull/140))

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -95,6 +95,7 @@ library
     App.Fossa.VPS.Scan.RunIPR
     App.Fossa.VPS.Scan.RunSherlock
     App.Fossa.VPS.Scan.ScotlandYard
+    App.Fossa.VPS.Test
     App.Fossa.VPS.Types
     App.OptionExtensions
     App.Pathfinder.Main
@@ -125,6 +126,7 @@ library
     Effect.Grapher
     Effect.Logger
     Effect.ReadFS
+    Fossa.API.Types
     Graphing
     Parse.XML
     Srclib.Converter

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -90,6 +90,7 @@ library
     App.Fossa.Test
     App.Fossa.VPS.EmbeddedBinary
     App.Fossa.VPS.NinjaGraph
+    App.Fossa.VPS.Report
     App.Fossa.VPS.Scan
     App.Fossa.VPS.Scan.Core
     App.Fossa.VPS.Scan.RunIPR

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -88,11 +88,6 @@ library
     App.Fossa.Report
     App.Fossa.Report.Attribution
     App.Fossa.Test
-    App.OptionExtensions
-    App.Pathfinder.Main
-    App.Pathfinder.Scan
-    App.Types
-    App.Util
     App.Fossa.VPS.EmbeddedBinary
     App.Fossa.VPS.NinjaGraph
     App.Fossa.VPS.Scan
@@ -101,6 +96,11 @@ library
     App.Fossa.VPS.Scan.RunSherlock
     App.Fossa.VPS.Scan.ScotlandYard
     App.Fossa.VPS.Types
+    App.OptionExtensions
+    App.Pathfinder.Main
+    App.Pathfinder.Scan
+    App.Types
+    App.Util
     Control.Carrier.Diagnostics
     Control.Carrier.Finally
     Control.Carrier.Output.IO
@@ -113,6 +113,7 @@ library
     Control.Effect.TaskPool
     Control.Exception.Extra
     Data.FileEmbed.Extra
+    Data.Flag
     Data.Text.Extra
     DepTypes
     Discovery.Archive

--- a/src/App/Fossa/API/BuildWait.hs
+++ b/src/App/Fossa/API/BuildWait.hs
@@ -1,54 +1,55 @@
 {-# LANGUAGE NumericUnderscores #-}
 
-module App.Fossa.API.BuildWait (
-    waitForBuild,
-    waitForIssues
-) where
+module App.Fossa.API.BuildWait
+  ( waitForBuild,
+    waitForIssues,
+  )
+where
 
-import App.Types
 import qualified App.Fossa.FossaAPIV1 as Fossa
-import Control.Effect.Lift (Lift, sendIO)
+import App.Types
 import Control.Carrier.Diagnostics
 import Control.Concurrent (threadDelay)
+import Control.Effect.Lift (Lift, sendIO)
 import Effect.Logger
-import Text.URI (URI)
+import Fossa.API.Types (ApiOpts)
 
 pollDelaySeconds :: Int
 pollDelaySeconds = 8
 
-data WaitError = BuildFailed -- ^ we encountered the FAILED status on a build
+data WaitError
+  = -- | we encountered the FAILED status on a build
+    BuildFailed
   deriving (Eq, Ord, Show)
 
 instance ToDiagnostic WaitError where
   renderDiagnostic BuildFailed = "The build failed. Check the FOSSA webapp for more details."
 
-waitForBuild
-  :: (Has Diagnostics sig m, Has (Lift IO) sig m, Has Logger sig m)
-  => URI
-  -> ApiKey -- ^ api key
-  -> ProjectRevision
-  -> m ()
-waitForBuild baseurl key revision = do
-  build <- Fossa.getLatestBuild baseurl key revision
- 
+waitForBuild ::
+  (Has Diagnostics sig m, Has (Lift IO) sig m, Has Logger sig m) =>
+  ApiOpts ->
+  ProjectRevision ->
+  m ()
+waitForBuild apiOpts revision = do
+  build <- Fossa.getLatestBuild apiOpts revision
+
   case Fossa.buildTaskStatus (Fossa.buildTask build) of
     Fossa.StatusSucceeded -> pure ()
     Fossa.StatusFailed -> fatal BuildFailed
     otherStatus -> do
       logSticky $ "[ Waiting for build completion... last status: " <> viaShow otherStatus <> " ]"
       sendIO $ threadDelay (pollDelaySeconds * 1_000_000)
-      waitForBuild baseurl key revision
+      waitForBuild apiOpts revision
 
-waitForIssues
-  :: (Has Diagnostics sig m, Has (Lift IO) sig m, Has Logger sig m)
-  => URI
-  -> ApiKey -- ^ api key
-  -> ProjectRevision
-  -> m Fossa.Issues
-waitForIssues baseurl key revision = do
-  issues <- Fossa.getIssues baseurl key revision
+waitForIssues ::
+  (Has Diagnostics sig m, Has (Lift IO) sig m, Has Logger sig m) =>
+  ApiOpts ->
+  ProjectRevision ->
+  m Fossa.Issues
+waitForIssues apiOpts revision = do
+  issues <- Fossa.getIssues apiOpts revision
   case Fossa.issuesStatus issues of
     "WAITING" -> do
       sendIO $ threadDelay (pollDelaySeconds * 1_000_000)
-      waitForIssues baseurl key revision
+      waitForIssues apiOpts revision
     _ -> pure issues

--- a/src/App/Fossa/FossaAPIV1.hs
+++ b/src/App/Fossa/FossaAPIV1.hs
@@ -325,7 +325,7 @@ instance FromJSON Issue where
     Issue <$> obj .: "id"
            <*> obj .:? "priorityString"
            <*> obj .: "resolved"
-           <*> obj .: "revisionId"
+           <*> obj .:? "revisionId" .!= "unknown project"
            <*> obj .: "type"
            <*> obj .:? "rule"
 

--- a/src/App/Fossa/FossaAPIV1.hs
+++ b/src/App/Fossa/FossaAPIV1.hs
@@ -317,6 +317,7 @@ instance FromJSON Issue where
     Issue <$> obj .: "id"
            <*> obj .:? "priorityString"
            <*> obj .: "resolved"
+           -- VPS issues don't have a revisionId
            <*> obj .:? "revisionId" .!= "unknown project"
            <*> obj .: "type"
            <*> obj .:? "rule"

--- a/src/App/Fossa/FossaAPIV1.hs
+++ b/src/App/Fossa/FossaAPIV1.hs
@@ -25,6 +25,9 @@ module App.Fossa.FossaAPIV1
   , renderIssueType
   , IssueRule(..)
 
+  , Organization(..)
+  , getOrganization
+
   , getAttribution
   ) where
 
@@ -245,7 +248,7 @@ getLatestBuild
 getLatestBuild apiOpts ProjectRevision {..} = fossaReq $ do
   (baseUrl, baseOpts) <- useApiOpts apiOpts
 
-  Organization orgId <- responseBody <$> req GET (organizationEndpoint baseUrl) NoReqBody jsonResponse baseOpts
+  Organization orgId <- getOrganization apiOpts
  
   response <- req GET (buildsEndpoint baseUrl orgId (Locator "custom" projectName (Just projectRevision))) NoReqBody jsonResponse baseOpts
   pure (responseBody response)
@@ -263,7 +266,7 @@ getIssues
 getIssues apiOpts ProjectRevision{..} = fossaReq $ do
   (baseUrl, baseOpts) <- useApiOpts apiOpts
  
-  Organization orgId <- responseBody <$> req GET (organizationEndpoint baseUrl) NoReqBody jsonResponse baseOpts
+  Organization orgId <- getOrganization apiOpts
   response <- req GET (issuesEndpoint baseUrl orgId (Locator "custom" projectName (Just projectRevision))) NoReqBody jsonResponse baseOpts
   pure (responseBody response)
 
@@ -378,7 +381,7 @@ getAttribution apiOpts ProjectRevision{..} = fossaReq $ do
         <> "includeDeepDependencies" =: True
         <> "includeHashAndVersionData" =: True
         <> "includeDownloadUrl" =: True
-  Organization orgId <- responseBody <$> req GET (organizationEndpoint baseUrl) NoReqBody jsonResponse opts
+  Organization orgId <- getOrganization apiOpts
   response <- req GET (attributionEndpoint baseUrl orgId (Locator "custom" projectName (Just projectRevision))) NoReqBody jsonResponse opts
   pure (responseBody response)
 
@@ -394,6 +397,11 @@ instance FromJSON Organization where
 
 organizationEndpoint :: Url scheme -> Url scheme
 organizationEndpoint baseurl = baseurl /: "api" /: "cli" /: "organization"
+
+getOrganization :: (Has (Lift IO) sig m, Has Diagnostics sig m) => ApiOpts -> m Organization
+getOrganization apiOpts = fossaReq $ do
+  (baseUrl, baseOpts) <- useApiOpts apiOpts
+  responseBody <$> req GET (organizationEndpoint baseUrl) NoReqBody jsonResponse baseOpts
 
 ----------
 

--- a/src/App/Fossa/FossaAPIV1.hs
+++ b/src/App/Fossa/FossaAPIV1.hs
@@ -29,6 +29,7 @@ module App.Fossa.FossaAPIV1
   , getOrganization
 
   , getAttribution
+  , getAttributionRaw
   ) where
 
 import App.Fossa.Analyze.Project
@@ -366,6 +367,22 @@ getAttribution
   -> ProjectRevision
   -> m Attr.Attribution
 getAttribution apiOpts ProjectRevision{..} = fossaReq $ do
+  (baseUrl, baseOpts) <- useApiOpts apiOpts
+
+  let opts = baseOpts
+        <> "includeDeepDependencies" =: True
+        <> "includeHashAndVersionData" =: True
+        <> "includeDownloadUrl" =: True
+  Organization orgId <- getOrganization apiOpts
+  response <- req GET (attributionEndpoint baseUrl orgId (Locator "custom" projectName (Just projectRevision))) NoReqBody jsonResponse opts
+  pure (responseBody response)
+
+getAttributionRaw
+  :: (Has (Lift IO) sig m, Has Diagnostics sig m)
+  => ApiOpts
+  -> ProjectRevision
+  -> m Value
+getAttributionRaw apiOpts ProjectRevision{..} = fossaReq $ do
   (baseUrl, baseOpts) <- useApiOpts apiOpts
 
   let opts = baseOpts

--- a/src/App/Fossa/Report.hs
+++ b/src/App/Fossa/Report.hs
@@ -10,11 +10,9 @@ import qualified App.Fossa.FossaAPIV1 as Fossa
 import App.Fossa.ProjectInference
 import App.Types
 import Control.Carrier.Diagnostics
-import Control.Concurrent (threadDelay)
-import qualified Control.Concurrent.Async as Async
 import Control.Effect.Lift (sendIO)
 import qualified Data.Aeson as Aeson
-import Data.Functor (void, ($>))
+import Data.Functor (void)
 import Data.Text (Text)
 import Data.Text.IO (hPutStrLn)
 import Data.Text.Lazy.Encoding (decodeUtf8)
@@ -83,10 +81,3 @@ reportMain basedir apiOpts logSeverity timeoutSeconds reportType override = do
 
   hPutStrLn stderr "Timed out while waiting for build/issues scan"
   exitFailure
-
-timeout
-  :: Int -- ^ number of seconds before timeout
-  -> IO a
-  -> IO (Maybe a)
--- timeout seconds act = either id id <$> Async.race (Just <$> act) (threadDelay (seconds * 1_000_000) *> pure Nothing)
-timeout seconds act = either id id <$> Async.race (Just <$> act) (threadDelay (seconds * 1_000_000) $> Nothing)

--- a/src/App/Fossa/Test.hs
+++ b/src/App/Fossa/Test.hs
@@ -10,11 +10,9 @@ import qualified App.Fossa.FossaAPIV1 as Fossa
 import App.Fossa.ProjectInference
 import App.Types
 import Control.Carrier.Diagnostics hiding (fromMaybe)
-import Control.Concurrent (threadDelay)
-import qualified Control.Concurrent.Async as Async
 import Control.Effect.Lift (sendIO)
 import qualified Data.Aeson as Aeson
-import Data.Functor (void, ($>))
+import Data.Functor (void)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as M
 import Data.Maybe (fromMaybe)
@@ -126,9 +124,3 @@ renderedIssues issues = rendered
         xs !? ix
           | length xs <= ix = Nothing
           | otherwise = Just (xs !! ix)
-
-timeout
-  :: Int -- ^ number of seconds before timeout
-  -> IO a
-  -> IO (Maybe a)
-timeout seconds act = either id id <$> Async.race (Just <$> act) (threadDelay (seconds * 1_000_000) $> Nothing)

--- a/src/App/Fossa/VPS/Report.hs
+++ b/src/App/Fossa/VPS/Report.hs
@@ -1,0 +1,121 @@
+{-# LANGUAGE NumericUnderscores #-}
+
+module App.Fossa.VPS.Report
+  ( reportMain
+  , ReportType (..)
+  ) where
+
+import App.Fossa.API.BuildWait
+import qualified App.Fossa.FossaAPIV1 as Fossa
+import App.Fossa.ProjectInference
+import Control.Effect.Lift (Lift)
+import App.Types
+import Control.Carrier.Diagnostics
+import Control.Concurrent (threadDelay)
+import qualified Control.Concurrent.Async as Async
+import Control.Effect.Lift (sendIO)
+import qualified Data.Aeson as Aeson
+import Data.Functor (void, ($>))
+import Data.Text (Text)
+import Data.Text.IO (hPutStrLn)
+import Data.Text.Lazy.Encoding (decodeUtf8)
+import Effect.Logger
+import Fossa.API.Types (ApiOpts)
+import System.Exit (exitFailure, exitSuccess)
+import System.IO (stderr)
+import qualified App.Fossa.VPS.Scan.Core as VPSCore
+import qualified App.Fossa.VPS.Scan.ScotlandYard as ScotlandYard
+
+data ReportType =
+    AttributionReport
+
+reportName :: ReportType -> Text
+reportName r = case r of
+  AttributionReport -> "attribution"
+
+reportMain ::
+  BaseDir
+  -> ApiOpts
+  -> Severity
+  -> Int -- ^ timeout (seconds)
+  -> ReportType
+  -> OverrideProject
+  -> IO ()
+reportMain basedir apiOpts logSeverity timeoutSeconds reportType override = do
+  -- TODO: refactor this code duplicate from `fossa test`
+  {-
+  Most of this module (almost everything below this line) has been copied
+  from App.Fossa.Test.  I wanted to push this out sooner, and refactoring
+  everything right away was not appropriate for the timing of this command.
+
+  Main points of refactor:
+  * Waiting for builds and issue scans (separately, but also together)
+    * Above includes errors, types, and scaffolding
+  * Timeout over `IO a` (easy to move, but where do we move it?)
+  * CLI command refactoring as laid out in https://github.com/fossas/issues/issues/129
+  -}
+  void $ timeout timeoutSeconds $ withLogger logSeverity $ do
+    result <- runDiagnostics $ do
+      revision <- mergeOverride override <$> inferProject (unBaseDir basedir)
+
+      logSticky "[ Getting latest scan ID ]"
+
+      Fossa.Organization orgId <- Fossa.getOrganization apiOpts
+      let locator = VPSCore.createLocator (projectName revision) orgId
+
+      scan <- ScotlandYard.getLatestScan apiOpts locator (projectRevision revision)
+
+      logSticky "[ Waiting for component scan... ]"
+
+      waitForSherlockScan apiOpts locator (ScotlandYard.responseScanId scan)
+
+      logSticky "[ Waiting for issue scan completion... ]"
+      _ <- waitForIssues apiOpts revision
+      logSticky ""
+
+      logSticky $ "[ Fetching " <> pretty (reportName reportType) <> " report... ]"
+      jsonValue <- case reportType of
+        AttributionReport ->
+          Fossa.getAttributionRaw apiOpts revision
+      logSticky ""
+        
+      logStdout . pretty . decodeUtf8 $ Aeson.encode jsonValue
+
+    case result of
+      Left err -> do
+        logError $ renderFailureBundle err
+        sendIO exitFailure
+      Right _ -> sendIO exitSuccess
+
+  hPutStrLn stderr "Timed out while waiting for build/issues scan"
+  exitFailure
+
+pollDelaySeconds :: Int
+pollDelaySeconds = 8
+
+waitForSherlockScan ::
+  (Has Diagnostics sig m, Has (Lift IO) sig m, Has Logger sig m) =>
+  ApiOpts ->
+  VPSCore.Locator ->
+  -- | scan ID
+  Text ->
+  m ()
+waitForSherlockScan apiOpts locator scanId = do
+  scan <- ScotlandYard.getScan apiOpts locator scanId
+  case ScotlandYard.responseScanStatus scan of
+    Just "AVAILABLE" -> pure ()
+    Just "ERROR" -> fatalText "The component scan failed. Check the FOSSA webapp for more details."
+    Just otherStatus -> do
+      logSticky $ "[ Waiting for component scan... last status: " <> pretty otherStatus <> " ]"
+      sendIO $ threadDelay (pollDelaySeconds * 1_000_000)
+      waitForSherlockScan apiOpts locator scanId
+    Nothing -> do
+      sendIO $ threadDelay (pollDelaySeconds * 1_000_000)
+      waitForSherlockScan apiOpts locator scanId
+
+timeout
+  :: Int -- ^ number of seconds before timeout
+  -> IO a
+  -> IO (Maybe a)
+-- timeout seconds act = either id id <$> Async.race (Just <$> act) (threadDelay (seconds * 1_000_000) *> pure Nothing)
+timeout seconds act = either id id <$> Async.race (Just <$> act) (threadDelay (seconds * 1_000_000) $> Nothing)

--- a/src/App/Fossa/VPS/Scan.hs
+++ b/src/App/Fossa/VPS/Scan.hs
@@ -20,17 +20,19 @@ import App.Fossa.VPS.Types
 import App.Fossa.ProjectInference
 import App.Types (BaseDir (..), ApiKey (..), OverrideProject (..), ProjectRevision (..))
 import Data.Aeson
+import Data.Flag (Flag, fromFlag)
 import Data.Text (Text)
 import Effect.Logger
 import Path
 import Text.URI (URI)
 
-newtype SkipIPRScan = SkipIPRScan {unSkipIPRScan :: Bool}
+-- | SkipIPRScan bool flag
+data SkipIPRScan = SkipIPRScan
 
-scanMain :: URI -> BaseDir -> ApiKey -> Severity -> OverrideProject -> FilterExpressions -> SkipIPRScan ->  IO ()
+scanMain :: URI -> BaseDir -> ApiKey -> Severity -> OverrideProject -> FilterExpressions -> Flag SkipIPRScan ->  IO ()
 scanMain baseuri basedir apikey logSeverity overrideProject fileFilters skipIprScan = do
   let fossaOpts = FossaOpts baseuri $ unApiKey apikey
-      partVpsOpts = PartialVPSOpts fossaOpts (unSkipIPRScan skipIprScan) fileFilters
+      partVpsOpts = PartialVPSOpts fossaOpts (fromFlag SkipIPRScan skipIprScan) fileFilters
 
   result <- runDiagnostics $ withEmbeddedBinaries $ vpsScan basedir logSeverity overrideProject partVpsOpts
   case result of

--- a/src/App/Fossa/VPS/Scan.hs
+++ b/src/App/Fossa/VPS/Scan.hs
@@ -72,7 +72,7 @@ vpsScan (BaseDir basedir) logSeverity overrideProject skipIprFlag fileFilters ap
   logDebug "[All] Creating scan in Scotland Yard"
   let syOpts = ScotlandYardOpts locator projectRevision sherlockOrgId vpsOpts'
   response <- context "creating scan ID" $ createScotlandYardScan apiOpts syOpts
-  let scanId = responseScanId response
+  let scanId = createScanResponseId response
 
   -- Run IPR and Sherlock CLIs concurrently
   logDebug . pretty $ "[All] Running scan on directory " ++ show basedir

--- a/src/App/Fossa/VPS/Scan.hs
+++ b/src/App/Fossa/VPS/Scan.hs
@@ -18,23 +18,20 @@ import App.Fossa.VPS.Scan.RunSherlock
 import App.Fossa.VPS.Scan.ScotlandYard
 import App.Fossa.VPS.Types
 import App.Fossa.ProjectInference
-import App.Types (BaseDir (..), ApiKey (..), OverrideProject (..), ProjectRevision (..))
+import App.Types (BaseDir (..), OverrideProject (..), ProjectRevision (..))
 import Data.Aeson
 import Data.Flag (Flag, fromFlag)
 import Data.Text (Text)
 import Effect.Logger
 import Path
-import Text.URI (URI)
+import Fossa.API.Types (ApiOpts(..))
 
 -- | SkipIPRScan bool flag
 data SkipIPRScan = SkipIPRScan
 
-scanMain :: URI -> BaseDir -> ApiKey -> Severity -> OverrideProject -> FilterExpressions -> Flag SkipIPRScan ->  IO ()
-scanMain baseuri basedir apikey logSeverity overrideProject fileFilters skipIprScan = do
-  let fossaOpts = FossaOpts baseuri $ unApiKey apikey
-      partVpsOpts = PartialVPSOpts fossaOpts (fromFlag SkipIPRScan skipIprScan) fileFilters
-
-  result <- runDiagnostics $ withEmbeddedBinaries $ vpsScan basedir logSeverity overrideProject partVpsOpts
+scanMain :: BaseDir -> ApiOpts -> Severity -> OverrideProject -> FilterExpressions -> Flag SkipIPRScan ->  IO ()
+scanMain basedir apiOpts logSeverity overrideProject fileFilters skipIprScan = do
+  result <- runDiagnostics $ withEmbeddedBinaries $ vpsScan basedir logSeverity overrideProject skipIprScan fileFilters apiOpts
   case result of
     Left failure -> do
       print $ renderFailureBundle failure
@@ -46,36 +43,35 @@ scanMain baseuri basedir apikey logSeverity overrideProject fileFilters skipIprS
 vpsScan ::
   ( Has Diagnostics sig m
   , Has (Lift IO) sig m
-  ) => BaseDir -> Severity -> OverrideProject -> PartialVPSOpts -> BinaryPaths -> m ()
-vpsScan (BaseDir basedir) logSeverity overrideProject partVpsOpts binaryPaths = withLogQueue logSeverity $ \queue -> runLogger queue $ do
+  ) => BaseDir -> Severity -> OverrideProject -> Flag SkipIPRScan -> FilterExpressions -> ApiOpts -> BinaryPaths -> m ()
+vpsScan (BaseDir basedir) logSeverity overrideProject skipIprFlag fileFilters apiOpts binaryPaths = withLogQueue logSeverity $ \queue -> runLogger queue $ do
   -- Build the revision
   ProjectRevision {..} <- mergeOverride overrideProject <$> inferProject basedir
 
   -- Get Sherlock info
   logDebug "[Sherlock] Retrieving Sherlock information from FOSSA"
-  SherlockInfo{..} <- getSherlockInfo (fossaOpts partVpsOpts)
+  SherlockInfo{..} <- getSherlockInfo apiOpts
 
   -- Build locator info
   let locator = createLocator projectName sherlockOrgId
   let revisionLocator = createRevisionLocator projectName sherlockOrgId projectRevision
 
   -- FIXME: use better type here
-  let PartialVPSOpts {..} = partVpsOpts
-  let vpsOpts = VPSOpts fossaOpts projectName (Just projectRevision) partSkipIprScan partFileFilter
+  let vpsOpts = VPSOpts projectName (Just projectRevision) (fromFlag SkipIPRScan skipIprFlag) fileFilters
 
   -- Update vpsOpts with overriding scan filter blob. 
   -- Previous uses of `vpsOpts` do not deconstruct the object due to this not yet being overridden.
-  (vpsOpts'@VPSOpts{..}, areFiltersOverridden) <- overrideScanFilters vpsOpts locator
+  (vpsOpts'@VPSOpts{..}, areFiltersOverridden) <- overrideScanFilters apiOpts vpsOpts locator
   logDebug $ pretty $ "[All] Creating project with locator '" <> unRevisionLocator revisionLocator <> "'"
 
   -- Create scan in Core
   logDebug "[All] Creating project in FOSSA"
-  _ <- context "creating project in FOSSA" $ createCoreProject vpsProjectName projectRevision fossa
+  _ <- context "creating project in FOSSA" $ createCoreProject vpsProjectName projectRevision apiOpts
 
   -- Create scan in SY
   logDebug "[All] Creating scan in Scotland Yard"
   let syOpts = ScotlandYardOpts locator projectRevision sherlockOrgId vpsOpts'
-  response <- context "creating scan ID" $ createScotlandYardScan syOpts
+  response <- context "creating scan ID" $ createScotlandYardScan apiOpts syOpts
   let scanId = responseScanId response
 
   -- Run IPR and Sherlock CLIs concurrently
@@ -87,7 +83,7 @@ vpsScan (BaseDir basedir) logSeverity overrideProject partVpsOpts binaryPaths = 
   let sherlockOpts = SherlockOpts basedir scanId sherlockClientToken sherlockClientId sherlockUrl sherlockOrgId locator projectRevision vpsOpts'
   let runIt = runLogger queue . runDiagnostics . runExecIO
   (iprResult, sherlockResult) <- sendIO $ concurrently
-                (runIt $ runIPRScan basedir scanId binaryPaths syOpts vpsOpts')
+                (runIt $ runIPRScan basedir apiOpts scanId binaryPaths syOpts vpsOpts')
                 (runIt $ runSherlockScan binaryPaths sherlockOpts)
 
   case (iprResult, sherlockResult) of
@@ -102,8 +98,8 @@ vpsScan (BaseDir basedir) logSeverity overrideProject partVpsOpts binaryPaths = 
       sendIO exitFailure
 
   logDebug "[All] Completing scan in FOSSA"
-  _ <- context "completing project in FOSSA" $ completeCoreProject revisionLocator fossa
-  _ <- context "updating scan file filter" $ updateScanFileFilter areFiltersOverridden locator fileFilter fossa
+  _ <- context "completing project in FOSSA" $ completeCoreProject revisionLocator apiOpts
+  _ <- context "updating scan file filter" $ updateScanFileFilter areFiltersOverridden locator fileFilter apiOpts
   logDebug "[All] Project is ready to view in FOSSA (Sherlock forensics may still be pending)"
 
 runSherlockScan ::
@@ -120,21 +116,21 @@ runIPRScan ::
   , Has Logger sig m
   , Has Exec sig m
   , Has (Lift IO) sig m
-  ) => Path Abs Dir -> Text -> BinaryPaths -> ScotlandYardOpts -> VPSOpts -> m ()
-runIPRScan basedir scanId binaryPaths syOpts vpsOpts =
+  ) => Path Abs Dir -> ApiOpts -> Text -> BinaryPaths -> ScotlandYardOpts -> VPSOpts -> m ()
+runIPRScan basedir apiOpts scanId binaryPaths syOpts vpsOpts =
   if skipIprScan vpsOpts then do
     logDebug "[IPR] IPR scan disabled. Uploading an empty IPR set"
-    context "uploading empty scan results" $ uploadIPRResults scanId (object ["Files" .= ()]) syOpts
+    context "uploading empty scan results" $ uploadIPRResults apiOpts scanId (object ["Files" .= ()]) syOpts
     logDebug "[IPR] Post to Scotland Yard complete"
   else do
     iprResult <- execIPR binaryPaths $ IPROpts basedir vpsOpts
     logDebug "[IPR] IPR scan completed. Posting results to Scotland Yard"
-    context "uploading scan results" $ uploadIPRResults scanId iprResult syOpts
+    context "uploading scan results" $ uploadIPRResults apiOpts scanId iprResult syOpts
     logDebug ""
     logDebug "[IPR] Post to Scotland Yard complete"
     logDebug "[IPR] IPR scan complete"
 
-updateScanFileFilter :: (Has (Lift IO) sig m, Has Diagnostics sig m, Has Logger sig m) => Bool -> Locator -> FilterExpressions -> FossaOpts -> m ()
+updateScanFileFilter :: (Has (Lift IO) sig m, Has Diagnostics sig m, Has Logger sig m) => Bool -> Locator -> FilterExpressions -> ApiOpts -> m ()
 updateScanFileFilter False locator filterBlob fossa = storeUpdatedScanFilters locator filterBlob fossa
 updateScanFileFilter True _ _ _ = do
   logDebug "[All] Scan file filter was set by FOSSA server, skipping update"

--- a/src/App/Fossa/VPS/Scan/Core.hs
+++ b/src/App/Fossa/VPS/Scan/Core.hs
@@ -2,8 +2,7 @@
 {-# LANGUAGE RecordWildCards #-}
 
 module App.Fossa.VPS.Scan.Core
-  ( coreAuthHeader
-  , createCoreProject
+  ( createCoreProject
   , completeCoreProject
   , getSherlockInfo
   , createLocator
@@ -18,7 +17,6 @@ module App.Fossa.VPS.Scan.Core
 where
 
 import App.Fossa.VPS.Types
-import App.Util (parseUri)
 import Data.Text (pack, Text)
 import Prelude
 import Network.HTTP.Req
@@ -27,8 +25,8 @@ import Control.Effect.Diagnostics
 import Control.Effect.Lift (Lift, sendIO)
 import Data.Aeson
 import Data.Time.Clock.POSIX (getPOSIXTime)
-import Data.Text.Encoding
 import Effect.Logger
+import Fossa.API.Types (useApiOpts, ApiOpts(..))
 
 data SherlockInfo = SherlockInfo
   { sherlockUrl :: Text
@@ -42,9 +40,6 @@ instance FromJSON SherlockInfo where
   parseJSON = withObject "SherlockInfo" $ \obj -> do
     auth <- obj .: "auth"
     SherlockInfo <$> obj .: "url" <*> auth .: "clientToken" <*> auth .: "clientId" <*> obj .: "orgId"
-
-coreAuthHeader :: Text -> Option scheme
-coreAuthHeader apiKey = header "Authorization" (encodeUtf8 ("Bearer " <> apiKey))
 
 buildRevision :: Has (Lift IO) sig m => Maybe Text -> m Text
 buildRevision (Just userProvidedRevision) = pure userProvidedRevision
@@ -84,58 +79,50 @@ projectScanFiltersEndpoint baseurl locator = baseurl /: "api" /: "vendored-packa
   FIXME: Every function below this line is using a data structure designed for the CLI.
   This tightly couples us to our CLI API, and is very tedious to change with the merge of `vpscli` and `fossa` exe's.
 -}
-createCoreProject :: (Has (Lift IO) sig m, Has Diagnostics sig m) => Text -> Text -> FossaOpts -> m ()
-createCoreProject name revision FossaOpts{..} = runHTTP $ do
-  let auth = coreAuthHeader fossaApiKey
+createCoreProject :: (Has (Lift IO) sig m, Has Diagnostics sig m) => Text -> Text -> ApiOpts -> m ()
+createCoreProject name revision apiOpts = runHTTP $ do
   let body = object ["name" .= name, "revision" .= revision]
 
-  (baseUrl, baseOptions) <- parseUri fossaUrl
-  _ <- req POST (createProjectEndpoint baseUrl) (ReqBodyJson body) ignoreResponse (baseOptions <> header "Content-Type" "application/json" <> auth)
+  (baseUrl, baseOptions) <- useApiOpts apiOpts
+  _ <- req POST (createProjectEndpoint baseUrl) (ReqBodyJson body) ignoreResponse (baseOptions <> header "Content-Type" "application/json")
   pure ()
 
-completeCoreProject :: (Has (Lift IO) sig m, Has Diagnostics sig m) => RevisionLocator -> FossaOpts -> m ()
-completeCoreProject locator FossaOpts{..} = runHTTP $ do
-  let auth = coreAuthHeader fossaApiKey
+completeCoreProject :: (Has (Lift IO) sig m, Has Diagnostics sig m) => RevisionLocator -> ApiOpts -> m ()
+completeCoreProject locator apiOpts = runHTTP $ do
   let body = object ["locator" .= unRevisionLocator locator]
 
-  (baseUrl, baseOptions) <- parseUri fossaUrl
-  _ <- req POST (completeProjectEndpoint baseUrl) (ReqBodyJson body) ignoreResponse (baseOptions <> header "Content-Type" "application/json" <> auth)
+  (baseUrl, baseOptions) <- useApiOpts apiOpts
+  _ <- req POST (completeProjectEndpoint baseUrl) (ReqBodyJson body) ignoreResponse (baseOptions <> header "Content-Type" "application/json")
   pure ()
 
-getSherlockInfo :: (Has (Lift IO) sig m, Has Diagnostics sig m) => FossaOpts -> m SherlockInfo
-getSherlockInfo FossaOpts{..} = runHTTP $ do
-  let auth = coreAuthHeader fossaApiKey
-
-  (baseUrl, baseOptions) <- parseUri fossaUrl
-  resp <- req GET (sherlockInfoEndpoint baseUrl) NoReqBody jsonResponse (baseOptions <> header "Content-Type" "application/json" <> auth)
+getSherlockInfo :: (Has (Lift IO) sig m, Has Diagnostics sig m) => ApiOpts -> m SherlockInfo
+getSherlockInfo apiOpts = runHTTP $ do
+  (baseUrl, baseOptions) <- useApiOpts apiOpts
+  resp <- req GET (sherlockInfoEndpoint baseUrl) NoReqBody jsonResponse (baseOptions <> header "Content-Type" "application/json" )
   pure (responseBody resp)
 
-getProjectScanFilters :: (Has (Lift IO) sig m, Has Diagnostics sig m) => FossaOpts -> Locator -> m FilterExpressions
-getProjectScanFilters FossaOpts{..} locator = runHTTP $ do
-  let auth = coreAuthHeader fossaApiKey
-
-  (baseUrl, baseOptions) <- parseUri fossaUrl
-  resp <- req GET (projectScanFiltersEndpoint baseUrl locator) NoReqBody jsonResponse (baseOptions <> header "Content-Type" "application/json" <> auth)
+getProjectScanFilters :: (Has (Lift IO) sig m, Has Diagnostics sig m) => ApiOpts -> Locator -> m FilterExpressions
+getProjectScanFilters apiOpts locator = runHTTP $ do
+  (baseUrl, baseOptions) <- useApiOpts apiOpts
+  resp <- req GET (projectScanFiltersEndpoint baseUrl locator) NoReqBody jsonResponse (baseOptions <> header "Content-Type" "application/json")
   pure (responseBody resp)
 
-overrideScanFilters :: (Has (Lift IO) sig m, Has Diagnostics sig m, Has Logger sig m) => VPSOpts -> Locator -> m (VPSOpts, Bool)
-overrideScanFilters vpsOpts@VPSOpts { fileFilter = (FilterExpressions []) } locator = do
-  let VPSOpts{..} = vpsOpts
+overrideScanFilters :: (Has (Lift IO) sig m, Has Diagnostics sig m, Has Logger sig m) => ApiOpts -> VPSOpts -> Locator -> m (VPSOpts, Bool)
+overrideScanFilters apiOpts vpsOpts@VPSOpts { fileFilter = (FilterExpressions []) } locator = do
   logDebug "[All] Fetching scan file filter from FOSSA"
-  overrideFilters <- getProjectScanFilters fossa locator
+  overrideFilters <- getProjectScanFilters apiOpts locator
   logDebug $ pretty $ "[All] Using scan file filter: " <> encodeFilterExpressions overrideFilters
   pure (vpsOpts{fileFilter = overrideFilters}, True)
-overrideScanFilters vpsOpts _ = do
+overrideScanFilters _ vpsOpts _ = do
   logDebug "[All] Scan file filters provided locally"
   pure (vpsOpts, False)
   
-storeUpdatedScanFilters :: (Has (Lift IO) sig m, Has Diagnostics sig m, Has Logger sig m) => Locator -> FilterExpressions -> FossaOpts -> m ()
+storeUpdatedScanFilters :: (Has (Lift IO) sig m, Has Diagnostics sig m, Has Logger sig m) => Locator -> FilterExpressions -> ApiOpts -> m ()
 storeUpdatedScanFilters _ (FilterExpressions []) _ = do
   logDebug "[All] No scan file filter was set, skipping update"
   pure ()
-storeUpdatedScanFilters locator filters FossaOpts{..} = runHTTP $ do
-  let auth = coreAuthHeader fossaApiKey
+storeUpdatedScanFilters locator filters apiOpts = runHTTP $ do
   logDebug "[All] Updating FOSSA with new scan file filter for this project"
-  (baseUrl, baseOptions) <- parseUri fossaUrl
-  _ <- req POST (projectScanFiltersEndpoint baseUrl locator) (ReqBodyJson filters) ignoreResponse (baseOptions <> header "Content-Type" "application/json" <> auth)
+  (baseUrl, baseOptions) <- useApiOpts apiOpts
+  _ <- req POST (projectScanFiltersEndpoint baseUrl locator) (ReqBodyJson filters) ignoreResponse (baseOptions <> header "Content-Type" "application/json")
   pure ()  

--- a/src/App/Fossa/VPS/Scan/ScotlandYard.hs
+++ b/src/App/Fossa/VPS/Scan/ScotlandYard.hs
@@ -6,6 +6,7 @@ module App.Fossa.VPS.Scan.ScotlandYard
   , uploadIPRResults
   , uploadBuildGraph
   , getLatestScan
+  , LatestScanResponse (..)
   , ScanResponse (..)
   , ScotlandYardOpts (..)
   , ScotlandYardNinjaOpts (..)
@@ -59,8 +60,8 @@ uploadIPRChunkEndpoint baseurl projectId scanId = coreProxyPrefix baseurl /: "pr
 uploadIPRCompleteEndpoint :: Url 'Https -> Text -> Text -> Url 'Https
 uploadIPRCompleteEndpoint baseurl projectId scanId = coreProxyPrefix baseurl /: "projects" /: projectId /: "scans" /: scanId /: "discovered_licenses" /: "complete"
 
-getLatestScanEndpoint :: Url 'Https -> Text -> Url 'Https
-getLatestScanEndpoint baseurl projectId = coreProxyPrefix baseurl /: "projects" /: "projects" /: projectId /: "scans" /: "latest"
+getLatestScanEndpoint :: Url 'Https -> Locator -> Url 'Https
+getLatestScanEndpoint baseurl (Locator projectId) = coreProxyPrefix baseurl /: "projects" /: "projects" /: projectId /: "scans" /: "latest"
 
 data LatestScanResponse = LatestScanResponse
   { latestScanId :: Text
@@ -97,10 +98,8 @@ createScotlandYardScan apiOpts ScotlandYardOpts {..} = runHTTP $ do
   resp <- req POST (createScanEndpoint baseUrl locator) (ReqBodyJson body) jsonResponse (baseOptions <> header "Content-Type" "application/json" )
   pure (responseBody resp)
 
-getLatestScan :: (Has (Lift IO) sig m, Has Diagnostics sig m) => ApiOpts -> ScotlandYardOpts -> m LatestScanResponse
-getLatestScan apiOpts ScotlandYardOpts {..} = runHTTP $ do
-  let locator = unLocator projectId
-
+getLatestScan :: (Has (Lift IO) sig m, Has Diagnostics sig m) => ApiOpts -> Locator -> m LatestScanResponse
+getLatestScan apiOpts locator = runHTTP $ do
   (baseUrl, baseOptions) <- useApiOpts apiOpts
   resp <- req GET (getLatestScanEndpoint baseUrl locator) NoReqBody jsonResponse (baseOptions <> header "Content-Type" "application/json" )
   pure (responseBody resp)

--- a/src/App/Fossa/VPS/Test.hs
+++ b/src/App/Fossa/VPS/Test.hs
@@ -61,9 +61,6 @@ testMain basedir apiOpts logSeverity timeoutSeconds outputType override = do
 
       logSticky "[ Waiting for component scan... ]"
 
-      -- FIXME: this should probably call out to the real API
-      -- we may not be able to count on stability for the API, though, which is
-      -- why we use this command instead
       waitForSherlockScan apiOpts locator (ScotlandYard.responseScanId scan)
 
       logSticky "[ Waiting for issue scan completion... ]"

--- a/src/App/Fossa/VPS/Test.hs
+++ b/src/App/Fossa/VPS/Test.hs
@@ -100,6 +100,7 @@ waitForSherlockScan apiOpts locator scanId = do
   scan <- ScotlandYard.getScan apiOpts locator scanId
   case ScotlandYard.responseScanStatus scan of
     Just "AVAILABLE" -> pure ()
+    Just "ERROR" -> fatalText "The component scan failed. Check the FOSSA webapp for more details."
     Just otherStatus -> do
       logSticky $ "[ Waiting for component scan... last status: " <> pretty otherStatus <> " ]"
       sendIO $ threadDelay (pollDelaySeconds * 1_000_000)

--- a/src/App/Fossa/VPS/Test.hs
+++ b/src/App/Fossa/VPS/Test.hs
@@ -1,0 +1,182 @@
+{-# LANGUAGE NumericUnderscores #-}
+
+module App.Fossa.VPS.Test
+  ( testMain,
+    TestOutputType (..),
+  )
+where
+
+import App.Fossa.API.BuildWait
+import App.Fossa.VPS.EmbeddedBinary
+import qualified App.Fossa.FossaAPIV1 as Fossa
+import App.Fossa.ProjectInference
+import qualified App.Fossa.VPS.Scan.Core as VPSCore
+import qualified App.Fossa.VPS.Scan.ScotlandYard as ScotlandYard
+import App.Types
+import Control.Carrier.Diagnostics hiding (fromMaybe)
+import Control.Concurrent (threadDelay)
+import qualified Control.Concurrent.Async as Async
+import Control.Effect.Lift (sendIO)
+import qualified Data.Aeson as Aeson
+import Data.Functor (($>))
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as M
+import Data.Maybe (fromMaybe)
+import Data.Text (Text)
+import qualified Data.Text as T
+import Data.Text.IO (hPutStrLn)
+import Data.Text.Lazy.Encoding (decodeUtf8)
+import Effect.Exec
+import Effect.Logger
+import Fossa.API.Types (ApiOpts)
+import Path
+import System.Exit (exitFailure, exitSuccess)
+import System.IO (stderr)
+
+data TestOutputType
+  = -- | pretty output format for issues
+    TestOutputPretty
+  | -- | use json output for issues
+    TestOutputJson
+
+sherlockMonitorCmd ::
+  -- | path to sherlock-cli binary
+  Path Abs File ->
+  VPSCore.SherlockInfo ->
+  -- | scan ID
+  Text ->
+  Command
+sherlockMonitorCmd sherlockCliPath sherlockInfo scanId =
+  Command
+    { cmdName = T.pack (fromAbsFile sherlockCliPath),
+      cmdArgs =
+        [ scanId,
+          "-sherlock-api-host",
+          VPSCore.sherlockUrl sherlockInfo,
+          "-sherlock-api-client-id",
+          VPSCore.sherlockClientId sherlockInfo,
+          "-sherlock-api-secret-key",
+          VPSCore.sherlockClientToken sherlockInfo
+        ],
+      cmdAllowErr = Never
+    }
+
+testMain ::
+  BaseDir ->
+  ApiOpts ->
+  Severity ->
+  -- | timeout (seconds)
+  Int ->
+  TestOutputType ->
+  OverrideProject ->
+  IO ()
+testMain basedir apiOpts logSeverity timeoutSeconds outputType override = do
+  _ <- timeout timeoutSeconds . withLogger logSeverity . runExecIO $ do
+    result <- runDiagnostics $ withEmbeddedBinaries $ \binaries -> do
+      revision <- mergeOverride override <$> inferProject (unBaseDir basedir)
+
+      logInfo ""
+      logInfo ("Using project name: `" <> pretty (projectName revision) <> "`")
+      logInfo ("Using revision: `" <> pretty (projectRevision revision) <> "`")
+
+      logSticky "[ Getting latest scan ID ]"
+
+      Fossa.Organization orgId <- Fossa.getOrganization apiOpts
+      ScotlandYard.LatestScanResponse scanId <- ScotlandYard.getLatestScan apiOpts (VPSCore.createLocator (projectName revision) orgId)
+      sherlockInfo <- VPSCore.getSherlockInfo apiOpts
+
+      logSticky "[ Waiting for component scan... ]"
+
+      -- FIXME: this should probably call out to the real API
+      -- we may not be able to count on stability for the API, though, which is
+      -- why we use this command instead
+      _ <- execThrow (unBaseDir basedir) (sherlockMonitorCmd (sherlockBinaryPath binaries) sherlockInfo scanId)
+
+      logSticky "[ Waiting for build completion... ]"
+
+      waitForBuild apiOpts revision
+
+      logSticky "[ Waiting for issue scan completion... ]"
+      issues <- waitForIssues apiOpts revision
+      logSticky ""
+
+      if null (Fossa.issuesIssues issues)
+        then logInfo "Test passed! 0 issues found"
+        else do
+          case outputType of
+            TestOutputPretty -> logError (renderedIssues issues)
+            TestOutputJson -> logStdout . pretty . decodeUtf8 . Aeson.encode $ issues
+          sendIO exitFailure
+
+    case result of
+      Left failure -> do
+        logError $ renderFailureBundle failure
+        sendIO exitFailure
+      Right _ -> sendIO exitSuccess
+
+  -- we call exitSuccess/exitFailure in each branch above. the only way we get
+  -- here is if we time out
+  hPutStrLn stderr "Timed out while waiting for issues scan"
+  exitFailure
+
+renderedIssues :: Fossa.Issues -> Doc ann
+renderedIssues issues = rendered
+  where
+    padding :: Int
+    padding = 20
+
+    issuesList :: [Fossa.Issue]
+    issuesList = Fossa.issuesIssues issues
+
+    categorize :: Ord k => (v -> k) -> [v] -> Map k [v]
+    categorize f = M.fromListWith (++) . map (\v -> (f v, [v]))
+
+    issuesByType :: Map Fossa.IssueType [Fossa.Issue]
+    issuesByType = categorize Fossa.issueType issuesList
+
+    renderSection :: Fossa.IssueType -> [Fossa.Issue] -> Doc ann
+    renderSection issueType rawIssues =
+      renderHeader issueType <> line <> vsep (map renderIssue rawIssues) <> line
+
+    rendered :: Doc ann
+    rendered =
+      vsep
+        [renderSection issueType rawIssues | (issueType, rawIssues) <- M.toList issuesByType]
+
+    renderHeader :: Fossa.IssueType -> Doc ann
+    renderHeader ty =
+      vsep
+        [ "========================================================================",
+          pretty $ Fossa.renderIssueType ty,
+          "========================================================================",
+          hsep $
+            map (fill padding) $ case ty of
+              Fossa.IssuePolicyConflict -> ["Dependency", "Revision", "License"]
+              Fossa.IssuePolicyFlag -> ["Dependency", "Revision", "License"]
+              _ -> ["Dependency", "Revision"],
+          ""
+        ]
+
+    renderIssue :: Fossa.Issue -> Doc ann
+    renderIssue issue = hsep (map format [name, revision, license])
+      where
+        format :: Text -> Doc ann
+        format = fill padding . pretty
+
+        locatorSplit = T.split (\c -> c == '$' || c == '+') (Fossa.issueRevisionId issue)
+
+        name = fromMaybe (Fossa.issueRevisionId issue) (locatorSplit !? 1)
+        revision = fromMaybe "" (locatorSplit !? 2)
+        license = fromMaybe "" (Fossa.ruleLicenseId =<< Fossa.issueRule issue)
+
+        (!?) :: [a] -> Int -> Maybe a
+        xs !? ix
+          | length xs <= ix = Nothing
+          | otherwise = Just (xs !! ix)
+
+timeout ::
+  -- | number of seconds before timeout
+  Int ->
+  IO a ->
+  IO (Maybe a)
+timeout seconds act = either id id <$> Async.race (Just <$> act) (threadDelay (seconds * 1_000_000) $> Nothing)

--- a/src/App/Fossa/VPS/Types.hs
+++ b/src/App/Fossa/VPS/Types.hs
@@ -11,17 +11,15 @@ module App.Fossa.VPS.Types
 , HTTP(..)
 , HTTPRequestFailed(..)
 , VPSOpts (..)
-, PartialVPSOpts (..)
-, FossaOpts (..)
 , NinjaGraphOpts (..)
 ) where
 
 import Control.Monad.IO.Class (MonadIO(..))
 import Control.Carrier.Diagnostics
 import Control.Effect.Lift (Lift, sendIO)
-import Text.URI (URI)
 import Data.Text (Text)
 import Data.Aeson
+import Fossa.API.Types (ApiOpts)
 import Network.HTTP.Req
 import Data.Text.Prettyprint.Doc (viaShow)
 import qualified Data.ByteString.Lazy as BSL
@@ -40,21 +38,8 @@ instance ToJSON FilterExpressions where
 
 -- FIXME: replace these with non-CLI types
 -- VPSOpts in particular is used as a God type, and is very unwieldy in the merged CLI form.
-data FossaOpts = FossaOpts
-  { fossaUrl :: URI
-  , fossaApiKey :: Text
-  }
-
-data PartialVPSOpts
-  = PartialVPSOpts
-    { fossaOpts :: FossaOpts,
-      partSkipIprScan :: Bool,
-      partFileFilter :: FilterExpressions
-    }
-
 data VPSOpts = VPSOpts
-  { fossa :: FossaOpts
-  , vpsProjectName :: Text
+  { vpsProjectName :: Text
   , userProvidedRevision :: Maybe Text  -- FIXME: Since we can now infer a revision, we should rename this field.
   , skipIprScan :: Bool
   , fileFilter :: FilterExpressions
@@ -90,7 +75,7 @@ instance ToJSON DepsDependency where
     ]
 
 data NinjaGraphOpts = NinjaGraphOpts
-  { ninjaFossaOpts :: FossaOpts
+  { ninjaFossaOpts :: ApiOpts
   , ninjaGraphNinjaPath :: Maybe FilePath
   , lunchTarget :: Maybe Text
   , scanId :: Text

--- a/src/App/Types.hs
+++ b/src/App/Types.hs
@@ -1,6 +1,5 @@
 module App.Types
-  ( ApiKey (..),
-    BaseDir (..),
+  ( BaseDir (..),
     NinjaGraphCLIOptions (..),
     OverrideProject (..),
     ProjectRevision (..),
@@ -10,7 +9,6 @@ where
 import Data.Text (Text)
 import Path
 
-newtype ApiKey = ApiKey {unApiKey :: Text} deriving (Eq, Ord, Show)
 newtype BaseDir = BaseDir {unBaseDir :: Path Abs Dir} deriving (Eq, Ord, Show)
 
 data OverrideProject = OverrideProject

--- a/src/App/Util.hs
+++ b/src/App/Util.hs
@@ -2,19 +2,13 @@
 
 module App.Util
   ( validateDir,
-    parseUri,
   )
 where
 
 import App.Types
-import Control.Carrier.Diagnostics
 import Control.Monad (unless)
-import Data.Coerce (coerce)
-import Network.HTTP.Req
 import qualified Path.IO as P
 import System.Exit (die)
-import Text.URI (URI, render)
-import qualified Unsafe.Coerce as Unsafe
 
 -- | Validate that a filepath points to a directory and the directory exists
 validateDir :: FilePath -> IO BaseDir
@@ -24,13 +18,3 @@ validateDir dir = do
 
   unless exists (die $ "ERROR: Directory " <> show absolute <> " does not exist")
   pure $ BaseDir absolute
-
--- parse a URI for use as a (base) Url, along with some default Options (e.g., port)
-parseUri :: Has Diagnostics sig m => URI -> m (Url 'Https, Option 'Https)
-parseUri uri = case useURI uri of
-  Nothing -> fatalText ("Invalid URL: " <> render uri)
-  -- Url is "type role Url nominal" in the scheme (Http/Https), so we have to
-  -- unsafeCoerce @Url 'Http@ into @Url 'Https@. Options isn't nominal in the
-  -- scheme, so we can coerce as usual.
-  Just (Left (url, options)) -> pure (Unsafe.unsafeCoerce url, coerce options)
-  Just (Right (url, options)) -> pure (url, options)

--- a/src/Data/Flag.hs
+++ b/src/Data/Flag.hs
@@ -1,0 +1,24 @@
+-- http://oleg.fi/gists/posts/2019-03-21-flag.html
+module Data.Flag
+  ( Flag,
+    fromFlag,
+    toFlag,
+    flagOpt,
+  )
+where
+
+import Options.Applicative (FlagFields, Mod, Parser, switch)
+
+-- | A Flag datatype with a phantom type argument. See link above for usage
+data Flag a = Flag {getFlag :: Bool}
+  deriving (Eq, Ord, Show)
+
+fromFlag :: a -> Flag a -> Bool
+fromFlag _ = getFlag
+
+toFlag :: a -> Bool -> Flag a
+toFlag _ = Flag
+
+-- | optparse-applicative helper
+flagOpt :: a -> Mod FlagFields Bool -> Parser (Flag a)
+flagOpt a fields = toFlag a <$> switch fields

--- a/src/Fossa/API/Types.hs
+++ b/src/Fossa/API/Types.hs
@@ -1,0 +1,38 @@
+{-# LANGUAGE DataKinds #-}
+
+module Fossa.API.Types
+  ( ApiKey (..),
+    ApiOpts (..),
+    useApiOpts,
+  )
+where
+
+import Control.Effect.Diagnostics
+import Data.Coerce (coerce)
+import Data.Text (Text)
+import Data.Text.Encoding (encodeUtf8)
+import Network.HTTP.Req
+import Text.URI (URI, render)
+import qualified Unsafe.Coerce as Unsafe
+
+newtype ApiKey = ApiKey {unApiKey :: Text}
+  deriving (Eq, Ord, Show)
+
+data ApiOpts = ApiOpts
+  { apiOptsUri :: URI,
+    apiOptsApiKey :: ApiKey
+  }
+  deriving (Eq, Ord, Show)
+
+-- | parse a URI for use as a base Url, along with some default options (auth, port, ...)
+useApiOpts :: Has Diagnostics sig m => ApiOpts -> m (Url 'Https, Option 'Https)
+useApiOpts opts = case useURI (apiOptsUri opts) of
+  Nothing -> fatalText ("Invalid URL: " <> render (apiOptsUri opts))
+  -- Url is "type role Url nominal" in the scheme (Http/Https), so we have to
+  -- unsafeCoerce @Url 'Http@ into @Url 'Https@. Options isn't nominal in the
+  -- scheme, so we can coerce as usual.
+  Just (Left (url, options)) -> pure (Unsafe.unsafeCoerce url, coerce options <> authHeader (apiOptsApiKey opts))
+  Just (Right (url, options)) -> pure (url, options <> authHeader (apiOptsApiKey opts))
+
+authHeader :: ApiKey -> Option 'Https
+authHeader key = header "Authorization" (encodeUtf8 ("Bearer " <> unApiKey key))


### PR DESCRIPTION
This adds the `fossa vps test` command, which works similarly to `fossa test`, but checks for sherlock scan status instead of normal build status.

This also introduces a few small refactors:
1. `Data.Flag` module to replace using `Bool` for cli option parsing
2. a new `ApiOpts` datatype containing base url and api key for fossa-core endpoints
3. extracting `ApiOpts` out of the VPS god objects