### PR TITLE
Filter container modules (again)

### DIFF
--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -176,6 +176,7 @@ library
     Control.Exception.Extra
     Data.FileEmbed.Extra
     Data.Flag
+    Data.Functor.Extra
     Data.Text.Extra
     DepTypes
     Discovery.Archive

--- a/src/App/Fossa/Container.hs
+++ b/src/App/Fossa/Container.hs
@@ -42,6 +42,7 @@ import Path.IO (getCurrentDir)
 import qualified Data.ByteString.Lazy as BL
 import Data.Aeson.Types (parseEither)
 import qualified Data.Text.Lazy.Encoding as TE
+import Data.Functor.Extra ((<$$>))
 
 newtype ImageText = ImageText {unImageText :: Text} deriving (Show, Eq, Ord)
 
@@ -77,7 +78,7 @@ data ResponseArtifact
         artifactType :: Text,
         artifactPkgUrl :: Text,
         artifactMetadataType :: Text,
-        artifactMetadata :: Map Text Value
+        artifactMetadata :: Maybe (Map Text Value)
       }
 
 instance FromJSON ResponseArtifact where
@@ -92,7 +93,7 @@ instance FromJSON ResponseArtifact where
       -- We use Lazy delete to avoid evaluating the innards of
       -- the field, since Aeson will try to avoid evaluating it
       -- as well.
-      <*> (LMap.delete "files" <$> obj .: "metadata")
+      <*> (LMap.delete "files" <$$> obj .:? "metadata")
 
 newtype ResponseSource
   = ResponseSource
@@ -180,21 +181,23 @@ extractRevision OverrideProject {..} ContainerScan {..} = ProjectRevision name r
 
 toContainerScan :: Has Diagnostics sig m => SyftResponse -> m ContainerScan
 toContainerScan SyftResponse {..} = do
-  let newArts = map convertArtifact responseArtifacts
-      image = ContainerImage newArts (distroName responseDistro) (distroVersion responseDistro)
+  newArts <- traverse convertArtifact responseArtifacts
+  let image = ContainerImage newArts (distroName responseDistro) (distroVersion responseDistro)
       target = sourceTarget responseSource
   tag <- extractTag $ targetTags target
   pure . ContainerScan image tag $ targetDigest target
 
-convertArtifact :: ResponseArtifact -> ContainerArtifact
-convertArtifact ResponseArtifact {..} =
-  ContainerArtifact
+convertArtifact :: Has Diagnostics sig m => ResponseArtifact -> m ContainerArtifact
+convertArtifact ResponseArtifact {..} = do
+  let errMsg = "No metadata for system package with name: " <> artifactName
+  validMetadata <- fromMaybeText errMsg artifactMetadata
+  pure ContainerArtifact
     { conArtifactName = artifactName,
       conArtifactVersion = artifactVersion,
       conArtifactType = artifactType,
       conArtifactPkgUrl = artifactPkgUrl,
       conArtifactMetadataType = artifactMetadataType,
-      conArtifactMetadata = artifactMetadata
+      conArtifactMetadata = validMetadata
     }
 
 extractTag :: Has Diagnostics sig m => [Text] -> m Text

--- a/src/App/Fossa/Container.hs
+++ b/src/App/Fossa/Container.hs
@@ -28,10 +28,14 @@ import Control.Carrier.Diagnostics hiding (fromMaybe)
 import Control.Effect.Lift (Lift, sendIO)
 import Control.Monad.IO.Class
 import Data.Aeson
+import Data.Aeson.Types (parseEither)
+import qualified Data.ByteString.Lazy as BL
+import Data.Functor.Extra ((<$$>))
 import qualified Data.Map.Lazy as LMap
 import Data.Map.Strict (Map)
 import Data.Maybe (listToMaybe, fromMaybe)
 import Data.Text (Text, pack)
+import qualified Data.Text.Lazy.Encoding as TE
 import Data.Text.Extra (breakOnAndRemove)
 import Effect.Exec (AllowErr (Never), Command (..), execJson, runExecIO, Exec, execThrow)
 import Effect.Logger
