### PR TITLE
Optional version field in Pipfile.lock

### DIFF
--- a/src/Strategy/Cocoapods/Podfile.hs
+++ b/src/Strategy/Cocoapods/Podfile.hs
@@ -36,9 +36,7 @@ buildGraph podfile = Graphing.fromList (map toDependency direct)
     toDependency Pod{..} =
       Dependency { dependencyType = PodType
                  , dependencyName = name
-                 , dependencyVersion = case version of
-                                            Nothing -> Nothing
-                                            Just ver -> Just (CEq ver)
+                 , dependencyVersion = CEq <$> version
                  , dependencyLocations = case M.lookup SourceProperty properties of
                                             Just repo -> [repo]
                                             _ -> [source podfile]

--- a/src/Strategy/Python/Pipenv.hs
+++ b/src/Strategy/Python/Pipenv.hs
@@ -128,7 +128,7 @@ buildNodes PipfileLock{..} = do
                -> PipfileDep
                -> m ()
   addWithEnv env sourcesMap depName dep = do
-    let pkg = PipPkg depName $ T.drop 2 <$> fileDepVersion dep
+    let pkg = PipPkg depName (T.drop 2 <$> fileDepVersion dep)
     -- TODO: reachable instead of direct
     direct pkg
     label pkg (PipEnvironment env)

--- a/src/Strategy/Python/Pipenv.hs
+++ b/src/Strategy/Python/Pipenv.hs
@@ -91,7 +91,9 @@ buildGraph lock maybeDeps = run . withLabeling toDependency $ do
     start = Dependency
       { dependencyType = PipType
       , dependencyName = pipPkgName pkg
-      , dependencyVersion = Just (CEq (pipPkgVersion pkg))
+      , dependencyVersion = case pipPkgVersion pkg of
+                              Nothing -> Nothing
+                              Just ver -> Just (CEq ver)
       , dependencyLocations = []
       , dependencyEnvironments = []
       , dependencyTags = M.empty
@@ -99,7 +101,7 @@ buildGraph lock maybeDeps = run . withLabeling toDependency $ do
 
 data PipPkg = PipPkg
   { pipPkgName    :: Text
-  , pipPkgVersion :: Text
+  , pipPkgVersion :: Maybe Text
   } deriving (Eq, Ord, Show)
 
 type PipGrapher = LabeledGrapher PipPkg PipLabel
@@ -128,7 +130,9 @@ buildNodes PipfileLock{..} = do
                -> PipfileDep
                -> m ()
   addWithEnv env sourcesMap depName dep = do
-    let pkg = PipPkg depName (T.drop 2 (fileDepVersion dep))
+    let pkg = PipPkg depName $ case fileDepVersion dep of
+                                 Nothing -> Nothing
+                                 Just ver -> Just (T.drop 2 ver)
     -- TODO: reachable instead of direct
     direct pkg
     label pkg (PipEnvironment env)
@@ -147,7 +151,7 @@ buildEdges pipenvDeps = do
   where
 
   mkPkg :: PipenvGraphDep -> PipPkg
-  mkPkg dep = PipPkg (depName dep) (depInstalled dep)
+  mkPkg dep = PipPkg (depName dep) $ Just (depInstalled dep)
 
   mkEdges :: Has PipGrapher sig m => PipenvGraphDep -> m ()
   mkEdges parentDep =
@@ -173,7 +177,7 @@ data PipfileSource = PipfileSource
   } deriving (Eq, Ord, Show)
 
 data PipfileDep = PipfileDep
-  { fileDepVersion :: Text
+  { fileDepVersion :: Maybe Text
   , fileDepIndex   :: Maybe Text
   } deriving (Eq, Ord, Show)
 
@@ -185,7 +189,7 @@ instance FromJSON PipfileLock where
 
 instance FromJSON PipfileDep where
   parseJSON = withObject "PipfileDep" $ \obj ->
-    PipfileDep <$> obj .:  "version"
+    PipfileDep <$> obj .:? "version"
                <*> obj .:? "index"
 
 instance FromJSON PipfileMeta where

--- a/src/Strategy/Python/Pipenv.hs
+++ b/src/Strategy/Python/Pipenv.hs
@@ -91,9 +91,7 @@ buildGraph lock maybeDeps = run . withLabeling toDependency $ do
     start = Dependency
       { dependencyType = PipType
       , dependencyName = pipPkgName pkg
-      , dependencyVersion = case pipPkgVersion pkg of
-                              Nothing -> Nothing
-                              Just ver -> Just (CEq ver)
+      , dependencyVersion = CEq <$> pipPkgVersion pkg
       , dependencyLocations = []
       , dependencyEnvironments = []
       , dependencyTags = M.empty
@@ -130,9 +128,7 @@ buildNodes PipfileLock{..} = do
                -> PipfileDep
                -> m ()
   addWithEnv env sourcesMap depName dep = do
-    let pkg = PipPkg depName $ case fileDepVersion dep of
-                                 Nothing -> Nothing
-                                 Just ver -> Just (T.drop 2 ver)
+    let pkg = PipPkg depName $ T.drop 2 <$> fileDepVersion dep
     -- TODO: reachable instead of direct
     direct pkg
     label pkg (PipEnvironment env)

--- a/test/Python/PipenvSpec.hs
+++ b/test/Python/PipenvSpec.hs
@@ -17,16 +17,19 @@ pipfileLock = PipfileLock
     ]
 
   , fileDefault = M.fromList
-    [ ("pkgTwo", PipfileDep { fileDepVersion = "==2.0.0"
+    [ ("pkgTwo", PipfileDep { fileDepVersion = Just "==2.0.0"
                             , fileDepIndex = Just "package-index"
                             })
-    , ("pkgThree", PipfileDep { fileDepVersion = "==3.0.0"
+    , ("pkgThree", PipfileDep { fileDepVersion = Just "==3.0.0"
+                              , fileDepIndex = Nothing
+                              })
+    , ("pkgFour", PipfileDep { fileDepVersion = Nothing
                               , fileDepIndex = Nothing
                               })
     ]
 
   , fileDevelop = M.fromList
-    [ ("pkgOne", PipfileDep { fileDepVersion = "==1.0.0"
+    [ ("pkgOne", PipfileDep { fileDepVersion = Just "==1.0.0"
                             , fileDepIndex = Nothing
                             })
     ]
@@ -81,6 +84,16 @@ depThree = Dependency
   , dependencyEnvironments = [EnvProduction]
   , dependencyTags = M.empty
   }
+  
+depFour :: Dependency
+depFour = Dependency
+  { dependencyType = PipType
+  , dependencyName = "pkgFour"
+  , dependencyVersion = Nothing
+  , dependencyLocations = []
+  , dependencyEnvironments = [EnvProduction]
+  , dependencyTags = M.empty
+  }
 
 xit :: String -> Expectation -> SpecWith (Arg Expectation)
 xit _ _ = it "is an ignored test" $ () `shouldBe` ()
@@ -100,6 +113,6 @@ spec = do
     it "should set all dependencies as direct" $ do
       let result = buildGraph pipfileLock Nothing
 
-      expectDeps [depOne, depTwo, depThree] result
-      expectDirect [depOne, depTwo, depThree] result
+      expectDeps [depOne, depTwo, depThree, depFour] result
+      expectDirect [depOne, depTwo, depThree, depFour] result
       expectEdges [] result

--- a/test/Python/testdata/Pipfile.lock
+++ b/test/Python/testdata/Pipfile.lock
@@ -1,0 +1,47 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "8d14434df45e0ef884d6c3f6e8048ba72335637a8631cc44792f52fd20b6f97a"
+        },
+        "pipfile-spec": 5,
+        "sources": [
+            {
+                "name": "package-index",
+                "url": "https://my-package-index/",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "pkgTwo": {
+            "hashes": [
+                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691",
+                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae"
+            ],
+            "index": "package-index",
+            "version": "==2.0.0"
+        },
+        "pkgThree": {
+            "hashes": [
+                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691",
+                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae"
+            ],
+            "version": "==3.0.0"
+        },
+        "pkgFour": {
+            "hashes": [
+                "sha256:2ccb79b01769d99115aa600d7eed99f524bf752bba8f041dc1c184853514655a",
+                "sha256:0f2d585d22050e90c7d293b6451c83db097df77871974d90efd5a30dc12fcde3"
+            ]
+        }
+    },
+    "develop": {
+        "pkgOne": {
+            "hashes": [
+                "sha256:54a07c09c586b0e4c619f02a5e94e36619da8e2b053e20f594348c0611803704",
+                "sha256:40523d2efb60523e113b44602298f0960e900388cf3bb6043f645cf57ea9e3f5"
+            ],
+            "version": "==1.0.0"
+        }
+    }
+}


### PR DESCRIPTION
This PR addresses an issue we have seen in the `Pipfile.lock` parser that did not handle an optional version field. This PR also includes expanded testing for pipenv that now uses an example file.

Example of the missing `version` field under `pkgFour`:
```
{
    "default": {
        "pkgThree": {
            "hashes": [
                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691",
                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae"
            ],
            "version": "==3.0.0"
        },
        "pkgFour": {
            "hashes": [
                "sha256:2ccb79b01769d99115aa600d7eed99f524bf752bba8f041dc1c184853514655a",
                "sha256:0f2d585d22050e90c7d293b6451c83db097df77871974d90efd5a30dc12fcde3"
            ]
        }
    }
} 
```