### PR TITLE
Golang: map package imports to modules

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+# v2.5.14
+
+- Golang: map package imports to modules ([#234](https://github.com/fossas/spectrometer/pull/234))
+
 # v2.5.13
 
 Update VPS plugin to 2021-04-27-312bbe8 ([#233](https://github.com/fossas/spectrometer/pull/233))

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -297,6 +297,7 @@ test-suite unit-tests
     Go.GomodSpec
     Go.GopkgLockSpec
     Go.GopkgTomlSpec
+    Go.TransitiveSpec
     Googlesource.RepoManifestSpec
     Gradle.GradleSpec
     GraphingSpec

--- a/src/Strategy/Go/Transitive.hs
+++ b/src/Strategy/Go/Transitive.hs
@@ -1,7 +1,10 @@
-module Strategy.Go.Transitive
-  ( fillInTransitive
-  )
-  where
+module Strategy.Go.Transitive (
+  fillInTransitive,
+  graphTransitive,
+  normalizeImportsToModules,
+  Module (..),
+  Package (..),
+) where
 
 import Control.Algebra
 import Control.Applicative (many)
@@ -14,6 +17,7 @@ import qualified Data.Attoparsec.ByteString as A
 import qualified Data.ByteString.Lazy as BL
 import Data.Foldable (traverse_)
 import Data.Functor (void)
+import Data.Maybe qualified as Maybe
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Vector as V
@@ -21,6 +25,7 @@ import Effect.Exec
 import Effect.Grapher
 import Path
 import Strategy.Go.Types
+import qualified Data.Map.Strict as M
 
 goListCmd :: Command
 goListCmd = Command
@@ -93,15 +98,40 @@ graphTransitive = void . traverse_ go
       Nothing -> pure ()
       Just ver -> label pkg (mkGolangVersion ver)
 
-
 fillInTransitive ::
   ( Has GolangGrapher sig m
   , Has Exec sig m
   , Has Diagnostics sig m
-  )
-  => Path x Dir -> m ()
+  ) =>
+  Path x Dir ->
+  m ()
 fillInTransitive dir = do
   goListOutput <- execThrow dir goListCmd
   case decodeMany goListOutput of
     Left (path, err) -> fatal (CommandParseError goListCmd (T.pack (formatError path err)))
-    Right (packages :: [Package]) -> graphTransitive packages
+    Right (packages :: [Package]) -> graphTransitive (normalizeImportsToModules packages)
+
+-- HACK(fossas/team-analysis#514) `go list -json all` emits golang dependencies
+-- at the _package_ level; e.g., `github.com/example/foo/some/package`. The
+-- fossa backend handles package-level imports poorly, especially when there are
+-- many of them from the same go module. See the ticket for details.
+--
+-- As a workaround, we map package imports to their modules, and use the modules
+-- in the final dependency graph.
+normalizeImportsToModules :: [Package] -> [Package]
+normalizeImportsToModules packages = map normalizeSingle packages
+ where
+  normalizeSingle :: Package -> Package
+  normalizeSingle package = package{packageImports = map replaceImport <$> packageImports package}
+
+  -- If a package doesn't have an associated module, use the package name instead
+  replaceImport :: Text -> Text
+  replaceImport package = Maybe.fromMaybe package (M.lookup package packageNameToModule)
+
+  packageNameToModule :: M.Map Text Text
+  packageNameToModule =
+    M.fromList
+      [ (packageImportPath package, modPath mod)
+      | package <- packages
+      , Just mod <- [packageModule package]
+      ]

--- a/src/Strategy/Go/Transitive.hs
+++ b/src/Strategy/Go/Transitive.hs
@@ -131,7 +131,7 @@ normalizeImportsToModules packages = map normalizeSingle packages
   packageNameToModule :: M.Map Text Text
   packageNameToModule =
     M.fromList
-      [ (packageImportPath package, modPath mod)
+      [ (packageImportPath package, modPath gomod)
       | package <- packages
-      , Just mod <- [packageModule package]
+      , Just gomod <- [packageModule package]
       ]

--- a/test/Go/TransitiveSpec.hs
+++ b/test/Go/TransitiveSpec.hs
@@ -1,0 +1,160 @@
+module Go.TransitiveSpec (spec) where
+
+import Control.Algebra (run)
+import DepTypes
+import GraphUtil
+import Strategy.Go.Transitive
+import Strategy.Go.Types (graphingGolang)
+import Test.Hspec
+
+spec :: Spec
+spec = spec_packageToModule
+
+-- HACK(fossas/team-analysis#514) see Strategy.Go.Transitive for more details
+--
+-- Ensure that packages are correctly mapped to their modules, and that packages
+-- aren't dropped from the dependency graph
+spec_packageToModule :: Spec
+spec_packageToModule =
+  describe "normalizeImportsToModules" $ do
+    it "should map package imports to their modules" $ do
+      let result = normalizeImportsToModules testPackages
+      result `shouldBe` normalizedPackages
+
+    it "should prevent packages from appearing in the final graph" $ do
+      let graph = run $ graphingGolang (graphTransitive (normalizeImportsToModules testPackages))
+      expectDeps [fooDep, barDep, bazDep] graph
+      expectEdges [(fooDep, barDep), (barDep, bazDep)] graph
+
+testPackages :: [Package]
+testPackages =
+  [ Package
+      { packageImportPath = "github.com/example/foo"
+      , packageModule = Nothing
+      , packageImports =
+          Just
+            [ "github.com/example/bar/some/package"
+            ]
+      , packageSystem = Nothing
+      }
+  , Package
+      { packageImportPath = "github.com/example/bar/some/package"
+      , packageModule =
+          Just
+            Module
+              { modPath = "github.com/example/bar"
+              , modVersion = Nothing
+              }
+      , packageImports =
+          Just
+            [ "github.com/example/baz"
+            , "github.com/example/baz/other"
+            ]
+      , packageSystem = Nothing
+      }
+  , Package
+      { packageImportPath = "github.com/example/baz/other"
+      , packageModule =
+          Just
+            Module
+              { modPath = "github.com/example/baz"
+              , modVersion = Nothing
+              }
+      , packageImports = Nothing
+      , packageSystem = Nothing
+      }
+  , Package
+      { packageImportPath = "github.com/example/baz"
+      , packageModule =
+          Just
+            Module
+              { modPath = "github.com/example/baz"
+              , modVersion = Nothing
+              }
+      , packageImports = Nothing
+      , packageSystem = Nothing
+      }
+  ]
+
+normalizedPackages :: [Package]
+normalizedPackages =
+  [ Package
+      { packageImportPath = "github.com/example/foo"
+      , packageModule = Nothing
+      , packageImports =
+          Just
+            [ "github.com/example/bar"
+            ]
+      , packageSystem = Nothing
+      }
+  , Package
+      { packageImportPath = "github.com/example/bar/some/package"
+      , packageModule =
+          Just
+            Module
+              { modPath = "github.com/example/bar"
+              , modVersion = Nothing
+              }
+      , packageImports =
+          Just
+            [ "github.com/example/baz"
+            , "github.com/example/baz"
+            ]
+      , packageSystem = Nothing
+      }
+  , Package
+      { packageImportPath = "github.com/example/baz/other"
+      , packageModule =
+          Just
+            Module
+              { modPath = "github.com/example/baz"
+              , modVersion = Nothing
+              }
+      , packageImports = Nothing
+      , packageSystem = Nothing
+      }
+  , Package
+      { packageImportPath = "github.com/example/baz"
+      , packageModule =
+          Just
+            Module
+              { modPath = "github.com/example/baz"
+              , modVersion = Nothing
+              }
+      , packageImports = Nothing
+      , packageSystem = Nothing
+      }
+  ]
+
+fooDep :: Dependency
+fooDep =
+  Dependency
+    { dependencyType = GoType
+    , dependencyName = "github.com/example/foo"
+    , dependencyVersion = Nothing
+    , dependencyLocations = []
+    , dependencyEnvironments = []
+    , dependencyTags = mempty
+    }
+
+barDep :: Dependency
+barDep =
+  Dependency
+    { dependencyType = GoType
+    , dependencyName = "github.com/example/bar"
+    , dependencyVersion = Nothing
+    , dependencyLocations = []
+    , dependencyEnvironments = []
+    , dependencyTags = mempty
+    }
+
+bazDep :: Dependency
+bazDep =
+  Dependency
+    { dependencyType = GoType
+    , dependencyName = "github.com/example/baz"
+    , dependencyVersion = Nothing
+    , dependencyLocations = []
+    , dependencyEnvironments = []
+    , dependencyTags = mempty
+    }

--- a/test/Go/TransitiveSpec.hs
+++ b/test/Go/TransitiveSpec.hs
@@ -26,6 +26,28 @@ spec_packageToModule =
       expectDeps [fooDep, barDep, bazDep] graph
       expectEdges [(fooDep, barDep), (barDep, bazDep)] graph
 
+    it "should be a no-op for non-module packages" $ do
+      normalizeImportsToModules nonModulePackages `shouldBe` nonModulePackages
+
+nonModulePackages :: [Package]
+nonModulePackages =
+  [ Package
+      { packageImportPath = "github.com/example/foo"
+      , packageModule = Nothing
+      , packageImports =
+          Just
+            [ "github.com/example/nonmodule/foo"
+            ]
+      , packageSystem = Nothing
+      }
+  , Package
+      { packageImportPath = "github.com/example/nonmodule/foo"
+      , packageModule = Nothing
+      , packageImports = Nothing
+      , packageSystem = Nothing
+      }
+  ]
+
 testPackages :: [Package]
 testPackages =
   [ Package


### PR DESCRIPTION
`go list -json all` emits golang dependencies the _package_ level; e.g.,
`github.com/example/foo/some/package`. The fossa backend handles
package-level imports poorly, especially when there are many of them
from the same go module. See the ticket for details.

As a workaround, we map package imports to their modules, and use the
modules in the final dependency graph.

Fixes https://github.com/fossas/team-analysis/issues/514