### PR TITLE
AOSP notice files: accept paths as arguments

### DIFF
--- a/src/App/Fossa/Main.hs
+++ b/src/App/Fossa/Main.hs
@@ -20,7 +20,7 @@ import qualified App.Fossa.VPS.Report as VPSReport
 import App.Fossa.VPS.Scan (LicenseOnlyScan (..), SkipIPRScan (..), scanMain)
 import App.Fossa.VPS.AOSPNotice (aospNoticeMain)
 import qualified App.Fossa.VPS.Test as VPSTest
-import App.Fossa.VPS.Types (FilterExpressions (..), NinjaScanID (..),NinjaFilePaths (NinjaFilePaths))
+import App.Fossa.VPS.Types (FilterExpressions (..), NinjaScanID (..), NinjaFilePaths (..))
 import App.OptionExtensions
 import App.Types
 import App.Util (validateDir, validateFile)

--- a/src/App/Fossa/Main.hs
+++ b/src/App/Fossa/Main.hs
@@ -20,10 +20,10 @@ import qualified App.Fossa.VPS.Report as VPSReport
 import App.Fossa.VPS.Scan (LicenseOnlyScan (..), SkipIPRScan (..), scanMain)
 import App.Fossa.VPS.AOSPNotice (aospNoticeMain)
 import qualified App.Fossa.VPS.Test as VPSTest
-import App.Fossa.VPS.Types (FilterExpressions (..), NinjaScanID (..))
+import App.Fossa.VPS.Types (FilterExpressions (..), NinjaScanID (..),NinjaFilePaths (NinjaFilePaths))
 import App.OptionExtensions
 import App.Types
-import App.Util (validateDir)
+import App.Util (validateDir, validateFile)
 import App.Version (fullVersionDescription)
 import Control.Monad (unless, when)
 import Data.Bifunctor (first)
@@ -42,6 +42,7 @@ import qualified System.Info as SysInfo
 import Text.Megaparsec (errorBundlePretty, runParser)
 import Text.URI (URI)
 import Text.URI.QQ (uri)
+import Path
 
 windowsOsName :: String
 windowsOsName = "mingw32"
@@ -118,7 +119,8 @@ appMain = do
         VPSAOSPNoticeCommand VPSAOSPNoticeOptions {..} -> do
           dieOnWindows "Vendored Package Scanning (VPS)"
           baseDir <- validateDir vpsAOSPNoticeBaseDir
-          aospNoticeMain baseDir logSeverity override (NinjaScanID vpsNinjaScanID) apiOpts
+          ninjaPaths <- parseCommaSeparatedFileArg vpsNinjaFileList
+          aospNoticeMain baseDir logSeverity override (NinjaScanID vpsNinjaScanID) (NinjaFilePaths ninjaPaths) apiOpts
 
     --
     ContainerCommand ContainerOptions {..} -> do
@@ -148,6 +150,10 @@ appMain = do
 
 dieOnWindows :: String -> IO ()
 dieOnWindows op = when (SysInfo.os == windowsOsName) $ die $ "Operation is not supported on Windows: " <> op
+
+
+parseCommaSeparatedFileArg :: Text -> IO [Path Abs File]
+parseCommaSeparatedFileArg arg = sequence $ validateFile . T.unpack <$> T.splitOn arg ","
 
 requireKey :: Maybe ApiKey -> IO ApiKey
 requireKey (Just key) = pure key
@@ -313,6 +319,7 @@ vpsAospNoticeOpts =
   VPSAOSPNoticeOptions
     <$> baseDirArg
     <*> strOption (long "scan-id" <> help "ID of the scan to which notice content should be added. Reported by `analyze` upon completion.")
+    <*> strOption (long "ninja-files" <> help "A comma-separated list of ninja files to parse for build graph information.")
     <*> metadataOpts
 
 -- FIXME: make report type a positional argument, rather than a subcommand
@@ -500,6 +507,7 @@ data VPSAnalyzeOptions = VPSAnalyzeOptions
 data VPSAOSPNoticeOptions = VPSAOSPNoticeOptions
   { vpsAOSPNoticeBaseDir :: FilePath,
     vpsNinjaScanID :: Text,
+    vpsNinjaFileList :: Text,
     vpsNinjaScanMeta :: ProjectMetadata
   }
 

