### PR TITLE
Never prune dependencies for graphs that don't have nodes marked as direct

### DIFF
--- a/src/App/Fossa/Analyze/Project.hs
+++ b/src/App/Fossa/Analyze/Project.hs
@@ -11,12 +11,21 @@ import Graphing (Graphing)
 import qualified Graphing
 import Path
 import Types
+import qualified Data.Set as S
 
 mkResult :: DiscoveredProject -> Graphing Dependency -> ProjectResult
 mkResult project graph = ProjectResult
   { projectResultType = projectType project
   , projectResultPath = projectPath project
-  , projectResultGraph = Graphing.pruneUnreachable graph
+  , projectResultGraph =
+      -- FIXME: this is a hack to work around analyzers that aren't able to
+      -- determine which dependencies are direct. Without this hack, all of
+      -- their dependencies would be filtered out. The real fix to this is to
+      -- have a separate designation for "reachable" vs "direct" on nodes in a
+      -- Graphing, where direct deps are inherently reachable.
+      if S.null (Graphing.graphingDirect graph)
+        then graph
+        else Graphing.pruneUnreachable graph
   }
 
 data ProjectResult = ProjectResult


### PR DESCRIPTION
At some point, we became much more strict about pruning "unreachable" dependencies in our graphs. This unfortunately breaks the analyzers that don't necessarily mark dependencies as direct -- because often times, e.g., for `yarn.lock`, we don't know which dependencies are direct.

Fixes https://github.com/fossas/issues/issues/335