### PR TITLE
Improve maven pom property interpolation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,6 +56,10 @@ jobs:
       run: |
         brew install upx jq
 
+    - name: Allow insecure actions commands for setup-haskell add-env
+      run: |
+        echo "ACTIONS_ALLOW_UNSECURE_COMMANDS=true" >> $GITHUB_ENV
+
     - uses: actions/setup-haskell@v1.1
       id: setup-haskell
       name: Setup ghc/cabal (non-alpine)

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -240,6 +240,7 @@ test-suite unit-tests
     Haskell.CabalSpec
     Haskell.StackSpec
     Maven.PluginStrategySpec
+    Maven.PomStrategySpec
     Node.NpmLockSpec
     Node.PackageJsonSpec
     NuGet.NuspecSpec

--- a/src/Data/Text/Extra.hs
+++ b/src/Data/Text/Extra.hs
@@ -1,6 +1,7 @@
 module Data.Text.Extra
   ( splitOnceOn,
     splitOnceOnEnd,
+    breakOnAndRemove,
   )
 where
 
@@ -20,3 +21,18 @@ splitOnceOnEnd needle haystack = (strippedInitial, end)
     len = T.length needle
     (initial, end) = T.breakOnEnd needle haystack
     strippedInitial = T.dropEnd len initial
+
+-- | Like Text.breakOn, but with two differences:
+-- 1. This removes the text that was broken on, e.g., `Text.breakOn "foo" "foobar" == ("", "foobar")` `breakOnAndRemove "foo" "foobar" == ("", "bar")`
+-- 2. This returns a `Maybe` value if the substring wasn't able to be found
+--
+-- >>> breakOnAndRemove "foo" "bazfoobar"
+-- Just ("baz","bar")
+--
+-- >>> breakOnAndRemove "foo" "bar"
+-- Nothing
+breakOnAndRemove :: Text -> Text -> Maybe (Text, Text)
+breakOnAndRemove needle haystack
+  | (before,after) <- T.breakOn needle haystack
+  , T.isPrefixOf needle after = Just (before, T.drop (T.length needle) after)
+  | otherwise = Nothing

--- a/test/Maven/PomStrategySpec.hs
+++ b/test/Maven/PomStrategySpec.hs
@@ -1,0 +1,24 @@
+module Maven.PomStrategySpec
+  ( spec,
+  )
+where
+
+import qualified Data.Map.Strict as M
+import Strategy.Maven.Pom (interpolateProperties)
+import Strategy.Maven.Pom.PomFile
+import Test.Hspec
+
+spec :: Spec
+spec = do
+  describe "interpolateProperties" $ do
+    let pom = Pom (MavenCoordinate "MYGROUP" "MYARTIFACT" "MYVERSION") Nothing M.empty M.empty M.empty []
+    it "should work for built-in properties" $ do
+      interpolateProperties pom "${project.groupId}" `shouldBe` "MYGROUP"
+      interpolateProperties pom "${project.artifactId}" `shouldBe` "MYARTIFACT"
+      interpolateProperties pom "${project.version}" `shouldBe` "MYVERSION"
+
+    it "should prefer user-specified properties over computed ones" $ do
+      let pom' = pom { pomProperties = M.singleton "project.groupId" "OTHERGROUP" }
+      interpolateProperties pom' "${project.groupId}" `shouldBe` "OTHERGROUP"
+      
+      

--- a/test/Maven/PomStrategySpec.hs
+++ b/test/Maven/PomStrategySpec.hs
@@ -20,5 +20,10 @@ spec = do
     it "should prefer user-specified properties over computed ones" $ do
       let pom' = pom { pomProperties = M.singleton "project.groupId" "OTHERGROUP" }
       interpolateProperties pom' "${project.groupId}" `shouldBe` "OTHERGROUP"
-      
+
+    it "should work in the middle of strings" $ do
+      interpolateProperties pom "foo${project.groupId}bar" `shouldBe` "fooMYGROUPbar"
+
+    it "should interpolate multiple properties" $ do
+      interpolateProperties pom "${project.groupId}${project.artifactId}" `shouldBe` "MYGROUPMYARTIFACT"
       


### PR DESCRIPTION
Our maven static analysis strategy does naive property interpolation for dependency resolution, e.g.,

```xml
<dependency>
      <version>${my.dep.version}</version>
      [...]
</dependency>
```

would have `${my.dep.version}` replaced with the value of the `my.dep.version` property.

---

Our property interpolation breaks in a couple of common ways:

1. We require that the property be the entire string, e.g., `${property}` would be correctly interpolated, but `foo${property}` would not
2. There are commonly-used builtin properties used for dependency resolution, e.g., `project.groupId` or `project.version` that aren't supported by our interpolation method

This PR resolves both of these issues, and is tested against the user project in https://fossa.atlassian.net/browse/FC-2529