--- a/src/App/Fossa/Main.hs
+++ b/src/App/Fossa/Main.hs
@@ -153,7 +153,7 @@ dieOnWindows op = when (SysInfo.os == windowsOsName) $ die $ "Operation is not s
 
 
 parseCommaSeparatedFileArg :: Text -> IO [Path Abs File]
-parseCommaSeparatedFileArg arg = sequence (validateFile . T.unpack <$> T.splitOn arg ",")
+parseCommaSeparatedFileArg arg = sequence (validateFile . T.unpack <$> T.splitOn "," arg)
 
 requireKey :: Maybe ApiKey -> IO ApiKey
 requireKey (Just key) = pure key

--- a/src/App/Fossa/Main.hs
+++ b/src/App/Fossa/Main.hs
@@ -153,7 +153,7 @@ dieOnWindows op = when (SysInfo.os == windowsOsName) $ die $ "Operation is not s
 
 
 parseCommaSeparatedFileArg :: Text -> IO [Path Abs File]
-parseCommaSeparatedFileArg arg = sequence $ validateFile . T.unpack <$> T.splitOn arg ","
+parseCommaSeparatedFileArg arg = sequence (validateFile . T.unpack <$> T.splitOn arg ",")
 
 requireKey :: Maybe ApiKey -> IO ApiKey
 requireKey (Just key) = pure key

--- a/src/App/Fossa/VPS/AOSPNotice.hs
+++ b/src/App/Fossa/VPS/AOSPNotice.hs
@@ -17,7 +17,7 @@ import App.Fossa.ProjectInference
 import Fossa.API.Types (ApiOpts(..))
 import Path (Path, Abs, Dir)
 
-aospNoticeMain :: BaseDir -> Severity -> OverrideProject -> NinjaScanID -> NinjaFilePaths  -> ApiOpts -> IO ()
+aospNoticeMain :: BaseDir -> Severity -> OverrideProject -> NinjaScanID -> NinjaFilePaths -> ApiOpts -> IO ()
 aospNoticeMain (BaseDir basedir) logSeverity overrideProject ninjaScanId ninjaFilePaths apiOpts = withLogger logSeverity $ do
   result <- runDiagnostics $ withWigginsBinary $ aospNoticeGenerate basedir logSeverity overrideProject ninjaScanId ninjaFilePaths apiOpts
   case result of
@@ -32,7 +32,7 @@ aospNoticeGenerate ::
   ( Has Diagnostics sig m
   , Has Logger sig m
   , Has (Lift IO) sig m
-  ) => Path Abs Dir -> Severity -> OverrideProject -> NinjaScanID -> NinjaFilePaths  -> ApiOpts -> BinaryPaths -> m ()
+  ) => Path Abs Dir -> Severity -> OverrideProject -> NinjaScanID -> NinjaFilePaths -> ApiOpts -> BinaryPaths -> m ()
 aospNoticeGenerate basedir logSeverity overrideProject ninjaScanId ninjaFilePaths apiOpts binaryPaths = do
   projectRevision <- mergeOverride overrideProject <$> (inferProjectFromVCS basedir <||> inferProjectDefault basedir)
 

--- a/src/App/Fossa/VPS/AOSPNotice.hs
+++ b/src/App/Fossa/VPS/AOSPNotice.hs
@@ -12,16 +12,15 @@ import App.Fossa.VPS.Scan.RunWiggins
 import App.Fossa.VPS.Types
 import App.Types (BaseDir (..), OverrideProject)
 import Effect.Logger
-import Data.Text (Text, isSuffixOf)
+import Data.Text (Text)
 import App.Fossa.ProjectInference
 import Fossa.API.Types (ApiOpts(..))
-import Path (Path, Abs, Dir, toFilePath)
+import Path (Path, Abs, Dir)
 import qualified Data.Text as T
-import Path.IO (listDirRecurRel)
 
