### PR TITLE
Add (very) basic replay logging documentation

### DIFF
--- a/devdocs/replay-logging.md
+++ b/devdocs/replay-logging.md
@@ -1,0 +1,39 @@
+
+# Replay Logging
+
+Replay Logging is a feature of `fossa analyze` that can aid in reproducing/resolving analysis issues.
+
+It leverages some unique properties of haskell that allow us to "record" an end-to-end analysis execution in a customer's environment, and "replay" the analysis in our local development environment, with all of the tools normally available to us as developers (allowing us to print-debug, make other code changes, etc)
+
+## Recording
+
+The `--record` flag is used to run `fossa analyze` in record mode. The analysis will run normally (if a bit slower), and create a file called `fossa.debug.json`.
+
+In addition to some basic metadata, `fossa.debug.json` contains the arguments and results of each method invocation from our `ReadFS` and `Exec` effects:
+
+```json
+{
+  "commit": "0abcdef",
+  "workdir": "/foo",
+  "args": ["analyze", "--record"],
+  "effects": {
+    "ReadFS": [...]
+    "Exec": [...]
+  }
+}
+```
+
+## Replaying
+
+The `--replay <file>` flag is used to run `fossa analyze` in replay mode. Rather than reading from real files with our `ReadFS` effect or running real commands with our `Exec` effect, we stub in the recorded effect calls from `fossa.debug.json`.
+
+For replay mode to work, we need to "run analysis" in the same directory (or a subdirectory) of the one used when recording `fossa.debug.json`. In the example above, this directory is `/foo`: `fossa analyze --replay fossa.debug.json /foo`. It's recommended to also use the same CLI commit and arguments (minus `--record`, of course)
+
+Replay mode has some substantial benefits over normal debug logs:
+- we can reproduce analysis issues as they occurred in a customer's environment, without the files and buildtools necessary for analysis
+- we can make code changes and see how they'd affect the analysis
+- for certain classes of issues, we can make code changes to resolve them, and confidently deliver bug fixes as a result
+
+There are some caveats:
+- any code changes that would require reading new files or running new/modified commands will not work under replay mode
+- `--unpack-archives` doesn't work with replay logging

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -36,6 +36,7 @@ common deps
     , conduit-extra                ^>=1.3.5
     , containers                   ^>=0.6.0
     , cpio-conduit                 ^>=0.7.0
+    , directory                    ^>=1.3.6.1
     , exceptions                   ^>=0.10.4
     , file-embed                   ^>=0.0.11
     , filepath                     ^>=1.4.2.1
@@ -87,6 +88,7 @@ library
     App.Fossa.Analyze.GraphBuilder
     App.Fossa.Analyze.GraphMangler
     App.Fossa.Analyze.Project
+    App.Fossa.Analyze.Record
     App.Fossa.API.BuildLink
     App.Fossa.API.BuildWait
     App.Fossa.Compatibility

--- a/src/App/Fossa/Analyze/Record.hs
+++ b/src/App/Fossa/Analyze/Record.hs
@@ -1,0 +1,81 @@
+{-# LANGUAGE RecordWildCards #-}
+
+module App.Fossa.Analyze.Record
+  ( AnalyzeJournal (..),
+    AnalyzeEffects (..),
+    saveReplayLog,
+    loadReplayLog,
+  )
+where
+
+import App.Version (fullVersionDescription)
+import Control.Effect.Record
+import Data.Aeson
+import Data.Text (Text)
+import System.Directory (getCurrentDirectory)
+import System.Environment (getArgs)
+
+data AnalyzeJournal = AnalyzeJournal
+  { analyzeCommit :: Text,
+    analyzeEffects :: AnalyzeEffects,
+    analyzeArgs :: [String],
+    analyzeWorkdir :: FilePath
+  }
+  deriving (Eq, Ord, Show)
+
+data AnalyzeEffects = AnalyzeEffects
+  { effectsReadFS :: Journal,
+    effectsExec :: Journal
+  }
+  deriving (Eq, Ord, Show)
+
+instance FromJSON AnalyzeJournal where
+  parseJSON = withObject "AnalyzeJournal" $ \obj ->
+    AnalyzeJournal <$> obj .: "commit"
+      <*> obj .: "effects"
+      <*> obj .: "args"
+      <*> obj .: "workdir"
+
+instance FromJSON AnalyzeEffects where
+  parseJSON = withObject "AnalyzeEffects" $ \obj ->
+    AnalyzeEffects <$> obj .: "ReadFS"
+      <*> obj .: "Exec"
+
+instance ToJSON AnalyzeJournal where
+  toJSON AnalyzeJournal {..} =
+    object
+      [ "commit" .= analyzeCommit,
+        "args" .= analyzeArgs,
+        "workdir" .= analyzeWorkdir,
+        "effects" .= analyzeEffects
+      ]
+
+instance ToJSON AnalyzeEffects where
+  toJSON AnalyzeEffects {..} =
+    object
+      [ "ReadFS" .= effectsReadFS,
+        "Exec" .= effectsExec
+      ]
+
+saveReplayLog :: Journal -> Journal -> FilePath -> IO ()
+saveReplayLog readFSJournal execJournal path = do
+  args <- getArgs
+  workdir <- getCurrentDirectory
+  let effects =
+        AnalyzeEffects
+          { effectsReadFS = readFSJournal,
+            effectsExec = execJournal
+          }
+
+      journal =
+        AnalyzeJournal
+          { analyzeCommit = fullVersionDescription,
+            analyzeEffects = effects,
+            analyzeArgs = args,
+            analyzeWorkdir = workdir
+          }
+
+  encodeFile path journal
+
+loadReplayLog :: FilePath -> IO (Either String AnalyzeJournal)
+loadReplayLog = eitherDecodeFileStrict'

--- a/src/App/Fossa/Analyze/Record.hs
+++ b/src/App/Fossa/Analyze/Record.hs
@@ -12,6 +12,8 @@ import App.Version (fullVersionDescription)
 import Control.Effect.Record
 import Data.Aeson
 import Data.Text (Text)
+import Effect.Exec (Exec)
+import Effect.ReadFS (ReadFS)
 import System.Directory (getCurrentDirectory)
 import System.Environment (getArgs)
 
@@ -24,8 +26,8 @@ data AnalyzeJournal = AnalyzeJournal
   deriving (Eq, Ord, Show)
 
 data AnalyzeEffects = AnalyzeEffects
-  { effectsReadFS :: Journal,
-    effectsExec :: Journal
+  { effectsReadFS :: Journal ReadFS,
+    effectsExec :: Journal Exec
   }
   deriving (Eq, Ord, Show)
 
@@ -57,7 +59,7 @@ instance ToJSON AnalyzeEffects where
         "Exec" .= effectsExec
       ]
 
-saveReplayLog :: Journal -> Journal -> FilePath -> IO ()
+saveReplayLog :: Journal ReadFS -> Journal Exec -> FilePath -> IO ()
 saveReplayLog readFSJournal execJournal path = do
   args <- getArgs
   workdir <- getCurrentDirectory

--- a/src/App/Fossa/Main.hs
+++ b/src/App/Fossa/Main.hs
@@ -6,7 +6,7 @@ module App.Fossa.Main
   )
 where
 
