### PR TITLE
Change container scanning layer scope

### DIFF
--- a/src/App/Fossa/Container.hs
+++ b/src/App/Fossa/Container.hs
@@ -260,7 +260,7 @@ syftCommand :: BinaryPaths -> ImageText -> Command
 syftCommand bin (ImageText image) =
   Command
     { cmdName = pack . toFilePath $ toExecutablePath bin,
-      cmdArgs = ["-o", "json", image],
+      cmdArgs = ["--scope", "all-layers", "-o", "json", image],
       cmdAllowErr = Never
     }
 

--- a/src/App/Fossa/Container.hs
+++ b/src/App/Fossa/Container.hs
@@ -257,6 +257,8 @@ runSyft ::
 runSyft image = runExecIO . withSyftBinary $ \syftBin -> do
   execJson @SyftResponse [reldir|.|] $ syftCommand syftBin image
 
+-- Scope to all layers, to prevent odd "squashing" that syft does
+-- Output to produce machine readable json that we can ingest
 syftCommand :: BinaryPaths -> ImageText -> Command
 syftCommand bin (ImageText image) =
   Command

--- a/src/App/Fossa/Container.hs
+++ b/src/App/Fossa/Container.hs
@@ -31,6 +31,7 @@ import Data.Aeson
 import Data.Aeson.Types (parseEither)
 import qualified Data.ByteString.Lazy as BL
 import Data.Functor.Extra ((<$$>))
+import Data.List (nub)
 import qualified Data.Map.Lazy as LMap
 import Data.Map.Strict (Map)
 import Data.Maybe (listToMaybe, fromMaybe)
@@ -205,7 +206,7 @@ instance ToJSON ContainerArtifact where
       [ "name" .= conArtifactName,
         "fullVersion" .= conArtifactVersion,
         "type" .= conArtifactType,
-        "locations" .= conArtifactLocations,
+        "locations" .= nub conArtifactLocations,
         "purl" .= conArtifactPkgUrl,
         "metadataType" .= conArtifactMetadataType,
         "metadata" .= LMap.delete "files" conArtifactMetadata


### PR DESCRIPTION
Change syft to capture [all layers scope rather than a squashed scoped](https://github.com/anchore/syft#getting-started) to improve layer location results.

Also de-dups `locations`.  
Previously, we would see duplicate location entries, with the same layerId due to the `path` parameter we filter out.

Out put gets reduced as follows:
**From**
```
      "locations": [
        {
          "path": "/var/lib/dpkg/status",
          "layerID": "sha256:e2c6ff46235709f5178ab7c1939f4fba7237ffde84e13b1582fa5f0837c1d978"
        },
        {
          "path": "/var/lib/dpkg/info/zlib1g:amd64.md5sums",
          "layerID": "sha256:e2c6ff46235709f5178ab7c1939f4fba7237ffde84e13b1582fa5f0837c1d978"
        },
        {
          "path": "/usr/share/doc/zlib1g/copyright",
          "layerID": "sha256:e2c6ff46235709f5178ab7c1939f4fba7237ffde84e13b1582fa5f0837c1d978"
        }
      ],
```

**To**
```
        "locations": [
          {
            "layerId": "sha256:e2c6ff46235709f5178ab7c1939f4fba7237ffde84e13b1582fa5f0837c1d978"
          }
        ],
```