-aospNoticeMain :: BaseDir -> Severity -> OverrideProject -> NinjaScanID -> ApiOpts -> IO ()
-aospNoticeMain (BaseDir basedir) logSeverity overrideProject ninjaScanId apiOpts = withLogger logSeverity $ do
-  result <- runDiagnostics $ withWigginsBinary $ aospNoticeGenerate basedir logSeverity overrideProject ninjaScanId apiOpts
+aospNoticeMain :: BaseDir -> Severity -> OverrideProject -> NinjaScanID -> NinjaFilePaths  -> ApiOpts -> IO ()
+aospNoticeMain (BaseDir basedir) logSeverity overrideProject ninjaScanId ninjaFilePaths apiOpts = withLogger logSeverity $ do
+  result <- runDiagnostics $ withWigginsBinary $ aospNoticeGenerate basedir logSeverity overrideProject ninjaScanId ninjaFilePaths apiOpts
   case result of
     Left failure -> do
       logError $ renderFailureBundle failure
@@ -34,12 +33,11 @@ aospNoticeGenerate ::
   ( Has Diagnostics sig m
   , Has Logger sig m
   , Has (Lift IO) sig m
-  ) => Path Abs Dir -> Severity -> OverrideProject -> NinjaScanID -> ApiOpts -> BinaryPaths -> m ()
-aospNoticeGenerate basedir logSeverity overrideProject ninjaScanId apiOpts binaryPaths = do
+  ) => Path Abs Dir -> Severity -> OverrideProject -> NinjaScanID -> NinjaFilePaths  -> ApiOpts -> BinaryPaths -> m ()
+aospNoticeGenerate basedir logSeverity overrideProject ninjaScanId ninjaFilePaths apiOpts binaryPaths = do
   projectRevision <- mergeOverride overrideProject <$> (inferProjectFromVCS basedir <||> inferProjectDefault basedir)
 
-  (_, files) <- sendIO $ listDirRecurRel basedir
-  let ninjaInputFiles = NinjaInputFiles $ filter (".ninja" `isSuffixOf`) $ map (T.pack . toFilePath) files
+  let ninjaInputFiles = NinjaInputFiles $ T.pack . show <$> unNinjaFilePaths ninjaFilePaths
   let wigginsOpts = generateWigginsAOSPNoticeOpts basedir logSeverity apiOpts projectRevision ninjaScanId ninjaInputFiles
 
   logInfo "Running VPS plugin: generating AOSP notice files"

--- a/src/App/Fossa/VPS/AOSPNotice.hs
+++ b/src/App/Fossa/VPS/AOSPNotice.hs
@@ -16,7 +16,6 @@ import Data.Text (Text)
 import App.Fossa.ProjectInference
 import Fossa.API.Types (ApiOpts(..))
 import Path (Path, Abs, Dir)
-import qualified Data.Text as T
 
 aospNoticeMain :: BaseDir -> Severity -> OverrideProject -> NinjaScanID -> NinjaFilePaths  -> ApiOpts -> IO ()
 aospNoticeMain (BaseDir basedir) logSeverity overrideProject ninjaScanId ninjaFilePaths apiOpts = withLogger logSeverity $ do
@@ -37,8 +36,7 @@ aospNoticeGenerate ::
 aospNoticeGenerate basedir logSeverity overrideProject ninjaScanId ninjaFilePaths apiOpts binaryPaths = do
   projectRevision <- mergeOverride overrideProject <$> (inferProjectFromVCS basedir <||> inferProjectDefault basedir)
 
-  let ninjaInputFiles = NinjaInputFiles $ T.pack . show <$> unNinjaFilePaths ninjaFilePaths
-  let wigginsOpts = generateWigginsAOSPNoticeOpts basedir logSeverity apiOpts projectRevision ninjaScanId ninjaInputFiles
+  let wigginsOpts = generateWigginsAOSPNoticeOpts basedir logSeverity apiOpts projectRevision ninjaScanId ninjaFilePaths
 
   logInfo "Running VPS plugin: generating AOSP notice files"
   stdout <- runExecIO $ runWiggins binaryPaths wigginsOpts

--- a/src/App/Fossa/VPS/Scan/RunWiggins.hs
+++ b/src/App/Fossa/VPS/Scan/RunWiggins.hs
@@ -23,7 +23,7 @@ import Fossa.API.Types
 import App.Types
 import Text.URI
 import qualified Data.ByteString.Lazy as BL
