### PR TITLE
Update with new Wiggins release

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+# v2.4.5
+
+- Update Wiggins CLI plugin to version `2020-12-11-5d581ea`
+
 # v2.4.4
 
 - Improves maven pom `${property}` interpolation ([#158](https://github.com/fossas/spectrometer/pull/158))

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,12 @@
-# v2.4.5
+# v2.4.6
 
 - Update Wiggins CLI plugin to version `2020-12-11-5d581ea`
+
+# v2.4.5
+
+- Update `fossa vps analyze` to use a new VPS project scanning engine: 
+  - Improve scan performance
+  - Support "License Only" scans, where the project is scanned for licenses but is not inspected for vendored dependencies.
 
 # v2.4.4
 

--- a/src/App/Fossa/VPS/EmbeddedBinary.hs
+++ b/src/App/Fossa/VPS/EmbeddedBinary.hs
@@ -68,7 +68,5 @@ makeExecutable path = do
 -- The versions vendored into the repository are suitable for running on MacOS.
 -- The below functions are expectd to warn since the vendor directory is typically populated in CI.
 -- If you wish to build `vpscli` for your local system, populate these binaries via `vendor_download.sh`.
-
--- Version: 2020-12-11-5d581ea
 embeddedBinaryWiggins :: ByteString
 embeddedBinaryWiggins = $(embedFileIfExists "vendor/wiggins")

--- a/src/App/Fossa/VPS/EmbeddedBinary.hs
+++ b/src/App/Fossa/VPS/EmbeddedBinary.hs
@@ -68,5 +68,7 @@ makeExecutable path = do
 -- The versions vendored into the repository are suitable for running on MacOS.
 -- The below functions are expectd to warn since the vendor directory is typically populated in CI.
 -- If you wish to build `vpscli` for your local system, populate these binaries via `vendor_download.sh`.
+
+-- Version: 2020-12-11-5d581ea
 embeddedBinaryWiggins :: ByteString
 embeddedBinaryWiggins = $(embedFileIfExists "vendor/wiggins")


### PR DESCRIPTION
Updates `fossa` with a newly released version of the Wiggins CLI.
Comment added so that this Spectrometer release doesn't have the same git hash as previous.