### PR TITLE
Traverse subdirectories in Yarn and NPM analysis

### DIFF
--- a/src/Discovery/Walk.hs
+++ b/src/Discovery/Walk.hs
@@ -15,7 +15,7 @@ where
 
 import Control.Carrier.Writer.Church
 import Control.Monad.Trans
-import Control.Carrier.Lift
+import Control.Carrier.Lift ( runM, LiftC )
 import Data.Foldable (find)
 import Data.Maybe (mapMaybe)
 import Data.Text (Text)
@@ -54,7 +54,7 @@ walk f = walkDir $ \dir subdirs files -> do
     WalkSkipSome dirs ->
       -- we normalize the passed in [Text] as relative directories for more reliable comparisons
       let parsedDirs = mapMaybe (parseRelDir . T.unpack) dirs
-       in pure . WalkExclude . filter (not . (`elem` parsedDirs) . dirname) $ subdirs
+       in pure . WalkExclude . filter ((`elem` parsedDirs) . dirname) $ subdirs
     WalkSkipAll -> pure $ WalkExclude subdirs
     WalkStop -> pure WalkFinish
 

--- a/src/Strategy/Npm.hs
+++ b/src/Strategy/Npm.hs
@@ -22,7 +22,7 @@ discover dir = map mkProject <$> findProjects dir
 findProjects :: MonadIO m => Path Abs Dir -> m [NpmProject]
 findProjects = walk' $ \dir _ files -> do
   case findFileNamed "package.json" files of
-    Nothing -> pure ([], WalkContinue)
+    Nothing -> pure ([], WalkSkipSome ["node_modules"])
     Just packageJson -> do
       let packageLock = findFileNamed "package-lock.json" files
 
@@ -33,7 +33,7 @@ findProjects = walk' $ \dir _ files -> do
                 npmPackageLock = packageLock
               }
 
-      pure ([project], WalkSkipAll)
+      pure ([project], WalkSkipSome ["node_modules"])
 
 data NpmProject = NpmProject
   { npmDir :: Path Abs Dir,

--- a/src/Strategy/Yarn.hs
+++ b/src/Strategy/Yarn.hs
@@ -18,7 +18,7 @@ discover dir = map mkProject <$> findProjects dir
 findProjects :: MonadIO m => Path Abs Dir -> m [YarnProject]
 findProjects = walk' $ \dir _ files -> do
   case findFileNamed "yarn.lock" files of
-    Nothing -> pure ([], WalkContinue)
+    Nothing -> pure ([], WalkSkipSome ["node_modules"])
     Just lock -> do
       let project =
             YarnProject
@@ -26,7 +26,7 @@ findProjects = walk' $ \dir _ files -> do
             , yarnLock = lock
             }
 
-      pure ([project], WalkSkipAll)
+      pure ([project], WalkSkipSome ["node_modules"])
 
 mkProject :: YarnProject -> DiscoveredProject
 mkProject project =


### PR DESCRIPTION
This issue arose to fix an issue for the react-rails project. Previously when we discovered NPM and yarn projects we stopped discovery after finding a project file. This results in us missing projects in subdirectories. In the following example directory structure, we would only find 1 target when we would like to find 3.
```
yarn.lock
build/yarn.lock
build/rails/yarn.lock
```

I also refactored the project filtering logic to happen before the upload step to make debugging analysis results easier.

Follow up work:
Relocate the project filtering logic to happen in between discovery and analysis.