### PR TITLE
Enable vps analyze on windows

### DIFF
--- a/src/App/Fossa/Main.hs
+++ b/src/App/Fossa/Main.hs
@@ -28,7 +28,7 @@ import App.Version (fullVersionDescription)
 import Control.Monad (unless, when)
 import Data.Bifunctor (first)
 import Data.Bool (bool)
-import Data.Flag (Flag, flagOpt)
+import Data.Flag (Flag, flagOpt, fromFlag)
 import Data.Foldable (for_)
 import Data.Text (Text)
 import qualified Data.Text as T
@@ -102,6 +102,7 @@ appMain = do
       let apiOpts = ApiOpts optBaseUrl apikey
       case vpsCommand of
         VPSAnalyzeCommand VPSAnalyzeOptions {..} -> do
+          when (SysInfo.os == windowsOsName) $ unless (fromFlag SkipIPRScan skipIprScan) $ die "Windows VPS scans require skipping IPR.  Please try `fossa vps analyze --skip-ipr-scan DIR`"
           baseDir <- validateDir vpsAnalyzeBaseDir
           scanMain baseDir apiOpts vpsAnalyzeMeta logSeverity override vpsFileFilter skipIprScan licenseOnlyScan
         NinjaGraphCommand ninjaGraphOptions -> do

--- a/src/App/Fossa/Main.hs
+++ b/src/App/Fossa/Main.hs
@@ -105,15 +105,19 @@ appMain = do
           baseDir <- validateDir vpsAnalyzeBaseDir
           scanMain baseDir apiOpts vpsAnalyzeMeta logSeverity override vpsFileFilter skipIprScan licenseOnlyScan
         NinjaGraphCommand ninjaGraphOptions -> do
+          dieOnWindows "Vendored Package Scanning (VPS)"
           ninjaGraphMain apiOpts logSeverity override ninjaGraphOptions
         VPSTestCommand VPSTestOptions {..} -> do
+          dieOnWindows "Vendored Package Scanning (VPS)"
           baseDir <- validateDir vpsTestBaseDir
           VPSTest.testMain baseDir apiOpts logSeverity vpsTestTimeout vpsTestOutputType override
         VPSReportCommand VPSReportOptions {..} -> do
+          dieOnWindows "Vendored Package Scanning (VPS)"
           unless vpsReportJsonOutput $ die "report command currently only supports JSON output.  Please try `fossa report --json REPORT_NAME`"
           baseDir <- validateDir vpsReportBaseDir
           VPSReport.reportMain baseDir apiOpts logSeverity vpsReportTimeout vpsReportType override
         VPSAOSPNoticeCommand VPSAOSPNoticeOptions {..} -> do
+          dieOnWindows "Vendored Package Scanning (VPS)"
           baseDir <- validateDir vpsAOSPNoticeBaseDir
           aospNoticeMain baseDir logSeverity vpsFileFilter vpsAOSPNoticeWriteEnabled
 

--- a/src/App/Fossa/Main.hs
+++ b/src/App/Fossa/Main.hs
@@ -98,7 +98,6 @@ appMain = do
       listTargetsMain baseDir
     --
     VPSCommand VPSOptions {..} -> do
-      dieOnWindows "Vendored Package Scanning (VPS)"
       apikey <- requireKey maybeApiKey
       let apiOpts = ApiOpts optBaseUrl apikey
       case vpsCommand of


### PR DESCRIPTION
Enable running `fossa vps analyze` on Windows platforms so long as `--skip-ipr-scan` is used.
Still prevent the other VPS subcommands from running on Windows since they were originally marked as such.

**Still pending testing.** I need to finish making the VPS plugin work in Windows before I can test this, but wanted to go ahead and put it in for review for any initial comments or guidance on approach.