### PR TITLE
Split inferProject into inferProjectFromVCS + inferProjectDefault + saveRevision; add inferProjectCached

### DIFF
--- a/src/App/Fossa/API/BuildLink.hs
+++ b/src/App/Fossa/API/BuildLink.hs
@@ -43,7 +43,7 @@ getFossaBuildUrl revision apiopts locator = do
 samlUrlPath :: Organization -> Locator -> ProjectRevision -> Text
 samlUrlPath Organization {organizationId} locator revision = "account/saml/" <> showT organizationId <> "?" <> opts
   where
-    opts = "next=/" <> urlEncode' redirectPath
+    opts = "next=%2F" <> urlEncode' redirectPath
     redirectPath = fossaProjectUrlPath locator revision
 
 urlEncode' :: Text -> Text

--- a/src/App/Fossa/API/BuildLink.hs
+++ b/src/App/Fossa/API/BuildLink.hs
@@ -20,7 +20,7 @@ import Srclib.Types (Locator (..))
 import qualified Text.URI as URI
 
 fossaProjectUrlPath :: Locator -> ProjectRevision -> Text
-fossaProjectUrlPath Locator {..} ProjectRevision {..} = "/projects/" <> encodedProject <> buildSelector
+fossaProjectUrlPath Locator {..} ProjectRevision {..} = "projects/" <> encodedProject <> buildSelector
   where
     encodedProject = urlEncode' (locatorFetcher <> "+" <> locatorProject)
     encodedRevision = urlEncode' $ fromMaybe projectRevision locatorRevision
@@ -43,7 +43,7 @@ getFossaBuildUrl revision apiopts locator = do
 samlUrlPath :: Organization -> Locator -> ProjectRevision -> Text
 samlUrlPath Organization {organizationId} locator revision = "account/saml/" <> showT organizationId <> "?" <> opts
   where
-    opts = "next=" <> urlEncode' redirectPath
+    opts = "next=/" <> urlEncode' redirectPath
     redirectPath = fossaProjectUrlPath locator revision
 
 urlEncode' :: Text -> Text

--- a/src/App/Fossa/Report.hs
+++ b/src/App/Fossa/Report.hs
@@ -37,7 +37,7 @@ reportMain ::
   -> ReportType
   -> OverrideProject
   -> IO ()
