### PR TITLE
Fix revision read

### DIFF
--- a/src/App/Fossa/VPS/Report.hs
+++ b/src/App/Fossa/VPS/Report.hs
@@ -17,6 +17,7 @@ import Data.Text (Text)
 import Data.Text.IO (hPutStrLn)
 import Data.Text.Lazy.Encoding (decodeUtf8)
 import Effect.Logger
+import Effect.ReadFS
 import Fossa.API.Types (ApiOpts)
 import System.Exit (exitFailure, exitSuccess)
 import System.IO (stderr)
@@ -52,8 +53,9 @@ reportMain basedir apiOpts logSeverity timeoutSeconds reportType override = do
   * CLI command refactoring as laid out in https://github.com/fossas/issues/issues/129
   -}
   void $ timeout timeoutSeconds $ withLogger logSeverity $ do
-    result <- runDiagnostics $ do
-      revision <- mergeOverride override <$> inferProject (unBaseDir basedir)
+    result <- runDiagnostics . runReadFSIO $ do
+      override' <- updateOverrideRevision override <$> readCachedRevision 
+      revision <- mergeOverride override' <$> inferProject (unBaseDir basedir)
 
       logSticky "[ Getting latest scan ID ]"
 

--- a/src/App/Types.hs
+++ b/src/App/Types.hs
@@ -4,6 +4,8 @@ module App.Types
     OverrideProject (..),
     ProjectMetadata (..),
     ProjectRevision (..),
+
+    updateOverrideRevision,
   )
 where
 
@@ -17,6 +19,9 @@ data OverrideProject = OverrideProject
     overrideRevision :: Maybe Text,
     overrideBranch :: Maybe Text
   }
+
+updateOverrideRevision :: OverrideProject -> Text -> OverrideProject
+updateOverrideRevision o r = o { overrideRevision = Just r }
 
 data ProjectMetadata = ProjectMetadata
   { projectTitle :: Maybe Text


### PR DESCRIPTION
We now properly read a cached `.fossa.revision` file.

There may still be a bug in `inferDefault` to not override that file, but that requires a few days to refactor and fix.  This should at least fix the issue where `fossa test` would NEVER work when using a non-VCS and non-CLI-option revision string.