### PR TITLE
Enable container scanning

### DIFF
--- a/src/App/Fossa/Container/Analyze.hs
+++ b/src/App/Fossa/Container/Analyze.hs
@@ -4,7 +4,8 @@ module App.Fossa.Container.Analyze
   )
 where
 
-import App.Fossa.Analyze (ScanDestination (..), fossaProjectUrl)
+import App.Fossa.Analyze (ScanDestination (..))
+import App.Fossa.API.BuildLink (getFossaBuildUrl)
 import App.Fossa.Container (ImageText (..), runSyft, toContainerScan, extractRevision)
 import App.Fossa.FossaAPIV1 (uploadContainerScan)
 import App.Types (OverrideProject (..), ProjectRevision (..))
@@ -14,7 +15,7 @@ import Control.Monad.IO.Class (MonadIO)
 import Data.Aeson
 import Data.Text.Lazy.Encoding (decodeUtf8)
 import Effect.Logger
-import Fossa.API.Types (ApiOpts (..))
+import Srclib.Types (parseLocator)
 
 analyzeMain :: ScanDestination -> Severity -> OverrideProject -> ImageText -> IO ()
 analyzeMain scanDestination logSeverity override image = withLogger logSeverity $ do
@@ -44,7 +45,8 @@ analyze scanDestination override image = do
       logInfo ("Using project revision: `" <> pretty (projectRevision revision) <> "`")
       locator <- uploadContainerScan apiOpts projectMeta containerScan
       logInfo "Container Analysis successfully uploaded!"
+      buildUrl <- getFossaBuildUrl revision apiOpts $ parseLocator locator
       logInfo "View FOSSA Report:"
-      logInfo ("  " <> pretty (fossaProjectUrl (apiOptsUri apiOpts) locator revision))
+      logInfo ("  " <> pretty buildUrl)
       pure ()
 

--- a/src/App/Fossa/FossaAPIV1.hs
+++ b/src/App/Fossa/FossaAPIV1.hs
@@ -126,14 +126,14 @@ uploadContainerScan
   -> ProjectMetadata
   -> ContainerScan
   -> m Text -- ^ Locator as text
-uploadContainerScan apiOpts metadata ContainerScan {..} = fossaReq $ do
+uploadContainerScan apiOpts metadata scan = fossaReq $ do
   (baseUrl, baseOpts) <- useApiOpts apiOpts
-  let locator = renderLocator (Locator "custom" imageTag $ Just imageDigest)
+  let locator = renderLocator $ Locator "custom" (imageTag scan) (Just $ imageDigest scan)
       opts = "locator" =: locator
           <> "cliVersion" =: cliVersion
           <> "managedBuild" =: True
-          <> mkMetadataOpts metadata imageTag
-  _ <- req POST (containerUploadUrl baseUrl) (ReqBodyJson imageData) ignoreResponse (baseOpts <> opts)
+          <> mkMetadataOpts metadata (imageTag scan)
+  _ <- req POST (containerUploadUrl baseUrl) (ReqBodyJson scan) ignoreResponse (baseOpts <> opts)
   pure locator
 
 

--- a/src/App/Fossa/FossaAPIV1.hs
+++ b/src/App/Fossa/FossaAPIV1.hs
@@ -131,6 +131,7 @@ uploadContainerScan apiOpts metadata ContainerScan {..} = fossaReq $ do
   let locator = renderLocator (Locator "custom" imageTag $ Just imageDigest)
       opts = "locator" =: locator
           <> "cliVersion" =: cliVersion
+          <> "managedBuild" =: True
           <> mkMetadataOpts metadata imageTag
   _ <- req POST (containerUploadUrl baseUrl) (ReqBodyJson imageData) ignoreResponse (baseOpts <> opts)
   pure locator

--- a/src/App/Fossa/Main.hs
+++ b/src/App/Fossa/Main.hs
@@ -113,7 +113,6 @@ appMain = do
 
     --
     ContainerCommand ContainerOptions {..} -> do
-      die "Fatal: Container scanning is not available yet" >> pure ()
       dieOnWindows "container scanning"
       case containerCommand of
         ContainerAnalyze ContainerAnalyzeOptions {..} ->
@@ -202,7 +201,13 @@ commands =
               (VPSCommand <$> vpsOpts)
               (progDesc "Run in Vendored Package Scan mode")
           )
+        <> command
+          "container"
+          ( info
+              (ContainerCommand <$> containerOpts)
+              (progDesc "Run in Container Scan mode")
           )
+    )
 
 hiddenCommands :: Parser Command
 hiddenCommands =
@@ -219,12 +224,6 @@ hiddenCommands =
           ( info
               (DumpBinsCommand <$> baseDirArg)
               (progDesc "Output all embedded binaries to specified path")
-          )
-        <> command
-          "container"
-          ( info
-              (ContainerCommand <$> containerOpts)
-              (progDesc "Run in Container Scan mode")
           )
         <> command
           "compatibility"


### PR DESCRIPTION
Fixes during E2E testing:

* Send `managedBuild` query param.
* Send the full payload over network.
* Use the common build link logic