### PR TITLE
Fix parsing loop for req.txt files

### DIFF
--- a/src/Strategy/Python/Util.hs
+++ b/src/Strategy/Python/Util.hs
@@ -114,6 +114,7 @@ requirementParser = specification
   where
   oneOfS = asum . map string
   isSpace c = c == ' ' || c == '\t'
+  oneOfSpecial = oneOf ['-', '_', '.', '*', '+', '!']
 
   whitespace = takeWhileP (Just "whitespace") isSpace :: Parser Text
   whitespace1 = label "whitespace1" $ takeWhile1P (Just "whitespace1") isSpace :: Parser Text
@@ -131,7 +132,7 @@ requirementParser = specification
     <|> OpLt         <$ string "<"
     <|> OpGt         <$ string ">"
 
-  version = label "version" $ whitespace *> some (letterOrDigit <|> oneOf ['-', '_', '.', '*', '+', '!'])
+  version = label "version" $ whitespace *> some (letterOrDigit <|> oneOfSpecial)
   version_one = label "version_one" $ Version <$> version_cmp <*> (T.pack <$> version) <* whitespace
   version_many = label "version_many" $ version_one `sepBy1` (whitespace *> char ',')
   versionspec = label "versionspec" $ between (char '(') (char ')') version_many <|> version_many
@@ -185,7 +186,7 @@ requirementParser = specification
                   special <- many (oneOf ['-', '_', '.'])
                   lod     <- letterOrDigit
                   pure (special ++ [lod])
-  identifier = label "identifier" $ (:) <$> letterOrDigit <*> (concat <$> many identifier_end)
+  identifier = label "identifier" $ (:) <$> (letterOrDigit <|> oneOfSpecial) <*> (concat <$> many identifier_end)
   name = label "name" $ T.pack <$> identifier
   extras_list :: Parser [Text]
   extras_list = label "extras_list" $

--- a/test/Python/testdata/req.txt
+++ b/test/Python/testdata/req.txt
@@ -5,3 +5,4 @@ three==3.0.0 \
   --hash=sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced \
   # via python-dateuti
 four==4.0.0 #help
+_fivewithunderscore==1.2.3


### PR DESCRIPTION
Problem: If a `requirements.txt` file has a line starting with a non-letter/word character, the CLI completely hangs and appears to be stuck in a `Parser` loop.

To recreate this, add a `requirements.txt` file containing the single line: `_depWithUnderscore=1.2.3`, and run `fossa analyze --output`. The CLI will hang, and never exit. 

I am very new to both `Haskell` and `Parser`'s especially, so am not 100% confident that this "fix" doesn't open up any other issues, however I do know that this change fixes the original problem that I discovered