### PR TITLE
Skip target folders in maven; Skip subdirectories of failed scala analysis directories

### DIFF
--- a/src/Strategy/Maven/Pom/Closure.hs
+++ b/src/Strategy/Maven/Pom/Closure.hs
@@ -37,7 +37,7 @@ findPomFiles dir = execState @[Path Abs File] [] $
     let poms = filter (\file -> "pom.xml" `isSuffixOf` fileName file || ".pom" `isSuffixOf` fileName file) files
     traverse_ (modify . (:)) poms
 
-    pure WalkContinue
+    pure (WalkSkipSome ["target"])
 
 buildProjectClosures :: Path Abs Dir -> GlobalClosure -> [MavenProjectClosure]
 buildProjectClosures basedir global = closures

--- a/src/Strategy/Scala.hs
+++ b/src/Strategy/Scala.hs
@@ -62,7 +62,7 @@ findProjects = walk' $ \dir _ files -> do
       case projectsRes of
         Left err -> do
           logWarn $ renderFailureBundle err
-          pure ([], WalkContinue)
+          pure ([], WalkSkipAll)
         Right projects -> pure (resultValue projects, WalkSkipAll)
 
 makePomCmd :: Command


### PR DESCRIPTION
Two issues:

1. After running sbt analysis, `sbt` generates pom.xml files that are picked up by the maven analyzer on the next cli run;
2. Scala projects, when they fail, pretty strongly indicate that analysis in subdirectories is going to fail too. `sbt` is an expensive tool to run, so in failing multi-module projects, this can drastically increase the scan time