### PR TITLE
Use real value in sourceunit type field

### DIFF
--- a/src/Srclib/Converter.hs
+++ b/src/Srclib/Converter.hs
@@ -24,7 +24,7 @@ toSourceUnit :: ProjectResult -> SourceUnit
 toSourceUnit ProjectResult{..} =
   SourceUnit
     { sourceUnitName = renderedPath,
-      sourceUnitType = SourceUnitTypeDummyCLI,
+      sourceUnitType = projectResultType,
       sourceUnitManifest = renderedPath, -- TODO: use a real value here instead of renderedPath?
       sourceUnitBuild =
         SourceUnitBuild
@@ -35,7 +35,7 @@ toSourceUnit ProjectResult{..} =
           }
     }
   where
-    renderedPath = Text.pack (toFilePath projectResultPath) <> "||" <> projectResultType
+    renderedPath = Text.pack (toFilePath projectResultPath)
 
     filteredGraph :: Graphing Dependency
     filteredGraph = Graphing.filter (\d -> shouldPublishDep d && isSupportedType d) projectResultGraph

--- a/src/Srclib/Converter.hs
+++ b/src/Srclib/Converter.hs
@@ -25,7 +25,7 @@ toSourceUnit ProjectResult{..} =
   SourceUnit
     { sourceUnitName = renderedPath,
       sourceUnitType = projectResultType,
-      sourceUnitManifest = renderedPath, -- TODO: use a real value here instead of renderedPath?
+      sourceUnitManifest = renderedPath,
       sourceUnitBuild =
         SourceUnitBuild
           { buildArtifact = "default",

--- a/src/Srclib/Types.hs
+++ b/src/Srclib/Types.hs
@@ -2,7 +2,6 @@
 
 module Srclib.Types
   ( SourceUnit(..)
-  , SourceUnitType(..)
   , SourceUnitBuild(..)
   , SourceUnitDependency(..)
   , Locator(..)
@@ -17,13 +16,10 @@ import qualified Data.Text as T
 
 data SourceUnit = SourceUnit
   { sourceUnitName :: Text
-  , sourceUnitType :: SourceUnitType
+  , sourceUnitType :: Text
   , sourceUnitManifest :: Text -- ^ path to manifest file
   , sourceUnitBuild :: SourceUnitBuild
   } deriving (Eq, Ord, Show)
-
-data SourceUnitType = SourceUnitTypeDummyCLI
-  deriving (Eq, Ord, Show)
 
 data SourceUnitBuild = SourceUnitBuild
   { buildArtifact :: Text -- ^ always "default"
@@ -76,9 +72,6 @@ instance ToJSON SourceUnitDependency where
     [ "locator" .= sourceDepLocator
     , "imports" .= sourceDepImports
     ]
-
-instance ToJSON SourceUnitType where
-  toJSON SourceUnitTypeDummyCLI = "dummy-cli"
 
 instance ToJSON Locator where
   -- render as text


### PR DESCRIPTION
Rather than using `"dummy-cli"` as the sourceunit type, use the real value from the analyzer name (e.g., `maven` or `gradle` or `setuptools`)

This also makes the `manifest` field a valid directory path