-import App.Fossa.Analyze (ScanDestination (..), UnpackArchives (..), analyzeMain)
+import App.Fossa.Analyze (ScanDestination (..), UnpackArchives (..), RecordMode (..), analyzeMain)
 import App.Fossa.Container (imageTextArg, ImageText (..), parseSyftOutputMain, dumpSyftScanMain)
 import qualified App.Fossa.Container.Analyze as ContainerAnalyze
 import qualified App.Fossa.Container.Test as ContainerTest
@@ -68,14 +68,13 @@ appMain = do
 
   case optCommand of
     AnalyzeCommand AnalyzeOptions {..} -> do
-      baseDir <- validateDir analyzeBaseDir
       let analyzeOverride = override {overrideBranch = analyzeBranch}
       if analyzeOutput
-        then analyzeMain baseDir optDebug logSeverity OutputStdout analyzeOverride analyzeUnpackArchives analyzeBuildTargetFilters
+        then analyzeMain analyzeBaseDir analyzeRecordMode logSeverity OutputStdout analyzeOverride analyzeUnpackArchives analyzeBuildTargetFilters
         else do
           key <- requireKey maybeApiKey
           let apiOpts = ApiOpts optBaseUrl key
-          analyzeMain baseDir optDebug logSeverity (UploadScan apiOpts analyzeMetadata) analyzeOverride analyzeUnpackArchives analyzeBuildTargetFilters
+          analyzeMain analyzeBaseDir analyzeRecordMode logSeverity (UploadScan apiOpts analyzeMetadata) analyzeOverride analyzeUnpackArchives analyzeBuildTargetFilters
     --
     TestCommand TestOptions {..} -> do
       baseDir <- validateDir testBaseDir
@@ -251,7 +250,14 @@ analyzeOpts =
     <*> optional (strOption (long "branch" <> help "this repository's current branch (default: current VCS branch)"))
     <*> metadataOpts
     <*> many filterOpt
+    <*> analyzeReplayOpt
     <*> baseDirArg
+
+analyzeReplayOpt :: Parser RecordMode
+analyzeReplayOpt =
+      flag' RecordModeRecord (long "record" <> hidden)
+  <|> (RecordModeReplay <$> strOption (long "replay" <> hidden))
+  <|> pure RecordModeNone
 
 filterOpt :: Parser BuildTargetFilter
 filterOpt = option (eitherReader parseFilter) (long "filter" <> help "Analysis-Target filters (default: none)" <> metavar "ANALYSIS-TARGET")
@@ -476,6 +482,7 @@ data AnalyzeOptions = AnalyzeOptions
     analyzeBranch :: Maybe Text,
     analyzeMetadata :: ProjectMetadata,
     analyzeBuildTargetFilters :: [BuildTargetFilter],
+    analyzeRecordMode :: RecordMode,
     analyzeBaseDir :: FilePath
   }
 

--- a/src/Control/Effect/Replay.hs
+++ b/src/Control/Effect/Replay.hs
@@ -53,7 +53,7 @@ newtype ReplayC (e :: (Type -> Type) -> Type -> Type) (sig :: (Type -> Type) -> 
 -- | Wrap an effect carrier, and replay its effects given the log produced by
 -- 'runRecord'. If a log entry isn't available for a given effect invocation, we
 -- pass the effect call down to the wrapped carrier
-runReplay :: Journal -> ReplayC e sig m a -> m a
+runReplay :: Journal e -> ReplayC e sig m a -> m a
 runReplay (Journal mapping) = runReader mapping . runReplayC
 
 instance (Member e sig, Has (Lift IO) sig m, Replayable (e m)) => Algebra (e :+: sig) (ReplayC e sig m) where


### PR DESCRIPTION
In addition to adding very basic documentation for replay logging, this PR improves the ergonomics of using replay logging by adding new (hidden) `--record` and `--replay <file>` flags to `fossa analyze`.

This also conceptually separates `--debug` mode from `--record` mode, whereas the former used to imply the latter.