### PR TITLE
Create and use URI helpers

### DIFF
--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -196,6 +196,7 @@ library
     Strategy.Ruby.GemfileLock
     Strategy.Scala
     Strategy.Yarn
+    Text.URI.Builder
     Types
     VCS.Git
 

--- a/src/Text/URI/Builder.hs
+++ b/src/Text/URI/Builder.hs
@@ -37,7 +37,7 @@ convertPaths (path : paths) (TrailingSlash slash) = do
 renderPath :: Has Diagnostics sig m => [PathComponent] -> TrailingSlash -> m Text
 renderPath paths slash = render <$> setPath paths slash uri
   where
-    uri = emptyURI { uriAuthority = Left True }
+    uri = emptyURI {uriAuthority = Left True}
 
 data Query
   = Flag Text

--- a/src/Text/URI/Builder.hs
+++ b/src/Text/URI/Builder.hs
@@ -1,0 +1,56 @@
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE LambdaCase #-}
+
+module Text.URI.Builder
+  ( Query (..),
+    PathComponent (..),
+    TrailingSlash (..),
+    renderPath,
+    setPath,
+    setQuery,
+  )
+where
+
+import Control.Effect.Diagnostics
+import Data.List.NonEmpty (NonEmpty (..))
+import Data.Text
+import Text.URI
+
+newtype PathComponent = PathComponent {unPathComponent :: Text} deriving (Eq, Ord, Show)
+
+newtype TrailingSlash = TrailingSlash {unTrailingSlash :: Bool} deriving (Eq, Ord, Show)
+
+type URIPath = Maybe (Bool, NonEmpty (RText 'PathPiece))
+
+setPath :: Has Diagnostics sig m => [PathComponent] -> TrailingSlash -> URI -> m URI
+setPath pcomlist slash uri = do
+  newpath <- convertPaths pcomlist slash
+  pure $ uri {uriPath = newpath}
+
+convertPaths :: Has Diagnostics sig m => [PathComponent] -> TrailingSlash -> m URIPath
+convertPaths [] _ = pure Nothing
+convertPaths (path : paths) (TrailingSlash slash) = do
+  pathstream <- fromEither $ traverse (mkPathPiece . unPathComponent) (path :| paths)
+  pure $ Just (slash, pathstream)
+
+renderPath :: Has Diagnostics sig m => [PathComponent] -> TrailingSlash -> m Text
+renderPath paths slash = render <$> setPath paths slash uri
+  where
+    uri = emptyURI { uriAuthority = Left True }
+
+data Query
+  = Flag Text
+  | Pair Text Text
+  deriving (Eq, Ord, Show)
+
+setQuery :: Has Diagnostics sig m => [Query] -> URI -> m URI
+setQuery qlist uri = do
+  let xform :: Has Diagnostics sig m => Query -> m QueryParam
+      xform =
+        fromEither . \case
+          Flag f -> QueryFlag <$> mkQueryKey f
+          Pair k v -> QueryParam <$> mkQueryKey k <*> mkQueryValue v
+
+  qplist <- traverse xform qlist
+  pure $ uri {uriQuery = qplist}

--- a/test/App/Fossa/API/BuildLinkSpec.hs
+++ b/test/App/Fossa/API/BuildLinkSpec.hs
@@ -2,18 +2,18 @@
 
 module App.Fossa.API.BuildLinkSpec (spec) where
 
-import Test.Hspec
 import App.Fossa.API.BuildLink
-import Srclib.Types (Locator(Locator))
-import App.Fossa.FossaAPIV1 (Organization(Organization))
-import App.Types (ProjectRevision(ProjectRevision))
-import Data.Text (Text)
-import Fossa.API.Types
-import Text.URI.QQ
-import Effect.Logger (IgnoreLoggerC, ignoreLogger)
+import App.Fossa.FossaAPIV1 (Organization (Organization))
+import App.Types (ProjectRevision (ProjectRevision))
 import Control.Carrier.Diagnostics (DiagnosticsC, logDiagnostic)
-import Data.Functor.Identity (Identity(runIdentity))
 import Control.Monad (join)
+import Data.Functor.Identity (Identity (runIdentity))
+import Data.Text (Text)
+import Effect.Logger (IgnoreLoggerC, ignoreLogger)
+import Fossa.API.Types
+import Srclib.Types (Locator (Locator))
+import Test.Hspec
+import Text.URI.QQ
 
 simpleSamlPath :: Text
 simpleSamlPath = "https://app.fossa.com/account/saml/1?next=/projects/fetcher123%2bproject123/refs/branch/master123/revision123"
@@ -40,30 +40,30 @@ spec = do
           org = Just $ Organization 1 True
           revision = ProjectRevision "" "not this revision" $ Just "master123"
           -- Loggers and Diagnostics modify monads, so we need a no-op monad
-          actual = runIdentity $ ignoreLogger $ logDiagnostic $ getBuildURLWithOrg org revision apiOpts locator 
+          actual = runIdentity $ ignoreLogger $ logDiagnostic $ getBuildURLWithOrg org revision apiOpts locator
 
       actual `shouldBe` Just simpleSamlPath
-    
+
     it "should render git@ locators" $ do
       let locator = Locator "fetcher@123/abc" "git@github.com/user/repo" $ Just "revision@123/abc"
           org = Just $ Organization 103 True
           revision = ProjectRevision "not this project name" "not this revision" $ Just "weird--branch"
-          actual = stripDiag $ getBuildURLWithOrg org revision apiOpts locator 
-      
+          actual = stripDiag $ getBuildURLWithOrg org revision apiOpts locator
+
       actual `shouldBe` Just gitSamlPath
-    
+
     it "should render full url correctly" $ do
       let locator = Locator "a" "b" $ Just "c"
           org = Just $ Organization 33 True
           revision = ProjectRevision "" "not this revision" $ Just "master"
-          actual = stripDiag $ getBuildURLWithOrg org revision apiOpts locator 
-          
+          actual = stripDiag $ getBuildURLWithOrg org revision apiOpts locator
+
       actual `shouldBe` Just fullSamlURL
-  
+
   describe "Standard URL Builder" $ do
     it "should render simple links" $ do
       let locator = Locator "haskell" "89/spectrometer" $ Just "revision123"
           revision = ProjectRevision "" "not this revision" $ Just "master"
-          actual = stripDiag $ getBuildURLWithOrg Nothing revision apiOpts locator 
+          actual = stripDiag $ getBuildURLWithOrg Nothing revision apiOpts locator
 
       actual `shouldBe` Just simpleStandardURL

--- a/test/App/Fossa/API/BuildLinkSpec.hs
+++ b/test/App/Fossa/API/BuildLinkSpec.hs
@@ -10,19 +10,26 @@ import App.Types (ProjectRevision(ProjectRevision))
 import Data.Text (Text)
 import Fossa.API.Types
 import Text.URI.QQ
+import Effect.Logger (IgnoreLoggerC, ignoreLogger)
+import Control.Carrier.Diagnostics (DiagnosticsC, logDiagnostic)
+import Data.Functor.Identity (Identity(runIdentity))
+import Control.Monad (join)
 
 simpleSamlPath :: Text
-simpleSamlPath = "https://app.fossa.com/account/saml/1?next=%2Fprojects%2Ffetcher123%252Bproject123%2Frefs%2Fbranch%2Fmaster123%2Frevision123"
+simpleSamlPath = "https://app.fossa.com/account/saml/1?next=/projects/fetcher123%2bproject123/refs/branch/master123/revision123"
 
 -- | Note the differences here between '%2F' and '%252F'.  The percent sign is re-encoded so that it's properly handled on the next redirect.
 gitSamlPath :: Text
-gitSamlPath = "https://app.fossa.com/account/saml/103?next=%2Fprojects%2Ffetcher%2540123%252Fabc%252Bgit%2540github.com%252Fuser%252Frepo%2Frefs%2Fbranch%2Fweird--branch%2Frevision%2540123%252Fabc"
+gitSamlPath = "https://app.fossa.com/account/saml/103?next=/projects/fetcher@123%252fabc%2bgit@github.com%252fuser%252frepo/refs/branch/weird--branch/revision@123%252fabc"
 
 fullSamlURL :: Text
-fullSamlURL = "https://app.fossa.com/account/saml/33?next=%2Fprojects%2Fa%252Bb%2Frefs%2Fbranch%2Fmaster%2Fc"
+fullSamlURL = "https://app.fossa.com/account/saml/33?next=/projects/a%2bb/refs/branch/master/c"
 
 simpleStandardURL :: Text
-simpleStandardURL = "https://app.fossa.com/projects/haskell%2B89%2Fspectrometer/refs/branch/master/revision123"
+simpleStandardURL = "https://app.fossa.com/projects/haskell+89%2fspectrometer/refs/branch/master/revision123"
+
+stripDiag :: DiagnosticsC (IgnoreLoggerC Maybe) a -> Maybe a
+stripDiag = join . ignoreLogger . logDiagnostic
 
 spec :: Spec
 spec = do
@@ -32,26 +39,31 @@ spec = do
       let locator = Locator "fetcher123" "project123" $ Just "revision123"
           org = Just $ Organization 1 True
           revision = ProjectRevision "" "not this revision" $ Just "master123"
+          -- Loggers and Diagnostics modify monads, so we need a no-op monad
+          actual = runIdentity $ ignoreLogger $ logDiagnostic $ getBuildURLWithOrg org revision apiOpts locator 
 
-      getBuildURLWithOrg org revision apiOpts locator `shouldBe` simpleSamlPath
+      actual `shouldBe` Just simpleSamlPath
     
     it "should render git@ locators" $ do
       let locator = Locator "fetcher@123/abc" "git@github.com/user/repo" $ Just "revision@123/abc"
           org = Just $ Organization 103 True
           revision = ProjectRevision "not this project name" "not this revision" $ Just "weird--branch"
+          actual = stripDiag $ getBuildURLWithOrg org revision apiOpts locator 
       
-      getBuildURLWithOrg org revision apiOpts locator `shouldBe` gitSamlPath
+      actual `shouldBe` Just gitSamlPath
     
     it "should render full url correctly" $ do
       let locator = Locator "a" "b" $ Just "c"
           org = Just $ Organization 33 True
           revision = ProjectRevision "" "not this revision" $ Just "master"
-      
-      getBuildURLWithOrg org revision apiOpts locator `shouldBe` fullSamlURL
+          actual = stripDiag $ getBuildURLWithOrg org revision apiOpts locator 
+          
+      actual `shouldBe` Just fullSamlURL
   
   describe "Standard URL Builder" $ do
     it "should render simple links" $ do
       let locator = Locator "haskell" "89/spectrometer" $ Just "revision123"
           revision = ProjectRevision "" "not this revision" $ Just "master"
-      
-      getBuildURLWithOrg Nothing revision apiOpts locator `shouldBe` simpleStandardURL
+          actual = stripDiag $ getBuildURLWithOrg Nothing revision apiOpts locator 
+
+      actual `shouldBe` Just simpleStandardURL


### PR DESCRIPTION
_Note: Please leave review comments for missing docs and code comments, I don't think we should leave this as code-only._

In short, the most painful points of working with `modern-uri` are the lack of setters and the use of `RText`.  By creating our own simple structs, and setters which use those new structs, we can solve both problems.  We can also compose multiple setter actions with `>>=` (can't use `fmap` because of `MonadThrow` constraint on the `RText` smart constructors).

Additionally, because our new setters take `[a]` as input (where `a` is one of our simpler types), we get `Semigroup/Monoid` instances for free, and well as literal building syntax.