### PR TITLE
Add version information

### DIFF
--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -40,6 +40,7 @@ common deps
     , fused-effects                ^>=1.1.0.0
     , fused-effects-exceptions     ^>=1.1.0.0
     , git-config                   ^>=0.1.2
+    , githash                      ^>=0.1.4.0
     , hedn                         ^>=0.3.0.1
     , http-client                  ^>=0.7.1
     , http-types                   ^>=0.12.3
@@ -59,11 +60,13 @@ common deps
     , tar                          ^>=0.5.1.1
     , template-haskell             >=2.15     && <2.17
     , text                         ^>=1.2.3
+    , th-lift-instances            ^>=0.1.17
     , time                         >=1.9      && <1.11
     , tomland                      ^>=1.3.0.0
     , typed-process                ^>=0.2.6
     , unordered-containers         ^>=0.2.10
     , vector                       ^>=0.12.0.3
+    , versions                     ^>=4.0.1
     , xml                          ^>=1.3.14
     , yaml                         ^>=0.11.1
     , yarn-lock                    ^>=0.6.2
@@ -104,6 +107,8 @@ library
     App.Pathfinder.Scan
     App.Types
     App.Util
+    App.Version
+    App.Version.TH
     Control.Carrier.Diagnostics
     Control.Carrier.Finally
     Control.Carrier.Output.IO

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -221,6 +221,7 @@ test-suite unit-tests
   other-modules:
     App.Fossa.FossaAPIV1Spec
     App.Fossa.Report.AttributionSpec
+    App.Fossa.VersionSpec
     App.Fossa.VPS.NinjaGraphSpec
     Cargo.MetadataSpec
     Carthage.CarthageSpec

--- a/src/App/Fossa/FossaAPIV1.hs
+++ b/src/App/Fossa/FossaAPIV1.hs
@@ -54,6 +54,7 @@ import Srclib.Types
 import Text.URI (URI)
 import qualified Text.URI as URI
 import Fossa.API.Types (ApiOpts, useApiOpts)
+import App.Version (versionNumber)
 
 newtype FossaReq m a = FossaReq { unFossaReq :: m a }
   deriving (Functor, Applicative, Monad, Algebra sig)
@@ -67,9 +68,9 @@ instance (Has (Lift IO) sig m, Has Diagnostics sig m) => MonadHttp (FossaReq m) 
 fossaReq :: FossaReq m a -> m a
 fossaReq = unFossaReq
 
--- TODO: git commit?
+-- Don't send any version if one doesn't exist
 cliVersion :: Text
-cliVersion = "spectrometer"
+cliVersion = fromMaybe "" versionNumber
 
 uploadUrl :: Url scheme -> Url scheme
 uploadUrl baseurl = baseurl /: "api" /: "builds" /: "custom"
@@ -141,7 +142,7 @@ uploadAnalysis rootDir apiOpts ProjectRevision{..} metadata projects = fossaReq 
 
       sourceUnits = map toSourceUnit filteredProjects
       opts = "locator" =: renderLocator (Locator "custom" projectName (Just projectRevision))
-          <> "v" =: cliVersion
+          <> "cliVersion" =: cliVersion
           <> "managedBuild" =: True
           <> mkMetadataOpts metadata projectName
           -- Don't include branch if it doesn't exist, core may not handle empty string properly.

--- a/src/App/Fossa/Main.hs
+++ b/src/App/Fossa/Main.hs
@@ -18,6 +18,7 @@ import App.Fossa.VPS.Types (FilterExpressions (..))
 import App.OptionExtensions
 import App.Types
 import App.Util (validateDir)
+import App.Version (fullVersionDescription)
 import Control.Monad (unless, when)
 import Data.Bifunctor (first)
 import Data.Bool (bool)
@@ -127,6 +128,7 @@ opts =
     <*> optional (strOption (long "revision" <> help "this repository's current revision hash (default: VCS hash HEAD)"))
     <*> optional (strOption (long "fossa-api-key" <> help "the FOSSA API server authenticaion key (default: FOSSA_API_KEY from env)"))
     <*> (commands <|> hiddenCommands)
+    <**> infoOption (T.unpack fullVersionDescription) (long "version" <> short 'V' <> help "show version text")
     <**> helper
 
 commands :: Parser Command

--- a/src/App/Version.hs
+++ b/src/App/Version.hs
@@ -44,7 +44,7 @@ fullVersionDescription = T.concat items
     version =
       if isDirty
         then branch
-        else maybe branch (<> "version ") versionNumber
+        else maybe branch ("version " <>) versionNumber
     branch = "branch " <> currentBranch
     dirty = if isDirty then " (dirty)" else ""
     items :: [Text]

