### PR TITLE
Filtered container scan

### DIFF
--- a/src/App/Fossa/Container.hs
+++ b/src/App/Fossa/Container.hs
@@ -42,6 +42,7 @@ import Path ( toFilePath, reldir, Dir, Rel )
 import Path.IO (getCurrentDir)
 import qualified Data.ByteString.Lazy as BL
 import Data.Aeson.Types (parseEither)
+import qualified Data.Text.Lazy.Encoding as TE
 
 newtype ImageText = ImageText {unImageText :: Text} deriving (Show, Eq, Ord)
 
@@ -237,7 +238,7 @@ parseSyftOutput filepath = do
   payload <- toContainerScan response
   logInfo "Payload is valid!"
 
-  sendIO . BL.putStr $ encode payload
+  logStdout . pretty . TE.decodeUtf8 $ encode payload
 
   pure ()
 

--- a/src/App/Fossa/Container.hs
+++ b/src/App/Fossa/Container.hs
@@ -60,9 +60,15 @@ data SyftResponse
 
 instance FromJSON SyftResponse where
   parseJSON = withObject "SyftResponse" $ \obj ->
-    SyftResponse <$> obj .: "artifacts"
+    SyftResponse <$> (filter artifactTypeIsOk <$> obj .: "artifacts")
       <*> obj .: "source"
       <*> obj .: "distro"
+
+artifactTypeIsOk :: ResponseArtifact -> Bool
+artifactTypeIsOk art = artifactType art `elem` acceptedArtifactTypes
+
+acceptedArtifactTypes :: [Text]
+acceptedArtifactTypes = ["deb", "rpm", "apk"]
 
 data ResponseArtifact
   = ResponseArtifact

--- a/src/App/Fossa/Main.hs
+++ b/src/App/Fossa/Main.hs
@@ -422,7 +422,7 @@ containerParseFileOptions = argument str (metavar "FILE" <> help "File to parse"
 containerDumpScanOptions :: Parser ContainerDumpScanOptions
 containerDumpScanOptions =
   ContainerDumpScanOptions
-    <$> option auto (short 'o' <> long "output-file" <> help "File to write the scan data (omit for stdout)")
+    <$> optional (strOption (short 'o' <> long "output-file" <> help "File to write the scan data (omit for stdout)"))
     <*> imageTextArg 
 
 compatibilityOpts :: Parser [Argument]


### PR DESCRIPTION
Fixes fossas/issues#453

## Description
When scanning container images, `syft` finds many packages in a large variety of formats.  For the purposes of container scanning, at least in it's current mode, we only care about "system-level" packages (don't read into the name too much, it's not official at all).  Specifically, we care about debian, redhat, and alpine packages, which are given the type identifiers `deb`, `rpm`, and `apk`.  The CLI should not report these "artifacts" (syft terminology) as part of the build.

## This PR
This PR performs three tasks:
* (For debugging) Add a hidden command `fossa container parse-file FILE` which checks that a given syft output file will parse correctly, and print the parsed and transformed result.  
* (For debugging) Add a hidden command `fossa container dump-scan IMAGE` which will print the raw output from the syft scan to stdout (or the file provided by `-o/--output-file FILE`).
* Filter the artifacts at parse-time, only accepting those whose types are one of the accepted artifact types.