### PR TITLE
fix: Embed vendored binaries before they are packaged for release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,20 +87,6 @@ jobs:
       run: |
         cabal test --project-file=${{ matrix.project-file }} all
 
-    - name: Find and move binaries (windows)
-      if: ${{ contains(matrix.os, 'windows') }}
-      run: |
-        mkdir release
-        find . -type f -path '*/fossa/fossa.exe' -exec cp {} release \;
-        find . -type f -path '*/pathfinder/pathfinder.exe' -exec cp {} release \;
-  
-    - name: Find and move binaries (non-windows)
-      if: ${{ !contains(matrix.os, 'windows') }}
-      run: |
-        mkdir release
-        find . -type f -path '*/fossa/fossa' -exec cp {} release \;
-        find . -type f -path '*/pathfinder/pathfinder' -exec cp {} release \;
-
     - name: Update vendored binaries
       if: ${{ !contains(matrix.os, 'windows') }}
       run: ./vendor_download.sh
@@ -112,6 +98,20 @@ jobs:
       run: |
         echo '' >> src/App/Fossa/VPS/EmbeddedBinary.hs
         cabal build --project-file=${{ matrix.project-file }} all
+
+    - name: Find and move binaries (windows)
+      if: ${{ contains(matrix.os, 'windows') }}
+      run: |
+        mkdir release
+        find . -type f -path '*/fossa/fossa.exe' -exec cp {} release \;
+        find . -type f -path '*/pathfinder/pathfinder.exe' -exec cp {} release \;
+
+    - name: Find and move binaries (non-windows)
+      if: ${{ !contains(matrix.os, 'windows') }}
+      run: |
+        mkdir release
+        find . -type f -path '*/fossa/fossa' -exec cp {} release \;
+        find . -type f -path '*/pathfinder/pathfinder' -exec cp {} release \;
 
     - name: Strip binaries
       run: |


### PR DESCRIPTION
The CI pipeline uploads artifacts in the `release` folder. However, the artifacts _in_ that folder were the ones generated _before_ embedding vendored binaries, not _after_ embedding vendored binaries. Therefore, the uploaded artifacts incorrectly vendored zero-byte binaries, causing the "no input" error.