-reportMain basedir apiOpts logSeverity timeoutSeconds reportType override = do
+reportMain (BaseDir basedir) apiOpts logSeverity timeoutSeconds reportType override = do
   -- TODO: refactor this code duplicate from `fossa test`
   {-
   Most of this module (almost everything below this line) has been copied
@@ -53,7 +53,7 @@ reportMain basedir apiOpts logSeverity timeoutSeconds reportType override = do
   void $ timeout timeoutSeconds $ withLogger logSeverity $ do
     result <- runDiagnostics . runReadFSIO $ do
       override' <- updateOverrideRevision override <$> readCachedRevision
-      revision <- mergeOverride override' <$> inferProject (unBaseDir basedir)
+      revision <- mergeOverride override' <$> (inferProjectFromVCS basedir <||> inferProjectCached basedir <||> inferProjectDefault basedir)
 
       logInfo ""
       logInfo ("Using project name: `" <> pretty (projectName revision) <> "`")

--- a/src/App/Fossa/Test.hs
+++ b/src/App/Fossa/Test.hs
@@ -30,11 +30,11 @@ testMain
   -> TestOutputType
   -> OverrideProject
   -> IO ()
-testMain basedir apiOpts logSeverity timeoutSeconds outputType override = do
+testMain (BaseDir basedir) apiOpts logSeverity timeoutSeconds outputType override = do
   void $ timeout timeoutSeconds $ withLogger logSeverity $ do
     result <- runDiagnostics . runReadFSIO $ do
       override' <- updateOverrideRevision override <$> readCachedRevision
-      revision <- mergeOverride override' <$> inferProject (unBaseDir basedir)
+      revision <- mergeOverride override' <$> (inferProjectFromVCS basedir <||> inferProjectCached basedir <||> inferProjectDefault basedir)
 
       logInfo ""
       logInfo ("Using project name: `" <> pretty (projectName revision) <> "`")

--- a/src/App/Fossa/VPS/Report.hs
+++ b/src/App/Fossa/VPS/Report.hs
@@ -37,7 +37,7 @@ reportMain ::
   -> ReportType
   -> OverrideProject
   -> IO ()
-reportMain basedir apiOpts logSeverity timeoutSeconds reportType override = do
+reportMain (BaseDir basedir) apiOpts logSeverity timeoutSeconds reportType override = do
   -- TODO: refactor this code duplicate from `fossa test`
   {-
   Most of this module (almost everything below this line) has been copied
@@ -53,7 +53,7 @@ reportMain basedir apiOpts logSeverity timeoutSeconds reportType override = do
   void $ timeout timeoutSeconds $ withLogger logSeverity $ do
     result <- runDiagnostics . runReadFSIO $ do
       override' <- updateOverrideRevision override <$> readCachedRevision 
-      revision <- mergeOverride override' <$> inferProject (unBaseDir basedir)
+      revision <- mergeOverride override' <$> (inferProjectFromVCS basedir <||> inferProjectCached basedir <||> inferProjectDefault basedir)
 
       logSticky "[ Getting latest scan ID ]"
 

--- a/src/App/Fossa/VPS/Scan.hs
+++ b/src/App/Fossa/VPS/Scan.hs
@@ -41,7 +41,9 @@ vpsScan ::
   , Has (Lift IO) sig m
   ) => BaseDir -> Severity -> OverrideProject -> Flag SkipIPRScan -> Flag LicenseOnlyScan -> FilterExpressions -> ApiOpts -> ProjectMetadata -> BinaryPaths -> m ()
 vpsScan (BaseDir basedir) logSeverity overrideProject skipIprFlag licenseOnlyScan fileFilters apiOpts metadata binaryPaths = withLogger logSeverity $ do
-  projectRevision <- mergeOverride overrideProject <$> inferProject basedir
+  projectRevision <- mergeOverride overrideProject <$> (inferProjectFromVCS basedir <||> inferProjectDefault basedir)
+  saveRevision projectRevision
+
   let scanType = ScanType (fromFlag SkipIPRScan skipIprFlag) (fromFlag LicenseOnlyScan licenseOnlyScan)
   let wigginsOpts = generateWigginsScanOpts basedir logSeverity projectRevision scanType fileFilters apiOpts metadata
 

--- a/src/App/Fossa/VPS/Test.hs
+++ b/src/App/Fossa/VPS/Test.hs
@@ -37,11 +37,11 @@ testMain ::
   TestOutputType ->
   OverrideProject ->
   IO ()
-testMain basedir apiOpts logSeverity timeoutSeconds outputType override = do
+testMain (BaseDir basedir) apiOpts logSeverity timeoutSeconds outputType override = do
   _ <- timeout timeoutSeconds . withLogger logSeverity . runExecIO $ do
     result <- runDiagnostics . runReadFSIO $ do
       override' <- updateOverrideRevision override <$> readCachedRevision 
-      revision <- mergeOverride override' <$> inferProject (unBaseDir basedir)
+      revision <- mergeOverride override' <$> (inferProjectFromVCS basedir <||> inferProjectCached basedir <||> inferProjectDefault basedir)
 
       logInfo ""
       logInfo ("Using project name: `" <> pretty (projectName revision) <> "`")

--- a/src/Control/Carrier/Diagnostics.hs
+++ b/src/Control/Carrier/Diagnostics.hs
@@ -82,7 +82,7 @@ renderWarnings :: [SomeDiagnostic] -> Doc AnsiStyle
 renderWarnings = align . vsep . map renderSomeDiagnostic
 
 logResultWarnings :: Has Logger sig m => ResultBundle a -> m a
-logResultWarnings ResultBundle {..} = logWarn (renderWarnings resultWarnings) $> resultValue
+logResultWarnings ResultBundle {..} = logDebug (renderWarnings resultWarnings) $> resultValue
 
 logErrorBundle :: Has Logger sig m => FailureBundle -> m ()
 logErrorBundle = logError . renderFailureBundle


### PR DESCRIPTION
This fixes a bug where a missing `.fossa.revision` file would prevent a successful analysis, and correctly overlays "override" information from the CLI args

Fixes fossas/issues#353