--- a/src/App/Version.hs
+++ b/src/App/Version.hs
@@ -3,6 +3,7 @@
 module App.Version
   ( versionNumber,
     fullVersionDescription,
+    isDirty,
   )
 where
 

--- a/src/App/Version.hs
+++ b/src/App/Version.hs
@@ -1,0 +1,60 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+module App.Version
+  ( versionNumber,
+    fullVersionDescription,
+  )
+where
+
+import App.Version.TH
+import Data.Text (Text)
+import qualified Data.Text as T
+import GitHash
+import System.Info
+import Data.Version (showVersion)
+
+versionNumber :: Maybe Text
+versionNumber = $$(getCurrentTag)
+
+info :: GitInfo
+info = $$(tGitInfoCwd)
+
+currentBranch :: Text
+currentBranch = T.pack $ giBranch info
+
+currentCommit :: Text
+currentCommit = T.pack $ giHash info
+
+shortCommit :: Text
+shortCommit = T.take 12 currentCommit
+
+isDirty :: Bool
+isDirty = giDirty info
+
+compilerId :: Text
+compilerId = name <> "-" <> version
+  where
+    name = T.pack compilerName
+    version = T.pack $ showVersion compilerVersion
+
+fullVersionDescription :: Text
+fullVersionDescription = T.concat items
+  where
+    version :: Text
+    version =
+      if isDirty
+        then branch
+        else maybe branch (<> "version ") versionNumber
+    branch = "branch " <> currentBranch
+    dirty = if isDirty then " (dirty)" else ""
+    items :: [Text]
+    items =
+      [ "spectrometer: ",
+        version,
+        " (revision ",
+        shortCommit,
+        dirty,
+        " compiled with ",
+        compilerId,
+        ")"
+      ]

--- a/src/App/Version/TH.hs
+++ b/src/App/Version/TH.hs
@@ -33,16 +33,23 @@ gitTagPointCommand commit =
       cmdAllowErr = Always
     }
 
-gitIndexFile :: Path Rel File
-gitIndexFile = $(mkRelFile ".git/index")
+gitLogFile :: Path Rel File
+gitLogFile = $(mkRelFile ".git/logs/HEAD")
 
 getCurrentTag :: TExpQ (Maybe Text)
 getCurrentTag = do
-  let commitHash = giHash $$(tGitInfo ".")
-  -- FIXME: boy it would be nice to not shell out during compilation.  So much that could go wrong.
-  indexFile <- runIO $ (</> gitIndexFile) <$> getCurrentDir
-  addDependentFile $ toFilePath indexFile
+  let commitHash = giHash $$(tGitInfoCwd)
   result <- runIO . runDiagnostics . runExecIO . getTags $ T.pack commitHash
+
+  {- addDependentFile will cause this function to recompile when .git/logs/HEAD
+      changes. This is required for accuracy during dev since this value is not
+      always needed in the final binary.
+
+      NOTE that there is poentially a bug with this function, which causes it to
+      do nothing.  https://github.com/haskell/cabal/issues/4746
+  -}
+  logFile <- runIO $ (</> gitLogFile) <$> getCurrentDir
+  addDependentFile $ toFilePath logFile
 
   case result of
     Left err -> reportWarning (show err) >> [||Nothing||]
@@ -50,11 +57,22 @@ getCurrentTag = do
 
 getTags :: (Has Exec sig m, Has Diagnostics sig m) => Text -> m [Text]
 getTags hash = do
+  -- FIXME: boy it would be nice to not shell out during compilation.  So much that could go wrong.
   result <- exec $(mkRelDir ".") $ gitTagPointCommand hash
   bsl <- fromEitherShow result
 
   pure . map T.strip . T.lines . TE.decodeUtf8 $ BSL.toStrict bsl
 
+{- We'd like to use this time to make sure we have tags when we build release
+    versions.  However, 2 things make that difficult at the time of writing:
+
+    * We don't know if we're in a GH PR or a Release build.
+    * We only build releases by pushing tags, so we can't even trigger the error case
+
+    For these reasons, we're ignoring the case where there is no tag.  Future enhancements
+    should apply to the [] case of the filterTags function below.  Theoretically, we COULD
+    do some IO to determine something about github, and execute using `runIO`.
+-}
 filterTags :: [Text] -> TExpQ (Maybe Text)
 filterTags [] = [||Nothing||]
 filterTags [x] = validateSingleTag x
@@ -67,6 +85,6 @@ validateSingleTag :: Text -> TExpQ (Maybe Text)
 validateSingleTag tag = do
   let normalized = fromMaybe tag $ T.stripPrefix "v" tag
 
-  case versioning tag of
+  case semver normalized of
     Left err -> reportWarning (errorBundlePretty err) >> [||Nothing||]