-import Data.Text.Encoding
+import Data.Text.Encoding ( decodeUtf8 )
 
 newtype NinjaInputFiles = NinjaInputFiles { unNinjaInputFiles :: [Text] }
 

--- a/src/App/Fossa/VPS/Scan/RunWiggins.hs
+++ b/src/App/Fossa/VPS/Scan/RunWiggins.hs
@@ -54,7 +54,7 @@ generateSpectrometerAOSPNoticeArgs logSeverity ApiOpts{..} ProjectRevision{..} n
       ++ ["-scan-id", unNinjaScanID ninjaScanId]
       ++ ["-name", projectName]
       ++ ["."]
-      ++ (T.pack . show <$> unNinjaFilePaths ninjaInputFiles)
+      ++ (T.pack . toFilePath <$> unNinjaFilePaths ninjaInputFiles)
 
 generateSpectrometerScanArgs :: Severity -> ProjectRevision -> ScanType -> FilterExpressions -> ApiOpts -> ProjectMetadata -> [Text]
 generateSpectrometerScanArgs logSeverity ProjectRevision{..} ScanType{..} fileFilters ApiOpts{..} ProjectMetadata{..} =

--- a/src/App/Fossa/VPS/Scan/RunWiggins.hs
+++ b/src/App/Fossa/VPS/Scan/RunWiggins.hs
@@ -10,9 +10,9 @@ module App.Fossa.VPS.Scan.RunWiggins
 where
 
 import App.Fossa.VPS.Types
-    ( FilterExpressions(FilterExpressions),
+    ( FilterExpressions (FilterExpressions),
       NinjaFilePaths (unNinjaFilePaths),
-      NinjaScanID(unNinjaScanID),
+      NinjaScanID (unNinjaScanID),
       encodeFilterExpressions )
 import App.Fossa.EmbeddedBinary
 import Control.Carrier.Error.Either

--- a/src/App/Fossa/VPS/Types.hs
+++ b/src/App/Fossa/VPS/Types.hs
@@ -13,6 +13,7 @@ module App.Fossa.VPS.Types
 , VPSOpts (..)
 , NinjaGraphOpts (..)
 , NinjaScanID (..)
+, NinjaFilePaths (..)
 ) where
 
 import Control.Monad.IO.Class (MonadIO(..))
@@ -25,8 +26,11 @@ import Network.HTTP.Req
 import Data.Text.Prettyprint.Doc (viaShow)
 import qualified Data.ByteString.Lazy as BSL
 import Data.Text.Encoding (decodeUtf8)
+import Path
 
 newtype NinjaScanID = NinjaScanID { unNinjaScanID :: Text }
+
+newtype NinjaFilePaths = NinjaFilePaths { unNinjaFilePaths :: [Path Abs File] }
 
 newtype FilterExpressions = FilterExpressions { unFilterExpressions :: [Text] }
 

--- a/src/App/Util.hs
+++ b/src/App/Util.hs
@@ -1,7 +1,8 @@
 {-# LANGUAGE DataKinds #-}
 
 module App.Util
-  ( validateDir,
+  ( validateDir
+  , validateFile
   )
 where
 
@@ -9,6 +10,7 @@ import App.Types
 import Control.Monad (unless)
 import qualified Path.IO as P
 import System.Exit (die)
+import Path ( Path, Abs, File )
 
 -- | Validate that a filepath points to a directory and the directory exists
 validateDir :: FilePath -> IO BaseDir
@@ -18,3 +20,11 @@ validateDir dir = do
 
   unless exists (die $ "ERROR: Directory " <> show absolute <> " does not exist")
   pure $ BaseDir absolute
+
+-- | Validate that a filepath points to a file and the file exists
+validateFile :: FilePath -> IO (Path Abs File)
+validateFile file = do
+  absolute <- P.resolveFile' file
+  exists <- P.doesFileExist absolute
+  unless exists (die $ "ERROR: File " <> show absolute <> " does not exist")
+  pure absolute


### PR DESCRIPTION
Updates `fossa vps aosp-notice-file` to require a `--ninja-files` argument, which is a comma separated list of Ninja file paths to use for reconstructing the build graph.

This replaces the existing functionality of "identify and use _all_ ninja files in the scan directory", which was not always valid.