### PR TITLE
Helptext cleanup

### DIFF
--- a/src/App/Fossa/Main.hs
+++ b/src/App/Fossa/Main.hs
@@ -48,7 +48,7 @@ windowsOsName = "mingw32"
 
 appMain :: IO ()
 appMain = do
-  CmdOptions {..} <- customExecParser (prefs (showHelpOnError <> subparserInline)) (info (opts <**> helper) (fullDesc <> header "fossa-cli - Flexible, performant dependency analysis"))
+  CmdOptions {..} <- customExecParser (prefs (showHelpOnError <> subparserInline <> helpShowGlobals)) (info (opts <**> helper) (fullDesc <> header "fossa-cli - Flexible, performant dependency analysis"))
   let logSeverity = bool SevInfo SevDebug optDebug
 
   maybeApiKey <- checkAPIKey optAPIKey

--- a/src/App/Fossa/Main.hs
+++ b/src/App/Fossa/Main.hs
@@ -46,9 +46,16 @@ import Text.URI.QQ (uri)
 windowsOsName :: String
 windowsOsName = "mingw32"
 
+mainPrefs :: ParserPrefs
+mainPrefs = prefs $ mconcat 
+  [ helpShowGlobals,
+    showHelpOnError,
+    subparserInline 
+  ]
+
 appMain :: IO ()
 appMain = do
-  CmdOptions {..} <- customExecParser (prefs (showHelpOnError <> subparserInline <> helpShowGlobals)) (info (opts <**> helper) (fullDesc <> header "fossa-cli - Flexible, performant dependency analysis"))
+  CmdOptions {..} <- customExecParser mainPrefs (info (opts <**> helper) (fullDesc <> header "fossa-cli - Flexible, performant dependency analysis"))
   let logSeverity = bool SevInfo SevDebug optDebug
 
   maybeApiKey <- checkAPIKey optAPIKey

--- a/src/App/Fossa/Main.hs
+++ b/src/App/Fossa/Main.hs
@@ -166,7 +166,6 @@ opts =
     <*> optional (strOption (long "fossa-api-key" <> help "the FOSSA API server authentication key (default: FOSSA_API_KEY from env)"))
     <*> (commands <|> hiddenCommands)
     <**> infoOption (T.unpack fullVersionDescription) (long "version" <> short 'V' <> help "show version text")
-    <**> helper
 
 commands :: Parser Command
 commands =
@@ -211,7 +210,7 @@ commands =
 
 hiddenCommands :: Parser Command
 hiddenCommands =
-  hsubparser
+  subparser
     ( internal
         <> command
           "init"


### PR DESCRIPTION
## Linked issues
fixes fossas/issues#366
fixes #147 

## Description
`<**> helper>` was duplicated from top-level parser (seen [here](https://github.com/fossas/spectrometer/blob/55644dd77ee0838f4507bdd31c52117229691a36/src/App/Fossa/Main.hs#L51) as `info (opts <**> helper)`)

Newly added preference is documented in [optparse-applicative](https://hackage.haskell.org/package/optparse-applicative-0.16.1.0/docs/Options-Applicative-Builder.html#v:helpShowGlobals)

## Acceptance criteria
* `fossa --help` does not show `-h, --help` multiple times
* `fossa <subcommand> --help` shows global options
* `fossa analyze` (without API key) exits non-zero and shows global options