### PR TITLE
v1 Compatibility mode

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,6 +87,7 @@ jobs:
         mkdir vendor
         touch vendor/wiggins
         touch vendor/syft
+        touch vendor/cliv1
 
     - name: Build
       run: |

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -88,6 +88,7 @@ library
     App.Fossa.Container
     App.Fossa.Container.Analyze
     App.Fossa.Container.Test
+    App.Fossa.Compatibility
     App.Fossa.EmbeddedBinary
     App.Fossa.FossaAPIV1
     App.Fossa.ListTargets

--- a/src/App/Fossa/Compatibility.hs
+++ b/src/App/Fossa/Compatibility.hs
@@ -3,7 +3,7 @@
 
 
 module App.Fossa.Compatibility
-  ( main,
+  ( compatibilityMain,
     argumentParser,
     Argument,
   )
@@ -25,10 +25,10 @@ type Argument = Text
 argumentParser :: Parser Argument
 argumentParser = pack <$> argument str (metavar "IMAGE" <> help "The image to scan")
 
-main ::
+compatibilityMain ::
   [Argument] ->
   IO ()
-main args = withLogger SevInfo . runExecIO . withCLIv1Binary $ \v1Bin -> do
+compatibilityMain args = withLogger SevInfo . runExecIO . withCLIv1Binary $ \v1Bin -> do
   logSticky "[ Waiting for fossa command completion ]"
   cmd <- exec [reldir|.|] $ v1Command v1Bin $ args
   logSticky ""

--- a/src/App/Fossa/Compatibility.hs
+++ b/src/App/Fossa/Compatibility.hs
@@ -1,0 +1,51 @@
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+
+module App.Fossa.Compatibility
+  ( main,
+    argumentParser,
+    Argument,
+  )
+where
+
+import App.Fossa.EmbeddedBinary (BinaryPaths, toExecutablePath, withCLIv1Binary)
+import Control.Effect.Lift (sendIO)
+import Data.Text (Text, pack)
+import Effect.Exec (CmdFailure(cmdFailureStdout), AllowErr (Never), Command (..), exec, runExecIO, cmdFailureStderr)
+import Path
+import qualified Data.ByteString.Lazy.Char8 as BL
+import Options.Applicative (Parser, argument, help, metavar, str)
+import System.Exit (exitFailure, exitSuccess)
+import Data.Text.Lazy.Encoding
+import Effect.Logger (Pretty(pretty), logInfo, logSticky, Severity(SevInfo), withLogger)
+
+type Argument = Text
+
+argumentParser :: Parser Argument
+argumentParser = pack <$> argument str (metavar "IMAGE" <> help "The image to scan")
+
+main ::
+  [Argument] ->
+  IO ()
+main args = withLogger SevInfo . runExecIO . withCLIv1Binary $ \v1Bin -> do
+  logSticky "[ Waiting for fossa command completion ]"
+  cmd <- exec [reldir|.|] $ v1Command v1Bin $ args
+  logSticky ""
+
+  case cmd of
+    Left err -> do
+      _ <- logInfo $ pretty $ decodeUtf8 $ cmdFailureStderr err
+      _ <- logInfo $ pretty $ decodeUtf8 $ cmdFailureStdout err
+      sendIO exitFailure
+    Right out -> do 
+      _ <- sendIO $ BL.putStr out
+      sendIO exitSuccess
+
+v1Command :: BinaryPaths -> [Text] -> Command
+v1Command bin args =
+  Command
+    { cmdName = pack . toFilePath $ toExecutablePath bin,
+      cmdArgs = args,
+      cmdAllowErr = Never
+    }

--- a/src/App/Fossa/Compatibility.hs
+++ b/src/App/Fossa/Compatibility.hs
@@ -23,13 +23,13 @@ import Effect.Logger (Pretty(pretty), logInfo, logSticky, Severity(SevInfo), wit
 type Argument = Text
 
 argumentParser :: Parser Argument
-argumentParser = pack <$> argument str (metavar "IMAGE" <> help "The image to scan")
+argumentParser = pack <$> argument str (metavar "ARGS" <> help "arguments to fossa v1 analyze")
 
 compatibilityMain ::
   [Argument] ->
   IO ()
 compatibilityMain args = withLogger SevInfo . runExecIO . withCLIv1Binary $ \v1Bin -> do
-  logSticky "[ Waiting for fossa command completion ]"
+  logSticky "[ Waiting for fossa analyze completion ]"
   cmd <- exec [reldir|.|] $ v1Command v1Bin $ args
   logSticky ""
 
@@ -46,6 +46,6 @@ v1Command :: BinaryPaths -> [Text] -> Command
 v1Command bin args =
   Command
     { cmdName = pack . toFilePath $ toExecutablePath bin,
-      cmdArgs = args,
+      cmdArgs = "analyze" : args,
       cmdAllowErr = Never
     }

--- a/src/App/Fossa/Compatibility.hs
+++ b/src/App/Fossa/Compatibility.hs
@@ -35,8 +35,7 @@ compatibilityMain args = withLogger SevInfo . runExecIO . withCLIv1Binary $ \v1B
 
   case cmd of
     Left err -> do
-      _ <- logInfo $ pretty $ decodeUtf8 $ cmdFailureStderr err
-      _ <- logInfo $ pretty $ decodeUtf8 $ cmdFailureStdout err
+      traverse_ (\accessor -> logInfo . pretty . decodeUtf8 $ accessor err)  [cmdFailureStderr, cmdFailureStdout]
       sendIO exitFailure
     Right out -> sendIO (BL.putStr out >> exitSuccess)
 

--- a/src/App/Fossa/Compatibility.hs
+++ b/src/App/Fossa/Compatibility.hs
@@ -38,9 +38,7 @@ compatibilityMain args = withLogger SevInfo . runExecIO . withCLIv1Binary $ \v1B
       _ <- logInfo $ pretty $ decodeUtf8 $ cmdFailureStderr err
       _ <- logInfo $ pretty $ decodeUtf8 $ cmdFailureStdout err
       sendIO exitFailure
-    Right out -> do 
-      _ <- sendIO $ BL.putStr out
-      sendIO exitSuccess
+    Right out -> sendIO (BL.putStr out >> exitSuccess)
 
 v1Command :: BinaryPaths -> [Text] -> Command
 v1Command bin args =

--- a/src/App/Fossa/Compatibility.hs
+++ b/src/App/Fossa/Compatibility.hs
@@ -12,6 +12,7 @@ where
 import App.Fossa.EmbeddedBinary (BinaryPaths, toExecutablePath, withCLIv1Binary)
 import Control.Effect.Lift (sendIO)
 import Data.Text (Text, pack)
+import Data.Foldable (traverse_)
 import Effect.Exec (CmdFailure(cmdFailureStdout), AllowErr (Never), Command (..), exec, runExecIO, cmdFailureStderr)
 import Path
 import qualified Data.ByteString.Lazy.Char8 as BL

--- a/src/App/Fossa/EmbeddedBinary.hs
+++ b/src/App/Fossa/EmbeddedBinary.hs
@@ -10,6 +10,7 @@ module App.Fossa.EmbeddedBinary
     BinaryPaths,
     withWigginsBinary,
     withSyftBinary,
+    withCLIv1Binary,
     allBins,
     PackagedBinary (..)
   )
@@ -27,6 +28,7 @@ import Prelude hiding (writeFile)
 data PackagedBinary
   = Syft
   | Wiggins
+  | CLIv1
   deriving (Show, Eq, Enum, Bounded)
 
 allBins :: [PackagedBinary]
@@ -56,6 +58,15 @@ withWigginsBinary ::
   (BinaryPaths -> m c) ->
   m c
 withWigginsBinary = withEmbeddedBinary Wiggins
+
+withCLIv1Binary ::
+  ( Has (Lift IO) sig m,
+    MonadIO m
+  ) =>
+  (BinaryPaths -> m c) ->
+  m c
+withCLIv1Binary = withEmbeddedBinary CLIv1
+
 
 withEmbeddedBinary ::
   ( Has (Lift IO) sig m,
@@ -87,6 +98,7 @@ writeBinary :: (Has (Lift IO) sig m) => Path Abs File -> PackagedBinary -> m ()
 writeBinary dest bin = sendIO . writeExecutable dest $ case bin of
   Syft -> embeddedBinarySyft
   Wiggins -> embeddedBinaryWiggins
+  CLIv1 -> embeddedBinaryCLIv1
 
 writeExecutable :: Path Abs File -> ByteString -> IO ()
 writeExecutable path content = do
@@ -98,6 +110,7 @@ extractedPath :: PackagedBinary -> Path Rel File
 extractedPath bin = case bin of
   Syft -> $(mkRelFile "syft")
   Wiggins -> $(mkRelFile "wiggins")
+  CLIv1 -> $(mkRelFile "cliv1")
 
 extractDir :: MonadIO m => m (Path Abs Dir)
 extractDir = do
@@ -118,3 +131,6 @@ embeddedBinaryWiggins = $(embedFileIfExists "vendor/wiggins")
 
 embeddedBinarySyft :: ByteString
 embeddedBinarySyft = $(embedFileIfExists "vendor/syft")
+
+embeddedBinaryCLIv1 :: ByteString
+embeddedBinaryCLIv1 = $(embedFileIfExists "vendor/cliv1")

--- a/src/App/Fossa/Main.hs
+++ b/src/App/Fossa/Main.hs
@@ -10,8 +10,7 @@ import App.Fossa.Analyze (ScanDestination (..), UnpackArchives (..), analyzeMain
 import App.Fossa.Container (imageTextArg, ImageText (..))
 import qualified App.Fossa.Container.Analyze as ContainerAnalyze
 import qualified App.Fossa.Container.Test as ContainerTest
-import qualified App.Fossa.Compatibility as Compatibility
-import App.Fossa.Compatibility (argumentParser, Argument)
+import App.Fossa.Compatibility (argumentParser, Argument, compatibilityMain)
 import qualified App.Fossa.EmbeddedBinary as Embed
 import App.Fossa.ListTargets (listTargetsMain)
 import qualified App.Fossa.Report as Report
@@ -125,7 +124,7 @@ appMain = do
           ContainerTest.testMain apiOpts logSeverity containerTestTimeout containerTestOutputType override containerTestImage
     --
     CompatibilityCommand args -> do
-      Compatibility.main args
+      compatibilityMain args
     --
     DumpBinsCommand dir -> do
       basedir <- validateDir dir

--- a/src/App/Fossa/Main.hs
+++ b/src/App/Fossa/Main.hs
@@ -225,7 +225,7 @@ hiddenCommands =
           "compatibility"
           ( info
               (CompatibilityCommand <$> compatibilityOpts)
-              (progDesc "Run fossa cli v1. Supply arguments as \"fossa compatibility -- analyze --project test\"")
+              (progDesc "Run fossa cli v1 analyze. Supply arguments as \"fossa compatibility -- --project test\"")
           )
     )
 

--- a/vendor_download.sh
+++ b/vendor_download.sh
@@ -103,7 +103,7 @@ curl -sSL \
 CLIV1_TAG=$(jq -cr '.name' $CLIV1_RELEASE_JSON | sed 's/^v//')
 echo "Using fossas/fossa-cli release: $CLIV1_TAG"
 FILTER=".name == \"fossa-cli_${CLIV1_TAG}_${ASSET_POSTFIX}_amd64.tar.gz\""
-jq -c ".assets | map({url: .url, name: .name}) | map(select($FILTER)) | .[]" $_RELEASE_JSON | while read ASSET; do
+jq -c ".assets | map({url: .url, name: .name}) | map(select($FILTER)) | .[]" $CLIV1_RELEASE_JSON | while read ASSET; do
   URL="$(echo $ASSET | jq -c -r '.url')"
   NAME="$(echo $ASSET | jq -c -r '.name')"
   OUTPUT=vendor/${NAME%"-$ASSET_POSTFIX"}

--- a/vendor_download.sh
+++ b/vendor_download.sh
@@ -41,55 +41,55 @@ TAG="latest"
 echo "Downloading asset information from latest tag for architecture '$ASSET_POSTFIX'"
 
 
-echo "Downloading wiggins binary"
-WIGGINS_RELEASE_JSON=vendor/wiggins-release.json
-curl -sSL \
-    -H "Authorization: token $GITHUB_TOKEN" \
-    -H "Accept: application/vnd.github.v3.raw" \
-    api.github.com/repos/fossas/basis/releases/latest > $WIGGINS_RELEASE_JSON
-
-WIGGINS_TAG=$(jq -cr ".name" $WIGGINS_RELEASE_JSON)
-FILTER=".name == \"wiggins-$ASSET_POSTFIX\""
-echo "Using wiggins release: $WIGGINS_TAG"
-jq -c ".assets | map({url: .url, name: .name}) | map(select($FILTER)) | .[]" $WIGGINS_RELEASE_JSON | while read ASSET; do
-  URL="$(echo $ASSET | jq -c -r '.url')"
-  NAME="$(echo $ASSET | jq -c -r '.name')"
-  OUTPUT=vendor/${NAME%"-$ASSET_POSTFIX"}
-
-  echo "Downloading '$NAME' to '$OUTPUT'"
-  curl -sL -H "Authorization: token $GITHUB_TOKEN" -H "Accept: application/octet-stream" -s $URL > $OUTPUT
-done
-rm $WIGGINS_RELEASE_JSON
-echo "Wiggins download successful"
-echo
-
-echo "Downloading forked syft binary"
-SYFT_RELEASE_JSON=vendor/syft-release.json
-curl -sSL \
-    -H "Authorization: token $GITHUB_TOKEN" \
-    -H "Accept: application/vnd.github.v3.raw" \
-    api.github.com/repos/fossas/syft/releases/latest > $SYFT_RELEASE_JSON
-
-# Remove leading 'v' from version tag
-# 'v123' -> '123'
-SYFT_TAG=$(jq -cr '.name' $SYFT_RELEASE_JSON | sed 's/^v//')
-echo "Using fossas/syft release: $SYFT_TAG"
-FILTER=".name == \"container-scanning_${SYFT_TAG}_${ASSET_POSTFIX}_amd64.tar.gz\""
-jq -c ".assets | map({url: .url, name: .name}) | map(select($FILTER)) | .[]" $SYFT_RELEASE_JSON | while read ASSET; do
-  URL="$(echo $ASSET | jq -c -r '.url')"
-  NAME="$(echo $ASSET | jq -c -r '.name')"
-  OUTPUT=vendor/${NAME%"-$ASSET_POSTFIX"}
-
-  echo "Downloading '$NAME' to '$OUTPUT'"
-  curl -sL -H "Authorization: token $GITHUB_TOKEN" -H "Accept: application/octet-stream" -s $URL > $OUTPUT
-  echo "Extracting syft binary from tarball"
-  tar xzf $OUTPUT fossa-container-scanning
-  mv fossa-container-scanning vendor/syft
-  rm $OUTPUT
-
-done
-rm $SYFT_RELEASE_JSON
-echo "Forked Syft download successful"
+# echo "Downloading wiggins binary"
+# WIGGINS_RELEASE_JSON=vendor/wiggins-release.json
+# curl -sSL \
+#     -H "Authorization: token $GITHUB_TOKEN" \
+#     -H "Accept: application/vnd.github.v3.raw" \
+#     api.github.com/repos/fossas/basis/releases/latest > $WIGGINS_RELEASE_JSON
+#
+# WIGGINS_TAG=$(jq -cr ".name" $WIGGINS_RELEASE_JSON)
+# FILTER=".name == \"wiggins-$ASSET_POSTFIX\""
+# echo "Using wiggins release: $WIGGINS_TAG"
+# jq -c ".assets | map({url: .url, name: .name}) | map(select($FILTER)) | .[]" $WIGGINS_RELEASE_JSON | while read ASSET; do
+#   URL="$(echo $ASSET | jq -c -r '.url')"
+#   NAME="$(echo $ASSET | jq -c -r '.name')"
+#   OUTPUT=vendor/${NAME%"-$ASSET_POSTFIX"}
+#
+#   echo "Downloading '$NAME' to '$OUTPUT'"
+#   curl -sL -H "Authorization: token $GITHUB_TOKEN" -H "Accept: application/octet-stream" -s $URL > $OUTPUT
+# done
+# rm $WIGGINS_RELEASE_JSON
+# echo "Wiggins download successful"
+# echo
+#
+# echo "Downloading forked syft binary"
+# SYFT_RELEASE_JSON=vendor/syft-release.json
+# curl -sSL \
+#     -H "Authorization: token $GITHUB_TOKEN" \
+#     -H "Accept: application/vnd.github.v3.raw" \
+#     api.github.com/repos/fossas/syft/releases/latest > $SYFT_RELEASE_JSON
+#
+# # Remove leading 'v' from version tag
+# # 'v123' -> '123'
+# SYFT_TAG=$(jq -cr '.name' $SYFT_RELEASE_JSON | sed 's/^v//')
+# echo "Using fossas/syft release: $SYFT_TAG"
+# FILTER=".name == \"container-scanning_${SYFT_TAG}_${ASSET_POSTFIX}_amd64.tar.gz\""
+# jq -c ".assets | map({url: .url, name: .name}) | map(select($FILTER)) | .[]" $SYFT_RELEASE_JSON | while read ASSET; do
+#   URL="$(echo $ASSET | jq -c -r '.url')"
+#   NAME="$(echo $ASSET | jq -c -r '.name')"
+#   OUTPUT=vendor/${NAME%"-$ASSET_POSTFIX"}
+#
+#   echo "Downloading '$NAME' to '$OUTPUT'"
+#   curl -sL -H "Authorization: token $GITHUB_TOKEN" -H "Accept: application/octet-stream" -s $URL > $OUTPUT
+#   echo "Extracting syft binary from tarball"
+#   tar xzf $OUTPUT fossa-container-scanning
+#   mv fossa-container-scanning vendor/syft
+#   rm $OUTPUT
+#
+# done
+# rm $SYFT_RELEASE_JSON
+# echo "Forked Syft download successful"
 
 echo ""
 echo "Downloading cliv1 binary"
@@ -112,8 +112,8 @@ jq -c ".assets | map({url: .url, name: .name}) | map(select($FILTER)) | .[]" $CL
   echo "Downloading '$NAME' to '$OUTPUT'"
   curl -sL -H "Authorization: token $GITHUB_TOKEN" -H "Accept: application/octet-stream" -s $URL > $OUTPUT
   echo "Extracting cliv1 binary from tarball"
-  tar xzf $OUTPUT fossa-cli
-  mv fossa-cli vendor/cliv1
+  tar xzf $OUTPUT fossa
+  mv fossa vendor/cliv1
   rm $OUTPUT
 
 done

--- a/vendor_download.sh
+++ b/vendor_download.sh
@@ -100,9 +100,9 @@ curl -sSL \
 
 # Remove leading 'v' from version tag
 # 'v123' -> '123'
-SYFT_TAG=$(jq -cr '.name' $CLIV1_RELEASE_JSON | sed 's/^v//')
+CLIV1_TAG=$(jq -cr '.name' $CLIV1_RELEASE_JSON | sed 's/^v//')
 echo "Using fossas/fossa-cli release: $CLIV1_TAG"
-FILTER=".name == \"fossa-cli__${CLIV1_TAG}_${ASSET_POSTFIX}_amd64.tar.gz\""
+FILTER=".name == \"fossa-cli_${CLIV1_TAG}_${ASSET_POSTFIX}_amd64.tar.gz\""
 jq -c ".assets | map({url: .url, name: .name}) | map(select($FILTER)) | .[]" $_RELEASE_JSON | while read ASSET; do
   URL="$(echo $ASSET | jq -c -r '.url')"
   NAME="$(echo $ASSET | jq -c -r '.name')"
@@ -116,7 +116,7 @@ jq -c ".assets | map({url: .url, name: .name}) | map(select($FILTER)) | .[]" $_R
   rm $OUTPUT
 
 done
-rm $SYFT_RELEASE_JSON
+rm $CLIV1_RELEASE_JSON
 echo "CLI v1 download successful"
 
 echo "Marking binaries executable"

--- a/vendor_download.sh
+++ b/vendor_download.sh
@@ -41,55 +41,55 @@ TAG="latest"
 echo "Downloading asset information from latest tag for architecture '$ASSET_POSTFIX'"
 
 
-# echo "Downloading wiggins binary"
-# WIGGINS_RELEASE_JSON=vendor/wiggins-release.json
-# curl -sSL \
-#     -H "Authorization: token $GITHUB_TOKEN" \
-#     -H "Accept: application/vnd.github.v3.raw" \
-#     api.github.com/repos/fossas/basis/releases/latest > $WIGGINS_RELEASE_JSON
-#
-# WIGGINS_TAG=$(jq -cr ".name" $WIGGINS_RELEASE_JSON)
-# FILTER=".name == \"wiggins-$ASSET_POSTFIX\""
-# echo "Using wiggins release: $WIGGINS_TAG"
-# jq -c ".assets | map({url: .url, name: .name}) | map(select($FILTER)) | .[]" $WIGGINS_RELEASE_JSON | while read ASSET; do
-#   URL="$(echo $ASSET | jq -c -r '.url')"
-#   NAME="$(echo $ASSET | jq -c -r '.name')"
-#   OUTPUT=vendor/${NAME%"-$ASSET_POSTFIX"}
-#
-#   echo "Downloading '$NAME' to '$OUTPUT'"
-#   curl -sL -H "Authorization: token $GITHUB_TOKEN" -H "Accept: application/octet-stream" -s $URL > $OUTPUT
-# done
-# rm $WIGGINS_RELEASE_JSON
-# echo "Wiggins download successful"
-# echo
-#
-# echo "Downloading forked syft binary"
-# SYFT_RELEASE_JSON=vendor/syft-release.json
-# curl -sSL \
-#     -H "Authorization: token $GITHUB_TOKEN" \
-#     -H "Accept: application/vnd.github.v3.raw" \
-#     api.github.com/repos/fossas/syft/releases/latest > $SYFT_RELEASE_JSON
-#
-# # Remove leading 'v' from version tag
-# # 'v123' -> '123'
-# SYFT_TAG=$(jq -cr '.name' $SYFT_RELEASE_JSON | sed 's/^v//')
-# echo "Using fossas/syft release: $SYFT_TAG"
-# FILTER=".name == \"container-scanning_${SYFT_TAG}_${ASSET_POSTFIX}_amd64.tar.gz\""
-# jq -c ".assets | map({url: .url, name: .name}) | map(select($FILTER)) | .[]" $SYFT_RELEASE_JSON | while read ASSET; do
-#   URL="$(echo $ASSET | jq -c -r '.url')"
-#   NAME="$(echo $ASSET | jq -c -r '.name')"
-#   OUTPUT=vendor/${NAME%"-$ASSET_POSTFIX"}
-#
-#   echo "Downloading '$NAME' to '$OUTPUT'"
-#   curl -sL -H "Authorization: token $GITHUB_TOKEN" -H "Accept: application/octet-stream" -s $URL > $OUTPUT
-#   echo "Extracting syft binary from tarball"
-#   tar xzf $OUTPUT fossa-container-scanning
-#   mv fossa-container-scanning vendor/syft
-#   rm $OUTPUT
-#
-# done
-# rm $SYFT_RELEASE_JSON
-# echo "Forked Syft download successful"
+echo "Downloading wiggins binary"
+WIGGINS_RELEASE_JSON=vendor/wiggins-release.json
+curl -sSL \
+    -H "Authorization: token $GITHUB_TOKEN" \
+    -H "Accept: application/vnd.github.v3.raw" \
+    api.github.com/repos/fossas/basis/releases/latest > $WIGGINS_RELEASE_JSON
+
+WIGGINS_TAG=$(jq -cr ".name" $WIGGINS_RELEASE_JSON)
+FILTER=".name == \"wiggins-$ASSET_POSTFIX\""
+echo "Using wiggins release: $WIGGINS_TAG"
+jq -c ".assets | map({url: .url, name: .name}) | map(select($FILTER)) | .[]" $WIGGINS_RELEASE_JSON | while read ASSET; do
+  URL="$(echo $ASSET | jq -c -r '.url')"
+  NAME="$(echo $ASSET | jq -c -r '.name')"
+  OUTPUT=vendor/${NAME%"-$ASSET_POSTFIX"}
+
+  echo "Downloading '$NAME' to '$OUTPUT'"
+  curl -sL -H "Authorization: token $GITHUB_TOKEN" -H "Accept: application/octet-stream" -s $URL > $OUTPUT
+done
+rm $WIGGINS_RELEASE_JSON
+echo "Wiggins download successful"
+echo
+
+echo "Downloading forked syft binary"
+SYFT_RELEASE_JSON=vendor/syft-release.json
+curl -sSL \
+    -H "Authorization: token $GITHUB_TOKEN" \
+    -H "Accept: application/vnd.github.v3.raw" \
+    api.github.com/repos/fossas/syft/releases/latest > $SYFT_RELEASE_JSON
+
+# Remove leading 'v' from version tag
+# 'v123' -> '123'
+SYFT_TAG=$(jq -cr '.name' $SYFT_RELEASE_JSON | sed 's/^v//')
+echo "Using fossas/syft release: $SYFT_TAG"
+FILTER=".name == \"container-scanning_${SYFT_TAG}_${ASSET_POSTFIX}_amd64.tar.gz\""
+jq -c ".assets | map({url: .url, name: .name}) | map(select($FILTER)) | .[]" $SYFT_RELEASE_JSON | while read ASSET; do
+  URL="$(echo $ASSET | jq -c -r '.url')"
+  NAME="$(echo $ASSET | jq -c -r '.name')"
+  OUTPUT=vendor/${NAME%"-$ASSET_POSTFIX"}
+
+  echo "Downloading '$NAME' to '$OUTPUT'"
+  curl -sL -H "Authorization: token $GITHUB_TOKEN" -H "Accept: application/octet-stream" -s $URL > $OUTPUT
+  echo "Extracting syft binary from tarball"
+  tar xzf $OUTPUT fossa-container-scanning
+  mv fossa-container-scanning vendor/syft
+  rm $OUTPUT
+
+done
+rm $SYFT_RELEASE_JSON
+echo "Forked Syft download successful"
 
 echo ""
 echo "Downloading cliv1 binary"

--- a/vendor_download.sh
+++ b/vendor_download.sh
@@ -91,6 +91,7 @@ done
 rm $SYFT_RELEASE_JSON
 echo "Forked Syft download successful"
 
+echo ""
 echo "Downloading cliv1 binary"
 CLIV1_RELEASE_JSON=vendor/cliv1-release.json
 curl -sSL \
@@ -111,8 +112,8 @@ jq -c ".assets | map({url: .url, name: .name}) | map(select($FILTER)) | .[]" $CL
   echo "Downloading '$NAME' to '$OUTPUT'"
   curl -sL -H "Authorization: token $GITHUB_TOKEN" -H "Accept: application/octet-stream" -s $URL > $OUTPUT
   echo "Extracting cliv1 binary from tarball"
-  tar xzf $OUTPUT fossa-cli-v1
-  mv fossa-cli-v1 vendor/cliv1
+  tar xzf $OUTPUT fossa-cli
+  mv fossa-cli vendor/cliv1
   rm $OUTPUT
 
 done


### PR DESCRIPTION
This PR introduces a `fossa compatibility` command which runs `fossa analyze` with the legacy fossa cli binary. The main use case of this feature is to allow users to access fossa cli v1's archive upload feature.