### PR TITLE
Add support for gzip-compressed RPM files

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@
 - Adds support for `--team` and other metadata flags to vps analysis ([#149](https://github.com/fossas/spectrometer/pull/149))
 - Adds `fossa vps test` command, analogous to `fossa test` for vps projects ([#150](https://github.com/fossas/spectrometer/pull/150))
 - Adds `fossa vps report` command, analogous to `fossa report` for vps projects ([#150](https://github.com/fossas/spectrometer/pull/150))
+- Adds support for unpacking of gzipped RPMs ([#154](https://github.com/fossas/spectrometer/pull/154))
 
 # v2.3.2
 

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -43,6 +43,7 @@ common deps
     , hedn                         ^>=0.3.0.1
     , http-client                  ^>=0.7.1
     , http-types                   ^>=0.12.3
+    , lzma-conduit                 ^>=1.2.1
     , megaparsec                   ^>=8.0
     , modern-uri                   ^>=0.3.1
     , mtl                          ^>=2.2.2

--- a/src/Discovery/Archive/RPM.hs
+++ b/src/Discovery/Archive/RPM.hs
@@ -1,11 +1,12 @@
 {-# LANGUAGE FlexibleContexts #-}
 
 module Discovery.Archive.RPM
-  ( extractRpm
+  ( extractRpm,
   )
 where
 
 import qualified Codec.RPM.Conduit as RPM
+import qualified Codec.RPM.Tags as Tags
 import qualified Codec.RPM.Types as RPMTypes
 import Conduit
 import Control.Effect.Lift
@@ -14,38 +15,55 @@ import Control.Monad.Except
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as BS8
 import qualified Data.ByteString.Lazy as BL
+import qualified Data.CPIO as CPIO
 import qualified Data.Conduit.Lzma as Lzma
 import qualified Data.Conduit.Zlib as Zlib
-import qualified Data.CPIO as CPIO
+import Data.Foldable (asum)
 import Path
-import Prelude
 import qualified Path.IO as PIO
+import Prelude
 
 extractRpm :: Has (Lift IO) sig m => Path Abs Dir -> Path Abs File -> m ()
 extractRpm dir rpmFile = do
   res <-
-    sendIO . runResourceT . runExceptT . runConduit $
-      readRPMEntries rpmFile .| filterC (not . CPIO.isEntryDirectory) .| sinkDir
+    sendIO . runResourceT . runExceptT . runConduit $ do
+      sourceFileBS (toFilePath rpmFile) .| RPM.parseRPMC .| awaitForever (extractEntries dir)
+
   case res of
     Left parseErr -> sendIO . throwIO $ parseErr
     Right () -> pure ()
+
+extractEntries :: (PrimMonad m, MonadThrow m, MonadIO m) => Path Abs Dir -> RPMTypes.RPM -> ConduitT i o m ()
+extractEntries dir rpm = yield rpm .| RPM.payloadC .| decompress rpm .| CPIO.readCPIO .| filterC (not . CPIO.isEntryDirectory) .| sinkDir dir
+
+sinkDir :: MonadIO m => Path Abs Dir -> ConduitT CPIO.Entry o m ()
+sinkDir dir = mapM_C $ \entry -> do
+  let filepath = BS8.unpack $ CPIO.cpioFileName entry
+
+  -- explicitly ignore absolute paths
+  case parseRelFile filepath of
+    Nothing -> pure ()
+    Just filepath' -> do
+      liftIO . PIO.ensureDir $ (dir </> parent filepath')
+      liftIO . BS.writeFile (fromAbsFile (dir </> filepath')) . BL.toStrict $ CPIO.cpioFileData entry
+
+decompress :: (PrimMonad m, MonadThrow m, MonadIO m) => RPMTypes.RPM -> ConduitT BS.ByteString BS.ByteString m ()
+decompress rpm =
+  case getCompressor rpm of
+    Nothing -> pure ()
+    Just GZIP -> Zlib.ungzip
+    Just LZMA -> Lzma.decompress Nothing
+
+data Compressor
+  = LZMA
+  | GZIP
+
+-- There are two types of supported compressors in RPM files: "gzip" and "lzma"
+-- We assume the RPM is well-formed, and pick the first tag we see.
+getCompressor :: RPMTypes.RPM -> Maybe Compressor
+getCompressor = asum . map go . concatMap RPMTypes.headerTags . RPMTypes.rpmHeaders
   where
-    -- morally: :: Path b File -> ConduitT i CPIO.Entry m ()
-    -- (has a couple of additional constraints, e.g., MonadError for attoparsec ParseError)
-    readRPMEntries file = sourceFileBS (toFilePath file) .| RPM.parseRPMC .| rpmPayload
-    --
-    sinkDir :: MonadIO m => ConduitT CPIO.Entry o m ()
-    sinkDir = mapM_C $ \entry -> do
-      let filepath = BS8.unpack $ CPIO.cpioFileName entry
-
-      -- explicitly ignore absolute paths
-      case parseRelFile filepath of
-        Nothing -> pure ()
-        Just filepath' -> do
-          liftIO . PIO.ensureDir $ (dir </> parent filepath')
-          liftIO . BS.writeFile (fromAbsFile (dir </> filepath')) . BL.toStrict $ CPIO.cpioFileData entry
-
--- TODO: lzma
--- TODO: comment about payloadContentsC
-rpmPayload :: (PrimMonad m, MonadThrow m) => ConduitT RPMTypes.RPM CPIO.Entry m ()
-rpmPayload = RPM.payloadC .| Zlib.ungzip .| CPIO.readCPIO
+    go :: Tags.Tag -> Maybe Compressor
+    go (Tags.PayloadCompressor "gzip") = Just GZIP
+    go (Tags.PayloadCompressor "lzma") = Just LZMA
+    go _ = Nothing


### PR DESCRIPTION
`codec-rpm`'s `payloadContentsC` function only supports `lzma`-compressed rpm files. This adds support for `gzip`-compressed rpm files as well.