### PR TITLE
Update subcommand for AOSP Notice Files

### DIFF
--- a/src/App/Fossa/VPS/AOSPNotice.hs
+++ b/src/App/Fossa/VPS/AOSPNotice.hs
@@ -1,6 +1,5 @@
 module App.Fossa.VPS.AOSPNotice
   ( aospNoticeMain,
-    WriteEnabled(..)
   ) where
 
 import Control.Effect.Lift (sendIO, Lift)
@@ -11,17 +10,16 @@ import System.Exit (exitFailure)
 import App.Fossa.EmbeddedBinary
 import App.Fossa.VPS.Scan.RunWiggins
 import App.Fossa.VPS.Types
-import App.Types (BaseDir (..))
-import Data.Flag (Flag, fromFlag)
+import App.Types (BaseDir (..), OverrideProject)
 import Effect.Logger
 import Data.Text (Text)
+import App.Fossa.ProjectInference
+import Fossa.API.Types (ApiOpts(..))
+import Path (Path, Abs, Dir)
 
--- | WriteEnabled bool flag
-data WriteEnabled = WriteEnabled
-
-aospNoticeMain :: BaseDir -> Severity -> FilterExpressions -> Flag WriteEnabled ->  IO ()
-aospNoticeMain basedir logSeverity fileFilters writeEnabled = withLogger logSeverity $ do
-  result <- runDiagnostics $ withWigginsBinary $ aospNoticeGenerate basedir logSeverity writeEnabled fileFilters
+aospNoticeMain :: BaseDir -> Severity -> OverrideProject -> NinjaScanID -> ApiOpts -> IO ()
+aospNoticeMain (BaseDir basedir) logSeverity overrideProject ninjaScanId apiOpts = withLogger logSeverity $ do
+  result <- runDiagnostics $ withWigginsBinary $ aospNoticeGenerate basedir logSeverity overrideProject ninjaScanId apiOpts
   case result of
     Left failure -> do
       logError $ renderFailureBundle failure
@@ -34,9 +32,10 @@ aospNoticeGenerate ::
   ( Has Diagnostics sig m
   , Has Logger sig m
   , Has (Lift IO) sig m
-  ) => BaseDir -> Severity -> Flag WriteEnabled -> FilterExpressions -> BinaryPaths -> m ()
-aospNoticeGenerate (BaseDir basedir) logSeverity writeEnabled fileFilters binaryPaths =  do
-  let wigginsOpts = generateWigginsAOSPNoticeOpts basedir logSeverity fileFilters (fromFlag WriteEnabled writeEnabled)
+  ) => Path Abs Dir -> Severity -> OverrideProject -> NinjaScanID -> ApiOpts -> BinaryPaths -> m ()
+aospNoticeGenerate basedir logSeverity overrideProject ninjaScanId apiOpts binaryPaths = do
+  projectRevision <- mergeOverride overrideProject <$> (inferProjectFromVCS basedir <||> inferProjectDefault basedir)
+  let wigginsOpts = generateWigginsAOSPNoticeOpts basedir logSeverity apiOpts projectRevision ninjaScanId
 
   logInfo "Running VPS plugin: generating AOSP notice files"
   stdout <- runExecIO $ runWiggins binaryPaths wigginsOpts

--- a/src/App/Fossa/VPS/Scan/RunWiggins.hs
+++ b/src/App/Fossa/VPS/Scan/RunWiggins.hs
@@ -38,17 +38,19 @@ generateWigginsScanOpts :: Path Abs Dir -> Severity -> ProjectRevision -> ScanTy
 generateWigginsScanOpts scanDir logSeverity projectRevision scanType fileFilters apiOpts metadata =
   WigginsOpts scanDir $ generateSpectrometerScanArgs logSeverity projectRevision scanType fileFilters apiOpts metadata
 
