### PR TITLE
Ignore Cargo dep source

### DIFF
--- a/src/Strategy/Cargo.hs
+++ b/src/Strategy/Cargo.hs
@@ -38,7 +38,7 @@ data PackageId = PackageId
 
 data PackageDependency = PackageDependency
   { pkgDepName :: T.Text
-  , pkgDepSource :: T.Text
+  , pkgDepSource :: Maybe T.Text
   , pkgDepReq :: T.Text
   , pkgDepKind :: Maybe T.Text
   } deriving (Eq, Ord, Show)
@@ -80,7 +80,7 @@ data CargoMetadata = CargoMetadata
 instance FromJSON PackageDependency where
   parseJSON = withObject "PackageDependency" $ \obj ->
     PackageDependency <$> obj .: "name"
-                      <*> obj .: "source"
+                      <*> obj .:? "source"
                       <*> obj .: "req"
                       <*> obj .:? "kind"
 

--- a/src/Strategy/Cargo.hs
+++ b/src/Strategy/Cargo.hs
@@ -38,7 +38,6 @@ data PackageId = PackageId
 
 data PackageDependency = PackageDependency
   { pkgDepName :: T.Text
-  , pkgDepSource :: Maybe T.Text
   , pkgDepReq :: T.Text
   , pkgDepKind :: Maybe T.Text
   } deriving (Eq, Ord, Show)
@@ -80,7 +79,6 @@ data CargoMetadata = CargoMetadata
 instance FromJSON PackageDependency where
   parseJSON = withObject "PackageDependency" $ \obj ->
     PackageDependency <$> obj .: "name"
-                      <*> obj .:? "source"
                       <*> obj .: "req"
                       <*> obj .:? "kind"
 


### PR DESCRIPTION
I can't actually reproduce this error, but apparently we don't even use the source field, so we can just remove that.

Fixes [this issue](https://github.com/fossas/spectrometer-tests/blob/959ef98c91fb539430be703fc29885fe61dd9bea/test/IntegrationSpec.hs#L185-L186)