### PR TITLE
Scala: use sbt.ci flag instead of closing stdin

### DIFF
--- a/src/Effect/Exec.hs
+++ b/src/Effect/Exec.hs
@@ -189,7 +189,7 @@ instance Has (Lift IO) sig m => Algebra (Exec :+: sig) (ExecIOC m) where
           ioExceptionToCmdFailure :: IOException -> CmdFailure
           ioExceptionToCmdFailure = mkFailure (ExitFailure 1) "" . fromString . show
 
-      processResult <- try $ readProcess (setStdin closed (setWorkingDir (fromAbsDir absolute) (proc cmdName' cmdArgs')))
+      processResult <- try $ readProcess (setWorkingDir (fromAbsDir absolute) (proc cmdName' cmdArgs'))
 
       -- apply business logic for considering whether exitcode + stderr constitutes a "failure"
       let mangleResult :: (ExitCode, Stdout, Stderr) -> Either CmdFailure Stdout

--- a/src/Strategy/Scala.hs
+++ b/src/Strategy/Scala.hs
@@ -79,6 +79,8 @@ makePomCmd :: Command
 makePomCmd =
   Command
     { cmdName = "sbt",
+      -- --no-colors to disable ANSI escape codes
+      -- --batch to disable interactivity. normally, if an `sbt` command fails, it'll drop into repl mode: --batch will disable the repl.
       cmdArgs = ["--no-colors", "--batch", "makePom"],
       cmdAllowErr = Never
     }

--- a/src/Strategy/Scala.hs
+++ b/src/Strategy/Scala.hs
@@ -79,7 +79,7 @@ makePomCmd :: Command
 makePomCmd =
   Command
     { cmdName = "sbt",
-      cmdArgs = ["makePom", "-no-colors"],
+      cmdArgs = ["--no-colors", "--batch", "makePom"],
       cmdAllowErr = Never
     }
 


### PR DESCRIPTION
In a previous PR, we decided to close stdin because some tools, like
sbt, start a repl and hang forever when a command fails. Closing stdin
prevents the tools from doing so.

Unfortunately this has a downside: other buildtools, like gradle, will
sometimes hang forever when stdin is closed.

This commit instead uses the `sbt.ci` flag, which disables its repl by
default, and restores the previous behavior of "inheriting" stdin from
the parent process

---

*Testing*

These changes were tested against:
- a local sbt project with a failing build, which would previously cause analysis to hang forever under the default "inherit stdin" behavior. I'm going to open a companion PR to spectrometer-tests that includes the failing project and a test for this behavior;
- the spectrometer-tests projects