### PR TITLE
fix(ci): Fix `cabal install` and CI breakages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,8 +65,9 @@ jobs:
 
     - name: Debugging information
       run: |
-        ghc --version
-        cabal --version
+        ghc --version || echo "no ghc"
+        cabal --version || echo "no cabal"
+        ghcup --version || echo "no ghcup"
 
     - uses: actions/cache@v2
       name: Cache cabal store

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,6 +63,11 @@ jobs:
       with:
         ghc-version: ${{ matrix.ghc }}
 
+    - name: Debugging information
+      run: |
+        ghc --version
+        cabal --version
+
     - uses: actions/cache@v2
       name: Cache cabal store
       with:
@@ -72,7 +77,7 @@ jobs:
           ${{ runner.os }}-${{ matrix.ghc }}-cabal-cache-
           ${{ runner.os }}-${{ matrix.ghc }}-
           ${{ runner.os }}-
-  
+
     - name: Update vendored binaries
       run: |
         mkdir vendor

--- a/.github/workflows/dependency-scan.yml
+++ b/.github/workflows/dependency-scan.yml
@@ -9,6 +9,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Debugging information
+        run: |
+          ghc --version
+          cabal --version
+
       - name: Update cabal cache for spectrometer run
         run: |
           cabal update

--- a/.github/workflows/dependency-scan.yml
+++ b/.github/workflows/dependency-scan.yml
@@ -11,8 +11,9 @@ jobs:
 
       - name: Debugging information
         run: |
-          ghc --version
-          cabal --version
+          ghc --version || echo "no ghc"
+          cabal --version || echo "no cabal"
+          ghcup --version || echo "no ghcup"
 
       - name: Update cabal cache for spectrometer run
         run: |

--- a/.github/workflows/dependency-scan.yml
+++ b/.github/workflows/dependency-scan.yml
@@ -23,7 +23,14 @@ jobs:
         run: |
           curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/spectrometer/master/install.sh | bash
 
-      - name: Run dependency scan
+      - name: Use Spectrometer's GHC and Cabal
+        run: |
+          ghcup install ghc 8.10.4
+          ghcup set ghc 8.10.4
+          ghcup install cabal 3.4.0.0
+          ghcup set cabal 3.4.0.0
+
+      - name: Run dependency scan on Spectrometer
         env:
           FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
         run: |

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -82,17 +82,17 @@ library
 
   -- cabal-fmt: expand src
   exposed-modules:
-    App.Fossa.API.BuildLink
-    App.Fossa.API.BuildWait
     App.Fossa.Analyze
     App.Fossa.Analyze.Graph
     App.Fossa.Analyze.GraphBuilder
     App.Fossa.Analyze.GraphMangler
     App.Fossa.Analyze.Project
+    App.Fossa.API.BuildLink
+    App.Fossa.API.BuildWait
+    App.Fossa.Compatibility
     App.Fossa.Container
     App.Fossa.Container.Analyze
     App.Fossa.Container.Test
-    App.Fossa.Compatibility
     App.Fossa.EmbeddedBinary
     App.Fossa.FossaAPIV1
     App.Fossa.ListTargets
@@ -101,10 +101,10 @@ library
     App.Fossa.Report
     App.Fossa.Report.Attribution
     App.Fossa.Test
+    App.Fossa.VPS.AOSPNotice
     App.Fossa.VPS.NinjaGraph
     App.Fossa.VPS.Report
     App.Fossa.VPS.Scan
-    App.Fossa.VPS.AOSPNotice
     App.Fossa.VPS.Scan.Core
     App.Fossa.VPS.Scan.RunWiggins
     App.Fossa.VPS.Scan.ScotlandYard
@@ -199,8 +199,8 @@ library
     Strategy.Python.SetupPy
     Strategy.Python.Setuptools
     Strategy.Python.Util
-    Strategy.RPM
     Strategy.Rebar3
+    Strategy.RPM
     Strategy.Ruby.BundleShow
     Strategy.Ruby.GemfileLock
     Strategy.Scala
@@ -256,8 +256,8 @@ test-suite unit-tests
     Go.GopkgTomlSpec
     Googlesource.RepoManifestSpec
     Gradle.GradleSpec