-    Right _ -> [||Just normalized||]
+    Right _ -> [|| Just normalized ||]

--- a/src/App/Version/TH.hs
+++ b/src/App/Version/TH.hs
@@ -1,0 +1,72 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+module App.Version.TH
+  ( getCurrentTag,
+  )
+where
+
+import Control.Carrier.Diagnostics (resultValue, runDiagnostics)
+import Control.Effect.Diagnostics
+  ( Diagnostics,
+    fromEitherShow,
+  )
+import qualified Data.ByteString.Lazy as BSL
+import Data.Maybe (fromMaybe)
+import Data.Text (Text)
+import qualified Data.Text.Encoding as TE
+import qualified Data.Text as T
+import Data.Versions
+import Effect.Exec
+import GitHash
+import Instances.TH.Lift ()
+import Language.Haskell.TH
+import Path
+import Language.Haskell.TH.Syntax (addDependentFile)
+import Path.IO (getCurrentDir)
+
+
+gitTagPointCommand :: Text -> Command
+gitTagPointCommand commit =
+  Command
+    { cmdName = "git",
+      cmdArgs = ["tag", "--points-at", commit],
+      cmdAllowErr = Always
+    }
+
+gitIndexFile :: Path Rel File
+gitIndexFile = $(mkRelFile ".git/index")
+
+getCurrentTag :: TExpQ (Maybe Text)
+getCurrentTag = do
+  let commitHash = giHash $$(tGitInfo ".")
+  -- FIXME: boy it would be nice to not shell out during compilation.  So much that could go wrong.
+  indexFile <- runIO $ (</> gitIndexFile) <$> getCurrentDir
+  addDependentFile $ toFilePath indexFile
+  result <- runIO . runDiagnostics . runExecIO . getTags $ T.pack commitHash
+
+  case result of
+    Left err -> reportWarning (show err) >> [||Nothing||]
+    Right tags -> filterTags $ resultValue tags
+
+getTags :: (Has Exec sig m, Has Diagnostics sig m) => Text -> m [Text]
+getTags hash = do
+  result <- exec $(mkRelDir ".") $ gitTagPointCommand hash
+  bsl <- fromEitherShow result
+
+  pure . map T.strip . T.lines . TE.decodeUtf8 $ BSL.toStrict bsl
+
+filterTags :: [Text] -> TExpQ (Maybe Text)
+filterTags [] = [||Nothing||]
+filterTags [x] = validateSingleTag x
+filterTags xs = reportWarning (T.unpack multiTagMesg) >> [||Nothing||]
+  where
+    multiTagMesg = header <> T.intercalate ", " xs
+    header = "Multiple tags defined at current commit: "
+
+validateSingleTag :: Text -> TExpQ (Maybe Text)
+validateSingleTag tag = do
+  let normalized = fromMaybe tag $ T.stripPrefix "v" tag
+
+  case versioning tag of
+    Left err -> reportWarning (errorBundlePretty err) >> [||Nothing||]
+    Right _ -> [||Just normalized||]

--- a/test/App/Fossa/VersionSpec.hs
+++ b/test/App/Fossa/VersionSpec.hs
@@ -4,7 +4,6 @@ module App.Fossa.VersionSpec
 where
 
 import App.Version
-import Data.Maybe (isJust)
 import Test.Hspec
 
 spec :: Spec

--- a/test/App/Fossa/VersionSpec.hs
+++ b/test/App/Fossa/VersionSpec.hs
@@ -4,13 +4,10 @@ module App.Fossa.VersionSpec
 where
 
 import App.Version
-import Test.Hspec
 import Data.Maybe (isJust)
+import Test.Hspec
 
 spec :: Spec
 spec = describe "Version" $ do
   it "is not dirty" $
     isDirty `shouldBe` False
-
-  it "should have a version" $
-    isJust versionNumber `shouldBe` True

--- a/test/App/Fossa/VersionSpec.hs
+++ b/test/App/Fossa/VersionSpec.hs
@@ -1,0 +1,16 @@
+module App.Fossa.VersionSpec
+  ( spec,
+  )
+where
+
+import App.Version
+import Test.Hspec
+import Data.Maybe (isJust)
+
+spec :: Spec
+spec = describe "Version" $ do
+  it "is not dirty" $
+    isDirty `shouldBe` False
+
+  it "should have a version" $
+    isJust versionNumber `shouldBe` True


### PR DESCRIPTION
tasks:

- [x] Compile with git info available
- [x] Emit warnings on existing tags with bad format
- [x] ~Recompile when git log changes~ (blocked by https://github.com/haskell/cabal/issues/4746)
- [x] Send version in API
- [x] Create version string and CLI option