### PR TITLE
Fix the fossa report attribution command

### DIFF
--- a/src/App/Fossa/Report/Attribution.hs
+++ b/src/App/Fossa/Report/Attribution.hs
@@ -39,13 +39,13 @@ data Dependency
         depVersion :: Maybe Text,
         depIsGolang :: Maybe Bool,
         depHash :: Maybe Text,
-        depAuthors :: [Text],
+        depAuthors :: [Maybe Text],
         depDescription :: Maybe Text,
         depLicenses :: Maybe [License],
         depOtherLicenses :: [License],
         depProjectUrl :: Maybe Text,
         depDependencyPaths :: [Text],
-        depNotes :: Maybe [Text],
+        depNotes :: Maybe [Maybe Text],
         depDownloadUrl :: Maybe Text,
         depTitle :: Text
       }

--- a/src/App/Fossa/Report/Attribution.hs
+++ b/src/App/Fossa/Report/Attribution.hs
@@ -14,6 +14,7 @@ where
 import Data.Aeson
 import Data.Text (Text)
 import Data.Map.Strict (Map)
+import Data.Maybe (catMaybes)
 
 newtype LicenseName
   = LicenseName {rawName :: Text}
@@ -39,13 +40,13 @@ data Dependency
         depVersion :: Maybe Text,
         depIsGolang :: Maybe Bool,
         depHash :: Maybe Text,
-        depAuthors :: [Maybe Text],
+        depAuthors :: [Text],
         depDescription :: Maybe Text,
         depLicenses :: Maybe [License],
         depOtherLicenses :: [License],
         depProjectUrl :: Maybe Text,
         depDependencyPaths :: [Text],
-        depNotes :: Maybe [Maybe Text],
+        depNotes :: [Text],
         depDownloadUrl :: Maybe Text,
         depTitle :: Text
       }
@@ -90,13 +91,13 @@ instance FromJSON Dependency where
       <*> obj .:? "version"
       <*> obj .:? "isGolang"
       <*> obj .:? "hash"
-      <*> obj .: "authors"
+      <*> (catMaybes <$> obj .: "authors")
       <*> obj .:? "description"
       <*> obj .:? "licenses"
       <*> obj .: "otherLicenses"
       <*> obj .:? "projectUrl"
       <*> obj .: "dependencyPaths"
-      <*> obj .:? "notes"
+      <*> (catMaybes <$> obj .: "notes")
       <*> obj .:? "downloadUrl"
       <*> obj .: "title"
 

--- a/test/App/Fossa/Report/AttributionSpec.hs
+++ b/test/App/Fossa/Report/AttributionSpec.hs
@@ -33,13 +33,13 @@ genDependency =
     <*> Gen.maybe arbitraryText
     <*> Gen.maybe Gen.bool
     <*> Gen.maybe arbitraryText
-    <*> Gen.list defaultRange arbitraryText
+    <*> Gen.list defaultRange (Gen.maybe arbitraryText)
     <*> Gen.maybe arbitraryText
     <*> Gen.maybe (Gen.list defaultRange genLicense)
     <*> Gen.list defaultRange genLicense
     <*> Gen.maybe arbitraryText
     <*> Gen.list defaultRange arbitraryText
-    <*> Gen.maybe (Gen.list defaultRange arbitraryText)
+    <*> Gen.maybe (Gen.list defaultRange (Gen.maybe arbitraryText))
     <*> Gen.maybe arbitraryText
     <*> arbitraryText
 

--- a/test/App/Fossa/Report/AttributionSpec.hs
+++ b/test/App/Fossa/Report/AttributionSpec.hs
@@ -33,13 +33,13 @@ genDependency =
     <*> Gen.maybe arbitraryText
     <*> Gen.maybe Gen.bool
     <*> Gen.maybe arbitraryText
-    <*> Gen.list defaultRange (Gen.maybe arbitraryText)
+    <*> Gen.list defaultRange arbitraryText
     <*> Gen.maybe arbitraryText
     <*> Gen.maybe (Gen.list defaultRange genLicense)
     <*> Gen.list defaultRange genLicense
     <*> Gen.maybe arbitraryText
     <*> Gen.list defaultRange arbitraryText
-    <*> Gen.maybe (Gen.list defaultRange (Gen.maybe arbitraryText))
+    <*> Gen.list defaultRange arbitraryText
     <*> Gen.maybe arbitraryText
     <*> arbitraryText
 


### PR DESCRIPTION
The `fossa report` command is erroring when we come across the array `authors":[null]"` which resulted in the error.

```
An error occurred when deserializing a response from the FOSSA API: Error in $.directDependencies[0].authors[0]: parsing Text failed, expected String, but encountered Null
```

This PR makes sure that we can handle these null values inside the array.