### PR TITLE
Initial configuration file

### DIFF
--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -97,6 +97,7 @@ library
     App.Fossa.API.BuildLink
     App.Fossa.API.BuildWait
     App.Fossa.Compatibility
+    App.Fossa.Configuration
     App.Fossa.Container
     App.Fossa.Container.Analyze
     App.Fossa.Container.Test

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -245,6 +245,7 @@ test-suite unit-tests
     App.Fossa.API.BuildLinkSpec
     App.Fossa.Report.AttributionSpec
     App.Fossa.VPS.NinjaGraphSpec
+    App.Fossa.Configuration.ConfigurationSpec
     Cargo.MetadataSpec
     Carthage.CarthageSpec
     Clojure.ClojureSpec

--- a/src/App/Fossa/API/BuildLink.hs
+++ b/src/App/Fossa/API/BuildLink.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE QuasiQuotes #-}
 
 module App.Fossa.API.BuildLink
   ( getBuildURLWithOrg,
@@ -19,6 +20,7 @@ import Fossa.API.Types (ApiOpts (..))
 import Srclib.Types (Locator (..))
 import qualified Text.URI as URI
 import Text.URI.Builder
+import Text.URI.QQ (uri)
 
 fossaProjectUrlPath :: Locator -> ProjectRevision -> [PathComponent]
 fossaProjectUrlPath Locator {..} ProjectRevision {..} = map PathComponent components
@@ -38,7 +40,7 @@ getFossaBuildUrl revision apiopts locator = do
 
 getBuildURLWithOrg :: Has Diagnostics sig m => Maybe Organization -> ProjectRevision -> ApiOpts -> Locator -> m Text
 getBuildURLWithOrg maybeOrg revision apiopts locator = do
-  let baseURI = apiOptsUri apiopts
+  let baseURI = fromMaybe [uri|https://app.fossa.com|] (apiOptsUri apiopts)
       projectPath = fossaProjectUrlPath locator revision
 
   (path, query) <- case maybeOrg of

--- a/src/App/Fossa/Configuration.hs
+++ b/src/App/Fossa/Configuration.hs
@@ -19,26 +19,26 @@ import Effect.ReadFS
 import Options.Applicative
 
 data ConfigFile = ConfigFile
-  { version :: Int
-  , server :: Maybe Text
-  , apiKey :: Maybe Text
-  , project :: Maybe ConfigProject
-  , revision :: Maybe ConfigRevision
+  { configVersion :: Int
+  , configServer :: Maybe Text
+  , configApiKey :: Maybe Text
+  , configProject :: Maybe ConfigProject
+  , configRevision :: Maybe ConfigRevision
   } deriving (Eq, Ord, Show)
 
 data ConfigProject = ConfigProject
-  { projID :: Maybe Text
-  , name :: Maybe Text
-  , link :: Maybe Text
-  , team :: Maybe Text
-  , jiraKey :: Maybe Text
-  , url :: Maybe Text
-  , policy :: Maybe Text
+  { configProjID :: Maybe Text
+  , configName :: Maybe Text
+  , configLink :: Maybe Text
+  , configTeam :: Maybe Text
+  , configJiraKey :: Maybe Text
+  , configUrl :: Maybe Text
+  , configPolicy :: Maybe Text
   } deriving (Eq, Ord, Show)
 
 data ConfigRevision = ConfigRevision
-  { commit :: Maybe Text
-  , branch :: Maybe Text
+  { configCommit :: Maybe Text
+  , configBranch :: Maybe Text
   } deriving (Eq, Ord, Show)
 
 instance FromJSON ConfigFile where
@@ -74,17 +74,17 @@ readConfigFile = do
         then pure Nothing 
         else do 
           file <- readContentsYaml @ConfigFile defaultFile
-          if version file < 3 
+          if configVersion file < 3 
             then pure Nothing 
             else pure $ Just file
 
 mergeFileCmdMetadata :: ProjectMetadata -> ConfigFile -> ProjectMetadata
 mergeFileCmdMetadata meta file =
   ProjectMetadata
-    { projectTitle = projectTitle meta <|> (project file >>= name)
-    , projectUrl = projectUrl meta <|> (project file >>= url)
-    , projectJiraKey = projectJiraKey meta <|> (project file >>= jiraKey)
-    , projectLink = projectLink meta <|> (project file >>= link)
-    , projectTeam = projectTeam meta <|> (project file >>= team)
-    , projectPolicy = projectPolicy meta <|> (project file >>= policy)
+    { projectTitle = projectTitle meta <|> (configProject file >>= configName)
+    , projectUrl = projectUrl meta <|> (configProject file >>= configUrl)
+    , projectJiraKey = projectJiraKey meta <|> (configProject file >>= configJiraKey)
+    , projectLink = projectLink meta <|> (configProject file >>= configLink)
+    , projectTeam = projectTeam meta <|> (configProject file >>= configTeam)
+    , projectPolicy = projectPolicy meta <|> (configProject file >>= configPolicy)
     }

--- a/src/App/Fossa/Configuration.hs
+++ b/src/App/Fossa/Configuration.hs
@@ -1,99 +1,102 @@
-{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeApplications #-}
 
 module App.Fossa.Configuration
-( mergeFileCmdMetadata
-, readConfigFileIO
-, readConfigFile
-, ConfigFile (..)
-, ConfigProject (..)
-, ConfigRevision (..)
-)
+  ( mergeFileCmdMetadata,
+    readConfigFileIO,
+    readConfigFile,
+    ConfigFile (..),
+    ConfigProject (..),
+    ConfigRevision (..),
+  )
 where
 
-import Data.Aeson ( FromJSON(parseJSON), (.:), (.:?), withObject )
-import Data.Text (Text)
 import App.Types
-import Path
 import qualified Control.Carrier.Diagnostics as Diag
+import Data.Aeson (FromJSON (parseJSON), withObject, (.:), (.:?))
+import Data.Text (Text)
 import Effect.ReadFS
+import Control.Applicative ( Alternative ((<|>)) )
+import Path
 import System.Exit (die)
-import Options.Applicative
 
 data ConfigFile = ConfigFile
-  { configVersion :: Int
-  , configServer :: Maybe Text
-  , configApiKey :: Maybe Text
-  , configProject :: Maybe ConfigProject
-  , configRevision :: Maybe ConfigRevision
-  } deriving (Eq, Ord, Show)
+  { configVersion :: Int,
+    configServer :: Maybe Text,
+    configApiKey :: Maybe Text,
+    configProject :: Maybe ConfigProject,
+    configRevision :: Maybe ConfigRevision
+  }
+  deriving (Eq, Ord, Show)
 
 data ConfigProject = ConfigProject
-  { configProjID :: Maybe Text
-  , configName :: Maybe Text
-  , configLink :: Maybe Text
-  , configTeam :: Maybe Text
-  , configJiraKey :: Maybe Text
-  , configUrl :: Maybe Text
-  , configPolicy :: Maybe Text
-  } deriving (Eq, Ord, Show)
+  { configProjID :: Maybe Text,
+    configName :: Maybe Text,
+    configLink :: Maybe Text,
+    configTeam :: Maybe Text,
+    configJiraKey :: Maybe Text,
+    configUrl :: Maybe Text,
+    configPolicy :: Maybe Text
+  }
+  deriving (Eq, Ord, Show)
 
 data ConfigRevision = ConfigRevision
-  { configCommit :: Maybe Text
-  , configBranch :: Maybe Text
-  } deriving (Eq, Ord, Show)
+  { configCommit :: Maybe Text,
+    configBranch :: Maybe Text
+  }
+  deriving (Eq, Ord, Show)
 
 instance FromJSON ConfigFile where
   parseJSON = withObject "ConfigFile" $ \obj ->
     ConfigFile <$> obj .: "version"
-               <*> obj .:? "server"
-               <*> obj .:? "apiKey"
-               <*> obj .:? "project"
-               <*> obj .:? "revision"
+      <*> obj .:? "server"
+      <*> obj .:? "apiKey"
+      <*> obj .:? "project"
+      <*> obj .:? "revision"
 
 instance FromJSON ConfigProject where
   parseJSON = withObject "ConfigProject" $ \obj ->
     ConfigProject <$> obj .:? "id"
-                  <*> obj .:? "name"
-                  <*> obj .:? "link"
-                  <*> obj .:? "team"
-                  <*> obj .:? "jiraProjectKey"
-                  <*> obj .:? "url"
-                  <*> obj .:? "policy"
+      <*> obj .:? "name"
+      <*> obj .:? "link"
+      <*> obj .:? "team"
+      <*> obj .:? "jiraProjectKey"
+      <*> obj .:? "url"
+      <*> obj .:? "policy"
 
 instance FromJSON ConfigRevision where
   parseJSON = withObject "ConfigRevision" $ \obj ->
     ConfigRevision <$> obj .:? "commit"
-                   <*> obj .:? "branch"
+      <*> obj .:? "branch"
 
 defaultFile :: Path Rel File
 defaultFile = $(mkRelFile ".fossa.yml")
 
 readConfigFile :: (Has ReadFS sig m, Has Diag.Diagnostics sig m) => Path Rel File -> m (Maybe ConfigFile)
 readConfigFile file = do
-      exists <- doesFileExist file
-      if not exists 
-        then pure Nothing 
-        else do 
-        readConfig <- readContentsYaml @ConfigFile file
-        if configVersion readConfig < 3 
-          then pure Nothing 
-          else pure $ Just readConfig
+  exists <- doesFileExist file
+  if not exists
+    then pure Nothing
+    else do
+      readConfig <- readContentsYaml @ConfigFile file
+      if configVersion readConfig < 3
+        then pure Nothing
+        else pure $ Just readConfig
 
 readConfigFileIO :: IO (Maybe ConfigFile)
 readConfigFileIO = do
-    config <- Diag.runDiagnosticsIO $ runReadFSIO $ readConfigFile defaultFile
-    case config of
-      Left err -> die $ show $ Diag.renderFailureBundle err
-      Right a -> pure $ Diag.resultValue a
+  config <- Diag.runDiagnostics $ runReadFSIO $ readConfigFile defaultFile
+  case config of
+    Left err -> die $ show $ Diag.renderFailureBundle err
+    Right a -> pure $ Diag.resultValue a
 
 mergeFileCmdMetadata :: ProjectMetadata -> ConfigFile -> ProjectMetadata
 mergeFileCmdMetadata meta file =
   ProjectMetadata
-    { projectTitle = projectTitle meta <|> (configProject file >>= configName)
-    , projectUrl = projectUrl meta <|> (configProject file >>= configUrl)
-    , projectJiraKey = projectJiraKey meta <|> (configProject file >>= configJiraKey)
-    , projectLink = projectLink meta <|> (configProject file >>= configLink)
-    , projectTeam = projectTeam meta <|> (configProject file >>= configTeam)
-    , projectPolicy = projectPolicy meta <|> (configProject file >>= configPolicy)
+    { projectTitle = projectTitle meta <|> (configProject file >>= configName),
+      projectUrl = projectUrl meta <|> (configProject file >>= configUrl),
+      projectJiraKey = projectJiraKey meta <|> (configProject file >>= configJiraKey),
+      projectLink = projectLink meta <|> (configProject file >>= configLink),
+      projectTeam = projectTeam meta <|> (configProject file >>= configTeam),
+      projectPolicy = projectPolicy meta <|> (configProject file >>= configPolicy)
     }

--- a/src/App/Fossa/Configuration.hs
+++ b/src/App/Fossa/Configuration.hs
@@ -1,0 +1,92 @@
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+module App.Fossa.Configuration
+( mergeMetadata
+, readConfigFile
+, ConfigFile (..)
+, ConfigProject (..)
+, ConfigRevision (..)
+)
+where
+
+import Data.Aeson
+import Data.Text (Text)
+import App.Types
+import Path
+import qualified Control.Carrier.Diagnostics as Diag
+import Effect.ReadFS
+import Options.Applicative
+
+data ConfigFile = ConfigFile
+  { version :: Int
+  , server :: Maybe Text
+  , apiKey :: Maybe Text
+  , project :: Maybe ConfigProject
+  , revision :: Maybe ConfigRevision
+  } deriving (Eq, Ord, Show)
+
+data ConfigProject = ConfigProject
+  { projID :: Maybe Text
+  , name :: Maybe Text
+  , link :: Maybe Text
+  , team :: Maybe Text
+  , jiraKey :: Maybe Text
+  , url :: Maybe Text
+  , policy :: Maybe Text
+  } deriving (Eq, Ord, Show)
+
+data ConfigRevision = ConfigRevision
+  { commit :: Maybe Text
+  , branch :: Maybe Text
+  } deriving (Eq, Ord, Show)
+
+instance FromJSON ConfigFile where
+  parseJSON = withObject "ConfigFile" $ \obj ->
+    ConfigFile <$> obj .: "version"
+               <*> obj .:? "server"
+               <*> obj .:? "apiKey"
+               <*> obj .:? "project"
+               <*> obj .:? "revision"
+
+instance FromJSON ConfigProject where
+  parseJSON = withObject "ConfigProject" $ \obj ->
+    ConfigProject <$> obj .:? "id"
+                  <*> obj .:? "name"
+                  <*> obj .:? "link"
+                  <*> obj .:? "team"
+                  <*> obj .:? "jirakey"
+                  <*> obj .:? "url"
+                  <*> obj .:? "policy"
+
+instance FromJSON ConfigRevision where
+  parseJSON = withObject "ConfigRevision" $ \obj ->
+    ConfigRevision <$> obj .:? "commit"
+                   <*> obj .:? "branch"
+
+fossaYml :: Path Rel File
+fossaYml = $(mkRelFile ".fossa.yml")
+
+readConfigFile :: IO ConfigFile
+readConfigFile = do
+      file <- Diag.runDiagnosticsIO $ runReadFSIO $ readContentsYaml @ConfigFile fossaYml
+      case file of
+        Left _ -> pure $ ConfigFile { version = -1
+                                    , server = Nothing
+                                    , apiKey = Nothing
+                                    , project = Nothing
+                                    , revision = Nothing
+                                    }
+        Right a -> pure $ Diag.resultValue a 
+
+mergeMetadata :: ConfigFile -> ProjectMetadata -> ProjectMetadata
+mergeMetadata file meta =
+  ProjectMetadata
+    { projectTitle = projectTitle meta <|> (project file >>= name)
+    , projectUrl = projectUrl meta <|> (project file >>= url)
+    , projectJiraKey = projectJiraKey meta <|> (project file >>= jiraKey)
+    , projectLink = projectLink meta <|> (project file >>= link)
+    , projectTeam = projectTeam meta <|> (project file >>= team)
+    , projectPolicy = projectPolicy meta <|> (project file >>= policy)
+    } 
+    

--- a/src/App/Fossa/Configuration.hs
+++ b/src/App/Fossa/Configuration.hs
@@ -72,8 +72,11 @@ readConfigFile = do
       exists <- doesFileExist defaultFile
       if not exists 
         then pure Nothing 
-        else (do file <- readContentsYaml @ConfigFile defaultFile
-                 pure $ Just file)
+        else do 
+          file <- readContentsYaml @ConfigFile defaultFile
+          if version file < 3 
+            then pure Nothing 
+            else pure $ Just file
 
 mergeFileCmdMetadata :: ProjectMetadata -> ConfigFile -> ProjectMetadata
 mergeFileCmdMetadata meta file =

--- a/src/App/Fossa/Main.hs
+++ b/src/App/Fossa/Main.hs
@@ -13,6 +13,7 @@ import qualified App.Fossa.Container.Test as ContainerTest
 import App.Fossa.Compatibility (argumentParser, Argument, compatibilityMain)
 import qualified App.Fossa.EmbeddedBinary as Embed
 import App.Fossa.ListTargets (listTargetsMain)
+import App.Fossa.Configuration
 import qualified App.Fossa.Report as Report
 import qualified App.Fossa.Test as Test
 import App.Fossa.VPS.NinjaGraph
@@ -40,23 +41,38 @@ import System.Environment (lookupEnv)
 import System.Exit (die)
 import qualified System.Info as SysInfo
 import Text.Megaparsec (errorBundlePretty, runParser)
-import Text.URI (URI)
 import Text.URI.QQ (uri)
 import Path
+import Text.URI (URI, mkURI)
 
 windowsOsName :: String
 windowsOsName = "mingw32"
 
 mainPrefs :: ParserPrefs
-mainPrefs = prefs $ mconcat 
+mainPrefs = prefs $ mconcat
   [ helpShowGlobals,
     showHelpOnError,
-    subparserInline 
+    subparserInline
   ]
+
+mergeConfig :: ConfigFile -> CmdOptions -> CmdOptions
+mergeConfig file cmd =
+  CmdOptions
+    { optDebug = optDebug cmd
+    , optBaseUrl = optBaseUrl cmd <|> (server file >>= mkURI)
+    , optProjectName = optProjectName cmd <|> (project file >>= projID)
+    , optProjectRevision = optProjectRevision cmd <|> (revision file >>= commit)
+    , optAPIKey = optAPIKey cmd <|> apiKey file
+    , optCommand = optCommand cmd
+    }
 
 appMain :: IO ()
 appMain = do
-  CmdOptions {..} <- customExecParser mainPrefs (info (opts <**> helper) (fullDesc <> header "fossa-cli - Flexible, performant dependency analysis"))
+  cmdConfig <- customExecParser mainPrefs (info (opts <**> helper) (fullDesc <> header "fossa-cli - Flexible, performant dependency analysis"))
+  fileConfig <- readConfigFile
+
+  let CmdOptions {..} = mergeConfig fileConfig cmdConfig
+
   let logSeverity = bool SevInfo SevDebug optDebug
 
   maybeApiKey <- checkAPIKey optAPIKey
@@ -69,13 +85,16 @@ appMain = do
 
   case optCommand of
     AnalyzeCommand AnalyzeOptions {..} -> do
-      let analyzeOverride = override {overrideBranch = analyzeBranch}
+      -- The branch override needs to be set here rather than above to preserve
+      -- the preference for command line options.
+      let analyzeOverride = override {overrideBranch = analyzeBranch <|> (revision fileConfig >>= branch)}
       if analyzeOutput
         then analyzeMain analyzeBaseDir analyzeRecordMode logSeverity OutputStdout analyzeOverride analyzeUnpackArchives analyzeBuildTargetFilters
         else do
           key <- requireKey maybeApiKey
           let apiOpts = ApiOpts optBaseUrl key
-          analyzeMain analyzeBaseDir analyzeRecordMode logSeverity (UploadScan apiOpts analyzeMetadata) analyzeOverride analyzeUnpackArchives analyzeBuildTargetFilters
+          let metadata = mergeMetadata fileConfig analyzeMetadata
+          analyzeMain analyzeBaseDir analyzeRecordMode logSeverity (UploadScan apiOpts metadata) analyzeOverride analyzeUnpackArchives analyzeBuildTargetFilters
     --
     TestCommand TestOptions {..} -> do
       baseDir <- validateDir testBaseDir
@@ -104,7 +123,8 @@ appMain = do
         VPSAnalyzeCommand VPSAnalyzeOptions {..} -> do
           when (SysInfo.os == windowsOsName) $ unless (fromFlag SkipIPRScan skipIprScan) $ die "Windows VPS scans require skipping IPR.  Please try `fossa vps analyze --skip-ipr-scan DIR`"
           baseDir <- validateDir vpsAnalyzeBaseDir
-          scanMain baseDir apiOpts vpsAnalyzeMeta logSeverity override vpsFileFilter skipIprScan licenseOnlyScan
+          let metadata = mergeMetadata fileConfig vpsAnalyzeMeta
+          scanMain baseDir apiOpts metadata logSeverity override vpsFileFilter skipIprScan licenseOnlyScan
         NinjaGraphCommand ninjaGraphOptions -> do
           _ <- die "This command is no longer supported"
           ninjaGraphMain apiOpts logSeverity override ninjaGraphOptions
@@ -131,7 +151,8 @@ appMain = do
             else do
               apikey <- requireKey maybeApiKey
               let apiOpts = ApiOpts optBaseUrl apikey
-              ContainerAnalyze.analyzeMain (UploadScan apiOpts containerMetadata) logSeverity override containerAnalyzeImage
+              let metadata = mergeMetadata fileConfig containerMetadata
+              ContainerAnalyze.analyzeMain (UploadScan apiOpts metadata) logSeverity override containerAnalyzeImage
         ContainerTest ContainerTestOptions {..} -> do
           apikey <- requireKey maybeApiKey
           let apiOpts = ApiOpts optBaseUrl apikey
@@ -176,7 +197,7 @@ opts :: Parser CmdOptions
 opts =
   CmdOptions
     <$> switch (long "debug" <> help "Enable debug logging")
-    <*> uriOption (long "endpoint" <> metavar "URL" <> help "The FOSSA API server base URL (default: https://app.fossa.com)" <> value [uri|https://app.fossa.com|])
+    <*> optional (uriOption (long "endpoint" <> metavar "URL" <> help "The FOSSA API server base URL (default: https://app.fossa.com)"))
     <*> optional (strOption (long "project" <> help "this repository's URL or VCS endpoint (default: VCS remote 'origin')"))
     <*> optional (strOption (long "revision" <> help "this repository's current revision hash (default: VCS hash HEAD)"))
     <*> optional (strOption (long "fossa-api-key" <> help "the FOSSA API server authentication key (default: FOSSA_API_KEY from env)"))
@@ -386,7 +407,7 @@ containerOpts = ContainerOptions <$> (containerCommands <|> hiddenContainerComma
 
 containerCommands :: Parser ContainerCommand
 containerCommands =
-  hsubparser 
+  hsubparser
     ( command
         "analyze"
         ( info (ContainerAnalyze <$> containerAnalyzeOpts) $
@@ -401,8 +422,8 @@ containerCommands =
 
 hiddenContainerCommands :: Parser ContainerCommand
 hiddenContainerCommands =
-  hsubparser 
-    ( internal 
+  hsubparser
+    ( internal
         <> command
           "parse-file"
           ( info (ContainerParseFile <$> containerParseFileOptions) $
@@ -413,7 +434,7 @@ hiddenContainerCommands =
           ( info (ContainerDumpScan <$> containerDumpScanOptions) $
               progDesc "Capture syft output for debugging"
           )
-    ) 
+    )
 
 containerAnalyzeOpts :: Parser ContainerAnalyzeOptions
 containerAnalyzeOpts =
@@ -436,7 +457,7 @@ containerDumpScanOptions :: Parser ContainerDumpScanOptions
 containerDumpScanOptions =
   ContainerDumpScanOptions
     <$> optional (strOption (short 'o' <> long "output-file" <> help "File to write the scan data (omit for stdout)"))
-    <*> imageTextArg 
+    <*> imageTextArg
 
 compatibilityOpts :: Parser [Argument]
 compatibilityOpts =
@@ -444,7 +465,7 @@ compatibilityOpts =
 
 data CmdOptions = CmdOptions
   { optDebug :: Bool,
-    optBaseUrl :: URI,
+    optBaseUrl :: Maybe URI,
     optProjectName :: Maybe Text,
     optProjectRevision :: Maybe Text,
     optAPIKey :: Maybe Text,

--- a/src/App/Fossa/Main.hs
+++ b/src/App/Fossa/Main.hs
@@ -60,10 +60,10 @@ mergeFileCmdConfig :: CmdOptions -> ConfigFile -> CmdOptions
 mergeFileCmdConfig cmd file =
   CmdOptions
     { optDebug = optDebug cmd
-    , optBaseUrl = optBaseUrl cmd <|> (server file >>= mkURI)
-    , optProjectName = optProjectName cmd <|> (project file >>= projID)
-    , optProjectRevision = optProjectRevision cmd <|> (revision file >>= commit)
-    , optAPIKey = optAPIKey cmd <|> apiKey file
+    , optBaseUrl = optBaseUrl cmd <|> (configServer file >>= mkURI)
+    , optProjectName = optProjectName cmd <|> (configProject file >>= configProjID)
+    , optProjectRevision = optProjectRevision cmd <|> (configRevision file >>= configCommit)
+    , optAPIKey = optAPIKey cmd <|> configApiKey file
     , optCommand = optCommand cmd
     }
 
@@ -91,7 +91,7 @@ appMain = do
     AnalyzeCommand AnalyzeOptions {..} -> do
       -- The branch override needs to be set here rather than above to preserve
       -- the preference for command line options.
-      let analyzeOverride = override {overrideBranch = analyzeBranch <|> ((fileConfig >>= revision) >>= branch)}
+      let analyzeOverride = override {overrideBranch = analyzeBranch <|> ((fileConfig >>= configRevision) >>= configBranch)}
       if analyzeOutput
         then analyzeMain analyzeBaseDir analyzeRecordMode logSeverity OutputStdout analyzeOverride analyzeUnpackArchives analyzeBuildTargetFilters
         else do

--- a/src/App/Fossa/Main.hs
+++ b/src/App/Fossa/Main.hs
@@ -26,7 +26,6 @@ import App.OptionExtensions
 import App.Types
 import App.Util (validateDir, validateFile)
 import App.Version (fullVersionDescription)
-import qualified Control.Carrier.Diagnostics as Diag
 import Control.Monad (unless, when)
 import Data.Bifunctor (first)
 import Data.Bool (bool)
@@ -36,7 +35,6 @@ import Data.Text (Text)
 import qualified Data.Text as T
 import Discovery.Filters (BuildTargetFilter (..), filterParser)
 import Effect.Logger
-import Effect.ReadFS
 import Fossa.API.Types (ApiKey(..), ApiOpts(..))
 import Options.Applicative
 import System.Environment (lookupEnv)
@@ -70,10 +68,7 @@ mergeFileCmdConfig cmd file =
 appMain :: IO ()
 appMain = do
   cmdConfig <- customExecParser mainPrefs (info (opts <**> helper) (fullDesc <> header "fossa-cli - Flexible, performant dependency analysis"))
-  configRead <- Diag.runDiagnosticsIO $ runReadFSIO readConfigFile
-  fileConfig <- case configRead of
-    Left err -> die $ show $ Diag.renderFailureBundle err
-    Right a -> pure $ Diag.resultValue a
+  fileConfig <- readConfigFileIO
 
   let CmdOptions {..} = maybe cmdConfig (mergeFileCmdConfig cmdConfig) fileConfig
 

--- a/src/App/Fossa/Main.hs
+++ b/src/App/Fossa/Main.hs
@@ -41,9 +41,9 @@ import System.Environment (lookupEnv)
 import System.Exit (die)
 import qualified System.Info as SysInfo
 import Text.Megaparsec (errorBundlePretty, runParser)
+import Text.URI (URI, mkURI)
 import Text.URI.QQ (uri)
 import Path
-import Text.URI (URI, mkURI)
 
 windowsOsName :: String
 windowsOsName = "mingw32"

--- a/src/App/Fossa/VPS/Scan/RunWiggins.hs
+++ b/src/App/Fossa/VPS/Scan/RunWiggins.hs
@@ -50,19 +50,19 @@ generateSpectrometerAOSPNoticeArgs :: Severity -> ApiOpts -> ProjectRevision -> 
 generateSpectrometerAOSPNoticeArgs logSeverity ApiOpts{..} ProjectRevision{..} ninjaScanId ninjaInputFiles =
   ["aosp-notice-files"]
       ++ optBool "-debug" (logSeverity == SevDebug)
+      ++ optMaybeText "-endpoint" (render <$> apiOptsUri)
       ++ ["-fossa-api-key", unApiKey apiOptsApiKey]
       ++ ["-scan-id", unNinjaScanID ninjaScanId]
       ++ ["-name", projectName]
       ++ ["."]
       ++ (T.pack . toFilePath <$> unNinjaFilePaths ninjaInputFiles)
-      ++ optMaybeText "-endpoint" (render <$> apiOptsUri)
 
 generateSpectrometerScanArgs :: Severity -> ProjectRevision -> ScanType -> FilterExpressions -> ApiOpts -> ProjectMetadata -> [Text]
 generateSpectrometerScanArgs logSeverity ProjectRevision{..} ScanType{..} fileFilters ApiOpts{..} ProjectMetadata{..} =
     "analyze"
-      : ["-fossa-api-key", unApiKey apiOptsApiKey]
+      : optMaybeText "-endpoint" (render <$> apiOptsUri)
+      ++ ["-fossa-api-key", unApiKey apiOptsApiKey]
       ++ ["-name", projectName, "-revision", projectRevision]
-      ++ optMaybeText "-endpoint" (render <$> apiOptsUri)
       ++ optMaybeText "-jira-project-key" projectJiraKey
       ++ optMaybeText "-link" projectLink
       ++ optMaybeText "-policy" projectPolicy

--- a/src/App/Fossa/VPS/Scan/RunWiggins.hs
+++ b/src/App/Fossa/VPS/Scan/RunWiggins.hs
@@ -50,17 +50,19 @@ generateSpectrometerAOSPNoticeArgs :: Severity -> ApiOpts -> ProjectRevision -> 
 generateSpectrometerAOSPNoticeArgs logSeverity ApiOpts{..} ProjectRevision{..} ninjaScanId ninjaInputFiles =
   ["aosp-notice-files"]
       ++ optBool "-debug" (logSeverity == SevDebug)
-      ++ ["-endpoint", render apiOptsUri, "-fossa-api-key", unApiKey apiOptsApiKey]
+      ++ ["-fossa-api-key", unApiKey apiOptsApiKey]
       ++ ["-scan-id", unNinjaScanID ninjaScanId]
       ++ ["-name", projectName]
       ++ ["."]
       ++ (T.pack . toFilePath <$> unNinjaFilePaths ninjaInputFiles)
+      ++ optMaybeText "-endpoint" (render <$> apiOptsUri)
 
 generateSpectrometerScanArgs :: Severity -> ProjectRevision -> ScanType -> FilterExpressions -> ApiOpts -> ProjectMetadata -> [Text]
 generateSpectrometerScanArgs logSeverity ProjectRevision{..} ScanType{..} fileFilters ApiOpts{..} ProjectMetadata{..} =
     "analyze"
-      : ["-endpoint", render apiOptsUri, "-fossa-api-key", unApiKey apiOptsApiKey]
+      : ["-fossa-api-key", unApiKey apiOptsApiKey]
       ++ ["-name", projectName, "-revision", projectRevision]
+      ++ optMaybeText "-endpoint" (render <$> apiOptsUri)
       ++ optMaybeText "-jira-project-key" projectJiraKey
       ++ optMaybeText "-link" projectLink
       ++ optMaybeText "-policy" projectPolicy

--- a/src/Control/Carrier/Diagnostics.hs
+++ b/src/Control/Carrier/Diagnostics.hs
@@ -67,9 +67,6 @@ data ResultBundle a = ResultBundle
     resultValue :: a
   }
 
-instance (Show a) => Show (ResultBundle a) where
-  show = show . resultValue
-
 renderFailureBundle :: FailureBundle -> Doc AnsiStyle
 renderFailureBundle FailureBundle {..} =
   vsep

--- a/src/Control/Carrier/Diagnostics.hs
+++ b/src/Control/Carrier/Diagnostics.hs
@@ -67,6 +67,9 @@ data ResultBundle a = ResultBundle
     resultValue :: a
   }
 
+instance (Show a) => Show (ResultBundle a) where
+  show = show . resultValue
+
 renderFailureBundle :: FailureBundle -> Doc AnsiStyle
 renderFailureBundle FailureBundle {..} =
   vsep

--- a/test/App/Fossa/API/BuildLinkSpec.hs
+++ b/test/App/Fossa/API/BuildLinkSpec.hs
@@ -33,7 +33,7 @@ stripDiag = join . ignoreLogger . logDiagnostic
 
 spec :: Spec
 spec = do
-  let apiOpts = ApiOpts [uri|https://app.fossa.com/|] $ ApiKey ""
+  let apiOpts = ApiOpts (Just [uri|https://app.fossa.com/|]) $ ApiKey ""
   describe "SAML URL builder" $ do
     it "should render simple locators" $ do
       let locator = Locator "fetcher123" "project123" $ Just "revision123"

--- a/test/App/Fossa/Configuration/ConfigurationSpec.hs
+++ b/test/App/Fossa/Configuration/ConfigurationSpec.hs
@@ -1,0 +1,67 @@
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE TemplateHaskell #-}
+module App.Fossa.Configuration.ConfigurationSpec
+  ( spec
+  ) where
+
+import qualified Control.Carrier.Diagnostics as Diag
+import Effect.ReadFS
+import App.Fossa.Configuration
+import qualified Test.Hspec as T
+import Path
+
+expectedConfigFile :: ConfigFile
+expectedConfigFile = ConfigFile { configVersion = 3
+                                , configServer = Just "https://app.fossa.com"
+                                , configApiKey = Just "123"
+                                , configProject = Just expectedConfigProject
+                                , configRevision = Just expectedConfigRevision
+                                }
+
+
+expectedConfigProject :: ConfigProject
+expectedConfigProject = ConfigProject { configProjID = Just "github.com/fossa-cli"
+                                      , configName = Just "fossa-cli"
+                                      , configLink = Just "fossa.com"
+                                      , configTeam = Just "fossa-team"
+                                      , configJiraKey = Just "key"
+                                      , configUrl = Just "fossa.com"
+                                      , configPolicy = Just "license-policy"
+                                      }
+
+expectedConfigRevision :: ConfigRevision
+expectedConfigRevision = ConfigRevision { configCommit = Just "12345"
+                                        , configBranch = Just "master"
+                                        }
+testFile :: Path Rel File
+testFile = $(mkRelFile "test/App/Fossa/Configuration/testdata/validconfig.yml")
+
+badFile :: Path Rel File
+badFile = $(mkRelFile "test/App/Fossa/Configuration/testdata/invalidconfig.yml")
+
+missingFile :: Path Rel File
+missingFile = $(mkRelFile "test/App/Fossa/Configuration/testdata/missingfile.yml")
+
+spec :: T.Spec
+spec = do
+  config <- T.runIO . Diag.runDiagnosticsIO $ runReadFSIO $ readConfigFile testFile
+  badConfig <- T.runIO . Diag.runDiagnosticsIO $ runReadFSIO $ readConfigFile badFile
+  missingConfig <- T.runIO . Diag.runDiagnosticsIO $ runReadFSIO $ readConfigFile missingFile
+
+  T.describe "config file parser" $ do
+    T.it "parses a full configuration file correctly" $
+      case config of
+        Left err -> T.expectationFailure ("failed to parse config file" <> show (Diag.renderFailureBundle err))
+        Right a -> case Diag.resultValue a of
+                     Nothing -> T.expectationFailure "config file was Nothing after parsing"
+                     Just result -> result `T.shouldBe` expectedConfigFile
+
+    T.it "returns failure for a bad file" $
+      case badConfig of
+        Left err -> show (Diag.renderFailureBundle err) `T.shouldNotBe` ""
+        Right _ -> T.expectationFailure "should have failed parsing"
+
+    T.it "returns Nothing for missing file" $
+      case missingConfig of
+        Left _ -> T.expectationFailure "should have failed parsing"
+        Right a -> Diag.resultValue a `T.shouldBe` Nothing 

--- a/test/App/Fossa/Configuration/ConfigurationSpec.hs
+++ b/test/App/Fossa/Configuration/ConfigurationSpec.hs
@@ -1,38 +1,46 @@
 {-# LANGUAGE BlockArguments #-}
 {-# LANGUAGE TemplateHaskell #-}
-module App.Fossa.Configuration.ConfigurationSpec
-  ( spec
-  ) where
 
+module App.Fossa.Configuration.ConfigurationSpec
+  ( spec,
+  )
+where
+
+import App.Fossa.Configuration
 import qualified Control.Carrier.Diagnostics as Diag
 import Effect.ReadFS
-import App.Fossa.Configuration
-import qualified Test.Hspec as T
 import Path
+import qualified Test.Hspec as T
 
 expectedConfigFile :: ConfigFile
-expectedConfigFile = ConfigFile { configVersion = 3
-                                , configServer = Just "https://app.fossa.com"
-                                , configApiKey = Just "123"
-                                , configProject = Just expectedConfigProject
-                                , configRevision = Just expectedConfigRevision
-                                }
-
+expectedConfigFile =
+  ConfigFile
+    { configVersion = 3,
+      configServer = Just "https://app.fossa.com",
+      configApiKey = Just "123",
+      configProject = Just expectedConfigProject,
+      configRevision = Just expectedConfigRevision
+    }
 
 expectedConfigProject :: ConfigProject
-expectedConfigProject = ConfigProject { configProjID = Just "github.com/fossa-cli"
-                                      , configName = Just "fossa-cli"
-                                      , configLink = Just "fossa.com"
-                                      , configTeam = Just "fossa-team"
-                                      , configJiraKey = Just "key"
-                                      , configUrl = Just "fossa.com"
-                                      , configPolicy = Just "license-policy"
-                                      }
+expectedConfigProject =
+  ConfigProject
+    { configProjID = Just "github.com/fossa-cli",
+      configName = Just "fossa-cli",
+      configLink = Just "fossa.com",
+      configTeam = Just "fossa-team",
+      configJiraKey = Just "key",
+      configUrl = Just "fossa.com",
+      configPolicy = Just "license-policy"
+    }
 
 expectedConfigRevision :: ConfigRevision
-expectedConfigRevision = ConfigRevision { configCommit = Just "12345"
-                                        , configBranch = Just "master"
-                                        }
+expectedConfigRevision =
+  ConfigRevision
+    { configCommit = Just "12345",
+      configBranch = Just "master"
+    }
+
 testFile :: Path Rel File
 testFile = $(mkRelFile "test/App/Fossa/Configuration/testdata/validconfig.yml")
 
@@ -44,17 +52,17 @@ missingFile = $(mkRelFile "test/App/Fossa/Configuration/testdata/missingfile.yml
 
 spec :: T.Spec
 spec = do
-  config <- T.runIO . Diag.runDiagnosticsIO $ runReadFSIO $ readConfigFile testFile
-  badConfig <- T.runIO . Diag.runDiagnosticsIO $ runReadFSIO $ readConfigFile badFile
-  missingConfig <- T.runIO . Diag.runDiagnosticsIO $ runReadFSIO $ readConfigFile missingFile
+  config <- T.runIO . Diag.runDiagnostics $ runReadFSIO $ readConfigFile testFile
+  badConfig <- T.runIO . Diag.runDiagnostics $ runReadFSIO $ readConfigFile badFile
+  missingConfig <- T.runIO . Diag.runDiagnostics $ runReadFSIO $ readConfigFile missingFile
 
   T.describe "config file parser" $ do
     T.it "parses a full configuration file correctly" $
       case config of
         Left err -> T.expectationFailure ("failed to parse config file" <> show (Diag.renderFailureBundle err))
         Right a -> case Diag.resultValue a of
-                     Nothing -> T.expectationFailure "config file was Nothing after parsing"
-                     Just result -> result `T.shouldBe` expectedConfigFile
+          Nothing -> T.expectationFailure "config file was Nothing after parsing"
+          Just result -> result `T.shouldBe` expectedConfigFile
 
     T.it "returns failure for a bad file" $
       case badConfig of
@@ -64,4 +72,4 @@ spec = do
     T.it "returns Nothing for missing file" $
       case missingConfig of
         Left _ -> T.expectationFailure "should have failed parsing"
-        Right a -> Diag.resultValue a `T.shouldBe` Nothing 
+        Right a -> Diag.resultValue a `T.shouldBe` Nothing

--- a/test/App/Fossa/Configuration/testdata/invalidconfig.yml
+++ b/test/App/Fossa/Configuration/testdata/invalidconfig.yml
@@ -1,0 +1,3 @@
+vers: two
+
+this file is invalid

--- a/test/App/Fossa/Configuration/testdata/validconfig.yml
+++ b/test/App/Fossa/Configuration/testdata/validconfig.yml
@@ -1,0 +1,20 @@
+version: 3
+
+server: https://app.fossa.com
+apiKey: "123"
+
+project:
+  id: github.com/fossa-cli
+  name: fossa-cli
+  team: fossa-team
+  policy: license-policy
+  link: fossa.com
+  url: fossa.com
+  releaseGroup:
+    name: release-group-name
+    version: "123"
+  jiraProjectKey: key
+
+revision:
+  commit: "12345"
+  branch: master

--- a/test/Ruby/testdata/bundleShow
+++ b/test/Ruby/testdata/bundleShow
@@ -1,3 +1,4 @@
 Gems included by the bundle:
   * pkgOne (1.0.0)
   * pkgTwo (2.0.0)
+Use `bundle info` to print more detailed information about a gem


### PR DESCRIPTION
This PR introduces a configuration file for project-level configuration to the spectrometer CLI. This allows users to save the configuration for multiple runs or send other users in their organization similar configuration for their team, policy, and so on.

The configuration file looks like this and the only required field is version:
```
version: 3

server: https://app.fossa.com
apiKey: "123423423423"

project:
- id: github.com/fossas/fossa-cli
- name: fossa-cli # as a flag, this is `--project.name`
- team: fossa-team
- policy: license-policy
- releaseGroup:
  - name: release-group-name
  - version: "123"
- jiraProjectKey: key

revision:
- commit: "1235"
- branch: master
```

Notes for this PR:
- I had to change how we set the default fossa URI. We used to do it after parsing the command-line options, but this made it difficult to adhere to preferring command line > file > default. These changes do not affect behavior for incorrect URIs as far as I am concerned as we only use the default if a user-specified URI has not been provided. That said... I do think we should be doing this validation before we start analysis. It's a little annoying to get to the end and find this out. This will be a follow-up ticket.
- I am unfortunately keeping `mergeFileCmdConfig` in `Main.hs` because I would be introducing a circular dependency through `CmdConfig`. If there is a recommendation to moving this that doesn't involve rewriting how we do configuration I am open to it.

Todo:
Clean up code where necessary
Add a simple test once that's done.