### PR TITLE
fix(composer): Don't crash when packages in lockfiles are missing source field

### DIFF
--- a/src/Discovery/Walk.hs
+++ b/src/Discovery/Walk.hs
@@ -62,6 +62,7 @@ walk f = walkDir $ \dir subdirs files -> do
     WalkSkipAll -> pure $ WalkExclude subdirs
     WalkStop -> pure WalkFinish
 
+-- Like @walk@, but collects the output of @f@ in a monoid.
 walk' ::
   forall o sig m.
   (Has ReadFS sig m, Has Diagnostics sig m, Monoid o) =>

--- a/src/Strategy/Composer.hs
+++ b/src/Strategy/Composer.hs
@@ -5,7 +5,6 @@ module Strategy.Composer
     buildGraph,
     ComposerLock (..),
     CompDep (..),
-    Source (..),
   )
 where
 
@@ -68,17 +67,9 @@ data ComposerLock = ComposerLock
 data CompDep = CompDep
   { depName :: Text,
     depVersion :: Text,
-    depSource :: Source,
     -- | name to version spec
     depRequire :: Maybe (Map Text Text),
     depRequireDev :: Maybe (Map Text Text)
-  }
-  deriving (Eq, Ord, Show)
-
-data Source = Source
-  { sourceType :: Text,
-    sourceUrl :: Text,
-    sourceReference :: Text
   }
   deriving (Eq, Ord, Show)
 
@@ -91,15 +82,8 @@ instance FromJSON CompDep where
   parseJSON = withObject "CompDep" $ \obj ->
     CompDep <$> obj .: "name"
       <*> obj .: "version"
-      <*> obj .: "source"
       <*> obj .:? "require"
       <*> obj .:? "require-dev"
-
-instance FromJSON Source where
-  parseJSON = withObject "Source" $ \obj ->
-    Source <$> obj .: "type"
-      <*> obj .: "url"
-      <*> obj .: "reference"
 
 newtype CompPkg = CompPkg {pkgName :: Text}
   deriving (Eq, Ord, Show)

--- a/test/Composer/ComposerLockSpec.hs
+++ b/test/Composer/ComposerLockSpec.hs
@@ -66,6 +66,17 @@ dependencyFive =
       dependencyTags = M.empty
     }
 
+dependencySourceless :: Dependency
+dependencySourceless =
+  Dependency
+    { dependencyType = ComposerType,
+      dependencyName = "sourceless",
+      dependencyVersion = Just (CEq "5.0.0"),
+      dependencyLocations = [],
+      dependencyEnvironments = [EnvProduction],
+      dependencyTags = M.empty
+    }
+
 spec :: Spec
 spec = do
   testFile <- runIO (BS.readFile "test/Composer/testdata/composer.lock")
@@ -74,7 +85,7 @@ spec = do
       case eitherDecodeStrict testFile of
         Right res -> do
           let graph = buildGraph res
-          expectDeps [dependencyOne, dependencyTwo, dependencyThree, dependencyFour, dependencyFive] graph
-          expectDirect [dependencyOne, dependencyTwo, dependencyThree, dependencyFour, dependencyFive] graph
+          expectDeps [dependencyOne, dependencyTwo, dependencyThree, dependencyFour, dependencyFive, dependencySourceless] graph
+          expectDirect [dependencyOne, dependencyTwo, dependencyThree, dependencyFour, dependencyFive, dependencySourceless] graph
           expectEdges [(dependencyOne, dependencyTwo), (dependencyOne, dependencyTwo), (dependencyTwo, dependencyFour)] graph
         Left err -> expectationFailure $ show err

--- a/test/Composer/testdata/composer.lock
+++ b/test/Composer/testdata/composer.lock
@@ -48,6 +48,10 @@
                 "url": "https://github.com/composer/four",
                 "reference": "4"
             }
+        },
+        {
+            "name": "sourceless",
+            "version": "5.0.0"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
## Overview

Fixes fossas/issues#417.

`composer.lock` packages only need to have _either_ `source` or `dist`, not both (note that metapackages may have neither!). See documentation [here](https://getcomposer.org/doc/05-repositories.md#package-2). But we never use that field anyway, so I just deleted the parsing.

## Testing plan

Run `fossa analyze` on a test project constructed from the `composer.lock` in fossas/issues#417. See that the analysis does not crash, and uploads correct dependencies.