### PR TITLE
Requirements.txt: fix hang when parsing unsupported fields

### DIFF
--- a/src/Strategy/Python/ReqTxt.hs
+++ b/src/Strategy/Python/ReqTxt.hs
@@ -34,22 +34,18 @@ reqParser = [] <$ char '-' <* ignored -- pip options
      <|> [] <$ char '/' <* ignored -- absolute path
      <|> [] <$ oneOfS ["http:", "https:", "git+", "hg+", "svn+", "bzr+"] <* ignored -- URLs
      <|> [] <$ comment
-     <|> (pure <$> requirementParser <* ignored)
-     <|> pure [] -- empty line
+     <|> (pure <$> try requirementParser <* ignored)
+     <|> [] <$ ignored -- something else we're not able to parse
 
   where
   isEndLine :: Char -> Bool
   isEndLine '\n' = True
   isEndLine '\r' = True
-  isEndLine '\\' = True
   isEndLine _    = False
 
   -- ignore content until the end of the line
   ignored :: Parser ()
-  ignored = () <$ takeWhileP (Just "ignored") (not . isEndLine) <* (try newLine <|> (() <$ takeWhileP (Just "end of line") isEndLine))
-
-  newLine :: Parser ()
-  newLine = char '\\' <* takeWhileP (Just "endLine") isEndLine *> ignored
+  ignored = () <$ takeWhileP (Just "ignored") (not . isEndLine) <* takeWhileP (Just "end of line") isEndLine
 
   comment :: Parser ()
   comment = char '#' *> ignored

--- a/test/Python/RequirementsSpec.hs
+++ b/test/Python/RequirementsSpec.hs
@@ -82,7 +82,7 @@ spec = do
     T.it "can parse" $
       case runParser requirementsTxtParser "" requirementsTextFile of
         Left r -> do
-          T.expectationFailure $ "failed to parse: error:" ++ show r
+          T.expectationFailure $ "failed to parse: error:" ++ errorBundlePretty r
         Right res -> do
           let result = buildGraph res
           expectDeps [depOne, depTwo, depThree, depFour] result

--- a/test/Python/testdata/req.txt
+++ b/test/Python/testdata/req.txt
@@ -4,4 +4,5 @@ three==3.0.0 \
   --hash=sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259 \
   --hash=sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced \
   # via python-dateuti
+[foo]
 four==4.0.0 #help


### PR DESCRIPTION
-------

# Overview

When scanning a project, a customer had an issue with the CLI hanging during python analysis: [ZD2450](https://fossa.zendesk.com/agent/tickets/2450)

This fixes the hang by ignoring lines in requirements.txt that we're unable to parse

## Acceptance criteria

- Lines with unexpected content in a requirements.txt file, e.g. a section marker like `[foo]`, should not cause the analysis to hang

## Testing plan

- Added a `[foo]` field to the file we use to test our requirements.txt parser
- Verified the fix by running analysis against requirements.txt files supplied by the customer files supplied by the customer. Zip file available on the ticket.

## Risks

None.

## References

Fixes https://github.com/fossas/team-analysis/issues/521