@@ -39,10 +43,6 @@ import Effect.ReadFS (ReadFS, readContentsJson, ReadFSIOC (runReadFSIO), resolve
 import Options.Applicative (Parser, argument, help, metavar, str)
 import Path ( toFilePath, reldir, Dir, Rel )
 import Path.IO (getCurrentDir)
-import qualified Data.ByteString.Lazy as BL
-import Data.Aeson.Types (parseEither)
-import qualified Data.Text.Lazy.Encoding as TE
-import Data.Functor.Extra ((<$$>))
 
 newtype ImageText = ImageText {unImageText :: Text} deriving (Show, Eq, Ord)
 

--- a/src/App/Fossa/Container.hs
+++ b/src/App/Fossa/Container.hs
@@ -181,10 +181,10 @@ extractRevision OverrideProject {..} ContainerScan {..} = ProjectRevision name r
 
 toContainerScan :: Has Diagnostics sig m => SyftResponse -> m ContainerScan
 toContainerScan SyftResponse {..} = do
-  newArts <- traverse convertArtifact responseArtifacts
+  newArts <- context "error while validating system artifacts" $ traverse convertArtifact responseArtifacts
   let image = ContainerImage newArts (distroName responseDistro) (distroVersion responseDistro)
       target = sourceTarget responseSource
-  tag <- extractTag $ targetTags target
+  tag <- context "error while extracting image tags" . extractTag $ targetTags target
   pure . ContainerScan image tag $ targetDigest target
 
 convertArtifact :: Has Diagnostics sig m => ResponseArtifact -> m ContainerArtifact

--- a/src/App/Fossa/Main.hs
+++ b/src/App/Fossa/Main.hs
@@ -30,6 +30,7 @@ import Data.Bifunctor (first)
 import Data.Bool (bool)
 import Data.Flag (Flag, flagOpt, fromFlag)
 import Data.Foldable (for_)
+import Data.Functor.Extra ((<$$>))
 import Data.Text (Text)
 import qualified Data.Text as T
 import Discovery.Filters (BuildTargetFilter (..), filterParser)
@@ -157,11 +158,6 @@ parseCommaSeparatedFileArg arg = sequence (validateFile . T.unpack <$> T.splitOn
 requireKey :: Maybe ApiKey -> IO ApiKey
 requireKey (Just key) = pure key
 requireKey Nothing = die "A FOSSA API key is required to run this command"
-
-infixl 4 <$$>
-
-(<$$>) :: (Functor f, Functor g) => (a -> b) -> f (g a) -> f (g b)
-(<$$>) = fmap . fmap
 
 -- | Try to fetch FOSSA_API_KEY from env if not supplied from cmdline
 checkAPIKey :: Maybe Text -> IO (Maybe ApiKey)

--- a/src/Data/Functor/Extra.hs
+++ b/src/Data/Functor/Extra.hs
@@ -1,0 +1,8 @@
+module Data.Functor.Extra ((<$$>)) where
+
+-- <$> is defined as infixl 4, so this stays consistent
+infixl 4 <$$>
+
+-- | Apply a function to a value nested in two functors.  e.g. (a -> b) -> IO (Maybe a) -> IO (Maybe b)
+(<$$>) :: (Functor f, Functor g) => (a -> b) -> f (g a) -> f (g b)
+(<$$>) = fmap . fmap


### PR DESCRIPTION
# Overview 
Syft produces output in the following shape (roughly):

```json
{
  "name": "github.com/google/pprof",
  "version": "v0.0.0-20190515194954-54271f7e092f",
  "type": "go-module",
  "foundBy": "go-cataloger",
  "locations": [
    {
      "path": "/usr/share/go-1.13/src/cmd/go.mod",
      "layerID": "sha256:cddf3ff6c23f0fbea3f4d19baf1459fe779905a038c4a642bf0483245c3d9646"
    }
  ],
  "licenses": [],
  "language": "go",
  "cpes": [
    "cpe:2.3:a:*:github.com/google/pprof:v0.0.0-20190515194954-54271f7e092f:*:*:*:*:*:*:*",
    "cpe:2.3:a:github.com/google/pprof:github.com/google/pprof:v0.0.0-20190515194954-54271f7e092f:*:*:*:*:*:*:*"
  ],
  "purl": "pkg:golang/github.com/google/pprof@v0.0.0-20190515194954-54271f7e092f",
  "metadataType": "",
  "metadata": null
}
```

This is referred to as an `artifact`.  For system-level artifacts (read: `type` is `deb`, `apk`, or `rpm`), we always expect metadata to be not null, and useful.  For non-system packages, we ignore the artifact.

# Problem
Currently, we cannot optionally parse a chunk of JSON based on some of its values.  Ideally, we could know that we should ignore parsing a certain field if we're ignoring the whole object, but that is not the case.  We have to parse every artifact successfully in order to ignore the non-system-level artifacts and not fail the whole parser.

# Changes
The main change is to push the validation of the parsed module to the transformation stage. The transformation stage is encapsulated in `toContainerScan :: Has Diagnostics sig m => SyftResponse -> m ContainerScan`
Rather than validating metadata during parsing, we validate it in `convertArifact :: Has Diagnostic sig m => ResponseArtifact -> m ContainerArtifact`, and use that to `traverse` a `[ResponseArtifact]`.