-    GraphUtil
     GraphingSpec
+    GraphUtil
     Haskell.CabalSpec
     Haskell.StackSpec
     Maven.PluginStrategySpec

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -4,9 +4,11 @@ version:            0.1.0.0
 license:            MPL-2.0
 build-type:         Simple
 extra-source-files:
-  scripts/*.jar
-  scripts/*.gradle
-  vendor/*
+  scripts/depgraph-maven-plugin-3.3.0.jar
+  scripts/jsondeps.gradle
+  vendor/cliv1
+  vendor/syft
+  vendor/wiggins
 
 common lang
   build-depends:      base >=4.12 && <4.15

--- a/src/App/Version.hs
+++ b/src/App/Version.hs
@@ -7,12 +7,12 @@ module App.Version
   )
 where
 
-import App.Version.TH
+import App.Version.TH (getCurrentTag)
 import Data.Text (Text)
 import qualified Data.Text as T
-import GitHash
-import System.Info
 import Data.Version (showVersion)
+import GitHash (GitInfo, giBranch, giDirty, giHash, tGitInfoCwd)
+import System.Info (compilerName, compilerVersion)
 
 versionNumber :: Maybe Text
 versionNumber = $$(getCurrentTag)

--- a/src/App/Version/TH.hs
+++ b/src/App/Version/TH.hs
@@ -23,7 +23,8 @@ import Effect.Exec
   )
 import GitHash (giHash, tGitInfoCwd)
 import Instances.TH.Lift ()
-import Language.Haskell.TH (TExpQ, reportWarning, runIO)
+import Language.Haskell.TH (TExpQ)
+import Language.Haskell.TH.Syntax (reportWarning, runIO)
 import Path (Dir, Rel, mkRelDir)
 
 gitTagPointCommand :: Text -> Command

--- a/src/App/Version/TH.hs
+++ b/src/App/Version/TH.hs
@@ -6,22 +6,25 @@ module App.Version.TH
 where
 
 import Control.Carrier.Diagnostics (resultValue, runDiagnostics)
-import Control.Effect.Diagnostics
-  ( Diagnostics,
-    fromEitherShow,
-  )
+import Control.Effect.Diagnostics (Diagnostics, fromEitherShow)
 import qualified Data.ByteString.Lazy as BSL
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
-import qualified Data.Text.Encoding as TE
 import qualified Data.Text as T
-import Data.Versions
+import qualified Data.Text.Encoding as TE
+import Data.Versions (errorBundlePretty, semver)
 import Effect.Exec
-import GitHash
+  ( AllowErr (Always),
+    Command (..),
+    Exec,
+    Has,
+    exec,
+    runExecIO,
+  )
+import GitHash (giHash, tGitInfoCwd)
 import Instances.TH.Lift ()
-import Language.Haskell.TH
-import Path
-
+import Language.Haskell.TH (TExpQ, reportWarning, runIO)
+import Path (Dir, Rel, mkRelDir)
 
 gitTagPointCommand :: Text -> Command
 gitTagPointCommand commit =
@@ -72,4 +75,4 @@ validateSingleTag tag = do
 
   case semver normalized of
     Left err -> reportWarning (errorBundlePretty err) >> [||Nothing||]
-    Right _ -> [|| Just normalized ||]
+    Right _ -> [||Just normalized||]


### PR DESCRIPTION
## Overview

This PR fixes our CI tests.

The dependency scan was failing because our build is broken with GHC 9, which is what the `ubuntu-latest` container was running. Obviously, this prevented a scan from working because we don't support static analysis with Haskell.

Other changes:
- Fully specify `extra-source-files`, to partially fix `cabal install`. Originally, the glob wasn't working: `cabal install` would report that they were invalid. This doesn't really make a difference, since `cabal build` ignores this field, and `cabal install` is still broken because we're not copying `.git` (see comment below).
- Ran `cabal-fmt` over `spectrometer.cabal`.
- Ran `ormolu` over some files I touched.
- Fully specified imports in files I touched.

## Testing plan

1. Check that the CI now passes.
2. Compile with `cabal build` and check that `cabal run fossa -- --version` still produces expected output.