### PR TITLE
Add container layers and artifact locations

### DIFF
--- a/src/App/Fossa/Container.hs
+++ b/src/App/Fossa/Container.hs
@@ -119,13 +119,29 @@ instance FromJSON ResponseDistro where
 data SourceTarget
   = SourceTarget
       { targetDigest :: Text,
+        targetLayers :: [LayerTarget],
         targetTags :: [Text]
       }
 
 instance FromJSON SourceTarget where
   parseJSON = withObject "SourceTarget" $ \obj ->
     SourceTarget <$> obj .: "digest"
+      <*> obj .: "layers"
       <*> obj .: "tags"
+
+newtype LayerTarget
+  = LayerTarget {
+    layerTargetDigest :: Text
+  } deriving (Eq, Show, Ord)
+
+instance FromJSON LayerTarget where
+  parseJSON = withObject "LayerTarget" $ \obj ->
+    LayerTarget <$> obj :. "digest"
+
+instance ToJSON LayerTarget where
+  toJSON LayerTarget {..} =
+    object ["digest" .= targetLayerDigest ]
+
 
 -- | The reorganized output of syft into a slightly different format
 data ContainerScan
@@ -142,7 +158,8 @@ data ContainerImage
   = ContainerImage
       { imageArtifacts :: [ContainerArtifact],
         imageOs :: Text,
-        imageOsRelease :: Text
+        imageOsRelease :: Text,
+        imageLayers :: [LayerTarget]
       }
 
 instance ToJSON ContainerImage where

--- a/src/App/Fossa/Container.hs
+++ b/src/App/Fossa/Container.hs
@@ -76,7 +76,7 @@ data ResponseArtifact
       { artifactName :: Text,
         artifactVersion :: Text,
         artifactType :: Text,
-        artifactLocations :: [ResponseLocation],
+        artifactLocations :: [ContainerLocation],
         artifactPkgUrl :: Text,
         artifactMetadataType :: Text,
         artifactMetadata :: Maybe (Map Text Value)
@@ -173,26 +173,19 @@ instance ToJSON ContainerImage where
 
 -- Define Layer types to capture layers in which a dep is found
 -- omitting "path" from the object to reduce noise
-newtype ResponseLocation
-  = ResponseLocation {
-    layerId :: Text
-  } deriving (Eq, Show, Ord)
-
-instance FromJSON ResponseLocation where
-  parseJSON = withObject "ResponseLocation" $ \obj ->
-    ResponseLocation <$> obj .: "layerID"
 
 newtype ContainerLocation
   = ContainerLocation {
     conLayerId :: Text
   } deriving (Eq, Show, Ord)
 
+instance FromJSON ContainerLocation where
+  parseJSON = withObject "ContainerLocation" $ \obj ->
+    ContainerLocation <$> obj .: "layerID"
+
 instance ToJSON ContainerLocation where
   toJSON ContainerLocation {..} =
     object [ "layerId" .= conLayerId ]
-
-toContainerLocation :: ResponseLocation -> ContainerLocation
-toContainerLocation = ContainerLocation . layerId
 
 data ContainerArtifact
   = ContainerArtifact
@@ -240,7 +233,7 @@ convertArtifact ResponseArtifact {..} = do
     { conArtifactName = artifactName,
       conArtifactVersion = artifactVersion,
       conArtifactType = artifactType,
-      conArtifactLocations = map toContainerLocation artifactLocations,
+      conArtifactLocations = artifactLocations,
       conArtifactPkgUrl = artifactPkgUrl,
       conArtifactMetadataType = artifactMetadataType,
       conArtifactMetadata = validMetadata

--- a/src/App/Fossa/Container.hs
+++ b/src/App/Fossa/Container.hs
@@ -129,6 +129,8 @@ instance FromJSON SourceTarget where
       <*> obj .: "layers"
       <*> obj .: "tags"
 
+-- Capture container layers from target
+-- The digest will correspond to location -> layerId
 newtype LayerTarget
   = LayerTarget {
     layerTargetDigest :: Text
@@ -171,9 +173,8 @@ instance ToJSON ContainerImage where
         "artifacts" .= imageArtifacts
       ]
 
--- Define Layer types to capture layers in which a dep is found
+-- Define Layer/Location type to capture layers in which a dep is found
 -- omitting "path" from the object to reduce noise
-
 newtype ContainerLocation
   = ContainerLocation {
     conLayerId :: Text

--- a/src/App/Fossa/Container.hs
+++ b/src/App/Fossa/Container.hs
@@ -76,6 +76,7 @@ data ResponseArtifact
       { artifactName :: Text,
         artifactVersion :: Text,
         artifactType :: Text,
+        artifactLocations :: [Map Text Value],
         artifactPkgUrl :: Text,
         artifactMetadataType :: Text,
         artifactMetadata :: Maybe (Map Text Value)
@@ -86,6 +87,7 @@ instance FromJSON ResponseArtifact where
     ResponseArtifact <$> obj .: "name"
       <*> obj .: "version"
       <*> obj .: "type"
+      <*> obj .: "locations"
       <*> obj .: "purl"
       <*> obj .: "metadataType"
       -- We delete "files" as early as possible, which reduces
@@ -156,6 +158,7 @@ data ContainerArtifact
       { conArtifactName :: Text,
         conArtifactVersion :: Text,
         conArtifactType :: Text,
+        conArtifactLocations :: [Map Text Value],
         conArtifactPkgUrl :: Text,
         conArtifactMetadataType :: Text,
         conArtifactMetadata :: Map Text Value
@@ -167,6 +170,7 @@ instance ToJSON ContainerArtifact where
       [ "name" .= conArtifactName,
         "fullVersion" .= conArtifactVersion,
         "type" .= conArtifactType,
+        "locations" .= conArtifactLocations,
         "purl" .= conArtifactPkgUrl,
         "metadataType" .= conArtifactMetadataType,
         "metadata" .= LMap.delete "files" conArtifactMetadata
@@ -195,6 +199,7 @@ convertArtifact ResponseArtifact {..} = do
     { conArtifactName = artifactName,
       conArtifactVersion = artifactVersion,
       conArtifactType = artifactType,
+      conArtifactLocations = artifactLocations,
       conArtifactPkgUrl = artifactPkgUrl,
       conArtifactMetadataType = artifactMetadataType,
       conArtifactMetadata = validMetadata


### PR DESCRIPTION
Adds `locations` to individual dependencies to indicate which layer a dependency exists on and adds `layers` to `image` which is the entire layer manifest of the image.