### PR TITLE
Updates for Syft 0.14

### DIFF
--- a/src/App/Fossa/Container.hs
+++ b/src/App/Fossa/Container.hs
@@ -126,7 +126,7 @@ data SourceTarget
 
 instance FromJSON SourceTarget where
   parseJSON = withObject "SourceTarget" $ \obj ->
-    SourceTarget <$> obj .: "digest"
+    SourceTarget <$> obj .: "imageID"
       <*> obj .: "layers"
       <*> obj .: "tags"
 


### PR DESCRIPTION
Update syft digest param for 0.14.0 - now imageID. (This is not to be confused with manifestDigest)

Verified scanning still works on org Serubin https://app.fossa.com/projects/custom%2B13453%2Ferror-test/refs/branch/master/sha256%3A2e6f503b8d20ca49209144d5e564f9d9aea09cce7e752656750ea786e3727004

Our version of syft has also been updated to version v0.14.0 - a new release will need to be cut.