### PR TITLE
Update Wiggins to 2021-03-26-042a071

### DIFF
--- a/vendor_download.sh
+++ b/vendor_download.sh
@@ -41,7 +41,7 @@ esac
 TAG="latest"
 echo "Downloading asset information from latest tag for architecture '$ASSET_POSTFIX'"
 
-WIGGINS_TAG="2021-03-24-f46fe27"
+WIGGINS_TAG="2021-03-26-042a071"
 echo "Downloading wiggins binary"
 echo "Using wiggins release: $WIGGINS_TAG"
 WIGGINS_RELEASE_JSON=vendor/wiggins-release.json

--- a/vendor_download.sh
+++ b/vendor_download.sh
@@ -41,7 +41,7 @@ esac
 TAG="latest"
 echo "Downloading asset information from latest tag for architecture '$ASSET_POSTFIX'"
 
-WIGGINS_TAG="2021-03-26-042a071"
+WIGGINS_TAG="2021-03-30-28383e8"
 echo "Downloading wiggins binary"
 echo "Using wiggins release: $WIGGINS_TAG"
 WIGGINS_RELEASE_JSON=vendor/wiggins-release.json


### PR DESCRIPTION
Update the tagged wiggins version.

This version of wiggins supports building NOTICE files for `Android.mk` files inside of an AOSP repository.