### PR TITLE
Container scan link fixes

### DIFF
--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -46,7 +46,7 @@ common deps
     , http-types                   ^>=0.12.3
     , lzma-conduit                 ^>=1.2.1
     , megaparsec                   ^>=8.0
-    , modern-uri                   ^>=0.3.1
+    , modern-uri                   ^>=0.3.4
     , mtl                          ^>=2.2.2
     , optparse-applicative         >=0.15     && <0.17
     , path                         ^>=0.8

--- a/src/App/Fossa/API/BuildLink.hs
+++ b/src/App/Fossa/API/BuildLink.hs
@@ -2,7 +2,8 @@
 {-# LANGUAGE RecordWildCards #-}
 
 module App.Fossa.API.BuildLink
-  ( getFossaBuildUrl,
+  ( getBuildURLWithOrg,
+    getFossaBuildUrl,
     samlUrlPath,
   )
 where
@@ -33,17 +34,20 @@ fossaProjectUrlPath Locator {..} ProjectRevision {..} = "/projects/" <> encodedP
 getFossaBuildUrl :: (Has Diagnostics sig m, Has (Lift IO) sig m) => ProjectRevision -> ApiOpts -> Locator -> m Text
 getFossaBuildUrl revision apiopts locator = do
   maybeOrg <- recover $ getOrganization apiopts
+  pure $ getBuildURLWithOrg maybeOrg revision apiopts locator
 
+getBuildURLWithOrg :: Maybe Organization -> ProjectRevision -> ApiOpts -> Locator -> Text
+getBuildURLWithOrg maybeOrg revision apiopts locator = do
   let baseURI = apiOptsUri apiopts
       relUriPath = case maybeOrg of
         Just org | orgUsesSAML org -> samlUrlPath org locator revision
         _ -> fossaProjectUrlPath locator revision
-  pure (URI.render baseURI <> relUriPath)
+  URI.render baseURI <> relUriPath
 
 samlUrlPath :: Organization -> Locator -> ProjectRevision -> Text
 samlUrlPath Organization {organizationId} locator revision = "/account/saml/" <> showT organizationId <> "?" <> opts
   where
-    opts = "next=%2F" <> urlEncode' redirectPath
+    opts = "next=" <> urlEncode' redirectPath
     redirectPath = fossaProjectUrlPath locator revision
 
 urlEncode' :: Text -> Text

--- a/src/App/Fossa/API/BuildLink.hs
+++ b/src/App/Fossa/API/BuildLink.hs
@@ -20,7 +20,7 @@ import Srclib.Types (Locator (..))
 import qualified Text.URI as URI
 
 fossaProjectUrlPath :: Locator -> ProjectRevision -> Text
-fossaProjectUrlPath Locator {..} ProjectRevision {..} = "projects/" <> encodedProject <> buildSelector
+fossaProjectUrlPath Locator {..} ProjectRevision {..} = "/projects/" <> encodedProject <> buildSelector
   where
     encodedProject = urlEncode' (locatorFetcher <> "+" <> locatorProject)
     encodedRevision = urlEncode' $ fromMaybe projectRevision locatorRevision
@@ -41,7 +41,7 @@ getFossaBuildUrl revision apiopts locator = do
   pure (URI.render baseURI <> relUriPath)
 
 samlUrlPath :: Organization -> Locator -> ProjectRevision -> Text
-samlUrlPath Organization {organizationId} locator revision = "account/saml/" <> showT organizationId <> "?" <> opts
+samlUrlPath Organization {organizationId} locator revision = "/account/saml/" <> showT organizationId <> "?" <> opts
   where
     opts = "next=%2F" <> urlEncode' redirectPath
     redirectPath = fossaProjectUrlPath locator revision

--- a/src/App/Fossa/FossaAPIV1.hs
+++ b/src/App/Fossa/FossaAPIV1.hs
@@ -125,7 +125,7 @@ uploadContainerScan
   => ApiOpts
   -> ProjectMetadata
   -> ContainerScan
-  -> m Text -- ^ Locator as text
+  -> m UploadResponse
 uploadContainerScan apiOpts metadata scan = fossaReq $ do
   (baseUrl, baseOpts) <- useApiOpts apiOpts
   let locator = renderLocator $ Locator "custom" (imageTag scan) (Just $ imageDigest scan)
@@ -133,8 +133,8 @@ uploadContainerScan apiOpts metadata scan = fossaReq $ do
           <> "cliVersion" =: cliVersion
           <> "managedBuild" =: True
           <> mkMetadataOpts metadata (imageTag scan)
-  _ <- req POST (containerUploadUrl baseUrl) (ReqBodyJson scan) ignoreResponse (baseOpts <> opts)
-  pure locator
+  resp <- req POST (containerUploadUrl baseUrl) (ReqBodyJson scan) jsonResponse (baseOpts <> opts)
+  pure $ responseBody resp
 
 
 uploadAnalysis

--- a/test/App/Fossa/API/BuildLinkSpec.hs
+++ b/test/App/Fossa/API/BuildLinkSpec.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE QuasiQuotes #-}
+
 module App.Fossa.API.BuildLinkSpec (spec) where
 
 import Test.Hspec
@@ -6,27 +8,50 @@ import Srclib.Types (Locator(Locator))
 import App.Fossa.FossaAPIV1 (Organization(Organization))
 import App.Types (ProjectRevision(ProjectRevision))
 import Data.Text (Text)
+import Fossa.API.Types
+import Text.URI.QQ
 
 simpleSamlPath :: Text
-simpleSamlPath = "account/saml/1?next=%2Fprojects%2Ffetcher123%252Bproject123%2Frefs%2Fbranch%2Fmaster123%2Frevision123"
+simpleSamlPath = "https://app.fossa.com/account/saml/1?next=%2Fprojects%2Ffetcher123%252Bproject123%2Frefs%2Fbranch%2Fmaster123%2Frevision123"
 
 -- | Note the differences here between '%2F' and '%252F'.  The percent sign is re-encoded so that it's properly handled on the next redirect.
 gitSamlPath :: Text
-gitSamlPath = "account/saml/103?next=%2Fprojects%2Ffetcher%2540123%252Fabc%252Bgit%2540github.com%252Fuser%252Frepo%2Frefs%2Fbranch%2Fweird--branch%2Frevision%2540123%252Fabc"
+gitSamlPath = "https://app.fossa.com/account/saml/103?next=%2Fprojects%2Ffetcher%2540123%252Fabc%252Bgit%2540github.com%252Fuser%252Frepo%2Frefs%2Fbranch%2Fweird--branch%2Frevision%2540123%252Fabc"
+
+fullSamlURL :: Text
+fullSamlURL = "https://app.fossa.com/account/saml/33?next=%2Fprojects%2Fa%252Bb%2Frefs%2Fbranch%2Fmaster%2Fc"
+
+simpleStandardURL :: Text
+simpleStandardURL = "https://app.fossa.com/projects/haskell%2B89%2Fspectrometer/refs/branch/master/revision123"
 
 spec :: Spec
 spec = do
+  let apiOpts = ApiOpts [uri|https://app.fossa.com/|] $ ApiKey ""
   describe "SAML URL builder" $ do
     it "should render simple locators" $ do
       let locator = Locator "fetcher123" "project123" $ Just "revision123"
-          org = Organization 1 False -- Bool is ignored at this point
+          org = Just $ Organization 1 True
           revision = ProjectRevision "" "not this revision" $ Just "master123"
 
-      samlUrlPath org locator revision `shouldBe` simpleSamlPath
+      getBuildURLWithOrg org revision apiOpts locator `shouldBe` simpleSamlPath
     
     it "should render git@ locators" $ do
       let locator = Locator "fetcher@123/abc" "git@github.com/user/repo" $ Just "revision@123/abc"
-          org = Organization 103 True
+          org = Just $ Organization 103 True
           revision = ProjectRevision "not this project name" "not this revision" $ Just "weird--branch"
       
-      samlUrlPath org locator revision `shouldBe` gitSamlPath
+      getBuildURLWithOrg org revision apiOpts locator `shouldBe` gitSamlPath
+    
+    it "should render full url correctly" $ do
+      let locator = Locator "a" "b" $ Just "c"
+          org = Just $ Organization 33 True
+          revision = ProjectRevision "" "not this revision" $ Just "master"
+      
+      getBuildURLWithOrg org revision apiOpts locator `shouldBe` fullSamlURL
+  
+  describe "Standard URL Builder" $ do
+    it "should render simple links" $ do
+      let locator = Locator "haskell" "89/spectrometer" $ Just "revision123"
+          revision = ProjectRevision "" "not this revision" $ Just "master"
+      
+      getBuildURLWithOrg Nothing revision apiOpts locator `shouldBe` simpleStandardURL


### PR DESCRIPTION
We have to steal the logic from `analyze` to correctly build links for container scanning.

Also, we were now missing slashes due to `modern-uri` updating their stance on rendering URL authorities.  We now have unit tests that prevent us from building incorrectly formatted URLs.

`modern-uri` has been bumped so that we don't switch between incompatible versions.