-generateWigginsAOSPNoticeOpts :: Path Abs Dir -> Severity -> FilterExpressions -> Bool -> WigginsOpts
-generateWigginsAOSPNoticeOpts scanDir logSeverity fileFilters enableWrite =
-  WigginsOpts scanDir $ generateSpectrometerAOSPNoticeArgs logSeverity fileFilters enableWrite
+generateWigginsAOSPNoticeOpts :: Path Abs Dir -> Severity -> ApiOpts -> ProjectRevision -> NinjaScanID -> WigginsOpts
+generateWigginsAOSPNoticeOpts scanDir logSeverity apiOpts projectRevision ninjaScanId =
+  WigginsOpts scanDir $ generateSpectrometerAOSPNoticeArgs logSeverity apiOpts projectRevision ninjaScanId
 
-generateSpectrometerAOSPNoticeArgs :: Severity -> FilterExpressions -> Bool -> [Text]
-generateSpectrometerAOSPNoticeArgs logSeverity fileFilters enableWrite =
+generateSpectrometerAOSPNoticeArgs :: Severity -> ApiOpts -> ProjectRevision -> NinjaScanID -> [Text]
+generateSpectrometerAOSPNoticeArgs logSeverity ApiOpts{..} ProjectRevision{..} ninjaScanId =
   ["aosp-notice-files"]
-      ++ optBool "-write" enableWrite
       ++ optBool "-debug" (logSeverity == SevDebug)
-      ++ optFilterExpressions fileFilters
+      ++ ["-endpoint", render apiOptsUri, "-fossa-api-key", unApiKey apiOptsApiKey]
+      ++ ["-scan-id", unNinjaScanID ninjaScanId]
+      ++ ["-name", projectName]
       ++ ["."]
+      ++ ["./out/**/*.ninja"]
 
 generateSpectrometerScanArgs :: Severity -> ProjectRevision -> ScanType -> FilterExpressions -> ApiOpts -> ProjectMetadata -> [Text]
 generateSpectrometerScanArgs logSeverity ProjectRevision{..} ScanType{..} fileFilters ApiOpts{..} ProjectMetadata{..} =

--- a/src/App/Fossa/VPS/Types.hs
+++ b/src/App/Fossa/VPS/Types.hs
@@ -12,6 +12,7 @@ module App.Fossa.VPS.Types
 , HTTPRequestFailed(..)
 , VPSOpts (..)
 , NinjaGraphOpts (..)
+, NinjaScanID (..)
 ) where
 
 import Control.Monad.IO.Class (MonadIO(..))
@@ -24,6 +25,8 @@ import Network.HTTP.Req
 import Data.Text.Prettyprint.Doc (viaShow)
 import qualified Data.ByteString.Lazy as BSL
 import Data.Text.Encoding (decodeUtf8)
+
+newtype NinjaScanID = NinjaScanID { unNinjaScanID :: Text }
 
 newtype FilterExpressions = FilterExpressions { unFilterExpressions :: [Text] }
 

--- a/vendor_download.sh
+++ b/vendor_download.sh
@@ -41,7 +41,7 @@ esac
 TAG="latest"
 echo "Downloading asset information from latest tag for architecture '$ASSET_POSTFIX'"
 
-WIGGINS_TAG="staging-2021-03-02-8dbe08a"
+WIGGINS_TAG="2021-03-03-dd812ed"
 echo "Downloading wiggins binary"
 echo "Using wiggins release: $WIGGINS_TAG"
 WIGGINS_RELEASE_JSON=vendor/wiggins-release.json

--- a/vendor_download.sh
+++ b/vendor_download.sh
@@ -41,7 +41,7 @@ esac
 TAG="latest"
 echo "Downloading asset information from latest tag for architecture '$ASSET_POSTFIX'"
 
-WIGGINS_TAG="2021-03-03-dd812ed"
+WIGGINS_TAG="staging-2021-03-05-492d37d"
 echo "Downloading wiggins binary"
 echo "Using wiggins release: $WIGGINS_TAG"
 WIGGINS_RELEASE_JSON=vendor/wiggins-release.json


### PR DESCRIPTION
* Updates the AOSP Notice Files subcommand to provide the latest options to the VPS plugin.
* Updates the VPS plugin.
* Removes support for the `ninja-graph` subcommand. Right now we just `die` if the command is invoked, but I plan to remove the actual code for this as well in a separate PR.