### PR TITLE
Glide.lock: Parse versions as Text

### DIFF
--- a/src/Strategy/Go/GlideLock.hs
+++ b/src/Strategy/Go/GlideLock.hs
@@ -11,6 +11,7 @@ module Strategy.Go.GlideLock
   )
   where
 
+import Control.Applicative ((<|>))
 import Control.Effect.Diagnostics
 import Data.Aeson
 import qualified Data.Map.Strict as M
@@ -32,7 +33,7 @@ buildGraph lockfile = Graphing.fromList (map toDependency direct)
   toDependency GlideDep{..} =
     Dependency { dependencyType = GoType
                , dependencyName = depName
-               , dependencyVersion = Just (CEq $ T.pack (show depVersion))
+               , dependencyVersion = Just (CEq depVersion)
                , dependencyLocations = []
                , dependencyEnvironments = []
                , dependencyTags = M.empty
@@ -46,7 +47,7 @@ data GlideLockfile = GlideLockfile
 
 data GlideDep = GlideDep
   { depName    :: Text
-  , depVersion :: Integer
+  , depVersion :: Text
   , depRepo    :: Maybe Text
   } deriving (Eq, Ord, Show)
 
@@ -59,5 +60,9 @@ instance FromJSON GlideLockfile where
 instance FromJSON GlideDep where
   parseJSON = withObject "GlideDep" $ \obj ->
     GlideDep <$> obj .:  "name"
-               <*> obj .: "version"
+               -- version field can be text or an int (hexadecimal hash)
+               <*> (obj .: "version" <|> (intToText <$> obj .: "version"))
                <*> obj .:? "repo"
+
+intToText :: Int -> Text
+intToText = T.pack . show

--- a/test/Go/GlideLockSpec.hs
+++ b/test/Go/GlideLockSpec.hs
@@ -19,7 +19,7 @@ expected = run . evalGrapher $ do
   direct $ Dependency
                { dependencyType = GoType
                , dependencyName = "github.com/pkg/one"
-               , dependencyVersion = Just (CEq "100")
+               , dependencyVersion = Just (CEq "1234")
                , dependencyLocations = []
                , dependencyEnvironments = []
                , dependencyTags = M.empty
@@ -27,7 +27,7 @@ expected = run . evalGrapher $ do
   direct $ Dependency
                { dependencyType = GoType
                , dependencyName = "github.com/pkg/three/v3"
-               , dependencyVersion = Just (CEq "300")
+               , dependencyVersion = Just (CEq "4bd8")
                , dependencyLocations = []
                , dependencyEnvironments = []
                , dependencyTags = M.empty
@@ -40,12 +40,12 @@ glideLockfile =
   , imports = 
     [ GlideDep 
         { depName = "github.com/pkg/one"
-        , depVersion = 100
+        , depVersion = "1234"
         , depRepo = Just "testRepo"
     }
     , GlideDep 
         { depName = "github.com/pkg/three/v3"
-        , depVersion = 300
+        , depVersion = "4bd8"
         , depRepo = Just "testRepo"
     }
   ]
@@ -63,4 +63,4 @@ spec = do
     it "works end to end" $ do
       case decodeEither' testFile of
         Right res -> buildGraph res `shouldBe` expected
-        Left _ -> expectationFailure "failed to parse"
+        Left err -> expectationFailure $ "failed to parse: " <> show err

--- a/test/Go/testdata/glide.lock
+++ b/test/Go/testdata/glide.lock
@@ -2,10 +2,10 @@ hash: a12345
 updated: 2018-10-12T14:37:49.968644-07:00
 imports:
 - name: github.com/pkg/one
-  version: 100
+  version: 1234
   subpackages:
   - compute
 - name: github.com/pkg/three/v3
-  version: 300
+  version: 4bd8
   repo: fossas/privatefork
 testImports: []


### PR DESCRIPTION
We were previously parsing them as integers, which passed the tests from cliv1.

Updated the test `glide.lock` to add an alphanumeric hexadecimal version string for one of the dependencies