### PR TITLE
[DO NOT REVIEW] Format everything

### DIFF
--- a/app/fossa/Main.hs
+++ b/app/fossa/Main.hs
@@ -1,8 +1,7 @@
 module Main (main) where
 
-import Prelude
-
 import App.Fossa.Main (appMain)
+import Prelude
 
 main :: IO ()
 main = appMain

--- a/app/pathfinder/Main.hs
+++ b/app/pathfinder/Main.hs
@@ -1,8 +1,7 @@
 module Main (main) where
 
-import Prelude
-
 import App.Pathfinder.Main (appMain)
+import Prelude
 
 main :: IO ()
 main = appMain

--- a/src/App/Fossa/API/BuildLink.hs
+++ b/src/App/Fossa/API/BuildLink.hs
@@ -1,5 +1,5 @@
-{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE RecordWildCards #-}
 
 module App.Fossa.API.BuildLink
   ( getBuildURLWithOrg,
@@ -17,7 +17,7 @@ import Data.Text (Text)
 import Data.Text.Extra (showT)
 import Fossa.API.Types (ApiOpts (..))
 import Srclib.Types (Locator (..))
-import qualified Text.URI as URI
+import Text.URI qualified as URI
 import Text.URI.Builder
 import Text.URI.QQ (uri)
 

--- a/src/App/Fossa/API/BuildWait.hs
+++ b/src/App/Fossa/API/BuildWait.hs
@@ -6,13 +6,13 @@ module App.Fossa.API.BuildWait
   )
 where
 
-import qualified App.Fossa.FossaAPIV1 as Fossa
-import qualified App.Fossa.VPS.Scan.Core as VPSCore
-import qualified App.Fossa.VPS.Scan.ScotlandYard as ScotlandYard
+import App.Fossa.FossaAPIV1 qualified as Fossa
+import App.Fossa.VPS.Scan.Core qualified as VPSCore
+import App.Fossa.VPS.Scan.ScotlandYard qualified as ScotlandYard
 import App.Types
 import Control.Carrier.Diagnostics
 import Control.Concurrent (threadDelay)
-import qualified Control.Concurrent.Async as Async
+import Control.Concurrent.Async qualified as Async
 import Control.Effect.Lift (Lift, sendIO)
 import Data.Functor (($>))
 import Data.Text (Text)

--- a/src/App/Fossa/Analyze/Graph.hs
+++ b/src/App/Fossa/Analyze/Graph.hs
@@ -1,36 +1,36 @@
 {-# LANGUAGE RecordWildCards #-}
 
 module App.Fossa.Analyze.Graph
-  ( Graph()
-  , DepRef()
-
-  , empty
-  , addDirect
-  , addEdge
-  , addNode
-  , graphAssocs
-  , graphDeps
-  , graphDirect
-  ) where
+  ( Graph (),
+    DepRef (),
+    empty,
+    addDirect,
+    addEdge,
+    addNode,
+    graphAssocs,
+    graphDeps,
+    graphDirect,
+  )
+where
 
 import Data.Aeson
 import Data.Bifunctor (bimap)
 import Data.Function ((&))
-import qualified Data.IntMap as IM
-import qualified Data.IntSet as IS
-import qualified Data.Sequence as S
-
+import Data.IntMap qualified as IM
+import Data.IntSet qualified as IS
+import Data.Sequence qualified as S
 import DepTypes
 
 -- | Opaque reference to a dependency in the graph. Used for adding edges to the graph (See: 'addEdge')
-newtype DepRef = DepRef { unDepRef :: Int } deriving (Eq, Ord, Show)
+newtype DepRef = DepRef {unDepRef :: Int} deriving (Eq, Ord, Show)
 
 -- | A Graph of dependencies. See 'empty', 'addNode', and 'addEdge'
 data Graph = Graph
-  { _graphDeps   :: S.Seq Dependency
-  , _graphAssocs :: IM.IntMap IS.IntSet -- references dependencies by their position in the _graphDeps Seq
-  , _graphDirect :: IS.IntSet
-  } deriving (Eq, Ord, Show)
+  { _graphDeps :: S.Seq Dependency,
+    _graphAssocs :: IM.IntMap IS.IntSet, -- references dependencies by their position in the _graphDeps Seq
+    _graphDirect :: IS.IntSet
+  }
+  deriving (Eq, Ord, Show)
 
 -- | Retrieve the nodes of the dependency graph
 graphDeps :: Graph -> S.Seq Dependency
@@ -52,37 +52,40 @@ empty = Graph S.empty IM.empty IS.empty
 
 -- | Add a new dependency node to the graph. The returned 'DepRef' can be used to 'addEdge's
 addNode :: Dependency -> Graph -> (Graph, DepRef)
-addNode dep graph = (graph { _graphDeps = curDeps S.|> dep }, DepRef (length curDeps))
+addNode dep graph = (graph {_graphDeps = curDeps S.|> dep}, DepRef (length curDeps))
   where
-  curDeps = _graphDeps graph
+    curDeps = _graphDeps graph
 
 -- | Add an edge to the dependency graph
 addEdge :: DepRef -> DepRef -> Graph -> Graph
-addEdge parent child graph = graph { _graphAssocs = IM.insertWith (<>) (unDepRef parent) (IS.singleton (unDepRef child)) (_graphAssocs graph) }
+addEdge parent child graph = graph {_graphAssocs = IM.insertWith (<>) (unDepRef parent) (IS.singleton (unDepRef child)) (_graphAssocs graph)}
 
 addDirect :: DepRef -> Graph -> Graph
-addDirect dep graph = graph { _graphDirect = IS.insert (unDepRef dep) (_graphDirect graph) }
+addDirect dep graph = graph {_graphDirect = IS.insert (unDepRef dep) (_graphDirect graph)}
 
 -- Graph is a semigroup: dependencies can be combined, with offsets applied to
 -- the assocs and direct deps of the second graph
 instance Semigroup Graph where
   Graph deps1 assocs1 direct1 <> Graph deps2 assocs2 direct2 =
-    Graph (deps1 <> deps2) -- combine deps
-          (IM.union assocs1 offsetAssocs2) -- offset the assocs entries
-          (direct1 <> IS.map (+offset) direct2) -- offset the direct entries
+    Graph
+      (deps1 <> deps2) -- combine deps
+      (IM.union assocs1 offsetAssocs2) -- offset the assocs entries
+      (direct1 <> IS.map (+ offset) direct2) -- offset the direct entries
     where
-    offsetAssocs2 = assocs2
-                  & IM.toList -- [(key, IntSet)]
-                  & map (bimap (+offset) (IS.map (+offset)))
-                  & IM.fromList
-    offset = length deps1
+      offsetAssocs2 =
+        assocs2
+          & IM.toList -- [(key, IntSet)]
+          & map (bimap (+ offset) (IS.map (+ offset)))
+          & IM.fromList
+      offset = length deps1
 
 instance Monoid Graph where
   mempty = empty
 
 instance ToJSON Graph where
-  toJSON Graph{..} = object
-    [ "deps"   .= _graphDeps
-    , "assocs" .= _graphAssocs
-    , "direct" .= _graphDirect
-    ]
+  toJSON Graph {..} =
+    object
+      [ "deps" .= _graphDeps,
+        "assocs" .= _graphAssocs,
+        "direct" .= _graphDirect
+      ]

--- a/src/App/Fossa/Analyze/GraphBuilder.hs
+++ b/src/App/Fossa/Analyze/GraphBuilder.hs
@@ -4,19 +4,19 @@
 
 -- | Legacy/deprecated GraphBuilder interface. Kept for compatibility with old code
 module App.Fossa.Analyze.GraphBuilder
-  ( GraphBuilder(..)
-  , addNode
-  , addEdge
-  , addDirect
-  , runGraphBuilder
-  , evalGraphBuilder
+  ( GraphBuilder (..),
+    addNode,
+    addEdge,
+    addDirect,
+    runGraphBuilder,
+    evalGraphBuilder,
   )
-  where
+where
 
+import App.Fossa.Analyze.Graph qualified as G
 import Control.Algebra
 import Control.Carrier.State.Strict
 import Control.Monad.IO.Class (MonadIO)
-import qualified App.Fossa.Analyze.Graph as G
 import Data.Kind (Type)
 import DepTypes
 
@@ -43,8 +43,8 @@ runGraphBuilder start = runState start . runGraphBuilderC
 evalGraphBuilder :: Functor m => G.Graph -> GraphBuilderC m a -> m G.Graph
 evalGraphBuilder start = execState start . runGraphBuilderC
 
-newtype GraphBuilderC m a = GraphBuilderC { runGraphBuilderC :: StateC G.Graph m a }
- deriving (Functor, Applicative, Monad, MonadIO)
+newtype GraphBuilderC m a = GraphBuilderC {runGraphBuilderC :: StateC G.Graph m a}
+  deriving (Functor, Applicative, Monad, MonadIO)
 
 instance Algebra sig m => Algebra (GraphBuilder :+: sig) (GraphBuilderC m) where
   alg hdl sig ctx = GraphBuilderC $ case sig of

--- a/src/App/Fossa/Analyze/GraphMangler.hs
+++ b/src/App/Fossa/Analyze/GraphMangler.hs
@@ -1,20 +1,20 @@
 module App.Fossa.Analyze.GraphMangler
-  ( graphingToGraph
-  ) where
+  ( graphingToGraph,
+  )
+where
 
 import Algebra.Graph.AdjacencyMap (AdjacencyMap)
-import qualified Algebra.Graph.AdjacencyMap as AM
+import Algebra.Graph.AdjacencyMap qualified as AM
 import Algebra.Graph.ToGraph (dfs)
+import App.Fossa.Analyze.Graph qualified as G
+import App.Fossa.Analyze.GraphBuilder
 import Control.Algebra
 import Data.Foldable (traverse_)
 import Data.Map.Strict (Map)
-import qualified Data.Map.Strict as M
-import qualified Data.Set as S
-
-import App.Fossa.Analyze.GraphBuilder
-import qualified App.Fossa.Analyze.Graph as G
+import Data.Map.Strict qualified as M
+import Data.Set qualified as S
 import DepTypes
-import Graphing (Graphing(..))
+import Graphing (Graphing (..))
 
 graphingToGraph :: Graphing Dependency -> G.Graph
 graphingToGraph graphing = run . evalGraphBuilder G.empty $ do
@@ -28,25 +28,23 @@ graphingToGraph graphing = run . evalGraphBuilder G.empty $ do
   traverse_ (visitNode refs depAmap) nodes
 
   traverse_ (\dep -> traverse_ addDirect (M.lookup dep refs)) depDirect
-
   where
+    -- add a node with GraphBuilder
+    addingNode :: Has GraphBuilder sig m => Dependency -> m (Dependency, G.DepRef)
+    addingNode k = do
+      ref <- addNode k
+      pure (k, ref)
 
-  -- add a node with GraphBuilder
-  addingNode :: Has GraphBuilder sig m => Dependency -> m (Dependency, G.DepRef)
-  addingNode k = do
-    ref <- addNode k
-    pure (k, ref)
+    -- visit a node, adding edges between it and all of its dependencies
+    visitNode :: Has GraphBuilder sig m => Map Dependency G.DepRef -> AdjacencyMap Dependency -> Dependency -> m ()
+    visitNode refs amap node = traverse_ (visitEdge refs node) (S.toList $ AM.postSet node amap)
 
-  -- visit a node, adding edges between it and all of its dependencies
-  visitNode :: Has GraphBuilder sig m => Map Dependency G.DepRef -> AdjacencyMap Dependency -> Dependency -> m ()
-  visitNode refs amap node = traverse_ (visitEdge refs node) (S.toList $ AM.postSet node amap)
+    -- visit an edge by adding it to the graph
+    visitEdge :: Has GraphBuilder sig m => Map Dependency G.DepRef -> Dependency -> Dependency -> m ()
+    visitEdge refs parent child = do
+      let edgeRefs = do
+            parentRef <- M.lookup parent refs
+            childRef <- M.lookup child refs
+            pure (parentRef, childRef)
 
-  -- visit an edge by adding it to the graph
-  visitEdge :: Has GraphBuilder sig m => Map Dependency G.DepRef -> Dependency -> Dependency -> m ()
-  visitEdge refs parent child = do
-    let edgeRefs = do
-          parentRef <- M.lookup parent refs
-          childRef <- M.lookup child refs
-          pure (parentRef, childRef)
-
-    traverse_ (uncurry addEdge) edgeRefs
+      traverse_ (uncurry addEdge) edgeRefs

--- a/src/App/Fossa/Analyze/Project.hs
+++ b/src/App/Fossa/Analyze/Project.hs
@@ -1,33 +1,35 @@
 module App.Fossa.Analyze.Project
-  ( ProjectResult(..)
-  , mkResult
-  ) where
+  ( ProjectResult (..),
+    mkResult,
+  )
+where
 
+import Data.Set qualified as S
 import Data.Text (Text)
 import DepTypes
 import Graphing (Graphing)
-import qualified Graphing
+import Graphing qualified
 import Path
 import Types
-import qualified Data.Set as S
 
 mkResult :: DiscoveredProject n -> Graphing Dependency -> ProjectResult
-mkResult project graph = ProjectResult
-  { projectResultType = projectType project
-  , projectResultPath = projectPath project
-  , projectResultGraph =
-      -- FIXME: this is a hack to work around analyzers that aren't able to
-      -- determine which dependencies are direct. Without this hack, all of
-      -- their dependencies would be filtered out. The real fix to this is to
-      -- have a separate designation for "reachable" vs "direct" on nodes in a
-      -- Graphing, where direct deps are inherently reachable.
-      if S.null (Graphing.graphingDirect graph)
-        then graph
-        else Graphing.pruneUnreachable graph
-  }
+mkResult project graph =
+  ProjectResult
+    { projectResultType = projectType project,
+      projectResultPath = projectPath project,
+      projectResultGraph =
+        -- FIXME: this is a hack to work around analyzers that aren't able to
+        -- determine which dependencies are direct. Without this hack, all of
+        -- their dependencies would be filtered out. The real fix to this is to
+        -- have a separate designation for "reachable" vs "direct" on nodes in a
+        -- Graphing, where direct deps are inherently reachable.
+        if S.null (Graphing.graphingDirect graph)
+          then graph
+          else Graphing.pruneUnreachable graph
+    }
 
 data ProjectResult = ProjectResult
-  { projectResultType :: Text
-  , projectResultPath :: Path Abs Dir
-  , projectResultGraph :: Graphing Dependency
+  { projectResultType :: Text,
+    projectResultPath :: Path Abs Dir,
+    projectResultGraph :: Graphing Dependency
   }

--- a/src/App/Fossa/Compatibility.hs
+++ b/src/App/Fossa/Compatibility.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE QuasiQuotes #-}
 
-
 module App.Fossa.Compatibility
   ( compatibilityMain,
     argumentParser,
@@ -10,15 +9,15 @@ where
 
 import App.Fossa.EmbeddedBinary (BinaryPaths, toExecutablePath, withCLIv1Binary)
 import Control.Effect.Lift (sendIO)
-import Data.Text (Text, pack)
+import Data.ByteString.Lazy.Char8 qualified as BL
 import Data.Foldable (traverse_)
-import Effect.Exec (CmdFailure(cmdFailureStdout), AllowErr (Never), Command (..), exec, runExecIO, cmdFailureStderr)
-import Path
-import qualified Data.ByteString.Lazy.Char8 as BL
-import Options.Applicative (Parser, argument, help, metavar, str)
-import System.Exit (exitFailure, exitSuccess)
+import Data.Text (Text, pack)
 import Data.Text.Lazy.Encoding
-import Effect.Logger (Pretty(pretty), logInfo, logSticky, Severity(SevInfo), withLogger)
+import Effect.Exec (AllowErr (Never), CmdFailure (cmdFailureStdout), Command (..), cmdFailureStderr, exec, runExecIO)
+import Effect.Logger (Pretty (pretty), Severity (SevInfo), logInfo, logSticky, withLogger)
+import Options.Applicative (Parser, argument, help, metavar, str)
+import Path
+import System.Exit (exitFailure, exitSuccess)
 
 type Argument = Text
 
@@ -35,7 +34,7 @@ compatibilityMain args = withLogger SevInfo . runExecIO . withCLIv1Binary $ \v1B
 
   case cmd of
     Left err -> do
-      traverse_ (\accessor -> logInfo . pretty . decodeUtf8 $ accessor err)  [cmdFailureStderr, cmdFailureStdout]
+      traverse_ (\accessor -> logInfo . pretty . decodeUtf8 $ accessor err) [cmdFailureStderr, cmdFailureStdout]
       sendIO exitFailure
     Right out -> sendIO (BL.putStr out >> exitSuccess)
 

--- a/src/App/Fossa/Configuration.hs
+++ b/src/App/Fossa/Configuration.hs
@@ -12,11 +12,11 @@ module App.Fossa.Configuration
 where
 
 import App.Types
-import qualified Control.Carrier.Diagnostics as Diag
+import Control.Applicative (Alternative ((<|>)))
+import Control.Carrier.Diagnostics qualified as Diag
 import Data.Aeson (FromJSON (parseJSON), withObject, (.:), (.:?))
 import Data.Text (Text)
 import Effect.ReadFS
-import Control.Applicative ( Alternative ((<|>)) )
 import Path
 import System.Exit (die)
 

--- a/src/App/Fossa/Container/Analyze.hs
+++ b/src/App/Fossa/Container/Analyze.hs
@@ -3,10 +3,10 @@ module App.Fossa.Container.Analyze
   )
 where
 
-import App.Fossa.Analyze (ScanDestination (..))
 import App.Fossa.API.BuildLink (getFossaBuildUrl)
-import App.Fossa.Container (ImageText (..), runSyft, toContainerScan, extractRevision)
-import App.Fossa.FossaAPIV1 (UploadResponse(uploadError, uploadLocator), uploadContainerScan)
+import App.Fossa.Analyze (ScanDestination (..))
+import App.Fossa.Container (ImageText (..), extractRevision, runSyft, toContainerScan)
+import App.Fossa.FossaAPIV1 (UploadResponse (uploadError, uploadLocator), uploadContainerScan)
 import App.Types (OverrideProject (..), ProjectRevision (..))
 import Control.Carrier.Diagnostics
 import Control.Effect.Lift (Lift)

--- a/src/App/Fossa/Container/Test.hs
+++ b/src/App/Fossa/Container/Test.hs
@@ -12,10 +12,10 @@ import App.Types (OverrideProject (..), ProjectRevision (..))
 import Control.Carrier.Diagnostics
 import Control.Effect.Lift
 import Control.Monad.IO.Class (MonadIO)
-import qualified Data.Aeson as Aeson
+import Data.Aeson qualified as Aeson
 import Data.Functor (void)
-import Data.Text.Lazy.Encoding (decodeUtf8)
 import Data.Text.IO (hPutStrLn)
+import Data.Text.Lazy.Encoding (decodeUtf8)
 import Effect.Logger
 import Fossa.API.Types (ApiOpts (..), Issues (..))
 import System.Exit (exitFailure, exitSuccess)
@@ -37,13 +37,15 @@ testMain ::
   ImageText ->
   IO ()
 testMain apiOpts logSeverity timeoutSeconds outputType override image = do
-  void $ timeout timeoutSeconds $ withLogger logSeverity $ do
-    result <- runDiagnostics $ testInner apiOpts outputType override image
-    case result of
-      Left err -> do
-        logError $ renderFailureBundle err
-        sendIO exitFailure
-      Right (ResultBundle _ _) -> sendIO exitSuccess
+  void $
+    timeout timeoutSeconds $
+      withLogger logSeverity $ do
+        result <- runDiagnostics $ testInner apiOpts outputType override image
+        case result of
+          Left err -> do
+            logError $ renderFailureBundle err
+            sendIO exitFailure
+          Right (ResultBundle _ _) -> sendIO exitSuccess
 
   hPutStrLn stderr "Timed out while wait for issues"
   exitFailure

--- a/src/App/Fossa/EmbeddedBinary.hs
+++ b/src/App/Fossa/EmbeddedBinary.hs
@@ -12,7 +12,7 @@ module App.Fossa.EmbeddedBinary
     withSyftBinary,
     withCLIv1Binary,
     allBins,
-    PackagedBinary (..)
+    PackagedBinary (..),
   )
 where
 
@@ -34,11 +34,10 @@ data PackagedBinary
 allBins :: [PackagedBinary]
 allBins = enumFromTo minBound maxBound
 
-data BinaryPaths
-  = BinaryPaths
-      { binaryPathContainer :: Path Abs Dir,
-        binaryFilePath :: Path Rel File
-      }
+data BinaryPaths = BinaryPaths
+  { binaryPathContainer :: Path Abs Dir,
+    binaryFilePath :: Path Rel File
+  }
 
 toExecutablePath :: BinaryPaths -> Path Abs File
 toExecutablePath BinaryPaths {..} = binaryPathContainer </> binaryFilePath
@@ -67,7 +66,6 @@ withCLIv1Binary ::
   m c
 withCLIv1Binary = withEmbeddedBinary CLIv1
 
-
 withEmbeddedBinary ::
   ( Has (Lift IO) sig m,
     MonadIO m
@@ -92,7 +90,8 @@ extractEmbeddedBinary bin = do
 
 dumpEmbeddedBinary :: Has (Lift IO) sig m => Path Abs Dir -> PackagedBinary -> m ()
 dumpEmbeddedBinary dir bin = writeBinary path bin
-  where path = dir </> extractedPath bin
+  where
+    path = dir </> extractedPath bin
 
 writeBinary :: (Has (Lift IO) sig m) => Path Abs File -> PackagedBinary -> m ()
 writeBinary dest bin = sendIO . writeExecutable dest $ case bin of

--- a/src/App/Fossa/FossaAPIV1.hs
+++ b/src/App/Fossa/FossaAPIV1.hs
@@ -5,54 +5,52 @@
 {-# LANGUAGE UndecidableInstances #-}
 
 module App.Fossa.FossaAPIV1
-  ( uploadAnalysis
-  , uploadContributors
-  , uploadContainerScan
-  , UploadResponse(..)
-  , mkMetadataOpts
-  , FossaError(..)
-  , FossaReq(..)
-  , Contributors(..)
-  , fossaReq
-
-  , getLatestBuild
-  , Build(..)
-  , BuildTask(..)
-  , BuildStatus(..)
-  , getIssues
-
-  , Organization(..)
-  , getOrganization
-
-  , getAttribution
-  , getAttributionRaw
-  ) where
+  ( uploadAnalysis,
+    uploadContributors,
+    uploadContainerScan,
+    UploadResponse (..),
+    mkMetadataOpts,
+    FossaError (..),
+    FossaReq (..),
+    Contributors (..),
+    fossaReq,
+    getLatestBuild,
+    Build (..),
+    BuildTask (..),
+    BuildStatus (..),
+    getIssues,
+    Organization (..),
+    getOrganization,
+    getAttribution,
+    getAttributionRaw,
+  )
+where
 
 import App.Fossa.Analyze.Project
 import App.Fossa.Container (ContainerScan (..))
-import qualified App.Fossa.Report.Attribution as Attr
+import App.Fossa.Report.Attribution qualified as Attr
 import App.Types
+import App.Version (versionNumber)
 import Control.Effect.Diagnostics hiding (fromMaybe)
 import Control.Effect.Lift (Lift, sendIO)
 import Control.Monad.IO.Class (MonadIO (..))
 import Data.Aeson
-import qualified Data.List.NonEmpty as NE
+import Data.List.NonEmpty qualified as NE
 import Data.Map (Map)
 import Data.Maybe (catMaybes, fromMaybe)
 import Data.Text (Text)
-import qualified Data.Text as T
+import Data.Text qualified as T
 import Effect.Logger
-import qualified Network.HTTP.Client as HTTP
+import Fossa.API.Types (ApiOpts, Issues, useApiOpts)
+import Network.HTTP.Client qualified as HTTP
 import Network.HTTP.Req
-import qualified Network.HTTP.Types as HTTP
+import Network.HTTP.Types qualified as HTTP
 import Srclib.Converter (toSourceUnit)
 import Srclib.Types
 import Text.URI (URI)
-import qualified Text.URI as URI
-import Fossa.API.Types (ApiOpts, useApiOpts, Issues)
-import App.Version (versionNumber)
+import Text.URI qualified as URI
 
-newtype FossaReq m a = FossaReq { unFossaReq :: m a }
+newtype FossaReq m a = FossaReq {unFossaReq :: m a}
   deriving (Functor, Applicative, Monad, Algebra sig)
 
 instance Has (Lift IO) sig m => MonadIO (FossaReq m) where
@@ -73,7 +71,7 @@ uploadUrl baseurl = baseurl /: "api" /: "builds" /: "custom"
 
 -- | This renders an organization + locator into a path piece for the fossa API
 renderLocatorUrl :: Int -> Locator -> Text
-renderLocatorUrl orgId Locator{..} =
+renderLocatorUrl orgId Locator {..} =
   locatorFetcher <> "+" <> T.pack (show orgId) <> "/" <> normalizeGitProjectName locatorProject <> "$" <> fromMaybe "" locatorRevision
 
 -- | The fossa backend treats http git locators in a specific way for the issues and builds endpoints.
@@ -82,24 +80,25 @@ normalizeGitProjectName :: Text -> Text
 normalizeGitProjectName project
   | "http" `T.isPrefixOf` project = dropPrefix "http://" . dropPrefix "https://" . dropSuffix ".git" $ project
   | otherwise = project
-    where
-      -- like Text.stripPrefix, but with a non-Maybe result (defaults to the original text)
-      dropPrefix :: Text -> Text -> Text
-      dropPrefix pre txt = fromMaybe txt (T.stripPrefix pre txt)
+  where
+    -- like Text.stripPrefix, but with a non-Maybe result (defaults to the original text)
+    dropPrefix :: Text -> Text -> Text
+    dropPrefix pre txt = fromMaybe txt (T.stripPrefix pre txt)
 
-      -- like Text.stripSuffix, but with a non-Maybe result (defaults to the original text)
-      dropSuffix :: Text -> Text -> Text
-      dropSuffix suf txt = fromMaybe txt (T.stripSuffix suf txt)
+    -- like Text.stripSuffix, but with a non-Maybe result (defaults to the original text)
+    dropSuffix :: Text -> Text -> Text
+    dropSuffix suf txt = fromMaybe txt (T.stripSuffix suf txt)
 
 data UploadResponse = UploadResponse
-  { uploadLocator :: Text
-  , uploadError   :: Maybe Text
-  } deriving (Eq, Ord, Show)
+  { uploadLocator :: Text,
+    uploadError :: Maybe Text
+  }
+  deriving (Eq, Ord, Show)
 
 instance FromJSON UploadResponse where
   parseJSON = withObject "UploadResponse" $ \obj ->
     UploadResponse <$> obj .: "locator"
-                   <*> obj .:? "error"
+      <*> obj .:? "error"
 
 data FossaError
   = InvalidProjectOrRevision HttpException
@@ -120,35 +119,36 @@ instance ToDiagnostic FossaError where
 containerUploadUrl :: Url scheme -> Url scheme
 containerUploadUrl baseurl = baseurl /: "api" /: "container" /: "upload"
 
-uploadContainerScan
-  :: (Has (Lift IO) sig m, Has Diagnostics sig m)
-  => ApiOpts
-  -> ProjectMetadata
-  -> ContainerScan
-  -> m UploadResponse
+uploadContainerScan ::
+  (Has (Lift IO) sig m, Has Diagnostics sig m) =>
+  ApiOpts ->
+  ProjectMetadata ->
+  ContainerScan ->
+  m UploadResponse
 uploadContainerScan apiOpts metadata scan = fossaReq $ do
   (baseUrl, baseOpts) <- useApiOpts apiOpts
   let locator = renderLocator $ Locator "custom" (imageTag scan) (Just $ imageDigest scan)
-      opts = "locator" =: locator
+      opts =
+        "locator" =: locator
           <> "cliVersion" =: cliVersion
           <> "managedBuild" =: True
           <> mkMetadataOpts metadata (imageTag scan)
   resp <- req POST (containerUploadUrl baseUrl) (ReqBodyJson scan) jsonResponse (baseOpts <> opts)
   pure $ responseBody resp
 
-
-uploadAnalysis
-  :: (Has (Lift IO) sig m, Has Diagnostics sig m)
-  => ApiOpts
-  -> ProjectRevision
-  -> ProjectMetadata
-  -> NE.NonEmpty ProjectResult
-  -> m UploadResponse
-uploadAnalysis apiOpts ProjectRevision{..} metadata projects = fossaReq $ do
+uploadAnalysis ::
+  (Has (Lift IO) sig m, Has Diagnostics sig m) =>
+  ApiOpts ->
+  ProjectRevision ->
+  ProjectMetadata ->
+  NE.NonEmpty ProjectResult ->
+  m UploadResponse
+uploadAnalysis apiOpts ProjectRevision {..} metadata projects = fossaReq $ do
   (baseUrl, baseOpts) <- useApiOpts apiOpts
 
   let sourceUnits = map toSourceUnit $ NE.toList projects
-      opts = "locator" =: renderLocator (Locator "custom" projectName (Just projectRevision))
+      opts =
+        "locator" =: renderLocator (Locator "custom" projectName (Just projectRevision))
           <> "cliVersion" =: cliVersion
           <> "managedBuild" =: True
           <> mkMetadataOpts metadata projectName
@@ -158,16 +158,16 @@ uploadAnalysis apiOpts ProjectRevision{..} metadata projects = fossaReq $ do
   pure (responseBody resp)
 
 mkMetadataOpts :: ProjectMetadata -> Text -> Option scheme
-mkMetadataOpts ProjectMetadata{..} projectName = mconcat $ catMaybes maybes
+mkMetadataOpts ProjectMetadata {..} projectName = mconcat $ catMaybes maybes
   where
     title = Just $ fromMaybe projectName projectTitle
     maybes =
-      [ ("projectURL" =:) <$> projectUrl
-      , ("jiraProjectKey" =:) <$> projectJiraKey
-      , ("link" =:) <$> projectLink
-      , ("team" =:) <$> projectTeam
-      , ("policy" =:) <$> projectPolicy
-      , ("title" =:) <$> title
+      [ ("projectURL" =:) <$> projectUrl,
+        ("jiraProjectKey" =:) <$> projectJiraKey,
+        ("link" =:) <$> projectLink,
+        ("team" =:) <$> projectTeam,
+        ("policy" =:) <$> projectPolicy,
+        ("title" =:) <$> title
       ]
 
 mangleError :: HttpException -> FossaError
@@ -176,7 +176,7 @@ mangleError err = case err of
     case HTTP.responseStatus resp of
       HTTP.Status 404 _ -> InvalidProjectOrRevision err
       HTTP.Status 403 _ -> NoPermission err
-      _                 -> OtherError err
+      _ -> OtherError err
   JsonHttpException msg -> JsonDeserializeError msg
   _ -> OtherError err
 
@@ -195,20 +195,22 @@ data BuildStatus
   deriving (Eq, Ord, Show)
 
 data Build = Build
-  { buildId :: Int
-  , buildError :: Maybe Text
-  , buildTask :: BuildTask
-  } deriving (Eq, Ord, Show)
+  { buildId :: Int,
+    buildError :: Maybe Text,
+    buildTask :: BuildTask
+  }
+  deriving (Eq, Ord, Show)
 
 newtype BuildTask = BuildTask
   { buildTaskStatus :: BuildStatus
-  } deriving (Eq, Ord, Show)
+  }
+  deriving (Eq, Ord, Show)
 
 instance FromJSON Build where
   parseJSON = withObject "Build" $ \obj ->
     Build <$> obj .: "id"
-          <*> obj .:? "error"
-          <*> obj .: "task"
+      <*> obj .:? "error"
+      <*> obj .: "task"
 
 instance FromJSON BuildTask where
   parseJSON = withObject "BuildTask" $ \obj ->
@@ -223,11 +225,11 @@ instance FromJSON BuildStatus where
     "RUNNING" -> pure StatusRunning
     other -> pure $ StatusUnknown other
 
-getLatestBuild
-  :: (Has (Lift IO) sig m, Has Diagnostics sig m)
-  => ApiOpts
-  -> ProjectRevision
-  -> m Build
+getLatestBuild ::
+  (Has (Lift IO) sig m, Has Diagnostics sig m) =>
+  ApiOpts ->
+  ProjectRevision ->
+  m Build
 getLatestBuild apiOpts ProjectRevision {..} = fossaReq $ do
   (baseUrl, baseOpts) <- useApiOpts apiOpts
 
@@ -241,12 +243,12 @@ getLatestBuild apiOpts ProjectRevision {..} = fossaReq $ do
 issuesEndpoint :: Url 'Https -> Int -> Locator -> Url 'Https
 issuesEndpoint baseUrl orgId locator = baseUrl /: "api" /: "cli" /: renderLocatorUrl orgId locator /: "issues"
 
-getIssues
-  :: (Has (Lift IO) sig m, Has Diagnostics sig m)
-  => ApiOpts
-  -> ProjectRevision
-  -> m Issues
-getIssues apiOpts ProjectRevision{..} = fossaReq $ do
+getIssues ::
+  (Has (Lift IO) sig m, Has Diagnostics sig m) =>
+  ApiOpts ->
+  ProjectRevision ->
+  m Issues
+getIssues apiOpts ProjectRevision {..} = fossaReq $ do
   (baseUrl, baseOpts) <- useApiOpts apiOpts
 
   Organization orgId _ <- getOrganization apiOpts
@@ -258,34 +260,36 @@ getIssues apiOpts ProjectRevision{..} = fossaReq $ do
 attributionEndpoint :: Url 'Https -> Int -> Locator -> Url 'Https
 attributionEndpoint baseurl orgId locator = baseurl /: "api" /: "revisions" /: renderLocatorUrl orgId locator /: "attribution" /: "json"
 
-getAttribution
-  :: (Has (Lift IO) sig m, Has Diagnostics sig m)
-  => ApiOpts
-  -> ProjectRevision
-  -> m Attr.Attribution
-getAttribution apiOpts ProjectRevision{..} = fossaReq $ do
+getAttribution ::
+  (Has (Lift IO) sig m, Has Diagnostics sig m) =>
+  ApiOpts ->
+  ProjectRevision ->
+  m Attr.Attribution
+getAttribution apiOpts ProjectRevision {..} = fossaReq $ do
   (baseUrl, baseOpts) <- useApiOpts apiOpts
 
-  let opts = baseOpts
-        <> "includeDeepDependencies" =: True
-        <> "includeHashAndVersionData" =: True
-        <> "includeDownloadUrl" =: True
+  let opts =
+        baseOpts
+          <> "includeDeepDependencies" =: True
+          <> "includeHashAndVersionData" =: True
+          <> "includeDownloadUrl" =: True
   Organization orgId _ <- getOrganization apiOpts
   response <- req GET (attributionEndpoint baseUrl orgId (Locator "custom" projectName (Just projectRevision))) NoReqBody jsonResponse opts
   pure (responseBody response)
 
-getAttributionRaw
-  :: (Has (Lift IO) sig m, Has Diagnostics sig m)
-  => ApiOpts
-  -> ProjectRevision
-  -> m Value
-getAttributionRaw apiOpts ProjectRevision{..} = fossaReq $ do
+getAttributionRaw ::
+  (Has (Lift IO) sig m, Has Diagnostics sig m) =>
+  ApiOpts ->
+  ProjectRevision ->
+  m Value
+getAttributionRaw apiOpts ProjectRevision {..} = fossaReq $ do
   (baseUrl, baseOpts) <- useApiOpts apiOpts
 
-  let opts = baseOpts
-        <> "includeDeepDependencies" =: True
-        <> "includeHashAndVersionData" =: True
-        <> "includeDownloadUrl" =: True
+  let opts =
+        baseOpts
+          <> "includeDeepDependencies" =: True
+          <> "includeHashAndVersionData" =: True
+          <> "includeDownloadUrl" =: True
   Organization orgId _ <- getOrganization apiOpts
   response <- req GET (attributionEndpoint baseUrl orgId (Locator "custom" projectName (Just projectRevision))) NoReqBody jsonResponse opts
   pure (responseBody response)
@@ -295,12 +299,13 @@ getAttributionRaw apiOpts ProjectRevision{..} = fossaReq $ do
 data Organization = Organization
   { organizationId :: Int,
     orgUsesSAML :: Bool
-  } deriving (Eq, Ord, Show)
+  }
+  deriving (Eq, Ord, Show)
 
 instance FromJSON Organization where
   parseJSON = withObject "Organization" $ \obj ->
     Organization <$> obj .: "organizationId"
-                 <*> obj .:? "usesSAML" .!= False
+      <*> obj .:? "usesSAML" .!= False
 
 organizationEndpoint :: Url scheme -> Url scheme
 organizationEndpoint baseurl = baseurl /: "api" /: "cli" /: "organization"
@@ -323,8 +328,9 @@ uploadContributors :: (Has (Lift IO) sig m, Has Diagnostics sig m) => ApiOpts ->
 uploadContributors apiOpts locator contributors = fossaReq $ do
   (baseUrl, baseOpts) <- useApiOpts apiOpts
 
-  let opts = baseOpts
-        <> "locator" =: locator
+  let opts =
+        baseOpts
+          <> "locator" =: locator
 
   _ <- req POST (contributorsEndpoint baseUrl) (ReqBodyJson contributors) ignoreResponse opts
   pure ()

--- a/src/App/Fossa/ListTargets.hs
+++ b/src/App/Fossa/ListTargets.hs
@@ -7,6 +7,7 @@ where
 
 import App.Fossa.Analyze (discoverFuncs)
 import App.Types (BaseDir (..))
+import Control.Carrier.Diagnostics qualified as Diag
 import Control.Carrier.Finally
 import Control.Carrier.TaskPool
 import Control.Concurrent (getNumCapabilities)
@@ -18,7 +19,6 @@ import Effect.ReadFS
 import Path (toFilePath)
 import Path.IO (makeRelative)
 import Types (BuildTarget (..), DiscoveredProject (..))
-import qualified Control.Carrier.Diagnostics as Diag
 
 type DummyM = ReadFSIOC (ExecIOC (Diag.DiagnosticsC IO))
 

--- a/src/App/Fossa/Main.hs
+++ b/src/App/Fossa/Main.hs
@@ -6,22 +6,22 @@ module App.Fossa.Main
   )
 where
 
-import App.Fossa.Analyze (ScanDestination (..), UnpackArchives (..), RecordMode (..), analyzeMain)
-import App.Fossa.Container (imageTextArg, ImageText (..), parseSyftOutputMain, dumpSyftScanMain)
-import qualified App.Fossa.Container.Analyze as ContainerAnalyze
-import qualified App.Fossa.Container.Test as ContainerTest
-import App.Fossa.Compatibility (argumentParser, Argument, compatibilityMain)
-import qualified App.Fossa.EmbeddedBinary as Embed
-import App.Fossa.ListTargets (listTargetsMain)
+import App.Fossa.Analyze (RecordMode (..), ScanDestination (..), UnpackArchives (..), analyzeMain)
+import App.Fossa.Compatibility (Argument, argumentParser, compatibilityMain)
 import App.Fossa.Configuration
-import qualified App.Fossa.Report as Report
-import qualified App.Fossa.Test as Test
-import App.Fossa.VPS.NinjaGraph
-import qualified App.Fossa.VPS.Report as VPSReport
-import App.Fossa.VPS.Scan (LicenseOnlyScan (..), SkipIPRScan (..), scanMain)
+import App.Fossa.Container (ImageText (..), dumpSyftScanMain, imageTextArg, parseSyftOutputMain)
+import App.Fossa.Container.Analyze qualified as ContainerAnalyze
+import App.Fossa.Container.Test qualified as ContainerTest
+import App.Fossa.EmbeddedBinary qualified as Embed
+import App.Fossa.ListTargets (listTargetsMain)
+import App.Fossa.Report qualified as Report
+import App.Fossa.Test qualified as Test
 import App.Fossa.VPS.AOSPNotice (aospNoticeMain)
-import qualified App.Fossa.VPS.Test as VPSTest
-import App.Fossa.VPS.Types (FilterExpressions (..), NinjaScanID (..), NinjaFilePaths (..))
+import App.Fossa.VPS.NinjaGraph
+import App.Fossa.VPS.Report qualified as VPSReport
+import App.Fossa.VPS.Scan (LicenseOnlyScan (..), SkipIPRScan (..), scanMain)
+import App.Fossa.VPS.Test qualified as VPSTest
+import App.Fossa.VPS.Types (FilterExpressions (..), NinjaFilePaths (..), NinjaScanID (..))
 import App.OptionExtensions
 import App.Types
 import App.Util (validateDir, validateFile)
@@ -33,37 +33,39 @@ import Data.Flag (Flag, flagOpt, fromFlag)
 import Data.Foldable (for_)
 import Data.Functor.Extra ((<$$>))
 import Data.Text (Text)
-import qualified Data.Text as T
+import Data.Text qualified as T
 import Discovery.Filters (BuildTargetFilter (..), filterParser)
 import Effect.Logger
-import Fossa.API.Types (ApiKey(..), ApiOpts(..))
+import Fossa.API.Types (ApiKey (..), ApiOpts (..))
 import Options.Applicative
+import Path
 import System.Environment (lookupEnv)
 import System.Exit (die)
-import qualified System.Info as SysInfo
+import System.Info qualified as SysInfo
 import Text.Megaparsec (errorBundlePretty, runParser)
 import Text.URI (URI, mkURI)
-import Path
 
 windowsOsName :: String
 windowsOsName = "mingw32"
 
 mainPrefs :: ParserPrefs
-mainPrefs = prefs $ mconcat
-  [ helpShowGlobals,
-    showHelpOnError,
-    subparserInline
-  ]
+mainPrefs =
+  prefs $
+    mconcat
+      [ helpShowGlobals,
+        showHelpOnError,
+        subparserInline
+      ]
 
 mergeFileCmdConfig :: CmdOptions -> ConfigFile -> CmdOptions
 mergeFileCmdConfig cmd file =
   CmdOptions
-    { optDebug = optDebug cmd
-    , optBaseUrl = optBaseUrl cmd <|> (configServer file >>= mkURI)
-    , optProjectName = optProjectName cmd <|> (configProject file >>= configProjID)
-    , optProjectRevision = optProjectRevision cmd <|> (configRevision file >>= configCommit)
-    , optAPIKey = optAPIKey cmd <|> configApiKey file
-    , optCommand = optCommand cmd
+    { optDebug = optDebug cmd,
+      optBaseUrl = optBaseUrl cmd <|> (configServer file >>= mkURI),
+      optProjectName = optProjectName cmd <|> (configProject file >>= configProjID),
+      optProjectRevision = optProjectRevision cmd <|> (configRevision file >>= configCommit),
+      optAPIKey = optAPIKey cmd <|> configApiKey file,
+      optCommand = optCommand cmd
     }
 
 appMain :: IO ()
@@ -167,10 +169,8 @@ appMain = do
       basedir <- validateDir dir
       for_ Embed.allBins $ Embed.dumpEmbeddedBinary $ unBaseDir basedir
 
-
 dieOnWindows :: String -> IO ()
 dieOnWindows op = when (SysInfo.os == windowsOsName) $ die $ "Operation is not supported on Windows: " <> op
-
 
 parseCommaSeparatedFileArg :: Text -> IO [Path Abs File]
 parseCommaSeparatedFileArg arg = sequence (validateFile . T.unpack <$> T.splitOn "," arg)
@@ -277,9 +277,9 @@ analyzeOpts =
 
 analyzeReplayOpt :: Parser RecordMode
 analyzeReplayOpt =
-      flag' RecordModeRecord (long "record" <> hidden)
-  <|> (RecordModeReplay <$> strOption (long "replay" <> hidden))
-  <|> pure RecordModeNone
+  flag' RecordModeRecord (long "record" <> hidden)
+    <|> (RecordModeReplay <$> strOption (long "replay" <> hidden))
+    <|> pure RecordModeNone
 
 filterOpt :: Parser BuildTargetFilter
 filterOpt = option (eitherReader parseFilter) (long "filter" <> help "Analysis-Target filters (default: none)" <> metavar "ANALYSIS-TARGET")
@@ -456,7 +456,7 @@ containerDumpScanOptions =
 
 compatibilityOpts :: Parser [Argument]
 compatibilityOpts =
-    many argumentParser
+  many argumentParser
 
 data CmdOptions = CmdOptions
   { optDebug :: Bool,
@@ -541,7 +541,7 @@ data VPSTestOptions = VPSTestOptions
   }
 
 newtype ContainerOptions = ContainerOptions
-  { containerCommand :: ContainerCommand }
+  {containerCommand :: ContainerCommand}
 
 data ContainerCommand
   = ContainerAnalyze ContainerAnalyzeOptions
@@ -557,7 +557,7 @@ data ContainerAnalyzeOptions = ContainerAnalyzeOptions
 
 data ContainerTestOptions = ContainerTestOptions
   { containerTestTimeout :: Int,
-    containerTestOutputType:: ContainerTest.TestOutputType,
+    containerTestOutputType :: ContainerTest.TestOutputType,
     containerTestImage :: ImageText
   }
 

--- a/src/App/Fossa/Report/Attribution.hs
+++ b/src/App/Fossa/Report/Attribution.hs
@@ -12,58 +12,52 @@ module App.Fossa.Report.Attribution
 where
 
 import Data.Aeson
-import Data.Text (Text)
 import Data.Map.Strict (Map)
 import Data.Maybe (catMaybes)
+import Data.Text (Text)
 
-newtype LicenseName
-  = LicenseName {rawName :: Text}
+newtype LicenseName = LicenseName {rawName :: Text}
   deriving (Eq, Ord, Show, FromJSON, FromJSONKey, ToJSON, ToJSONKey)
 
-newtype LicenseContents
-  = LicenseContents {rawContents :: Text}
+newtype LicenseContents = LicenseContents {rawContents :: Text}
   deriving (Eq, Ord, Show, FromJSON, ToJSON)
 
-data Attribution
-  = Attribution
-      { attribProject :: Project,
-        attribDirectDeps :: [Dependency],
-        attribDeepDeps :: [Dependency],
-        attribLicenses :: Map LicenseName LicenseContents
-      }
+data Attribution = Attribution
+  { attribProject :: Project,
+    attribDirectDeps :: [Dependency],
+    attribDeepDeps :: [Dependency],
+    attribLicenses :: Map LicenseName LicenseContents
+  }
   deriving (Eq, Show, Ord)
 
-data Dependency
-  = Dependency
-      { depPackage :: Text,
-        depSource :: Text,
-        depVersion :: Maybe Text,
-        depIsGolang :: Maybe Bool,
-        depHash :: Maybe Text,
-        depAuthors :: [Text],
-        depDescription :: Maybe Text,
-        depLicenses :: Maybe [License],
-        depOtherLicenses :: [License],
-        depProjectUrl :: Maybe Text,
-        depDependencyPaths :: [Text],
-        depNotes :: [Text],
-        depDownloadUrl :: Maybe Text,
-        depTitle :: Text
-      }
+data Dependency = Dependency
+  { depPackage :: Text,
+    depSource :: Text,
+    depVersion :: Maybe Text,
+    depIsGolang :: Maybe Bool,
+    depHash :: Maybe Text,
+    depAuthors :: [Text],
+    depDescription :: Maybe Text,
+    depLicenses :: Maybe [License],
+    depOtherLicenses :: [License],
+    depProjectUrl :: Maybe Text,
+    depDependencyPaths :: [Text],
+    depNotes :: [Text],
+    depDownloadUrl :: Maybe Text,
+    depTitle :: Text
+  }
   deriving (Eq, Show, Ord)
 
-data License
-  = License
-      { licenseName :: LicenseName,
-        licenseAttribution :: Maybe LicenseContents
-      }
+data License = License
+  { licenseName :: LicenseName,
+    licenseAttribution :: Maybe LicenseContents
+  }
   deriving (Eq, Show, Ord)
 
-data Project
-  = Project
-      { projectName :: Text,
-        projectRevision :: Text
-      }
+data Project = Project
+  { projectName :: Text,
+    projectRevision :: Text
+  }
   deriving (Eq, Show, Ord)
 
 instance FromJSON Attribution where

--- a/src/App/Fossa/Test.hs
+++ b/src/App/Fossa/Test.hs
@@ -1,71 +1,76 @@
 module App.Fossa.Test
-  ( testMain
-  , TestOutputType(..)
-  ) where
+  ( testMain,
+    TestOutputType (..),
+  )
+where
 
 import App.Fossa.API.BuildWait
 import App.Fossa.ProjectInference
 import App.Types
 import Control.Carrier.Diagnostics hiding (fromMaybe)
 import Control.Effect.Lift (sendIO)
-import qualified Data.Aeson as Aeson
+import Data.Aeson qualified as Aeson
 import Data.Functor (void)
 import Data.Text.IO (hPutStrLn)
 import Data.Text.Lazy.Encoding (decodeUtf8)
 import Effect.Logger
 import Effect.ReadFS
-import Fossa.API.Types (ApiOpts, Issues(..))
+import Fossa.API.Types (ApiOpts, Issues (..))
 import System.Exit (exitFailure, exitSuccess)
 import System.IO (stderr)
 
 data TestOutputType
-  = TestOutputPretty -- ^ pretty output format for issues
-  | TestOutputJson -- ^ use json output for issues
+  = -- | pretty output format for issues
+    TestOutputPretty
+  | -- | use json output for issues
+    TestOutputJson
 
-testMain
-  :: BaseDir
-  -> ApiOpts
-  -> Severity
-  -> Int -- ^ timeout (seconds)
-  -> TestOutputType
-  -> OverrideProject
-  -> IO ()
+testMain ::
+  BaseDir ->
+  ApiOpts ->
+  Severity ->
+  -- | timeout (seconds)
+  Int ->
+  TestOutputType ->
+  OverrideProject ->
+  IO ()
 testMain (BaseDir basedir) apiOpts logSeverity timeoutSeconds outputType override = do
-  void $ timeout timeoutSeconds $ withLogger logSeverity $ do
-    result <- runDiagnostics . runReadFSIO $ do
-      revision <- mergeOverride override <$> (inferProjectFromVCS basedir <||> inferProjectCached basedir <||> inferProjectDefault basedir)
+  void $
+    timeout timeoutSeconds $
+      withLogger logSeverity $ do
+        result <- runDiagnostics . runReadFSIO $ do
+          revision <- mergeOverride override <$> (inferProjectFromVCS basedir <||> inferProjectCached basedir <||> inferProjectDefault basedir)
 
-      logInfo ""
-      logInfo ("Using project name: `" <> pretty (projectName revision) <> "`")
-      logInfo ("Using revision: `" <> pretty (projectRevision revision) <> "`")
+          logInfo ""
+          logInfo ("Using project name: `" <> pretty (projectName revision) <> "`")
+          logInfo ("Using revision: `" <> pretty (projectRevision revision) <> "`")
 
-      logSticky "[ Waiting for build completion... ]"
+          logSticky "[ Waiting for build completion... ]"
 
-      waitForBuild apiOpts revision
+          waitForBuild apiOpts revision
 
-      logSticky "[ Waiting for issue scan completion... ]"
-      issues <- waitForIssues apiOpts revision
-      logSticky ""
-      logInfo ""
+          logSticky "[ Waiting for issue scan completion... ]"
+          issues <- waitForIssues apiOpts revision
+          logSticky ""
+          logInfo ""
 
-      case issuesCount issues of
-        0 -> logInfo "Test passed! 0 issues found"
-        n -> do
-          logError $ "Test failed. Number of issues found: " <> pretty n
-          if null (issuesIssues issues)
-            then logError "Check the webapp for more details, or use a full-access API key (currently using a push-only API key)"
-            else
-              case outputType of
-                TestOutputPretty -> logError $ pretty issues
-                TestOutputJson -> logStdout . pretty . decodeUtf8 . Aeson.encode $ issues
+          case issuesCount issues of
+            0 -> logInfo "Test passed! 0 issues found"
+            n -> do
+              logError $ "Test failed. Number of issues found: " <> pretty n
+              if null (issuesIssues issues)
+                then logError "Check the webapp for more details, or use a full-access API key (currently using a push-only API key)"
+                else case outputType of
+                  TestOutputPretty -> logError $ pretty issues
+                  TestOutputJson -> logStdout . pretty . decodeUtf8 . Aeson.encode $ issues
 
-          sendIO exitFailure
+              sendIO exitFailure
 
-    case result of
-      Left failure -> do
-        logError $ renderFailureBundle failure
-        sendIO exitFailure
-      Right _ -> sendIO exitSuccess
+        case result of
+          Left failure -> do
+            logError $ renderFailureBundle failure
+            sendIO exitFailure
+          Right _ -> sendIO exitSuccess
 
   -- we call exitSuccess/exitFailure in each branch above. the only way we get
   -- here is if we time out

--- a/src/App/Fossa/VPS/NinjaGraph.hs
+++ b/src/App/Fossa/VPS/NinjaGraph.hs
@@ -3,57 +3,58 @@
 {-# LANGUAGE RecordWildCards #-}
 
 module App.Fossa.VPS.NinjaGraph
-(
-  ninjaGraphMain
-, NinjaGraphCmdOpts(..)
-, scanNinjaDeps
-) where
+  ( ninjaGraphMain,
+    NinjaGraphCmdOpts (..),
+    scanNinjaDeps,
+  )
+where
 
-import App.Fossa.VPS.Types
+import App.Fossa.ProjectInference
 import App.Fossa.VPS.Scan.Core
 import App.Fossa.VPS.Scan.ScotlandYard
-import App.Fossa.ProjectInference
+import App.Fossa.VPS.Types
 import App.Types (BaseDir (..), NinjaGraphCLIOptions (..), OverrideProject (..), ProjectRevision (..))
 import App.Util (validateDir)
 import Control.Carrier.Diagnostics hiding (fromMaybe)
 import Control.Effect.Lift (Lift, sendIO)
 import Data.ByteString (ByteString)
-import qualified Data.ByteString as BS
-import qualified Data.ByteString.Lazy as BL
+import Data.ByteString qualified as BS
+import Data.ByteString.Lazy qualified as BL
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
-import qualified Data.Text as T
+import Data.Text qualified as T
 import Data.Text.Encoding (decodeUtf8)
 import Effect.Exec
 import Effect.Logger hiding (line)
 import Effect.ReadFS
-import Path
-import qualified System.FilePath as FP
-import System.Process.Typed as PROC
 import Fossa.API.Types (ApiOpts)
+import Path
+import System.FilePath qualified as FP
+import System.Process.Typed as PROC
 
 data NinjaGraphCmdOpts = NinjaGraphCmdOpts
-  { ninjaCmdBasedir :: FilePath
-  , ninjaCmdNinjaGraphOpts :: NinjaGraphOpts
+  { ninjaCmdBasedir :: FilePath,
+    ninjaCmdNinjaGraphOpts :: NinjaGraphOpts
   }
 
-data NinjaGraphError = ErrorRunningNinja Text
-                     | NoNinjaDepsStartLineFound
-                     | NoNinjaDepsEndLineFound
-                     | NinjaDepsParseError
+data NinjaGraphError
+  = ErrorRunningNinja Text
+  | NoNinjaDepsStartLineFound
+  | NoNinjaDepsEndLineFound
+  | NinjaDepsParseError
   deriving (Eq, Ord, Show)
 
 instance ToDiagnostic NinjaGraphError where
   renderDiagnostic = \case
     ErrorRunningNinja err -> "Error while running Ninja: " <> pretty err
     NoNinjaDepsStartLineFound -> "The output of \"ninja -t deps\" did not contain the \"Starting ninja...\" line"
-    NoNinjaDepsEndLineFound   -> "The output of \"ninja -t deps\" did not contain the \"build completed successfully\" line"
-    NinjaDepsParseError   -> "There was an error while parsing the output of \"ninja -t deps\""
+    NoNinjaDepsEndLineFound -> "The output of \"ninja -t deps\" did not contain the \"build completed successfully\" line"
+    NinjaDepsParseError -> "There was an error while parsing the output of \"ninja -t deps\""
 
 data NinjaParseState = Starting | Parsing | Complete | Error
 
 ninjaGraphMain :: ApiOpts -> Severity -> OverrideProject -> NinjaGraphCLIOptions -> IO ()
-ninjaGraphMain apiOpts logSeverity overrideProject NinjaGraphCLIOptions{..} = do
+ninjaGraphMain apiOpts logSeverity overrideProject NinjaGraphCLIOptions {..} = do
   BaseDir basedir <- validateDir ninjaBaseDir
 
   withLogger logSeverity . logWithExit_ $ do
@@ -65,12 +66,11 @@ ninjaGraphMain apiOpts logSeverity overrideProject NinjaGraphCLIOptions{..} = do
 ninjaGraphInner :: (Has Logger sig m, Has (Lift IO) sig m, Has Diagnostics sig m) => Path Abs Dir -> ApiOpts -> NinjaGraphOpts -> m ()
 ninjaGraphInner basedir apiOpts ninjaGraphOpts = getAndParseNinjaDeps basedir apiOpts ninjaGraphOpts
 
-
 getAndParseNinjaDeps :: (Has Diagnostics sig m, Has (Lift IO) sig m, Has Logger sig m) => Path Abs Dir -> ApiOpts -> NinjaGraphOpts -> m ()
-getAndParseNinjaDeps dir apiOpts ninjaGraphOpts@NinjaGraphOpts{..} = do
+getAndParseNinjaDeps dir apiOpts ninjaGraphOpts@NinjaGraphOpts {..} = do
   ninjaDepsContents <- runReadFSIO . runExecIO $ getNinjaDeps dir ninjaGraphOpts
   graph <- scanNinjaDeps ninjaDepsContents
-  SherlockInfo{..} <- getSherlockInfo ninjaFossaOpts
+  SherlockInfo {..} <- getSherlockInfo ninjaFossaOpts
   let locator = createLocator ninjaProjectName sherlockOrgId
       syOpts = ScotlandYardNinjaOpts locator sherlockOrgId ninjaGraphOpts
   _ <- uploadBuildGraph apiOpts syOpts graph
@@ -80,7 +80,7 @@ getAndParseNinjaDeps dir apiOpts ninjaGraphOpts@NinjaGraphOpts{..} = do
 -- read that file to get the ninja deps. Otherwise, generate it with
 -- NINJA_ARGS="-t deps" make
 getNinjaDeps :: (Has ReadFS sig m, Has Diagnostics sig m, Has Logger sig m, Has (Lift IO) sig m) => Path Abs Dir -> NinjaGraphOpts -> m ByteString
-getNinjaDeps baseDir opts@NinjaGraphOpts{..} =
+getNinjaDeps baseDir opts@NinjaGraphOpts {..} =
   case ninjaGraphNinjaPath of
     Nothing -> BL.toStrict <$> generateNinjaDeps baseDir opts
     Just ninjaPath -> readNinjaDepsFile ninjaPath
@@ -97,7 +97,7 @@ readNinjaDepsFile ninjaPath = do
   readContentsBS path
 
 generateNinjaDeps :: (Has Logger sig m, Has Diagnostics sig m, Has (Lift IO) sig m) => Path Abs Dir -> NinjaGraphOpts -> m BL.ByteString
-generateNinjaDeps baseDir NinjaGraphOpts{..} = do
+generateNinjaDeps baseDir NinjaGraphOpts {..} = do
   logDebug . pretty $ "Generating ninja deps with this command: " ++ commandString
   (exitcode, stdout, stderr) <- sendIO $ PROC.readProcess (setWorkingDir (fromAbsDir baseDir) (PROC.shell commandString))
   case (exitcode, stdout, stderr) of
@@ -106,15 +106,15 @@ generateNinjaDeps baseDir NinjaGraphOpts{..} = do
   where
     commandString = case lunchTarget of
       Nothing -> "cd " ++ show baseDir ++ " && NINJA_ARGS=\"-t deps\" make"
-      Just lunch ->  "cd " ++ show baseDir ++ " && source ./build/envsetup.sh && lunch " ++ T.unpack lunch ++ " && NINJA_ARGS=\"-t deps\" make"
+      Just lunch -> "cd " ++ show baseDir ++ " && source ./build/envsetup.sh && lunch " ++ T.unpack lunch ++ " && NINJA_ARGS=\"-t deps\" make"
 
 correctedTarget :: DepsTarget -> DepsTarget
-correctedTarget target@DepsTarget { targetDependencies = [] } =
+correctedTarget target@DepsTarget {targetDependencies = []} =
   target
-correctedTarget target@DepsTarget { targetDependencies = [singleDep] } =
-  target { targetDependencies = [], targetInputs = [singleDep] }
-correctedTarget target@DepsTarget { targetDependencies = (firstDep : remainingDeps) } =
-  fromMaybe (target { targetInputs = [firstDep], targetDependencies = remainingDeps }) (correctTargetWithLeadingTxtDeps target)
+correctedTarget target@DepsTarget {targetDependencies = [singleDep]} =
+  target {targetDependencies = [], targetInputs = [singleDep]}
+correctedTarget target@DepsTarget {targetDependencies = (firstDep : remainingDeps)} =
+  fromMaybe (target {targetInputs = [firstDep], targetDependencies = remainingDeps}) (correctTargetWithLeadingTxtDeps target)
 
 -- There are cases where the first N dependencies are .txt files and do not match the basename
 -- of the target, and the N+1th dependency is a non-.txt file and matches the basename of
@@ -131,13 +131,12 @@ correctTargetWithLeadingTxtDeps target =
     ([], _) -> Nothing
     (_, []) -> Nothing
     (_, firstNonTxtDep : remainingDeps) ->
-      if firstNonTxtDepBasename == targetBasenameWithoutExt then
-        Just corrected
-      else
-        Nothing
+      if firstNonTxtDepBasename == targetBasenameWithoutExt
+        then Just corrected
+        else Nothing
       where
         (firstNonTxtDepBasename, _) = splitBasenameExt $ dependencyPath firstNonTxtDep
-        corrected = target { targetDependencies = leadingTxtDeps ++ remainingDeps, targetInputs = [firstNonTxtDep]}
+        corrected = target {targetDependencies = leadingTxtDeps ++ remainingDeps, targetInputs = [firstNonTxtDep]}
   where
     splitBasenameExt :: Text -> (String, String)
     splitBasenameExt = FP.splitExtension . FP.takeFileName . T.unpack
@@ -156,8 +155,8 @@ parseNinjaDeps ninjaDepsLines =
   case finalState of
     Complete -> pure $ reverse reversedDependenciesResults
     Starting -> fatal NoNinjaDepsStartLineFound
-    Parsing  -> fatal NoNinjaDepsEndLineFound
-    Error    -> fatal NinjaDepsParseError
+    Parsing -> fatal NoNinjaDepsEndLineFound
+    Error -> fatal NinjaDepsParseError
   where
     newLine = BS.head "\n" -- This is gross, but I couldn't get "BS.split '\n' ninjaDepsLines" to work
     nLines = BS.split newLine ninjaDepsLines
@@ -168,7 +167,7 @@ parseNinjaDeps ninjaDepsLines =
 -- beginning of the array. Fix that here.
 reverseDependencies :: DepsTarget -> DepsTarget
 reverseDependencies target =
-  target { targetDependencies = reverse deps }
+  target {targetDependencies = reverse deps}
   where
     deps = targetDependencies target
 
@@ -202,10 +201,9 @@ parseNinjaLine :: ((NinjaParseState, [DepsTarget]) -> ByteString -> (NinjaParseS
 parseNinjaLine (state, targets) line =
   case state of
     Starting ->
-      if line == "Starting ninja..." then
-        (Parsing, [])
-      else
-        (Starting, [])
+      if line == "Starting ninja..."
+        then (Parsing, [])
+        else (Starting, [])
     Parsing ->
       actuallyParseLine line targets
     Complete ->
@@ -217,26 +215,24 @@ actuallyParseLine :: ByteString -> [DepsTarget] -> (NinjaParseState, [DepsTarget
 -- ignore empty lines
 actuallyParseLine "" targets =
   (Parsing, targets)
-
 actuallyParseLine line []
--- error if you're trying to add a dependency and there are no targets yet
--- or if you reach the end of the file and no targets have been found
+  -- error if you're trying to add a dependency and there are no targets yet
+  -- or if you reach the end of the file and no targets have been found
   | BS.isPrefixOf " " line || BS.isInfixOf "build completed successfully" line =
     (Error, [])
--- Add the first target
+  -- Add the first target
   | otherwise =
     (Parsing, [newDepsTarget])
   where
     newDepsTarget = targetFromLine line
-
 actuallyParseLine line (currentDepsTarget : restOfDepsTargets)
--- The "build completed successfully" line signals that parsing is complete
+  -- The "build completed successfully" line signals that parsing is complete
   | BS.isInfixOf "build completed successfully" line =
     (Complete, currentDepsTarget : restOfDepsTargets)
--- Lines starting with a space add a new dep to the current target
+  -- Lines starting with a space add a new dep to the current target
   | BS.isPrefixOf " " line =
     (Parsing, updatedDepsTarget : restOfDepsTargets)
--- Lines starting with a non-blank char are new targets
+  -- Lines starting with a non-blank char are new targets
   | otherwise =
     (Parsing, newDepsTarget : currentDepsTarget : restOfDepsTargets)
   where
@@ -251,7 +247,7 @@ targetFromLine line =
 
 addDepToDepsTarget :: DepsTarget -> ByteString -> DepsTarget
 addDepToDepsTarget target line =
-  target { targetDependencies = newDep : currentDeps}
+  target {targetDependencies = newDep : currentDeps}
   where
     currentDeps = targetDependencies target
     newDep = parseDepLine line

--- a/src/App/Fossa/VPS/Report.hs
+++ b/src/App/Fossa/VPS/Report.hs
@@ -1,15 +1,18 @@
 module App.Fossa.VPS.Report
-  ( reportMain
-  , ReportType (..)
-  ) where
+  ( reportMain,
+    ReportType (..),
+  )
+where
 
 import App.Fossa.API.BuildWait
-import qualified App.Fossa.FossaAPIV1 as Fossa
+import App.Fossa.FossaAPIV1 qualified as Fossa
 import App.Fossa.ProjectInference
+import App.Fossa.VPS.Scan.Core qualified as VPSCore
+import App.Fossa.VPS.Scan.ScotlandYard qualified as ScotlandYard
 import App.Types
 import Control.Carrier.Diagnostics
 import Control.Effect.Lift (sendIO)
-import qualified Data.Aeson as Aeson
+import Data.Aeson qualified as Aeson
 import Data.Functor (void)
 import Data.Text (Text)
 import Data.Text.IO (hPutStrLn)
@@ -19,24 +22,23 @@ import Effect.ReadFS
 import Fossa.API.Types (ApiOpts)
 import System.Exit (exitFailure, exitSuccess)
 import System.IO (stderr)
-import qualified App.Fossa.VPS.Scan.Core as VPSCore
-import qualified App.Fossa.VPS.Scan.ScotlandYard as ScotlandYard
 
-data ReportType =
-    AttributionReport
+data ReportType
+  = AttributionReport
 
 reportName :: ReportType -> Text
 reportName r = case r of
   AttributionReport -> "attribution"
 
 reportMain ::
-  BaseDir
-  -> ApiOpts
-  -> Severity
-  -> Int -- ^ timeout (seconds)
-  -> ReportType
-  -> OverrideProject
-  -> IO ()
+  BaseDir ->
+  ApiOpts ->
+  Severity ->
+  -- | timeout (seconds)
+  Int ->
+  ReportType ->
+  OverrideProject ->
+  IO ()
 reportMain (BaseDir basedir) apiOpts logSeverity timeoutSeconds reportType override = do
   -- TODO: refactor this code duplicate from `fossa test`
   {-
@@ -50,38 +52,40 @@ reportMain (BaseDir basedir) apiOpts logSeverity timeoutSeconds reportType overr
   * Timeout over `IO a` (easy to move, but where do we move it?)
   * CLI command refactoring as laid out in https://github.com/fossas/issues/issues/129
   -}
-  void $ timeout timeoutSeconds $ withLogger logSeverity $ do
-    result <- runDiagnostics . runReadFSIO $ do
-      revision <- mergeOverride override <$> (inferProjectFromVCS basedir <||> inferProjectCached basedir <||> inferProjectDefault basedir)
+  void $
+    timeout timeoutSeconds $
+      withLogger logSeverity $ do
+        result <- runDiagnostics . runReadFSIO $ do
+          revision <- mergeOverride override <$> (inferProjectFromVCS basedir <||> inferProjectCached basedir <||> inferProjectDefault basedir)
 
-      logSticky "[ Getting latest scan ID ]"
+          logSticky "[ Getting latest scan ID ]"
 
-      Fossa.Organization orgId _ <- Fossa.getOrganization apiOpts
-      let locator = VPSCore.createLocator (projectName revision) orgId
+          Fossa.Organization orgId _ <- Fossa.getOrganization apiOpts
+          let locator = VPSCore.createLocator (projectName revision) orgId
 
-      scan <- ScotlandYard.getLatestScan apiOpts locator (projectRevision revision)
+          scan <- ScotlandYard.getLatestScan apiOpts locator (projectRevision revision)
 
-      logSticky "[ Waiting for component scan... ]"
+          logSticky "[ Waiting for component scan... ]"
 
-      waitForSherlockScan apiOpts locator (ScotlandYard.responseScanId scan)
+          waitForSherlockScan apiOpts locator (ScotlandYard.responseScanId scan)
 
-      logSticky "[ Waiting for issue scan completion... ]"
-      _ <- waitForIssues apiOpts revision
-      logSticky ""
+          logSticky "[ Waiting for issue scan completion... ]"
+          _ <- waitForIssues apiOpts revision
+          logSticky ""
 
-      logSticky $ "[ Fetching " <> pretty (reportName reportType) <> " report... ]"
-      jsonValue <- case reportType of
-        AttributionReport ->
-          Fossa.getAttributionRaw apiOpts revision
-      logSticky ""
+          logSticky $ "[ Fetching " <> pretty (reportName reportType) <> " report... ]"
+          jsonValue <- case reportType of
+            AttributionReport ->
+              Fossa.getAttributionRaw apiOpts revision
+          logSticky ""
 
-      logStdout . pretty . decodeUtf8 $ Aeson.encode jsonValue
+          logStdout . pretty . decodeUtf8 $ Aeson.encode jsonValue
 
-    case result of
-      Left err -> do
-        logError $ renderFailureBundle err
-        sendIO exitFailure
-      Right _ -> sendIO exitSuccess
+        case result of
+          Left err -> do
+            logError $ renderFailureBundle err
+            sendIO exitFailure
+          Right _ -> sendIO exitSuccess
 
   hPutStrLn stderr "Timed out while waiting for build/issues scan"
   exitFailure

--- a/src/App/Fossa/VPS/Scan/Core.hs
+++ b/src/App/Fossa/VPS/Scan/Core.hs
@@ -1,30 +1,30 @@
 {-# LANGUAGE DataKinds #-}
 
 module App.Fossa.VPS.Scan.Core
-  ( createLocator
-  , createRevisionLocator
-  , getSherlockInfo
-  , Locator(..)
-  , RevisionLocator(..)
-  , SherlockInfo(..)
+  ( createLocator,
+    createRevisionLocator,
+    getSherlockInfo,
+    Locator (..),
+    RevisionLocator (..),
+    SherlockInfo (..),
   )
 where
 
 import App.Fossa.VPS.Types
-import Data.Text (pack, Text)
-import Prelude
-import Network.HTTP.Req
 import Control.Carrier.Trace.Printing
 import Control.Effect.Diagnostics
 import Control.Effect.Lift (Lift)
 import Data.Aeson
-import Fossa.API.Types (useApiOpts, ApiOpts(..))
+import Data.Text (Text, pack)
+import Fossa.API.Types (ApiOpts (..), useApiOpts)
+import Network.HTTP.Req
+import Prelude
 
 data SherlockInfo = SherlockInfo
-  { sherlockUrl :: Text
-  , sherlockClientToken :: Text
-  , sherlockClientId :: Text
-  , sherlockOrgId :: Int
+  { sherlockUrl :: Text,
+    sherlockClientToken :: Text,
+    sherlockClientId :: Text,
+    sherlockOrgId :: Int
   }
   deriving (Eq, Ord, Show)
 
@@ -33,12 +33,12 @@ instance FromJSON SherlockInfo where
     auth <- obj .: "auth"
     SherlockInfo <$> obj .: "url" <*> auth .: "clientToken" <*> auth .: "clientId" <*> obj .: "orgId"
 
-newtype Locator = Locator { unLocator :: Text }
+newtype Locator = Locator {unLocator :: Text}
 
 createLocator :: Text -> Int -> Locator
 createLocator projectName organizationId = Locator $ "custom+" <> pack (show organizationId) <> "/" <> projectName
 
-newtype RevisionLocator = RevisionLocator { unRevisionLocator :: Text }
+newtype RevisionLocator = RevisionLocator {unRevisionLocator :: Text}
 
 createRevisionLocator :: Text -> Int -> Text -> RevisionLocator
 createRevisionLocator projectName organizationId revision = do
@@ -52,5 +52,5 @@ sherlockInfoEndpoint baseurl = baseurl /: "api" /: "vendored-package-scan" /: "s
 getSherlockInfo :: (Has (Lift IO) sig m, Has Diagnostics sig m) => ApiOpts -> m SherlockInfo
 getSherlockInfo apiOpts = runHTTP $ do
   (baseUrl, baseOptions) <- useApiOpts apiOpts
-  resp <- req GET (sherlockInfoEndpoint baseUrl) NoReqBody jsonResponse (baseOptions <> header "Content-Type" "application/json" )
+  resp <- req GET (sherlockInfoEndpoint baseUrl) NoReqBody jsonResponse (baseOptions <> header "Content-Type" "application/json")
   pure (responseBody resp)

--- a/src/App/Fossa/VPS/Scan/RunWiggins.hs
+++ b/src/App/Fossa/VPS/Scan/RunWiggins.hs
@@ -1,41 +1,42 @@
 {-# LANGUAGE RecordWildCards #-}
 
 module App.Fossa.VPS.Scan.RunWiggins
-  ( execWiggins
-  , generateWigginsScanOpts
-  , generateWigginsAOSPNoticeOpts
-  , WigginsOpts(..)
-  , ScanType(..)
+  ( execWiggins,
+    generateWigginsScanOpts,
+    generateWigginsAOSPNoticeOpts,
+    WigginsOpts (..),
+    ScanType (..),
   )
 where
 
-import App.Fossa.VPS.Types
-    ( FilterExpressions (FilterExpressions),
-      NinjaFilePaths (unNinjaFilePaths),
-      NinjaScanID (unNinjaScanID),
-      encodeFilterExpressions )
 import App.Fossa.EmbeddedBinary
+import App.Fossa.VPS.Types
+  ( FilterExpressions (FilterExpressions),
+    NinjaFilePaths (unNinjaFilePaths),
+    NinjaScanID (unNinjaScanID),
+    encodeFilterExpressions,
+  )
+import App.Types
 import Control.Carrier.Error.Either
 import Control.Effect.Diagnostics
+import Data.ByteString.Lazy qualified as BL
 import Data.Text (Text)
-import qualified Data.Text as T
+import Data.Text qualified as T
+import Data.Text.Encoding (decodeUtf8)
 import Effect.Exec
-import Path
 import Effect.Logger
 import Fossa.API.Types
-import App.Types
+import Path
 import Text.URI
-import qualified Data.ByteString.Lazy as BL
-import Data.Text.Encoding ( decodeUtf8 )
 
 data ScanType = ScanType
-  { scanSkipIpr :: Bool
-  , scanLicenseOnly :: Bool
+  { scanSkipIpr :: Bool,
+    scanLicenseOnly :: Bool
   }
 
 data WigginsOpts = WigginsOpts
-  { scanDir :: Path Abs Dir
-  , spectrometerArgs :: [Text]
+  { scanDir :: Path Abs Dir,
+    spectrometerArgs :: [Text]
   }
 
 generateWigginsScanOpts :: Path Abs Dir -> Severity -> ProjectRevision -> ScanType -> FilterExpressions -> ApiOpts -> ProjectMetadata -> WigginsOpts
@@ -47,33 +48,33 @@ generateWigginsAOSPNoticeOpts scanDir logSeverity apiOpts projectRevision ninjaS
   WigginsOpts scanDir $ generateSpectrometerAOSPNoticeArgs logSeverity apiOpts projectRevision ninjaScanId ninjaInputFiles
 
 generateSpectrometerAOSPNoticeArgs :: Severity -> ApiOpts -> ProjectRevision -> NinjaScanID -> NinjaFilePaths -> [Text]
-generateSpectrometerAOSPNoticeArgs logSeverity ApiOpts{..} ProjectRevision{..} ninjaScanId ninjaInputFiles =
+generateSpectrometerAOSPNoticeArgs logSeverity ApiOpts {..} ProjectRevision {..} ninjaScanId ninjaInputFiles =
   ["aosp-notice-files"]
-      ++ optBool "-debug" (logSeverity == SevDebug)
-      ++ optMaybeText "-endpoint" (render <$> apiOptsUri)
-      ++ ["-fossa-api-key", unApiKey apiOptsApiKey]
-      ++ ["-scan-id", unNinjaScanID ninjaScanId]
-      ++ ["-name", projectName]
-      ++ ["."]
-      ++ (T.pack . toFilePath <$> unNinjaFilePaths ninjaInputFiles)
+    ++ optBool "-debug" (logSeverity == SevDebug)
+    ++ optMaybeText "-endpoint" (render <$> apiOptsUri)
+    ++ ["-fossa-api-key", unApiKey apiOptsApiKey]
+    ++ ["-scan-id", unNinjaScanID ninjaScanId]
+    ++ ["-name", projectName]
+    ++ ["."]
+    ++ (T.pack . toFilePath <$> unNinjaFilePaths ninjaInputFiles)
 
 generateSpectrometerScanArgs :: Severity -> ProjectRevision -> ScanType -> FilterExpressions -> ApiOpts -> ProjectMetadata -> [Text]
-generateSpectrometerScanArgs logSeverity ProjectRevision{..} ScanType{..} fileFilters ApiOpts{..} ProjectMetadata{..} =
-    "analyze"
-      : optMaybeText "-endpoint" (render <$> apiOptsUri)
-      ++ ["-fossa-api-key", unApiKey apiOptsApiKey]
-      ++ ["-name", projectName, "-revision", projectRevision]
-      ++ optMaybeText "-jira-project-key" projectJiraKey
-      ++ optMaybeText "-link" projectLink
-      ++ optMaybeText "-policy" projectPolicy
-      ++ optMaybeText "-project-url" projectUrl
-      ++ optMaybeText "-team" projectTeam
-      ++ optMaybeText "-title" projectTitle
-      ++ optBool "-license-only" scanLicenseOnly
-      ++ optBool "-skip-ipr-scan" scanSkipIpr
-      ++ optBool "-debug" (logSeverity == SevDebug)
-      ++ optFilterExpressions fileFilters
-      ++ ["."]
+generateSpectrometerScanArgs logSeverity ProjectRevision {..} ScanType {..} fileFilters ApiOpts {..} ProjectMetadata {..} =
+  "analyze" :
+  optMaybeText "-endpoint" (render <$> apiOptsUri)
+    ++ ["-fossa-api-key", unApiKey apiOptsApiKey]
+    ++ ["-name", projectName, "-revision", projectRevision]
+    ++ optMaybeText "-jira-project-key" projectJiraKey
+    ++ optMaybeText "-link" projectLink
+    ++ optMaybeText "-policy" projectPolicy
+    ++ optMaybeText "-project-url" projectUrl
+    ++ optMaybeText "-team" projectTeam
+    ++ optMaybeText "-title" projectTitle
+    ++ optBool "-license-only" scanLicenseOnly
+    ++ optBool "-skip-ipr-scan" scanSkipIpr
+    ++ optBool "-debug" (logSeverity == SevDebug)
+    ++ optFilterExpressions fileFilters
+    ++ ["."]
 
 optFilterExpressions :: FilterExpressions -> [Text]
 optFilterExpressions (FilterExpressions []) = []
@@ -91,7 +92,7 @@ execWiggins :: (Has Exec sig m, Has Diagnostics sig m) => BinaryPaths -> Wiggins
 execWiggins binaryPaths opts = decodeUtf8 . BL.toStrict <$> execThrow (scanDir opts) (wigginsCommand binaryPaths opts)
 
 wigginsCommand :: BinaryPaths -> WigginsOpts -> Command
-wigginsCommand bin WigginsOpts{..} = do
+wigginsCommand bin WigginsOpts {..} = do
   Command
     { cmdName = T.pack $ fromAbsFile $ toExecutablePath bin,
       cmdArgs = spectrometerArgs,

--- a/src/App/Fossa/VPS/Test.hs
+++ b/src/App/Fossa/VPS/Test.hs
@@ -5,14 +5,14 @@ module App.Fossa.VPS.Test
 where
 
 import App.Fossa.API.BuildWait
-import qualified App.Fossa.FossaAPIV1 as Fossa
+import App.Fossa.FossaAPIV1 qualified as Fossa
 import App.Fossa.ProjectInference
-import qualified App.Fossa.VPS.Scan.Core as VPSCore
-import qualified App.Fossa.VPS.Scan.ScotlandYard as ScotlandYard
+import App.Fossa.VPS.Scan.Core qualified as VPSCore
+import App.Fossa.VPS.Scan.ScotlandYard qualified as ScotlandYard
 import App.Types
 import Control.Carrier.Diagnostics hiding (fromMaybe)
 import Control.Effect.Lift (sendIO)
-import qualified Data.Aeson as Aeson
+import Data.Aeson qualified as Aeson
 import Data.Text.IO (hPutStrLn)
 import Data.Text.Lazy.Encoding (decodeUtf8)
 import Effect.Exec
@@ -67,10 +67,9 @@ testMain (BaseDir basedir) apiOpts logSeverity timeoutSeconds outputType overrid
           logError $ "Test failed. Number of issues found: " <> pretty n
           if null (issuesIssues issues)
             then logError "Check the webapp for more details, or use a full-access API key (currently using a push-only API key)"
-            else
-              case outputType of
-                TestOutputPretty -> pure ()
-                TestOutputJson -> logStdout . pretty . decodeUtf8 . Aeson.encode $ issues
+            else case outputType of
+              TestOutputPretty -> pure ()
+              TestOutputJson -> logStdout . pretty . decodeUtf8 . Aeson.encode $ issues
           sendIO exitFailure
 
     case result of

--- a/src/App/Fossa/VPS/Types.hs
+++ b/src/App/Fossa/VPS/Types.hs
@@ -3,36 +3,37 @@
 {-# LANGUAGE UndecidableInstances #-}
 
 module App.Fossa.VPS.Types
-( FilterExpressions(..)
-, DepsTarget(..)
-, DepsDependency(..)
-, runHTTP
-, encodeFilterExpressions
-, HTTP(..)
-, HTTPRequestFailed(..)
-, VPSOpts (..)
-, NinjaGraphOpts (..)
-, NinjaScanID (..)
-, NinjaFilePaths (..)
-) where
+  ( FilterExpressions (..),
+    DepsTarget (..),
+    DepsDependency (..),
+    runHTTP,
+    encodeFilterExpressions,
+    HTTP (..),
+    HTTPRequestFailed (..),
+    VPSOpts (..),
+    NinjaGraphOpts (..),
+    NinjaScanID (..),
+    NinjaFilePaths (..),
+  )
+where
 
-import Control.Monad.IO.Class (MonadIO(..))
 import Control.Carrier.Diagnostics
 import Control.Effect.Lift (Lift, sendIO)
-import Data.Text (Text)
+import Control.Monad.IO.Class (MonadIO (..))
 import Data.Aeson
+import Data.ByteString.Lazy qualified as BSL
+import Data.Text (Text)
+import Data.Text.Encoding (decodeUtf8)
+import Data.Text.Prettyprint.Doc (viaShow)
 import Fossa.API.Types (ApiOpts)
 import Network.HTTP.Req
-import Data.Text.Prettyprint.Doc (viaShow)
-import qualified Data.ByteString.Lazy as BSL
-import Data.Text.Encoding (decodeUtf8)
 import Path
 
-newtype NinjaScanID = NinjaScanID { unNinjaScanID :: Text }
+newtype NinjaScanID = NinjaScanID {unNinjaScanID :: Text}
 
-newtype NinjaFilePaths = NinjaFilePaths { unNinjaFilePaths :: [Path Abs File] }
+newtype NinjaFilePaths = NinjaFilePaths {unNinjaFilePaths :: [Path Abs File]}
 
-newtype FilterExpressions = FilterExpressions { unFilterExpressions :: [Text] }
+newtype FilterExpressions = FilterExpressions {unFilterExpressions :: [Text]}
 
 encodeFilterExpressions :: FilterExpressions -> Text
 encodeFilterExpressions filters = decodeUtf8 $ BSL.toStrict $ encode (unFilterExpressions filters)
@@ -46,48 +47,53 @@ instance ToJSON FilterExpressions where
 -- FIXME: replace these with non-CLI types
 -- VPSOpts in particular is used as a God type, and is very unwieldy in the merged CLI form.
 data VPSOpts = VPSOpts
-  { vpsProjectName :: Text
-  , userProvidedRevision :: Maybe Text  -- FIXME: Since we can now infer a revision, we should rename this field.
-  , skipIprScan :: Bool
-  , fileFilter :: FilterExpressions
+  { vpsProjectName :: Text,
+    userProvidedRevision :: Maybe Text, -- FIXME: Since we can now infer a revision, we should rename this field.
+    skipIprScan :: Bool,
+    fileFilter :: FilterExpressions
   }
+
 -- end FIXME
 
 data DepsTarget = DepsTarget
-  { targetPath :: Text
-  , targetDependencies :: [DepsDependency]
-  , targetInputs :: [DepsDependency]
-  , targetComponentName :: Maybe Text
-  } deriving (Eq, Ord, Show)
+  { targetPath :: Text,
+    targetDependencies :: [DepsDependency],
+    targetInputs :: [DepsDependency],
+    targetComponentName :: Maybe Text
+  }
+  deriving (Eq, Ord, Show)
 
 instance ToJSON DepsTarget where
-  toJSON DepsTarget{..} = object
-    [ "path" .= targetPath
-    , "dependencies" .= targetDependencies
-    , "inputs" .= targetInputs
-    , "componentName" .=  targetComponentName
-    ]
+  toJSON DepsTarget {..} =
+    object
+      [ "path" .= targetPath,
+        "dependencies" .= targetDependencies,
+        "inputs" .= targetInputs,
+        "componentName" .= targetComponentName
+      ]
 
 data DepsDependency = DepsDependency
-  { dependencyPath :: Text
-  , dependencyComponentName :: Maybe Text
-  , hasDependencies :: Bool
-  } deriving (Eq, Ord, Show)
+  { dependencyPath :: Text,
+    dependencyComponentName :: Maybe Text,
+    hasDependencies :: Bool
+  }
+  deriving (Eq, Ord, Show)
 
 instance ToJSON DepsDependency where
-  toJSON DepsDependency{..} = object
-    [ "path" .= dependencyPath
-    , "componentName" .= dependencyComponentName
-    , "hasDependencies" .= hasDependencies
-    ]
+  toJSON DepsDependency {..} =
+    object
+      [ "path" .= dependencyPath,
+        "componentName" .= dependencyComponentName,
+        "hasDependencies" .= hasDependencies
+      ]
 
 data NinjaGraphOpts = NinjaGraphOpts
-  { ninjaFossaOpts :: ApiOpts
-  , ninjaGraphNinjaPath :: Maybe FilePath
-  , lunchTarget :: Maybe Text
-  , scanId :: Text
-  , ninjaProjectName :: Text
-  , buildName :: Text
+  { ninjaFossaOpts :: ApiOpts,
+    ninjaGraphNinjaPath :: Maybe FilePath,
+    lunchTarget :: Maybe Text,
+    scanId :: Text,
+    ninjaProjectName :: Text,
+    buildName :: Text
   }
 
 newtype HTTP m a = HTTP {unHTTP :: m a}

--- a/src/App/OptionExtensions.hs
+++ b/src/App/OptionExtensions.hs
@@ -1,10 +1,10 @@
 module App.OptionExtensions (uriOption, jsonOption) where
 
-import qualified Data.Text as T
-import Options.Applicative
-import Text.URI (URI, mkURI)
 import Data.Aeson
 import Data.String
+import Data.Text qualified as T
+import Options.Applicative
+import Text.URI (URI, mkURI)
 
 uriOption :: Mod OptionFields URI -> Parser URI
 uriOption = option parseUri

--- a/src/App/Pathfinder/Main.hs
+++ b/src/App/Pathfinder/Main.hs
@@ -1,6 +1,7 @@
 module App.Pathfinder.Main
-  ( appMain
-  ) where
+  ( appMain,
+  )
+where
 
 import App.Pathfinder.Scan (scanMain)
 import App.Types (BaseDir (..))
@@ -24,21 +25,25 @@ appMain = do
           scanMain (unBaseDir resolved) debug
 
 data CommandOpts = LicenseScan (Maybe FilePath) Bool
-  deriving Show
+  deriving (Show)
 
 opts :: ParserInfo CommandOpts
-opts = info (commands <**> helper)
-  ( fullDesc <> header "pathfinder - finds declared licenses in manifest files")
+opts =
+  info
+    (commands <**> helper)
+    (fullDesc <> header "pathfinder - finds declared licenses in manifest files")
 
 commands :: Parser CommandOpts
-commands = hsubparser
-  ( command "scan" scanCmd
-  -- <> command "other" -- etc
-  )
+commands =
+  hsubparser
+    ( command "scan" scanCmd
+    -- <> command "other" -- etc
+    )
 
 scanCmd :: ParserInfo CommandOpts
-scanCmd = info
-  (LicenseScan <$> optional (strOption $ long "basedir" <> short 'd' <> metavar "DIR" <> help "Base directory for scanning")
-           <*> (fromMaybe False <$> optional (switch $ long "debug" <> help "Enable debug logging"))
-  )
-  (progDesc "Scan for licenses")
+scanCmd =
+  info
+    ( LicenseScan <$> optional (strOption $ long "basedir" <> short 'd' <> metavar "DIR" <> help "Base directory for scanning")
+        <*> (fromMaybe False <$> optional (switch $ long "debug" <> help "Enable debug logging"))
+    )
+    (progDesc "Scan for licenses")

--- a/src/App/Types.hs
+++ b/src/App/Types.hs
@@ -19,19 +19,21 @@ data OverrideProject = OverrideProject
   }
 
 data ProjectMetadata = ProjectMetadata
-  { projectTitle :: Maybe Text
-  , projectUrl :: Maybe Text
-  , projectJiraKey :: Maybe Text
-  , projectLink :: Maybe Text
-  , projectTeam :: Maybe Text
-  , projectPolicy :: Maybe Text
-  } deriving (Eq, Ord, Show)
+  { projectTitle :: Maybe Text,
+    projectUrl :: Maybe Text,
+    projectJiraKey :: Maybe Text,
+    projectLink :: Maybe Text,
+    projectTeam :: Maybe Text,
+    projectPolicy :: Maybe Text
+  }
+  deriving (Eq, Ord, Show)
 
 data ProjectRevision = ProjectRevision
-  { projectName :: Text
-  , projectRevision :: Text
-  , projectBranch :: Maybe Text
-  } deriving (Eq, Ord, Show)
+  { projectName :: Text,
+    projectRevision :: Text,
+    projectBranch :: Maybe Text
+  }
+  deriving (Eq, Ord, Show)
 
 data NinjaGraphCLIOptions = NinjaGraphCLIOptions
   { ninjaBaseDir :: FilePath,

--- a/src/App/Util.hs
+++ b/src/App/Util.hs
@@ -1,16 +1,16 @@
 {-# LANGUAGE DataKinds #-}
 
 module App.Util
-  ( validateDir
-  , validateFile
+  ( validateDir,
+    validateFile,
   )
 where
 
 import App.Types
 import Control.Monad (unless)
-import qualified Path.IO as P
+import Path (Abs, File, Path)
+import Path.IO qualified as P
 import System.Exit (die)
-import Path ( Path, Abs, File )
 
 -- | Validate that a filepath points to a directory and the directory exists
 validateDir :: FilePath -> IO BaseDir

--- a/src/App/Version.hs
+++ b/src/App/Version.hs
@@ -9,7 +9,7 @@ where
 
 import App.Version.TH (getCurrentTag)
 import Data.Text (Text)
-import qualified Data.Text as T
+import Data.Text qualified as T
 import Data.Version (showVersion)
 import GitHash (GitInfo, giBranch, giDirty, giHash, tGitInfoCwd)
 import System.Info (compilerName, compilerVersion)

--- a/src/App/Version/TH.hs
+++ b/src/App/Version/TH.hs
@@ -7,11 +7,11 @@ where
 
 import Control.Carrier.Diagnostics (resultValue, runDiagnostics)
 import Control.Effect.Diagnostics (Diagnostics, fromEitherShow)
-import qualified Data.ByteString.Lazy as BSL
+import Data.ByteString.Lazy qualified as BSL
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
-import qualified Data.Text as T
-import qualified Data.Text.Encoding as TE
+import Data.Text qualified as T
+import Data.Text.Encoding qualified as TE
 import Data.Versions (errorBundlePretty, semver)
 import Effect.Exec
   ( AllowErr (Always),

--- a/src/Control/Carrier/TaskPool.hs
+++ b/src/Control/Carrier/TaskPool.hs
@@ -4,78 +4,84 @@
 {-# LANGUAGE UndecidableInstances #-}
 
 module Control.Carrier.TaskPool
-  ( withTaskPool
-  , TaskPoolC
+  ( withTaskPool,
+    TaskPoolC,
+    Progress (..),
+    module X,
+  )
+where
 
-  , Progress(..)
-
-  , module X
-  ) where
-
-import Control.Monad (replicateM, join)
-import Control.Effect.Exception
-import Control.Effect.TaskPool as X
 import Control.Carrier.Reader
 import Control.Carrier.Threaded
 import Control.Concurrent.STM
+import Control.Effect.Exception
 import Control.Effect.Lift (sendIO)
+import Control.Effect.TaskPool as X
+import Control.Monad (join, replicateM)
 import Control.Monad.IO.Class (MonadIO)
-import Control.Monad.Trans (MonadTrans(..))
+import Control.Monad.Trans (MonadTrans (..))
 import Data.Foldable (traverse_)
 import Data.Functor (void)
 
-withTaskPool :: Has (Lift IO) sig m
-  => Int -- number of workers
-  -> (Progress -> m ()) -- get progress updates
-  -> TaskPoolC m a
-  -> m ()
+withTaskPool ::
+  Has (Lift IO) sig m =>
+  Int -> -- number of workers
+  (Progress -> m ()) -> -- get progress updates
+  TaskPoolC m a ->
+  m ()
 withTaskPool numWorkers reportProgress act = do
-  state <- sendIO $
-    State <$> newTVarIO []
-          <*> newTVarIO 0
-          <*> newTVarIO 0
-          <*> newEmptyTMVarIO
+  state <-
+    sendIO $
+      State <$> newTVarIO []
+        <*> newTVarIO 0
+        <*> newTVarIO 0
+        <*> newEmptyTMVarIO
 
-  let enqueue action = sendIO $ atomically $ modifyTVar (stQueued state) (action:)
+  let enqueue action = sendIO $ atomically $ modifyTVar (stQueued state) (action :)
   sendIO $ (enqueue (void (runTaskPool (stQueued state) act)))
 
   let mkThreads = do
         workerHandles <- replicateM numWorkers (fork (worker state))
         progressHandle <- fork (updateProgress reportProgress state)
-        pure (progressHandle:workerHandles)
+        pure (progressHandle : workerHandles)
 
   let cleanup handles = traverse_ kill handles
 
-  let waitForCompletion _ = join $ sendIO $ atomically $ do
-        maybeErr <- tryReadTMVar $ stError state
-        case maybeErr of
-          Just err -> pure $ throwIO err
-          Nothing -> do
-            queued  <- readTVar (stQueued state)
-            check (null queued)
-            running <- readTVar (stRunning state)
-            check (running == 0)
-            pure $ pure ()
+  let waitForCompletion _ = join $
+        sendIO $
+          atomically $ do
+            maybeErr <- tryReadTMVar $ stError state
+            case maybeErr of
+              Just err -> pure $ throwIO err
+              Nothing -> do
+                queued <- readTVar (stQueued state)
+                check (null queued)
+                running <- readTVar (stRunning state)
+                check (running == 0)
+                pure $ pure ()
 
   bracket mkThreads cleanup waitForCompletion
 
 updateProgress :: Has (Lift IO) sig m => (Progress -> m ()) -> State any -> m ()
-updateProgress f st@State{..} = do
+updateProgress f st@State {..} = do
   loop (Progress 0 0 0)
   where
-  loop prev = join $ sendIO $ atomically $ stopWhenDone st $ do
-    running <- readTVar stRunning
-    queued <- length <$> readTVar stQueued
-    completed <- readTVar stCompleted
+    loop prev = join $
+      sendIO $
+        atomically $
+          stopWhenDone st $ do
+            running <- readTVar stRunning
+            queued <- length <$> readTVar stQueued
+            completed <- readTVar stCompleted
 
-    let new = Progress running queued completed
+            let new = Progress running queued completed
 
-    check (prev /= new)
+            check (prev /= new)
 
-    pure $ f new *> loop new
+            pure $ f new *> loop new
 
 stopWhenDone :: Applicative m => State any -> STM (m ()) -> STM (m ())
-stopWhenDone State{..} act = do
+stopWhenDone State {..} act = do
   queued <- readTVar stQueued
   case queued of
     [] -> do
@@ -86,41 +92,44 @@ stopWhenDone State{..} act = do
     _ -> act
 
 worker :: (Has (Lift IO) sig m) => State m -> m ()
-worker st@State{..} = loop
+worker st@State {..} = loop
   where
+    loop = join $
+      sendIO $
+        atomically $
+          stopWhenDone st $ do
+            queued <- readTVar stQueued
+            case queued of
+              [] -> retry
+              (x : xs) -> do
+                writeTVar stQueued xs
+                addRunning
+                pure $
+                  mask $ \restore -> do
+                    res <- try $ restore x
+                    case res of
+                      Left err -> do
+                        _ <- sendIO $ atomically $ tryPutTMVar stError err
+                        pure ()
+                      Right () -> complete *> loop
 
-  loop = join $ sendIO $ atomically $ stopWhenDone st $ do
-    queued <- readTVar stQueued
-    case queued of
-      [] -> retry
-      (x:xs) -> do
-        writeTVar stQueued xs
-        addRunning
-        pure $
-          mask $ \restore -> do
-            res <- try $ restore x
-            case res of
-              Left err -> do
-                _ <- sendIO $ atomically $ tryPutTMVar stError err
-                pure ()
-              Right () -> complete *> loop
+    addRunning :: STM ()
+    addRunning = modifyTVar stRunning (+ 1)
 
-  addRunning :: STM ()
-  addRunning = modifyTVar stRunning (+1)
-
-  complete :: Has (Lift IO) sig m => m ()
-  complete = sendIO $ atomically $ modifyTVar stRunning (subtract 1) *> modifyTVar stCompleted (+1)
+    complete :: Has (Lift IO) sig m => m ()
+    complete = sendIO $ atomically $ modifyTVar stRunning (subtract 1) *> modifyTVar stCompleted (+ 1)
 
 runTaskPool :: TVar [m ()] -> TaskPoolC m a -> m a
 runTaskPool var = runReader var . runTaskPoolC
 
 data Progress = Progress
-  { pRunning   :: Int
-  , pQueued    :: Int
-  , pCompleted :: Int
-  } deriving (Eq, Ord, Show)
+  { pRunning :: Int,
+    pQueued :: Int,
+    pCompleted :: Int
+  }
+  deriving (Eq, Ord, Show)
 
-newtype TaskPoolC m a = TaskPoolC { runTaskPoolC :: ReaderC (TVar [m ()]) m a }
+newtype TaskPoolC m a = TaskPoolC {runTaskPoolC :: ReaderC (TVar [m ()]) m a}
   deriving (Functor, Applicative, Monad, MonadIO, MonadFail)
 
 instance MonadTrans TaskPoolC where
@@ -130,13 +139,13 @@ instance (Has (Lift IO) sig m, Algebra sig m) => Algebra (TaskPool :+: sig) (Tas
   alg hdl sig ctx = TaskPoolC $ case sig of
     L (ForkTask m) -> do
       var <- ask @(TVar [m ()])
-      sendIO $ atomically $ modifyTVar' var (runReader var (runTaskPoolC (void (hdl (m <$ ctx)))):)
+      sendIO $ atomically $ modifyTVar' var (runReader var (runTaskPoolC (void (hdl (m <$ ctx)))) :)
       pure ctx
     R other -> alg (runTaskPoolC . hdl) (R other) ctx
 
 data State m = State
-  { stQueued    :: TVar [m ()]
-  , stRunning   :: TVar Int
-  , stCompleted :: TVar Int
-  , stError     :: TMVar SomeException
+  { stQueued :: TVar [m ()],
+    stRunning :: TVar Int,
+    stCompleted :: TVar Int,
+    stError :: TMVar SomeException
   }

--- a/src/Control/Carrier/Threaded.hs
+++ b/src/Control/Carrier/Threaded.hs
@@ -7,8 +7,8 @@ module Control.Carrier.Threaded
 where
 
 import Control.Carrier.Lift
-import qualified Control.Concurrent as Conc
-import qualified Control.Concurrent.Async as Async
+import Control.Concurrent qualified as Conc
+import Control.Concurrent.Async qualified as Async
 import Control.Concurrent.STM
 import Control.Effect.Exception
 import Control.Monad.IO.Class

--- a/src/Control/Effect/AtomicState.hs
+++ b/src/Control/Effect/AtomicState.hs
@@ -7,7 +7,7 @@ module Control.Effect.AtomicState
   ( AtomicState (..),
     modify,
     get,
-    put
+    put,
   )
 where
 
@@ -21,7 +21,7 @@ modify :: Has (AtomicState s) sig m => (s -> s) -> m ()
 modify f = send (Modify (\s -> (f s, ())))
 
 get :: Has (AtomicState s) sig m => m s
-get = send (Modify (\s -> (s,s)))
+get = send (Modify (\s -> (s, s)))
 
 put :: Has (AtomicState s) sig m => s -> m ()
-put s = send (Modify (const (s,())))
+put s = send (Modify (const (s, ())))

--- a/src/Control/Effect/Diagnostics.hs
+++ b/src/Control/Effect/Diagnostics.hs
@@ -31,11 +31,11 @@ where
 
 import Control.Algebra as X
 import Control.Exception (SomeException (..))
-import qualified Data.List.NonEmpty as NE
+import Data.List.NonEmpty qualified as NE
 import Data.Maybe (catMaybes)
 import Data.Semigroup (sconcat)
 import Data.Text (Text)
-import qualified Data.Text as T
+import Data.Text qualified as T
 import Data.Text.Prettyprint.Doc
 import Data.Text.Prettyprint.Doc.Render.Terminal (AnsiStyle)
 import Prelude

--- a/src/Control/Effect/Output.hs
+++ b/src/Control/Effect/Output.hs
@@ -1,10 +1,11 @@
 {-# LANGUAGE GADTs #-}
 
 module Control.Effect.Output
-  ( Output(..)
-  , output
-  , module X
-  ) where
+  ( Output (..),
+    output,
+    module X,
+  )
+where
 
 import Control.Algebra as X
 import Data.Kind (Type)

--- a/src/Control/Effect/Path.hs
+++ b/src/Control/Effect/Path.hs
@@ -6,7 +6,7 @@ where
 
 import Control.Effect.Lift
 import Path
-import qualified Path.IO as PIO
+import Path.IO qualified as PIO
 import Prelude
 
 withSystemTempDir ::

--- a/src/Control/Effect/Record.hs
+++ b/src/Control/Effect/Record.hs
@@ -18,15 +18,15 @@ import Control.Effect.Lift
 import Control.Effect.Sum
 import Control.Monad.Trans
 import Data.Aeson
-import qualified Data.ByteString as BS
-import qualified Data.ByteString.Lazy as BL
+import Data.ByteString qualified as BS
+import Data.ByteString.Lazy qualified as BL
 import Data.Kind
 import Data.Map.Strict (Map)
-import qualified Data.Map.Strict as M
-import qualified Data.Text as Text
-import qualified Data.Text.Encoding as Encoding
-import qualified Data.Text.Lazy as LText
-import qualified Data.Text.Lazy.Encoding as LEncoding
+import Data.Map.Strict qualified as M
+import Data.Text qualified as Text
+import Data.Text.Encoding qualified as Encoding
+import Data.Text.Lazy qualified as LText
+import Data.Text.Lazy.Encoding qualified as LEncoding
 import Path
 import System.Exit
 import Unsafe.Coerce

--- a/src/Control/Effect/Record/TH.hs
+++ b/src/Control/Effect/Record/TH.hs
@@ -19,9 +19,9 @@ deriveRecordable tyName = do
         (pure [])
         (appT [t|Recordable|] (appT (conT tyName) (varT (mkName "m"))))
         -- recordKey :: ...
-        [ recordKeyMethod tyCons
-        -- recordValue :: ...
-        , recordValueMethod tyCons
+        [ recordKeyMethod tyCons,
+          -- recordValue :: ...
+          recordValueMethod tyCons
         ]
     ]
 

--- a/src/Control/Effect/Replay.hs
+++ b/src/Control/Effect/Replay.hs
@@ -5,32 +5,32 @@
 module Control.Effect.Replay
   ( Replayable (..),
     ReplayableValue (..),
-    runReplay
+    runReplay,
   )
 where
 
 import Control.Algebra
+import Control.Applicative
 import Control.Carrier.Reader
 import Control.Effect.Lift
+import Control.Effect.Record
 import Control.Effect.Sum
 import Control.Monad.Trans
 import Data.Aeson
+import Data.Aeson.Types (Parser)
+import Data.ByteString qualified as BS
+import Data.ByteString.Lazy qualified as BL
 import Data.Kind
 import Data.Map.Strict (Map)
-import qualified Data.Text as Text
-import qualified Data.Text.Lazy as LText
-import Control.Effect.Record
-import Unsafe.Coerce
-import qualified Data.Map.Strict as M
-import Data.Aeson.Types (Parser)
-import Control.Applicative
-import qualified Data.Text as T
-import qualified Data.Text.Encoding as Encoding
-import qualified Data.ByteString as BS
-import qualified Data.ByteString.Lazy as BL
-import qualified Data.Text.Lazy.Encoding as LEncoding
+import Data.Map.Strict qualified as M
+import Data.Text qualified as T
+import Data.Text qualified as Text
+import Data.Text.Encoding qualified as Encoding
+import Data.Text.Lazy qualified as LText
+import Data.Text.Lazy.Encoding qualified as LEncoding
 import Path
 import System.Exit
+import Unsafe.Coerce
 
 -- | A class of "replayable" effects -- i.e. an effect whose "result values"
 -- (the @a@ in @e m a@) can be deserialized from JSON values produced by
@@ -113,39 +113,39 @@ instance (ReplayableValue a, ReplayableValue b) => ReplayableValue (Either a b) 
   fromRecordedValue = withObject "Either" $ \obj -> do
     (Left <$> (obj .: "Left" >>= fromRecordedValue)) <|> (Right <$> (obj .: "Right" >>= fromRecordedValue))
 
-instance (ReplayableValue a, ReplayableValue b) => ReplayableValue (a,b) where
+instance (ReplayableValue a, ReplayableValue b) => ReplayableValue (a, b) where
   fromRecordedValue val = do
-    [a,b] <- fromRecordedValue val
+    [a, b] <- fromRecordedValue val
     (,) <$> fromRecordedValue a <*> fromRecordedValue b
 
-instance (ReplayableValue a, ReplayableValue b, ReplayableValue c) => ReplayableValue (a,b,c) where
+instance (ReplayableValue a, ReplayableValue b, ReplayableValue c) => ReplayableValue (a, b, c) where
   fromRecordedValue val = do
-    [a,b,c] <- fromRecordedValue val
+    [a, b, c] <- fromRecordedValue val
     (,,) <$> fromRecordedValue a <*> fromRecordedValue b <*> fromRecordedValue c
 
-instance (ReplayableValue a, ReplayableValue b, ReplayableValue c, ReplayableValue d) => ReplayableValue (a,b,c,d) where
+instance (ReplayableValue a, ReplayableValue b, ReplayableValue c, ReplayableValue d) => ReplayableValue (a, b, c, d) where
   fromRecordedValue val = do
-    [a,b,c,d] <- fromRecordedValue val
+    [a, b, c, d] <- fromRecordedValue val
     (,,,) <$> fromRecordedValue a <*> fromRecordedValue b <*> fromRecordedValue c <*> fromRecordedValue d
 
-instance (ReplayableValue a, ReplayableValue b, ReplayableValue c, ReplayableValue d, ReplayableValue e) => ReplayableValue (a,b,c,d,e) where
+instance (ReplayableValue a, ReplayableValue b, ReplayableValue c, ReplayableValue d, ReplayableValue e) => ReplayableValue (a, b, c, d, e) where
   fromRecordedValue val = do
-    [a,b,c,d,e] <- fromRecordedValue val
+    [a, b, c, d, e] <- fromRecordedValue val
     (,,,,) <$> fromRecordedValue a <*> fromRecordedValue b <*> fromRecordedValue c <*> fromRecordedValue d <*> fromRecordedValue e
 
-instance (ReplayableValue a, ReplayableValue b, ReplayableValue c, ReplayableValue d, ReplayableValue e, ReplayableValue f) => ReplayableValue (a,b,c,d,e,f) where
+instance (ReplayableValue a, ReplayableValue b, ReplayableValue c, ReplayableValue d, ReplayableValue e, ReplayableValue f) => ReplayableValue (a, b, c, d, e, f) where
   fromRecordedValue val = do
-    [a,b,c,d,e,f] <- fromRecordedValue val
+    [a, b, c, d, e, f] <- fromRecordedValue val
     (,,,,,) <$> fromRecordedValue a <*> fromRecordedValue b <*> fromRecordedValue c <*> fromRecordedValue d <*> fromRecordedValue e <*> fromRecordedValue f
 
-instance (ReplayableValue a, ReplayableValue b, ReplayableValue c, ReplayableValue d, ReplayableValue e, ReplayableValue f, ReplayableValue g) => ReplayableValue (a,b,c,d,e,f,g) where
+instance (ReplayableValue a, ReplayableValue b, ReplayableValue c, ReplayableValue d, ReplayableValue e, ReplayableValue f, ReplayableValue g) => ReplayableValue (a, b, c, d, e, f, g) where
   fromRecordedValue val = do
-    [a,b,c,d,e,f,g] <- fromRecordedValue val
+    [a, b, c, d, e, f, g] <- fromRecordedValue val
     (,,,,,,) <$> fromRecordedValue a <*> fromRecordedValue b <*> fromRecordedValue c <*> fromRecordedValue d <*> fromRecordedValue e <*> fromRecordedValue f <*> fromRecordedValue g
 
-instance (ReplayableValue a, ReplayableValue b, ReplayableValue c, ReplayableValue d, ReplayableValue e, ReplayableValue f, ReplayableValue g, ReplayableValue h) => ReplayableValue (a,b,c,d,e,f,g,h) where
+instance (ReplayableValue a, ReplayableValue b, ReplayableValue c, ReplayableValue d, ReplayableValue e, ReplayableValue f, ReplayableValue g, ReplayableValue h) => ReplayableValue (a, b, c, d, e, f, g, h) where
   fromRecordedValue val = do
-    [a,b,c,d,e,f,g,h] <- fromRecordedValue val
+    [a, b, c, d, e, f, g, h] <- fromRecordedValue val
     (,,,,,,,) <$> fromRecordedValue a <*> fromRecordedValue b <*> fromRecordedValue c <*> fromRecordedValue d <*> fromRecordedValue e <*> fromRecordedValue f <*> fromRecordedValue g <*> fromRecordedValue h
 
 ----- Additional instances
@@ -157,8 +157,11 @@ instance ReplayableValue BL.ByteString where
   fromRecordedValue = fmap LEncoding.encodeUtf8 . parseJSON
 
 instance ReplayableValue (Path Abs Dir)
+
 instance ReplayableValue (Path Abs File)
+
 instance ReplayableValue (Path Rel Dir)
+
 instance ReplayableValue (Path Rel File)
 
 instance ReplayableValue ExitCode where

--- a/src/Control/Effect/Replay/TH.hs
+++ b/src/Control/Effect/Replay/TH.hs
@@ -6,10 +6,10 @@ module Control.Effect.Replay.TH
 where
 
 import Control.Effect.Replay
-import Language.Haskell.TH
 import Control.Monad (replicateM)
 import Data.Aeson
 import Data.Aeson.Types (parse)
+import Language.Haskell.TH
 
 deriveReplayable :: Name -> Q [Dec]
 deriveReplayable tyName = do

--- a/src/Control/Effect/TaskPool.hs
+++ b/src/Control/Effect/TaskPool.hs
@@ -1,10 +1,11 @@
 {-# LANGUAGE GADTs #-}
 
 module Control.Effect.TaskPool
-  ( TaskPool(..)
-  , forkTask
-  , module X
-  ) where
+  ( TaskPool (..),
+    forkTask,
+    module X,
+  )
+where
 
 import Control.Algebra as X
 

--- a/src/Control/Exception/Extra.hs
+++ b/src/Control/Exception/Extra.hs
@@ -5,7 +5,7 @@ module Control.Exception.Extra
 where
 
 import Control.Effect.Exception
-import Control.Effect.Lift
+import Control.Effect.Lift ()
 
 safeCatch :: (Exception e, Has (Lift IO) sig m) => m a -> (e -> m a) -> m a
 safeCatch act hdl = act `catch` (\e -> if isSyncException e then hdl e else throwIO e)

--- a/src/Control/Exception/Extra.hs
+++ b/src/Control/Exception/Extra.hs
@@ -4,8 +4,8 @@ module Control.Exception.Extra
   )
 where
 
-import Control.Effect.Lift
 import Control.Effect.Exception
+import Control.Effect.Lift
 
 safeCatch :: (Exception e, Has (Lift IO) sig m) => m a -> (e -> m a) -> m a
 safeCatch act hdl = act `catch` (\e -> if isSyncException e then hdl e else throwIO e)

--- a/src/Data/Text/Extra.hs
+++ b/src/Data/Text/Extra.hs
@@ -9,8 +9,8 @@ where
 
 import Data.ByteString (ByteString)
 import Data.Text (Text)
-import qualified Data.Text as T
-import qualified Data.Text.Encoding as TE
+import Data.Text qualified as T
+import Data.Text.Encoding qualified as TE
 
 splitOnceOn :: Text -> Text -> (Text, Text)
 splitOnceOn needle haystack = (first, strippedRemaining)
@@ -37,8 +37,9 @@ splitOnceOnEnd needle haystack = (strippedInitial, end)
 -- Nothing
 breakOnAndRemove :: Text -> Text -> Maybe (Text, Text)
 breakOnAndRemove needle haystack
-  | (before,after) <- T.breakOn needle haystack
-  , T.isPrefixOf needle after = Just (before, T.drop (T.length needle) after)
+  | (before, after) <- T.breakOn needle haystack,
+    T.isPrefixOf needle after =
+    Just (before, T.drop (T.length needle) after)
   | otherwise = Nothing
 
 underBS :: (ByteString -> ByteString) -> Text -> Text

--- a/src/DepTypes.hs
+++ b/src/DepTypes.hs
@@ -2,113 +2,145 @@
 {-# LANGUAGE RecordWildCards #-}
 
 module DepTypes
-  ( Dependency(..)
-  , insertEnvironment
-  , insertTag
-  , insertLocation
-  , DepEnvironment(..)
-  , DepType(..)
-  , VerConstraint(..)
-  ) where
+  ( Dependency (..),
+    insertEnvironment,
+    insertTag,
+    insertLocation,
+    DepEnvironment (..),
+    DepType (..),
+    VerConstraint (..),
+  )
+where
 
 import Data.Aeson
 import Data.Map.Strict (Map)
+import Data.Map.Strict qualified as M
 import Data.Text (Text)
-import qualified Data.Map.Strict as M
 import GHC.Generics (Generic)
 
 -- FIXME: this needs a smart constructor with empty tags/environments/etc.
 -- We've historically relied on the compile error for making sure we fill all
 -- of these fields. Tests should be used to ensure this instead.
 data Dependency = Dependency
-  { dependencyType         :: DepType
-  , dependencyName         :: Text
-  , dependencyVersion      :: Maybe VerConstraint
-  , dependencyLocations    :: [Text]
-  , dependencyEnvironments :: [DepEnvironment] -- FIXME: this should be a Set
-  , dependencyTags         :: Map Text [Text]
-  } deriving (Eq, Ord, Show)
+  { dependencyType :: DepType,
+    dependencyName :: Text,
+    dependencyVersion :: Maybe VerConstraint,
+    dependencyLocations :: [Text],
+    dependencyEnvironments :: [DepEnvironment], -- FIXME: this should be a Set
+    dependencyTags :: Map Text [Text]
+  }
+  deriving (Eq, Ord, Show)
 
 insertEnvironment :: DepEnvironment -> Dependency -> Dependency
-insertEnvironment env dep = dep { dependencyEnvironments = env : dependencyEnvironments dep }
+insertEnvironment env dep = dep {dependencyEnvironments = env : dependencyEnvironments dep}
 
 insertTag :: Text -> Text -> Dependency -> Dependency
-insertTag key value dep = dep { dependencyTags = M.insertWith (++) key [value] (dependencyTags dep) }
+insertTag key value dep = dep {dependencyTags = M.insertWith (++) key [value] (dependencyTags dep)}
 
 insertLocation :: Text -> Dependency -> Dependency
-insertLocation loc dep = dep { dependencyLocations = loc : dependencyLocations dep }
+insertLocation loc dep = dep {dependencyLocations = loc : dependencyLocations dep}
 
-data DepEnvironment =
-    EnvProduction
+data DepEnvironment
+  = EnvProduction
   | EnvDevelopment
   | EnvTesting
-  | EnvOther Text -- ^ Other environments -- specifically for things like gradle configurations
+  | -- | Other environments -- specifically for things like gradle configurations
+    EnvOther Text
   deriving (Eq, Ord, Show)
 
 -- | A Dependency type. This corresponds to a "fetcher" on the backend
-data DepType =
-    SubprojectType -- ^ A first-party subproject
-  | ComposerType -- ^ Dependency found from the composer fetcher.
-  | GitType -- ^ Repository in Github
-  | GemType    -- ^ Gem registry
-  | GooglesourceType  -- ^ android.googlesource.com
-  | HexType    -- ^ Hex registry
-  | MavenType -- ^ Maven registry
-  | NodeJSType -- ^ NPM registry (or similar)
-  | NuGetType -- ^ Nuget registry
-  | PipType    -- ^ Pip registry
-  | PodType    -- ^ Cocoapods registry
-  | GoType -- ^ Go dependency
-  | CargoType -- ^ Rust Cargo Dependency
-  | RPMType -- ^ RPM dependency
-  | URLType -- ^ URL dependency
-  | HackageType -- ^ Hackage Registry
-  -- TODO: does this break the "location" abstraction?
-  | CarthageType -- ^ A Carthage dependency -- effectively a "git" dependency. Name is repo path and version is tag/branch/hash
+data DepType
+  = -- | A first-party subproject
+    SubprojectType
+  | -- | Dependency found from the composer fetcher.
+    ComposerType
+  | -- | Repository in Github
+    GitType
+  | -- | Gem registry
+    GemType
+  | -- | android.googlesource.com
+    GooglesourceType
+  | -- | Hex registry
+    HexType
+  | -- | Maven registry
+    MavenType
+  | -- | NPM registry (or similar)
+    NodeJSType
+  | -- | Nuget registry
+    NuGetType
+  | -- | Pip registry
+    PipType
+  | -- | Cocoapods registry
+    PodType
+  | -- | Go dependency
+    GoType
+  | -- | Rust Cargo Dependency
+    CargoType
+  | -- | RPM dependency
+    RPMType
+  | -- | URL dependency
+    URLType
+  | -- | Hackage Registry
+    -- TODO: does this break the "location" abstraction?
+    HackageType
+  | -- | A Carthage dependency -- effectively a "git" dependency. Name is repo path and version is tag/branch/hash
+    CarthageType
   deriving (Eq, Ord, Show, Generic)
 
-data VerConstraint =
-    CEq Text -- ^ equal to, e.g., @CEq "2.0.0"@
-  | CURI Text -- ^ An exact version, at some URI
-  | CCompatible Text -- ^ compatible range. e.g., "~=" in python, "^>=" in haskell
-  | CAnd VerConstraint VerConstraint -- ^ Both constraints need to be satisfied, e.g., @CAnd (CGreaterOrEq "1.0.0") (CLessThan "2.0.0")@
-  | COr  VerConstraint VerConstraint -- ^ At least one constraint needs to be satisfied
-  | CLess Text -- ^ less than
-  | CLessOrEq Text -- ^ less than or equal to
-  | CGreater Text -- ^ greater than
-  | CGreaterOrEq Text -- ^ greater than or equal to
-  | CNot Text -- ^ not this version
+data VerConstraint
+  = -- | equal to, e.g., @CEq "2.0.0"@
+    CEq Text
+  | -- | An exact version, at some URI
+    CURI Text
+  | -- | compatible range. e.g., "~=" in python, "^>=" in haskell
+    CCompatible Text
+  | -- | Both constraints need to be satisfied, e.g., @CAnd (CGreaterOrEq "1.0.0") (CLessThan "2.0.0")@
+    CAnd VerConstraint VerConstraint
+  | -- | At least one constraint needs to be satisfied
+    COr VerConstraint VerConstraint
+  | -- | less than
+    CLess Text
+  | -- | less than or equal to
+    CLessOrEq Text
+  | -- | greater than
+    CGreater Text
+  | -- | greater than or equal to
+    CGreaterOrEq Text
+  | -- | not this version
+    CNot Text
   deriving (Eq, Ord, Show)
 
 instance FromJSON DepType -- use the generic instance
+
 instance ToJSON DepType -- use the generic instance
 
 instance ToJSON Dependency where
-  toJSON Dependency{..} = object
-    [ "type"      .= dependencyType
-    , "name"      .= dependencyName
-    , "version"   .= dependencyVersion
-    , "locations" .= dependencyLocations
-    , "tags"      .= dependencyTags
-    ]
+  toJSON Dependency {..} =
+    object
+      [ "type" .= dependencyType,
+        "name" .= dependencyName,
+        "version" .= dependencyVersion,
+        "locations" .= dependencyLocations,
+        "tags" .= dependencyTags
+      ]
 
 instance ToJSON VerConstraint where
-  toJSON constraint = let (name, value) = toValue constraint
-                       in object [ "type"  .= name
-                                 , "value" .= value
-                                 ]
-
+  toJSON constraint =
+    let (name, value) = toValue constraint
+     in object
+          [ "type" .= name,
+            "value" .= value
+          ]
     where
-
-    toValue :: VerConstraint -> (Text, Value)
-    toValue = \case
-      CEq text -> ("EQUAL", toJSON text)
-      CURI text -> ("URI", toJSON text)
-      CCompatible text -> ("COMPATIBLE", toJSON text)
-      CAnd a b -> ("AND", toJSON [toJSON a, toJSON b])
-      COr a b -> ("OR", toJSON [toJSON a, toJSON b])
-      CLess text -> ("LESSTHAN", toJSON text)
-      CLessOrEq text -> ("LESSOREQUAL", toJSON text)
-      CGreater text -> ("GREATERTHAN", toJSON text)
-      CGreaterOrEq text -> ("GREATEROREQUAL", toJSON text)
-      CNot text -> ("NOT", toJSON text)
+      toValue :: VerConstraint -> (Text, Value)
+      toValue = \case
+        CEq text -> ("EQUAL", toJSON text)
+        CURI text -> ("URI", toJSON text)
+        CCompatible text -> ("COMPATIBLE", toJSON text)
+        CAnd a b -> ("AND", toJSON [toJSON a, toJSON b])
+        COr a b -> ("OR", toJSON [toJSON a, toJSON b])
+        CLess text -> ("LESSTHAN", toJSON text)
+        CLessOrEq text -> ("LESSOREQUAL", toJSON text)
+        CGreater text -> ("GREATERTHAN", toJSON text)
+        CGreaterOrEq text -> ("GREATEROREQUAL", toJSON text)
+        CNot text -> ("NOT", toJSON text)

--- a/src/Discovery/Archive.hs
+++ b/src/Discovery/Archive.hs
@@ -3,22 +3,22 @@ module Discovery.Archive
   )
 where
 
-import qualified Codec.Archive.Tar as Tar
-import qualified Codec.Archive.Zip as Zip
-import qualified Codec.Compression.GZip as GZip
+import Codec.Archive.Tar qualified as Tar
+import Codec.Archive.Zip qualified as Zip
+import Codec.Compression.GZip qualified as GZip
+import Control.Carrier.Diagnostics
 import Control.Effect.Finally
 import Control.Effect.Lift
 import Control.Effect.TaskPool (TaskPool, forkTask)
-import qualified Data.ByteString.Lazy as BL
+import Data.ByteString.Lazy qualified as BL
 import Data.Foldable (traverse_)
 import Data.List (isSuffixOf)
 import Discovery.Archive.RPM (extractRpm)
 import Discovery.Walk
-import Path
-import qualified Path.IO as PIO
-import Prelude hiding (zip)
-import Control.Carrier.Diagnostics
 import Effect.ReadFS (ReadFS)
+import Path
+import Path.IO qualified as PIO
+import Prelude hiding (zip)
 
 -- Given a function to run over unarchived contents, unpack archives
 discover :: (Has (Lift IO) sig m, Has ReadFS sig m, Has Diagnostics sig m, Has Finally sig m, Has TaskPool sig m) => (Path Abs Dir -> m ()) -> Path Abs Dir -> m ()

--- a/src/Discovery/Archive/RPM.hs
+++ b/src/Discovery/Archive/RPM.hs
@@ -3,22 +3,22 @@ module Discovery.Archive.RPM
   )
 where
 
-import qualified Codec.RPM.Conduit as RPM
-import qualified Codec.RPM.Tags as Tags
-import qualified Codec.RPM.Types as RPMTypes
+import Codec.RPM.Conduit qualified as RPM
+import Codec.RPM.Tags qualified as Tags
+import Codec.RPM.Types qualified as RPMTypes
 import Conduit
 import Control.Effect.Lift
 import Control.Exception (throwIO)
 import Control.Monad.Except
-import qualified Data.ByteString as BS
-import qualified Data.ByteString.Char8 as BS8
-import qualified Data.ByteString.Lazy as BL
-import qualified Data.CPIO as CPIO
-import qualified Data.Conduit.Lzma as Lzma
-import qualified Data.Conduit.Zlib as Zlib
+import Data.ByteString qualified as BS
+import Data.ByteString.Char8 qualified as BS8
+import Data.ByteString.Lazy qualified as BL
+import Data.CPIO qualified as CPIO
+import Data.Conduit.Lzma qualified as Lzma
+import Data.Conduit.Zlib qualified as Zlib
 import Data.Foldable (asum)
 import Path
-import qualified Path.IO as PIO
+import Path.IO qualified as PIO
 import Prelude
 
 extractRpm :: Has (Lift IO) sig m => Path Abs Dir -> Path Abs File -> m ()

--- a/src/Discovery/Filters.hs
+++ b/src/Discovery/Filters.hs
@@ -6,13 +6,13 @@ module Discovery.Filters
   )
 where
 
-import qualified Data.List.NonEmpty as NE
+import Data.List.NonEmpty qualified as NE
 import Data.Maybe (mapMaybe)
 import Data.Semigroup (sconcat)
 import Data.Set (Set)
-import qualified Data.Set as S
+import Data.Set qualified as S
 import Data.Text (Text)
-import qualified Data.Text as T
+import Data.Text qualified as T
 import Data.Void (Void)
 import Path
 import Text.Megaparsec

--- a/src/Discovery/Projects.hs
+++ b/src/Discovery/Projects.hs
@@ -3,14 +3,14 @@ module Discovery.Projects
   )
 where
 
-import qualified Control.Carrier.Diagnostics as Diag
+import Control.Carrier.Diagnostics qualified as Diag
 import Control.Effect.Finally
 import Control.Effect.Lift
 import Control.Effect.TaskPool
 import Control.Monad (when)
 import Control.Monad.IO.Class (MonadIO)
 import Data.Foldable (for_, traverse_)
-import qualified Discovery.Archive as Archive
+import Discovery.Archive qualified as Archive
 import Effect.Logger
 import Effect.ReadFS (ReadFS)
 import Path
@@ -36,7 +36,6 @@ withDiscoveredProjects discoverFuncs unpackArchives basedir f = do
   when unpackArchives $ do
     res <- Diag.runDiagnosticsIO $ Archive.discover (\dir -> liftFoo $ withDiscoveredProjects discoverFuncs unpackArchives dir f) basedir
     Diag.withResult SevError res (const (pure ()))
-
 
 liftFoo :: m a -> Diag.DiagnosticsC m a
 liftFoo = undefined

--- a/src/Discovery/Walk.hs
+++ b/src/Discovery/Walk.hs
@@ -18,9 +18,9 @@ import Data.Foldable (find)
 import Data.Functor (void)
 import Data.List ((\\))
 import Data.Maybe (mapMaybe)
-import qualified Data.Set as S
+import Data.Set qualified as S
 import Data.Text (Text)
-import qualified Data.Text as T
+import Data.Text qualified as T
 import Effect.ReadFS
 import Path
 

--- a/src/Effect/Exec.hs
+++ b/src/Effect/Exec.hs
@@ -1,7 +1,7 @@
-{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -34,12 +34,12 @@ import Control.Exception (IOException, try)
 import Control.Monad.IO.Class (MonadIO)
 import Data.Aeson
 import Data.Bifunctor (first)
-import qualified Data.ByteString.Lazy as BL
+import Data.ByteString.Lazy qualified as BL
 import Data.Kind (Type)
 import Data.String (fromString)
 import Data.Text (Text)
-import qualified Data.Text as T
-import qualified Data.Text.Lazy as TL
+import Data.Text qualified as T
+import Data.Text.Lazy qualified as TL
 import Data.Text.Lazy.Encoding (decodeUtf8)
 import Data.Text.Prettyprint.Doc (pretty, viaShow)
 import Data.Void (Void)
@@ -62,6 +62,7 @@ data Command = Command
   deriving (Eq, Ord, Show, Generic)
 
 instance ToJSON Command
+
 instance RecordableValue Command
 
 data CmdFailure = CmdFailure
@@ -75,24 +76,27 @@ data CmdFailure = CmdFailure
   deriving (Eq, Ord, Show)
 
 instance ToJSON CmdFailure where
-  toJSON CmdFailure{..} = object
-    [ "cmdFailureName" .= cmdFailureName
-    , "cmdFailureArgs" .= cmdFailureArgs
-    , "cmdFailureDir" .= cmdFailureDir
-    , "cmdFailureExit" .= toRecordedValue cmdFailureExit
-    , "cmdFailureStdout" .= toRecordedValue cmdFailureStdout
-    , "cmdFailureStderr" .= toRecordedValue cmdFailureStderr
-    ]
+  toJSON CmdFailure {..} =
+    object
+      [ "cmdFailureName" .= cmdFailureName,
+        "cmdFailureArgs" .= cmdFailureArgs,
+        "cmdFailureDir" .= cmdFailureDir,
+        "cmdFailureExit" .= toRecordedValue cmdFailureExit,
+        "cmdFailureStdout" .= toRecordedValue cmdFailureStdout,
+        "cmdFailureStderr" .= toRecordedValue cmdFailureStderr
+      ]
+
 instance RecordableValue CmdFailure
 
 instance FromJSON CmdFailure where
   parseJSON = withObject "CmdFailure" $ \obj ->
     CmdFailure <$> obj .: "cmdFailureName"
-               <*> obj .: "cmdFailureArgs"
-               <*> obj .: "cmdFailureDir"
-               <*> (obj .: "cmdFailureExit" >>= fromRecordedValue)
-               <*> (obj .: "cmdFailureStdout" >>= fromRecordedValue)
-               <*> (obj .: "cmdFailureStderr" >>= fromRecordedValue)
+      <*> obj .: "cmdFailureArgs"
+      <*> obj .: "cmdFailureDir"
+      <*> (obj .: "cmdFailureExit" >>= fromRecordedValue)
+      <*> (obj .: "cmdFailureStdout" >>= fromRecordedValue)
+      <*> (obj .: "cmdFailureStderr" >>= fromRecordedValue)
+
 instance ReplayableValue CmdFailure
 
 data AllowErr
@@ -105,6 +109,7 @@ data AllowErr
   deriving (Eq, Ord, Show, Generic)
 
 instance ToJSON AllowErr
+
 instance RecordableValue AllowErr
 
 type Stdout = BL.ByteString

--- a/src/Effect/Grapher.hs
+++ b/src/Effect/Grapher.hs
@@ -24,7 +24,7 @@ module Effect.Grapher
     MappedGrapherC,
     mapping,
     withMapping,
-    MappingError(..),
+    MappingError (..),
 
     -- * Re-exports
     module X,
@@ -32,19 +32,19 @@ module Effect.Grapher
 where
 
 import Control.Algebra as X
-import Control.Carrier.Diagnostics (ToDiagnostic(..))
+import Control.Carrier.Diagnostics (ToDiagnostic (..))
 import Control.Carrier.State.Strict
 import Control.Monad.IO.Class (MonadIO)
 import Data.Kind (Type)
 import Data.Map.Strict (Map)
-import qualified Data.Map.Strict as M
+import Data.Map.Strict qualified as M
 import Data.Maybe (fromMaybe)
 import Data.Set (Set)
-import qualified Data.Set as S
+import Data.Set qualified as S
 import Data.Text (Text)
-import qualified Data.Text as T
+import Data.Text qualified as T
+import Graphing qualified as G
 import Prettyprinter (pretty)
-import qualified Graphing as G
 
 data Grapher ty (m :: Type -> Type) k where
   Direct :: ty -> Grapher ty m ()
@@ -167,7 +167,6 @@ unlabel f labels = G.gmap (\ty -> f ty (findLabels ty))
 -- third primitive, 'mapping'.
 --
 -- > mapping :: Has CabalGrapher sig m => UnitId -> CabalPackage -> m ()
-
 type MappedGrapher ty val = State (Map ty val) :+: Grapher ty
 
 type MappedGrapherC ty val m a = StateC (Map ty val) (GrapherC ty m) a
@@ -191,7 +190,9 @@ withMapping f act = do
   pure result
 
 -- | Errors that may occur when using 'withMapping'
-newtype MappingError = MissingKey Text -- ^ A key did not have an associated value
+newtype MappingError
+  = -- | A key did not have an associated value
+    MissingKey Text
   deriving (Eq, Ord, Show)
 
 instance ToDiagnostic MappingError where

--- a/src/Effect/Logger.hs
+++ b/src/Effect/Logger.hs
@@ -3,30 +3,27 @@
 {-# LANGUAGE UndecidableInstances #-}
 
 module Effect.Logger
-  ( Logger(..)
-  , LogMsg(..)
-  , LogQueue
-  , Severity(..)
-
-  , LoggerC(..)
-  , IgnoreLoggerC(..)
-  , withLogger
-  , withLogQueue
-  , runLogger
-  , ignoreLogger
-
-  , log
-  , logSticky
-
-  , logTrace
-  , logDebug
-  , logInfo
-  , logWarn
-  , logError
-  , logStdout
-
-  , module X
-  ) where
+  ( Logger (..),
+    LogMsg (..),
+    LogQueue,
+    Severity (..),
+    LoggerC (..),
+    IgnoreLoggerC (..),
+    withLogger,
+    withLogQueue,
+    runLogger,
+    ignoreLogger,
+    log,
+    logSticky,
+    logTrace,
+    logDebug,
+    logInfo,
+    logWarn,
+    logError,
+    logStdout,
+    module X,
+  )
+where
 
 import Control.Algebra as X
 import Control.Applicative (Alternative)
@@ -42,12 +39,12 @@ import Data.Bool (bool)
 import Data.Functor (void)
 import Data.Kind (Type)
 import Data.Text (Text)
-import qualified Data.Text as T
-import qualified Data.Text.IO as TIO
+import Data.Text qualified as T
+import Data.Text.IO qualified as TIO
 import Data.Text.Prettyprint.Doc as X
 import Data.Text.Prettyprint.Doc.Render.Terminal as X
+import System.IO (BufferMode (NoBuffering), hIsTerminalDevice, hSetBuffering, stderr, stdout)
 import Prelude hiding (log)
-import System.IO (hIsTerminalDevice, hSetBuffering, BufferMode(NoBuffering), stdout, stderr)
 
 data Logger (m :: Type -> Type) k where
   Log :: LogMsg -> Logger m ()
@@ -56,7 +53,7 @@ data LogMsg
   = LogNormal Severity (Doc AnsiStyle)
   | LogSticky (Doc AnsiStyle)
   | LogStdout (Doc AnsiStyle)
-  deriving Show
+  deriving (Show)
 
 -- | Log a message with the given severity
 log :: Has Logger sig m => Severity -> Doc AnsiStyle -> m ()
@@ -72,8 +69,8 @@ logSticky logLine = send (Log (LogSticky logLine))
 logStdout :: Has Logger sig m => Doc AnsiStyle -> m ()
 logStdout logLine = send (Log (LogStdout logLine))
 
-data Severity =
-    SevTrace
+data Severity
+  = SevTrace
   | SevDebug
   | SevInfo
   | SevWarn
@@ -112,9 +109,10 @@ withLogQueue minSeverity f = do
         atomically $ closeTMQueue queue
         void (wait tid)
 
-  bracket mkLogger
-          flushLogger
-          (\_ -> f (LogQueue queue))
+  bracket
+    mkLogger
+    flushLogger
+    (\_ -> f (LogQueue queue))
 
 runLogger :: LogQueue -> LoggerC m a -> m a
 runLogger (LogQueue queue) = runReader queue . runLoggerC
@@ -122,49 +120,49 @@ runLogger (LogQueue queue) = runReader queue . runLoggerC
 rawLogger :: Severity -> TMQueue LogMsg -> IO ()
 rawLogger minSeverity queue = go
   where
-  go = do
-    maybeMsg <- atomically $ readTMQueue queue
-    case maybeMsg of
-      Nothing -> pure ()
-      Just (LogNormal sev logLine) -> do
-        when (sev >= minSeverity) $ printIt (unAnnotate logLine <> line)
-        go
-      Just (LogSticky logLine) -> do
-        printIt (unAnnotate logLine <> line)
-        go
-      Just (LogStdout logLine) -> do
-        TIO.putStrLn (renderIt logLine)
-        go
+    go = do
+      maybeMsg <- atomically $ readTMQueue queue
+      case maybeMsg of
+        Nothing -> pure ()
+        Just (LogNormal sev logLine) -> do
+          when (sev >= minSeverity) $ printIt (unAnnotate logLine <> line)
+          go
+        Just (LogSticky logLine) -> do
+          printIt (unAnnotate logLine <> line)
+          go
+        Just (LogStdout logLine) -> do
+          TIO.putStrLn (renderIt logLine)
+          go
 
 termLogger :: Severity -> TMQueue LogMsg -> IO ()
 termLogger minSeverity queue = go ""
   where
-  go sticky = do
-    maybeMsg <- atomically $ readTMQueue queue
-    case maybeMsg of
-      Nothing -> pure ()
-      Just msg -> do
-        let stickyLen   = T.length sticky
-            clearSticky = TIO.hPutStr stderr (T.replicate stickyLen "\b" <> T.replicate stickyLen " " <> T.replicate stickyLen "\b")
-        case msg of
-          LogNormal sev logLine -> do
-            when (sev >= minSeverity) $ do
+    go sticky = do
+      maybeMsg <- atomically $ readTMQueue queue
+      case maybeMsg of
+        Nothing -> pure ()
+        Just msg -> do
+          let stickyLen = T.length sticky
+              clearSticky = TIO.hPutStr stderr (T.replicate stickyLen "\b" <> T.replicate stickyLen " " <> T.replicate stickyLen "\b")
+          case msg of
+            LogNormal sev logLine -> do
+              when (sev >= minSeverity) $ do
+                clearSticky
+                printIt $ logLine <> line
+                TIO.hPutStr stderr sticky
+              go sticky
+            LogSticky logLine -> do
               clearSticky
-              printIt $ logLine <> line
+              let rendered = renderIt logLine
+              TIO.hPutStr stderr rendered
+              go rendered
+            LogStdout logLine -> do
+              clearSticky
+              TIO.hPutStr stdout $ renderIt $ logLine <> line
               TIO.hPutStr stderr sticky
-            go sticky
-          LogSticky logLine -> do
-            clearSticky
-            let rendered = renderIt logLine
-            TIO.hPutStr stderr rendered
-            go rendered
-          LogStdout logLine -> do
-            clearSticky
-            TIO.hPutStr stdout $ renderIt $ logLine <> line
-            TIO.hPutStr stderr sticky
-            go sticky
+              go sticky
 
-newtype LoggerC m a = LoggerC { runLoggerC :: ReaderC (TMQueue LogMsg) m a }
+newtype LoggerC m a = LoggerC {runLoggerC :: ReaderC (TMQueue LogMsg) m a}
   deriving (Functor, Applicative, Alternative, Monad, MonadIO)
 
 instance (Algebra sig m, Has (Lift IO) sig m) => Algebra (Logger :+: sig) (LoggerC m) where
@@ -175,7 +173,7 @@ instance (Algebra sig m, Has (Lift IO) sig m) => Algebra (Logger :+: sig) (Logge
       pure ctx
     R other -> alg (runLoggerC . hdl) (R other) ctx
 
-newtype IgnoreLoggerC m a = IgnoreLoggerC { runIgnoreLoggerC :: m a }
+newtype IgnoreLoggerC m a = IgnoreLoggerC {runIgnoreLoggerC :: m a}
   deriving (Functor, Applicative, Monad, MonadIO)
 
 ignoreLogger :: IgnoreLoggerC m a -> m a

--- a/src/Effect/ReadFS.hs
+++ b/src/Effect/ReadFS.hs
@@ -50,15 +50,15 @@ import Control.Effect.Record
 import Control.Effect.Record.TH (deriveRecordable)
 import Control.Effect.Replay
 import Control.Effect.Replay.TH (deriveReplayable)
-import qualified Control.Exception as E
+import Control.Exception qualified as E
 import Control.Monad ((<=<))
 import Control.Monad.IO.Class
 import Data.Aeson
 import Data.ByteString (ByteString)
-import qualified Data.ByteString as BS
+import Data.ByteString qualified as BS
 import Data.Kind (Type)
 import Data.Text (Text)
-import qualified Data.Text as T
+import Data.Text qualified as T
 import Data.Text.Encoding (decodeUtf8)
 import Data.Text.Prettyprint.Doc (pretty)
 import Data.Void (Void)
@@ -66,10 +66,10 @@ import Data.Yaml (decodeEither', prettyPrintParseException)
 import GHC.Generics (Generic)
 import Parse.XML (FromXML, parseXML, xmlErrorPretty)
 import Path
-import qualified Path.IO as PIO
+import Path.IO qualified as PIO
 import Text.Megaparsec (Parsec, runParser)
 import Text.Megaparsec.Error (errorBundlePretty)
-import qualified Toml
+import Toml qualified
 
 data ReadFS (m :: Type -> Type) k where
   ReadContentsBS' :: Path x File -> ReadFS m (Either ReadFSErr ByteString)
@@ -92,9 +92,13 @@ data ReadFSErr
   deriving (Eq, Ord, Show, Generic)
 
 instance ToJSON ReadFSErr
+
 instance RecordableValue ReadFSErr
+
 instance FromJSON ReadFSErr
+
 instance ReplayableValue ReadFSErr
+
 $(deriveRecordable ''ReadFS)
 $(deriveReplayable ''ReadFS)
 

--- a/src/Fossa/API/Types.hs
+++ b/src/Fossa/API/Types.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE RecordWildCards #-}
 
 module Fossa.API.Types
   ( ApiKey (..),
@@ -18,16 +18,16 @@ import Control.Effect.Diagnostics hiding (fromMaybe)
 import Data.Aeson
 import Data.Coerce (coerce)
 import Data.Map.Strict (Map)
-import qualified Data.Map.Strict as M
+import Data.Map.Strict qualified as M
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
-import qualified Data.Text as T
-import Data.Text.Prettyprint.Doc
+import Data.Text qualified as T
 import Data.Text.Encoding (encodeUtf8)
+import Data.Text.Prettyprint.Doc
 import Network.HTTP.Req
 import Text.URI (URI, render)
-import qualified Unsafe.Coerce as Unsafe
 import Text.URI.QQ (uri)
+import Unsafe.Coerce qualified as Unsafe
 
 newtype ApiKey = ApiKey {unApiKey :: Text}
   deriving (Eq, Ord, Show)
@@ -39,10 +39,11 @@ data ApiOpts = ApiOpts
   deriving (Eq, Ord, Show)
 
 data Issues = Issues
-  { issuesCount :: Int
-  , issuesIssues :: [Issue]
-  , issuesStatus :: Text
-  } deriving (Eq, Ord, Show)
+  { issuesCount :: Int,
+    issuesIssues :: [Issue],
+    issuesStatus :: Text
+  }
+  deriving (Eq, Ord, Show)
 
 data IssueType
   = IssuePolicyConflict
@@ -63,50 +64,54 @@ renderIssueType = \case
   IssueOther other -> other
 
 data Issue = Issue
-  { issueId :: Int
-  , issuePriorityString :: Maybe Text -- we only use this field for `fossa test --json`
-  , issueResolved :: Bool
-  , issueRevisionId :: Text
-  , issueType :: IssueType
-  , issueRule :: Maybe IssueRule
-  } deriving (Eq, Ord, Show)
+  { issueId :: Int,
+    issuePriorityString :: Maybe Text, -- we only use this field for `fossa test --json`
+    issueResolved :: Bool,
+    issueRevisionId :: Text,
+    issueType :: IssueType,
+    issueRule :: Maybe IssueRule
+  }
+  deriving (Eq, Ord, Show)
 
 newtype IssueRule = IssueRule
   { ruleLicenseId :: Maybe Text
-  } deriving (Eq, Ord, Show)
+  }
+  deriving (Eq, Ord, Show)
 
 instance FromJSON Issues where
   parseJSON = withObject "Issues" $ \obj ->
     Issues <$> obj .: "count"
-           <*> obj .:? "issues" .!= []
-           <*> obj .: "status"
+      <*> obj .:? "issues" .!= []
+      <*> obj .: "status"
 
 instance ToJSON Issues where
-  toJSON Issues{..} = object
-    [ "count" .= issuesCount
-    , "issues" .= issuesIssues
-    , "status" .= issuesStatus
-    ]
+  toJSON Issues {..} =
+    object
+      [ "count" .= issuesCount,
+        "issues" .= issuesIssues,
+        "status" .= issuesStatus
+      ]
 
 instance FromJSON Issue where
   parseJSON = withObject "Issue" $ \obj ->
     Issue <$> obj .: "id"
-           <*> obj .:? "priorityString"
-           <*> obj .: "resolved"
-           -- VPS issues don't have a revisionId
-           <*> obj .:? "revisionId" .!= "unknown project"
-           <*> obj .: "type"
-           <*> obj .:? "rule"
+      <*> obj .:? "priorityString"
+      <*> obj .: "resolved"
+      -- VPS issues don't have a revisionId
+      <*> obj .:? "revisionId" .!= "unknown project"
+      <*> obj .: "type"
+      <*> obj .:? "rule"
 
 instance ToJSON Issue where
-  toJSON Issue{..} = object
-    [ "id" .= issueId
-    , "priorityString" .= issuePriorityString
-    , "resolved" .= issueResolved
-    , "revisionId" .= issueRevisionId
-    , "type" .= issueType
-    , "rule" .= issueRule
-    ]
+  toJSON Issue {..} =
+    object
+      [ "id" .= issueId,
+        "priorityString" .= issuePriorityString,
+        "resolved" .= issueResolved,
+        "revisionId" .= issueRevisionId,
+        "type" .= issueType,
+        "rule" .= issueRule
+      ]
 
 instance FromJSON IssueType where
   parseJSON = withText "IssueType" $ \case
@@ -118,20 +123,21 @@ instance FromJSON IssueType where
     other -> pure (IssueOther other)
 
 instance ToJSON IssueType where
-  toJSON = String . \case
-    IssuePolicyConflict -> "policy_conflict"
-    IssuePolicyFlag -> "policy_flag"
-    IssueVulnerability -> "vulnerability"
-    IssueUnlicensedDependency -> "unlicensed_dependency"
-    IssueOutdatedDependency -> "outdated_dependency"
-    IssueOther text -> text
+  toJSON =
+    String . \case
+      IssuePolicyConflict -> "policy_conflict"
+      IssuePolicyFlag -> "policy_flag"
+      IssueVulnerability -> "vulnerability"
+      IssueUnlicensedDependency -> "unlicensed_dependency"
+      IssueOutdatedDependency -> "outdated_dependency"
+      IssueOther text -> text
 
 instance FromJSON IssueRule where
   parseJSON = withObject "IssueRule" $ \obj ->
     IssueRule <$> obj .:? "licenseId"
 
 instance ToJSON IssueRule where
-  toJSON IssueRule{..} = object ["licenseId" .= ruleLicenseId]
+  toJSON IssueRule {..} = object ["licenseId" .= ruleLicenseId]
 
 instance Pretty Issues where
   pretty = renderedIssues
@@ -158,20 +164,23 @@ renderedIssues issues = rendered
       renderHeader issueType <> line <> vsep (map renderIssue rawIssues) <> line
 
     rendered :: Doc ann
-    rendered = vsep
-      [renderSection issueType rawIssues | (issueType,rawIssues) <- M.toList issuesByType]
+    rendered =
+      vsep
+        [renderSection issueType rawIssues | (issueType, rawIssues) <- M.toList issuesByType]
 
     renderHeader :: IssueType -> Doc ann
-    renderHeader ty = vsep
-      [ "========================================================================"
-      , pretty $ renderIssueType ty
-      , "========================================================================"
-      , hsep $ map (fill padding) $ case ty of
-          IssuePolicyConflict -> ["Dependency", "Revision", "License"]
-          IssuePolicyFlag -> ["Dependency", "Revision", "License"]
-          _ -> ["Dependency", "Revision"]
-      , ""
-      ]
+    renderHeader ty =
+      vsep
+        [ "========================================================================",
+          pretty $ renderIssueType ty,
+          "========================================================================",
+          hsep $
+            map (fill padding) $ case ty of
+              IssuePolicyConflict -> ["Dependency", "Revision", "License"]
+              IssuePolicyFlag -> ["Dependency", "Revision", "License"]
+              _ -> ["Dependency", "Revision"],
+          ""
+        ]
 
     renderIssue :: Issue -> Doc ann
     renderIssue issue = hsep (map format [name, revision, license])
@@ -190,7 +199,6 @@ renderedIssues issues = rendered
           | length xs <= ix = Nothing
           | otherwise = Just (xs !! ix)
 
-
 -- | parse a URI for use as a base Url, along with some default options (auth, port, ...)
 useApiOpts :: Has Diagnostics sig m => ApiOpts -> m (Url 'Https, Option 'Https)
 useApiOpts opts = case useURI serverURI of
@@ -200,7 +208,7 @@ useApiOpts opts = case useURI serverURI of
   -- scheme, so we can coerce as usual.
   Just (Left (url, options)) -> pure (Unsafe.unsafeCoerce url, coerce options <> authHeader (apiOptsApiKey opts))
   Just (Right (url, options)) -> pure (url, options <> authHeader (apiOptsApiKey opts))
-  where 
+  where
     serverURI = fromMaybe [uri|https://app.fossa.com|] (apiOptsUri opts)
 
 authHeader :: ApiKey -> Option 'Https

--- a/src/Parse/XML.hs
+++ b/src/Parse/XML.hs
@@ -43,36 +43,36 @@
 -- >     Foo <$> optional (child "baz" el) `defaultsTo` "defaultbaz"
 module Parse.XML
   ( -- * Types
-    FromXML(..)
-  , Parser(..)
-  , parseXML
+    FromXML (..),
+    Parser (..),
+    parseXML,
 
-  -- * Parsing an XML element
-  , attr
-  , child
-  , children
-  , content
+    -- * Parsing an XML element
+    attr,
+    child,
+    children,
+    content,
 
-  -- * Helper functions
-  , defaultsTo
+    -- * Helper functions
+    defaultsTo,
 
-  -- * Error formatting
-  , ParseError(..)
-  , ParsePath
-  , xmlErrorPretty
-  ) where
-
-import Prelude
+    -- * Error formatting
+    ParseError (..),
+    ParsePath,
+    xmlErrorPretty,
+  )
+where
 
 import Control.Algebra
 import Control.Carrier.Error.Either
 import Control.Carrier.NonDet.Church
 import Control.Carrier.Reader
 import Data.Functor.Identity (Identity)
-import qualified Data.Map.Strict as M
-import qualified Data.Text as T
+import Data.Map.Strict qualified as M
 import Data.Maybe (fromMaybe)
-import qualified Text.XML.Light as XML
+import Data.Text qualified as T
+import Text.XML.Light qualified as XML
+import Prelude
 
 -- | A type that can be converted from XML
 --
@@ -91,13 +91,13 @@ instance FromXML T.Text where
 instance FromXML v => FromXML (M.Map T.Text v) where
   parseElement el = M.fromList <$> traverse mkSingle (XML.elChildren el)
     where
-    mkSingle e = do
-      let key :: T.Text
-          key = T.pack (XML.qName (XML.elName e))
-      value <- parseElement e
-      pure (key, value)
+      mkSingle e = do
+        let key :: T.Text
+            key = T.pack (XML.qName (XML.elName e))
+        value <- parseElement e
+        pure (key, value)
 
-newtype Parser a = Parser { unParser :: ReaderC ParsePath (ErrorC ParseError Identity) a }
+newtype Parser a = Parser {unParser :: ReaderC ParsePath (ErrorC ParseError Identity) a}
   deriving (Functor, Applicative, Monad)
 
 instance Alternative Parser where
@@ -110,11 +110,15 @@ instance MonadFail Parser where
 runParser :: String -> Parser a -> Either ParseError a
 runParser rootName = run . runError . runReader [rootName] . unParser
 
-data ParseError =
-    ParseElementMissing ParsePath String -- ^ A 'child' element was missing
-  | ParseAttrMissing ParsePath String -- ^ An 'attr' was missing
-  | ParseXMLDocFailed -- ^ The input 'T.Text' didn't contain valid XML
-  | UnknownError ParsePath String -- ^ A custom error, likely invoked via 'fail'
+data ParseError
+  = -- | A 'child' element was missing
+    ParseElementMissing ParsePath String
+  | -- | An 'attr' was missing
+    ParseAttrMissing ParsePath String
+  | -- | The input 'T.Text' didn't contain valid XML
+    ParseXMLDocFailed
+  | -- | A custom error, likely invoked via 'fail'
+    UnknownError ParsePath String
   deriving (Eq, Ord, Show)
 
 -- | Pretty-print a ParseError into strict 'T.Text'
@@ -154,7 +158,7 @@ attr :: String -> XML.Element -> Parser T.Text
 attr attrName el =
   case XML.findAttrBy (\elName -> XML.qName elName == attrName) el of
     Nothing -> Parser $ ask >>= \path -> throwError (ParseAttrMissing path attrName)
-    Just a  -> pure (T.pack a)
+    Just a -> pure (T.pack a)
 
 -- | Find a child of an XML Element by its name. This will fail if a child with
 -- the given name does not exist
@@ -170,7 +174,7 @@ child :: FromXML a => String -> XML.Element -> Parser a
 child childName el =
   case XML.filterChildName (\elName -> XML.qName elName == childName) el of
     Nothing -> Parser $ ask >>= \path -> throwError (ParseElementMissing path childName)
-    Just a  -> subparse childName a
+    Just a -> subparse childName a
 
 -- | Find all children of an XML element with a given name. __This never
 -- fails__, and will return an empty list if no elements are found.
@@ -212,4 +216,4 @@ defaultsTo fa a = fmap (fromMaybe a) fa
 
 -- parse a child element, and add its name to the parse path
 subparse :: FromXML a => String -> XML.Element -> Parser a
-subparse path el = Parser $ local (path:) (unParser (parseElement el))
+subparse path el = Parser $ local (path :) (unParser (parseElement el))

--- a/src/Srclib/Converter.hs
+++ b/src/Srclib/Converter.hs
@@ -2,25 +2,25 @@
 {-# LANGUAGE RecordWildCards #-}
 
 module Srclib.Converter
-  ( toSourceUnit
-  ) where
+  ( toSourceUnit,
+  )
+where
 
-import Prelude
-
-import qualified Algebra.Graph.AdjacencyMap as AM
+import Algebra.Graph.AdjacencyMap qualified as AM
 import App.Fossa.Analyze.Project
 import Control.Applicative ((<|>))
+import Data.Set qualified as Set
 import Data.Text (Text)
-import qualified Data.Text as Text
-import qualified Data.Set as Set
+import Data.Text qualified as Text
 import DepTypes
 import Graphing (Graphing)
-import qualified Graphing
+import Graphing qualified
 import Path (toFilePath)
 import Srclib.Types
+import Prelude
 
 toSourceUnit :: ProjectResult -> SourceUnit
-toSourceUnit ProjectResult{..} =
+toSourceUnit ProjectResult {..} =
   SourceUnit
     { sourceUnitName = renderedPath,
       sourceUnitType = projectResultType,
@@ -52,13 +52,14 @@ toSourceUnit ProjectResult{..} =
     imports = Set.toList $ Graphing.graphingDirect locatorGraph
 
 mkSourceUnitDependency :: AM.AdjacencyMap Locator -> Locator -> SourceUnitDependency
-mkSourceUnitDependency gr locator = SourceUnitDependency
-  { sourceDepLocator = locator
-  , sourceDepImports = Set.toList $ AM.postSet locator gr
-  }
+mkSourceUnitDependency gr locator =
+  SourceUnitDependency
+    { sourceDepLocator = locator,
+      sourceDepImports = Set.toList $ AM.postSet locator gr
+    }
 
 shouldPublishDep :: Dependency -> Bool
-shouldPublishDep Dependency{dependencyEnvironments} =
+shouldPublishDep Dependency {dependencyEnvironments} =
   null dependencyEnvironments || EnvProduction `elem` dependencyEnvironments || any isOtherEnv dependencyEnvironments
 
 isOtherEnv :: DepEnvironment -> Bool
@@ -67,14 +68,15 @@ isOtherEnv _ = False
 
 -- core can't handle subprojects
 isSupportedType :: Dependency -> Bool
-isSupportedType Dependency{dependencyType} = dependencyType /= SubprojectType && dependencyType /= GooglesourceType
+isSupportedType Dependency {dependencyType} = dependencyType /= SubprojectType && dependencyType /= GooglesourceType
 
 toLocator :: Dependency -> Locator
-toLocator dep = Locator
-  { locatorFetcher = depTypeToFetcher (dependencyType dep)
-  , locatorProject = dependencyName dep
-  , locatorRevision = verConstraintToRevision =<< dependencyVersion dep
-  }
+toLocator dep =
+  Locator
+    { locatorFetcher = depTypeToFetcher (dependencyType dep),
+      locatorProject = dependencyName dep,
+      locatorRevision = verConstraintToRevision =<< dependencyVersion dep
+    }
 
 verConstraintToRevision :: VerConstraint -> Maybe Text
 verConstraintToRevision = \case

--- a/src/Srclib/Types.hs
+++ b/src/Srclib/Types.hs
@@ -1,77 +1,88 @@
 {-# LANGUAGE RecordWildCards #-}
 
 module Srclib.Types
-  ( SourceUnit(..)
-  , SourceUnitBuild(..)
-  , SourceUnitDependency(..)
-  , Locator(..)
-  , renderLocator
-  , parseLocator
-  ) where
+  ( SourceUnit (..),
+    SourceUnitBuild (..),
+    SourceUnitDependency (..),
+    Locator (..),
+    renderLocator,
+    parseLocator,
+  )
+where
 
 import Data.Aeson
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
-import qualified Data.Text as T
+import Data.Text qualified as T
 
 data SourceUnit = SourceUnit
-  { sourceUnitName :: Text
-  , sourceUnitType :: Text
-  , sourceUnitManifest :: Text -- ^ path to manifest file
-  , sourceUnitBuild :: SourceUnitBuild
-  } deriving (Eq, Ord, Show)
+  { sourceUnitName :: Text,
+    sourceUnitType :: Text,
+    -- | path to manifest file
+    sourceUnitManifest :: Text,
+    sourceUnitBuild :: SourceUnitBuild
+  }
+  deriving (Eq, Ord, Show)
 
 data SourceUnitBuild = SourceUnitBuild
-  { buildArtifact :: Text -- ^ always "default"
-  , buildSucceeded :: Bool -- ^ always true
-  , buildImports :: [Locator]
-  , buildDependencies :: [SourceUnitDependency]
-  } deriving (Eq, Ord, Show)
+  { -- | always "default"
+    buildArtifact :: Text,
+    -- | always true
+    buildSucceeded :: Bool,
+    buildImports :: [Locator],
+    buildDependencies :: [SourceUnitDependency]
+  }
+  deriving (Eq, Ord, Show)
 
 data SourceUnitDependency = SourceUnitDependency
-  { sourceDepLocator :: Locator
-  , sourceDepImports :: [Locator] -- omitempty
-  -- , sourceDepData :: Aeson.Value
-  } deriving (Eq, Ord, Show)
+  { sourceDepLocator :: Locator,
+    sourceDepImports :: [Locator] -- omitempty
+    -- , sourceDepData :: Aeson.Value
+  }
+  deriving (Eq, Ord, Show)
 
 data Locator = Locator
-  { locatorFetcher :: Text
-  , locatorProject :: Text
-  , locatorRevision :: Maybe Text
-  } deriving (Eq, Ord, Show)
+  { locatorFetcher :: Text,
+    locatorProject :: Text,
+    locatorRevision :: Maybe Text
+  }
+  deriving (Eq, Ord, Show)
 
 renderLocator :: Locator -> Text
-renderLocator Locator{..} =
+renderLocator Locator {..} =
   locatorFetcher <> "+" <> locatorProject <> "$" <> fromMaybe "" locatorRevision
 
 parseLocator :: Text -> Locator
 parseLocator raw = Locator fetcher project (if T.null revision then Nothing else Just revision)
   where
-    (fetcher,xs) = T.breakOn "+" raw
-    (project,xs') = T.breakOn "$" (T.drop 1 xs)
+    (fetcher, xs) = T.breakOn "+" raw
+    (project, xs') = T.breakOn "$" (T.drop 1 xs)
     revision = T.drop 1 xs'
 
 instance ToJSON SourceUnit where
-  toJSON SourceUnit{..} = object
-    [ "Name" .= sourceUnitName
-    , "Type" .= sourceUnitType
-    , "Manifest" .= sourceUnitManifest
-    , "Build" .= sourceUnitBuild
-    ]
+  toJSON SourceUnit {..} =
+    object
+      [ "Name" .= sourceUnitName,
+        "Type" .= sourceUnitType,
+        "Manifest" .= sourceUnitManifest,
+        "Build" .= sourceUnitBuild
+      ]
 
 instance ToJSON SourceUnitBuild where
-  toJSON SourceUnitBuild{..} = object
-    [ "Artifact" .= buildArtifact
-    , "Succeeded" .= buildSucceeded
-    , "Imports" .= buildImports
-    , "Dependencies" .= buildDependencies
-    ]
+  toJSON SourceUnitBuild {..} =
+    object
+      [ "Artifact" .= buildArtifact,
+        "Succeeded" .= buildSucceeded,
+        "Imports" .= buildImports,
+        "Dependencies" .= buildDependencies
+      ]
 
 instance ToJSON SourceUnitDependency where
-  toJSON SourceUnitDependency{..} = object
-    [ "locator" .= sourceDepLocator
-    , "imports" .= sourceDepImports
-    ]
+  toJSON SourceUnitDependency {..} =
+    object
+      [ "locator" .= sourceDepLocator,
+        "imports" .= sourceDepImports
+      ]
 
 instance ToJSON Locator where
   -- render as text

--- a/src/Strategy/Bundler.hs
+++ b/src/Strategy/Bundler.hs
@@ -7,14 +7,14 @@ module Strategy.Bundler
 where
 
 import Control.Effect.Diagnostics (Diagnostics, (<||>))
-import qualified Control.Effect.Diagnostics as Diag
+import Control.Effect.Diagnostics qualified as Diag
 import Discovery.Walk
 import Effect.Exec
 import Effect.ReadFS
 import Graphing
 import Path
-import qualified Strategy.Ruby.BundleShow as BundleShow
-import qualified Strategy.Ruby.GemfileLock as GemfileLock
+import Strategy.Ruby.BundleShow qualified as BundleShow
+import Strategy.Ruby.GemfileLock qualified as GemfileLock
 import Types
 
 discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has ReadFS rsig run, Has Exec rsig run, Has Diagnostics rsig run) => Path Abs Dir -> m [DiscoveredProject run]

--- a/src/Strategy/Cargo.hs
+++ b/src/Strategy/Cargo.hs
@@ -1,111 +1,119 @@
 module Strategy.Cargo
-  ( discover
-  , CargoMetadata(..)
-  , NodeDependency(..)
-  , NodeDepKind(..)
-  , PackageId(..)
-  , Resolve(..)
-  , ResolveNode(..)
-  , buildGraph
-  , getDeps
-  , mkProject
-  , findProjects
+  ( discover,
+    CargoMetadata (..),
+    NodeDependency (..),
+    NodeDepKind (..),
+    PackageId (..),
+    Resolve (..),
+    ResolveNode (..),
+    buildGraph,
+    getDeps,
+    mkProject,
+    findProjects,
   )
-  where
+where
 
 import Control.Effect.Diagnostics
 import Data.Aeson.Types
 import Data.Foldable (for_, traverse_)
-import qualified Data.Map.Strict as M
+import Data.Map.Strict qualified as M
 import Data.Set (Set)
-import qualified Data.Text as T
+import Data.Text qualified as T
 import Discovery.Walk
 import Effect.Exec
 import Effect.Grapher
+import Effect.ReadFS (ReadFS)
 import Graphing (Graphing, stripRoot)
 import Path
 import Types
-import Effect.ReadFS (ReadFS)
 
-newtype CargoLabel =
-  CargoDepKind DepEnvironment
+newtype CargoLabel
+  = CargoDepKind DepEnvironment
   deriving (Eq, Ord, Show)
 
 data PackageId = PackageId
-  { pkgIdName :: T.Text
-  , pkgIdVersion :: T.Text
-  , pkgIdSource :: T.Text
-  } deriving (Eq, Ord, Show)
+  { pkgIdName :: T.Text,
+    pkgIdVersion :: T.Text,
+    pkgIdSource :: T.Text
+  }
+  deriving (Eq, Ord, Show)
 
 data PackageDependency = PackageDependency
-  { pkgDepName :: T.Text
-  , pkgDepReq :: T.Text
-  , pkgDepKind :: Maybe T.Text
-  } deriving (Eq, Ord, Show)
+  { pkgDepName :: T.Text,
+    pkgDepReq :: T.Text,
+    pkgDepKind :: Maybe T.Text
+  }
+  deriving (Eq, Ord, Show)
 
 data Package = Package
-  { pkgName :: T.Text
-  , pkgVersion :: T.Text
-  , pkgId :: PackageId
-  , pkgLicense :: Maybe T.Text
-  , pkgLicenseFile :: Maybe T.Text
-  , pkgDependencies :: [PackageDependency]
-  } deriving (Eq, Ord, Show)
+  { pkgName :: T.Text,
+    pkgVersion :: T.Text,
+    pkgId :: PackageId,
+    pkgLicense :: Maybe T.Text,
+    pkgLicenseFile :: Maybe T.Text,
+    pkgDependencies :: [PackageDependency]
+  }
+  deriving (Eq, Ord, Show)
 
 data NodeDepKind = NodeDepKind
-  { nodeDepKind :: Maybe T.Text
-  , nodeDepTarget :: Maybe T.Text
-  } deriving (Eq, Ord, Show)
+  { nodeDepKind :: Maybe T.Text,
+    nodeDepTarget :: Maybe T.Text
+  }
+  deriving (Eq, Ord, Show)
 
 data NodeDependency = NodeDependency
-  { nodePkg :: PackageId
-  , nodeDepKinds :: [NodeDepKind]
-  } deriving (Eq, Ord, Show)
+  { nodePkg :: PackageId,
+    nodeDepKinds :: [NodeDepKind]
+  }
+  deriving (Eq, Ord, Show)
 
 data ResolveNode = ResolveNode
-  { resolveNodeId :: PackageId
-  , resolveNodeDeps :: [NodeDependency]
-  } deriving (Eq, Ord, Show)
+  { resolveNodeId :: PackageId,
+    resolveNodeDeps :: [NodeDependency]
+  }
+  deriving (Eq, Ord, Show)
 
 newtype Resolve = Resolve
   { resolvedNodes :: [ResolveNode]
-  } deriving (Eq, Ord, Show)
+  }
+  deriving (Eq, Ord, Show)
 
 data CargoMetadata = CargoMetadata
-  { metadataPackages :: [Package]
-  , metadataWorkspaceMembers :: [PackageId]
-  , metadataResolve :: Resolve
-  } deriving (Eq, Ord, Show)
+  { metadataPackages :: [Package],
+    metadataWorkspaceMembers :: [PackageId],
+    metadataResolve :: Resolve
+  }
+  deriving (Eq, Ord, Show)
 
 instance FromJSON PackageDependency where
   parseJSON = withObject "PackageDependency" $ \obj ->
     PackageDependency <$> obj .: "name"
-                      <*> obj .: "req"
-                      <*> obj .:? "kind"
+      <*> obj .: "req"
+      <*> obj .:? "kind"
 
 instance FromJSON Package where
   parseJSON = withObject "Package" $ \obj ->
     Package <$> obj .: "name"
-            <*> obj .: "version"
-            <*> (obj .: "id" >>= parsePkgId)
-            <*> obj .:? "license"
-            <*> obj .:? "license_file"
-            <*> obj .: "dependencies"
+      <*> obj .: "version"
+      <*> (obj .: "id" >>= parsePkgId)
+      <*> obj .:? "license"
+      <*> obj .:? "license_file"
+      <*> obj .: "dependencies"
 
 instance FromJSON NodeDepKind where
   parseJSON = withObject "NodeDepKind" $ \obj ->
     NodeDepKind <$> obj .:? "kind"
-                <*> obj .:? "target"
+      <*> obj .:? "target"
 
 instance FromJSON NodeDependency where
   parseJSON = withObject "NodeDependency" $ \obj ->
     NodeDependency <$> (obj .: "pkg" >>= parsePkgId)
-                   <*> obj .: "dep_kinds"
+      <*> obj .: "dep_kinds"
 
 instance FromJSON ResolveNode where
   parseJSON = withObject "ResolveNode" $ \obj ->
     ResolveNode <$> (obj .: "id" >>= parsePkgId)
-                <*> obj .: "deps"
+      <*> obj .: "deps"
 
 instance FromJSON Resolve where
   parseJSON = withObject "Resolve" $ \obj ->
@@ -114,8 +122,8 @@ instance FromJSON Resolve where
 instance FromJSON CargoMetadata where
   parseJSON = withObject "CargoMetadata" $ \obj ->
     CargoMetadata <$> obj .: "packages"
-                  <*> (obj .: "workspace_members" >>= traverse parsePkgId)
-                  <*> obj .: "resolve"
+      <*> (obj .: "workspace_members" >>= traverse parsePkgId)
+      <*> obj .: "resolve"
 
 discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has Exec rsig run, Has Diagnostics rsig run) => Path Abs Dir -> m [DiscoveredProject run]
 discover dir = map mkProject <$> findProjects dir
@@ -136,7 +144,8 @@ findProjects = walk' $ \dir _ files -> do
 data CargoProject = CargoProject
   { cargoDir :: Path Abs Dir,
     cargoToml :: Path Abs File
-  } deriving (Eq, Ord, Show)
+  }
+  deriving (Eq, Ord, Show)
 
 mkProject :: (Has Exec sig n, Has Diagnostics sig n) => CargoProject -> DiscoveredProject n
 mkProject project =
@@ -152,21 +161,25 @@ getDeps :: (Has Exec sig m, Has Diagnostics sig m) => CargoProject -> m (Graphin
 getDeps = analyze . cargoDir
 
 cargoGenLockfileCmd :: Command
-cargoGenLockfileCmd = Command
-  { cmdName = "cargo"
-  , cmdArgs = ["generate-lockfile"]
-  , cmdAllowErr = Never
-  }
+cargoGenLockfileCmd =
+  Command
+    { cmdName = "cargo",
+      cmdArgs = ["generate-lockfile"],
+      cmdAllowErr = Never
+    }
 
 cargoMetadataCmd :: Command
-cargoMetadataCmd = Command
-  { cmdName = "cargo"
-  , cmdArgs = ["metadata"]
-  , cmdAllowErr = Never
-  }
+cargoMetadataCmd =
+  Command
+    { cmdName = "cargo",
+      cmdArgs = ["metadata"],
+      cmdAllowErr = Never
+    }
 
-analyze :: (Has Exec sig m, Has Diagnostics sig m)
-  => Path Abs Dir -> m (Graphing Dependency)
+analyze ::
+  (Has Exec sig m, Has Diagnostics sig m) =>
+  Path Abs Dir ->
+  m (Graphing Dependency)
 analyze manifestDir = do
   _ <- execThrow manifestDir cargoGenLockfileCmd
   meta <- execJson @CargoMetadata manifestDir cargoMetadataCmd
@@ -174,17 +187,20 @@ analyze manifestDir = do
   pure $ buildGraph meta
 
 toDependency :: PackageId -> Set CargoLabel -> Dependency
-toDependency pkg = foldr applyLabel Dependency
-  { dependencyType = CargoType
-  , dependencyName = pkgIdName pkg
-  , dependencyVersion = Just $ CEq $ pkgIdVersion pkg
-  , dependencyLocations = []
-  , dependencyEnvironments = []
-  , dependencyTags = M.empty
-  }
+toDependency pkg =
+  foldr
+    applyLabel
+    Dependency
+      { dependencyType = CargoType,
+        dependencyName = pkgIdName pkg,
+        dependencyVersion = Just $ CEq $ pkgIdVersion pkg,
+        dependencyLocations = [],
+        dependencyEnvironments = [],
+        dependencyTags = M.empty
+      }
   where
     applyLabel :: CargoLabel -> Dependency -> Dependency
-    applyLabel (CargoDepKind env) dep = dep { dependencyEnvironments = env : dependencyEnvironments dep }
+    applyLabel (CargoDepKind env) dep = dep {dependencyEnvironments = env : dependencyEnvironments dep}
 
 -- Possible values here are "build", "dev", and null.
 -- Null refers to productions, while dev and build refer to development-time dependencies
@@ -192,7 +208,7 @@ toDependency pkg = foldr applyLabel Dependency
 -- so we just simplify it to Development.
 kindToLabel :: Maybe T.Text -> CargoLabel
 kindToLabel (Just _) = CargoDepKind EnvDevelopment
-kindToLabel Nothing  = CargoDepKind EnvProduction
+kindToLabel Nothing = CargoDepKind EnvProduction
 
 addLabel :: Has (LabeledGrapher PackageId CargoLabel) sig m => NodeDependency -> m ()
 addLabel dep = do
@@ -207,12 +223,13 @@ addEdge node = do
     edge parentId $ nodePkg dep
 
 buildGraph :: CargoMetadata -> Graphing Dependency
-buildGraph meta = stripRoot $ run . withLabeling toDependency $ do
-  traverse_ direct $ metadataWorkspaceMembers meta
-  traverse_ addEdge $ resolvedNodes $ metadataResolve meta
+buildGraph meta = stripRoot $
+  run . withLabeling toDependency $ do
+    traverse_ direct $ metadataWorkspaceMembers meta
+    traverse_ addEdge $ resolvedNodes $ metadataResolve meta
 
 parsePkgId :: T.Text -> Parser PackageId
 parsePkgId t =
   case T.splitOn " " t of
-    [a,b,c] -> pure $ PackageId a b c
+    [a, b, c] -> pure $ PackageId a b c
     _ -> fail "malformed Package ID"

--- a/src/Strategy/Carthage.hs
+++ b/src/Strategy/Carthage.hs
@@ -1,33 +1,34 @@
 {-# LANGUAGE TemplateHaskell #-}
 
 module Strategy.Carthage
-  ( discover
-  , findProjects
-  , getDeps
-  , mkProject
-  , analyze
-  , ResolvedEntry(..)
-  , EntryType(..)
-  ) where
+  ( discover,
+    findProjects,
+    getDeps,
+    mkProject,
+    analyze,
+    ResolvedEntry (..),
+    EntryType (..),
+  )
+where
 
 import Control.Effect.Diagnostics
 import Data.Char (isSpace)
 import Data.Foldable (for_, traverse_)
 import Data.Functor (void)
-import qualified Data.Map.Strict as M
+import Data.Map.Strict qualified as M
 import Data.Text (Text)
-import qualified Data.Text as T
+import Data.Text qualified as T
 import Data.Void (Void)
 import DepTypes
 import Discovery.Walk
 import Effect.Grapher
 import Effect.ReadFS
 import Graphing (Graphing)
-import qualified Graphing as G
+import Graphing qualified as G
 import Path
 import Text.Megaparsec
 import Text.Megaparsec.Char
-import qualified Text.Megaparsec.Char.Lexer as L
+import Text.Megaparsec.Char.Lexer qualified as L
 import Types
 
 discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has ReadFS rsig run, Has Diagnostics rsig run) => Path Abs Dir -> m [DiscoveredProject run]
@@ -38,7 +39,6 @@ findProjects = walk' $ \dir _ files -> do
   case findFileNamed "Cartfile.resolved" files of
     Nothing -> pure ([], WalkContinue)
     Just cartfile -> do
-
       let project =
             CarthageProject
               { carthageLock = cartfile,
@@ -48,9 +48,10 @@ findProjects = walk' $ \dir _ files -> do
       pure ([project], WalkSkipAll)
 
 data CarthageProject = CarthageProject
-  { carthageDir :: Path Abs Dir
-  , carthageLock :: Path Abs File
-  } deriving (Eq, Ord, Show)
+  { carthageDir :: Path Abs Dir,
+    carthageLock :: Path Abs File
+  }
+  deriving (Eq, Ord, Show)
 
 mkProject :: (Has ReadFS sig n, Has Diagnostics sig n) => CarthageProject -> DiscoveredProject n
 mkProject project =
@@ -69,10 +70,11 @@ relCheckoutsDir :: Path Abs File -> Path Abs Dir
 relCheckoutsDir file = parent file </> $(mkRelDir "Carthage/Checkouts")
 
 analyze ::
-  ( Has ReadFS sig m
-  , Has Diagnostics sig m
-  )
-  => Path Abs File -> m (G.Graphing ResolvedEntry)
+  ( Has ReadFS sig m,
+    Has Diagnostics sig m
+  ) =>
+  Path Abs File ->
+  m (G.Graphing ResolvedEntry)
 analyze topPath = evalGrapher $ do
   -- We only care about top-level resolved cartfile errors, so we don't
   -- 'recover' here, but we do below in 'descend'
@@ -81,37 +83,38 @@ analyze topPath = evalGrapher $ do
   for_ topEntries $ \entry -> do
     direct entry
     descend (relCheckoutsDir topPath) entry
-
   where
+    analyzeSingle ::
+      ( Has ReadFS sig m,
+        Has Diagnostics sig m,
+        Has (Grapher ResolvedEntry) sig m
+      ) =>
+      Path Abs File ->
+      m [ResolvedEntry]
+    analyzeSingle path = do
+      entries <- readContentsParser @[ResolvedEntry] resolvedCartfileParser path
+      traverse_ (descend (relCheckoutsDir path)) entries
+      pure entries
 
-  analyzeSingle ::
-    ( Has ReadFS sig m
-    , Has Diagnostics sig m
-    , Has (Grapher ResolvedEntry) sig m
-    )
-    => Path Abs File -> m [ResolvedEntry]
-  analyzeSingle path = do
-    entries <- readContentsParser @[ResolvedEntry] resolvedCartfileParser path
-    traverse_ (descend (relCheckoutsDir path)) entries
-    pure entries
+    descend ::
+      ( Has ReadFS sig m,
+        Has Diagnostics sig m,
+        Has (Grapher ResolvedEntry) sig m
+      ) =>
+      Path Abs Dir {- checkouts directory -} ->
+      ResolvedEntry ->
+      m ()
+    descend checkoutsDir entry = do
+      let checkoutName = T.unpack $ entryToCheckoutName entry
 
-  descend ::
-    ( Has ReadFS sig m
-    , Has Diagnostics sig m
-    , Has (Grapher ResolvedEntry) sig m
-    )
-    => Path Abs Dir {- checkouts directory -} -> ResolvedEntry -> m ()
-  descend checkoutsDir entry = do
-    let checkoutName = T.unpack $ entryToCheckoutName entry
+      case parseRelDir checkoutName of
+        Nothing -> pure ()
+        Just path -> do
+          let checkoutPath :: Path Abs Dir
+              checkoutPath = checkoutsDir </> path
 
-    case parseRelDir checkoutName of
-      Nothing -> pure ()
-      Just path -> do
-        let checkoutPath :: Path Abs Dir
-            checkoutPath = checkoutsDir </> path
-
-        deeper <- recover $ analyzeSingle (checkoutPath </> $(mkRelFile "Cartfile.resolved"))
-        traverse_ (traverse_ (edge entry)) deeper
+          deeper <- recover $ analyzeSingle (checkoutPath </> $(mkRelFile "Cartfile.resolved"))
+          traverse_ (traverse_ (edge entry)) deeper
 
 entryToCheckoutName :: ResolvedEntry -> Text
 entryToCheckoutName entry =
@@ -129,14 +132,15 @@ entryToDepName entry =
     BinaryType -> resolvedName entry
 
 toDependency :: ResolvedEntry -> Dependency
-toDependency entry = Dependency
-  { dependencyType = CarthageType
-  , dependencyName = entryToDepName entry
-  , dependencyVersion = Just (CEq (resolvedVersion entry))
-  , dependencyTags = M.empty
-  , dependencyEnvironments = []
-  , dependencyLocations = [] -- TODO: git location?
-  }
+toDependency entry =
+  Dependency
+    { dependencyType = CarthageType,
+      dependencyName = entryToDepName entry,
+      dependencyVersion = Just (CEq (resolvedVersion entry)),
+      dependencyTags = M.empty,
+      dependencyEnvironments = [],
+      dependencyLocations = [] -- TODO: git location?
+    }
 
 -- Exemplary Cartfile.resolved:
 -- https://github.com/Carthage/Carthage/blob/8b34a90f607c5da85c75fee1f0cf20ae742bdeb2/Tests/CarthageKitTests/Resources/TestResolvedCartfile.resolved
@@ -148,29 +152,33 @@ resolvedCartfileParser = many parseSingleEntry <* eof
 
 parseSingleEntry :: Parser ResolvedEntry
 parseSingleEntry = L.nonIndented scn $ do
-  entryType <- lexeme $ choice
-    [ GithubType <$ chunk "github"
-    , GitEntry    <$ chunk "git"
-    , BinaryType <$ chunk "binary"
-    ]
+  entryType <-
+    lexeme $
+      choice
+        [ GithubType <$ chunk "github",
+          GitEntry <$ chunk "git",
+          BinaryType <$ chunk "binary"
+        ]
 
-  entryName    <- word
+  entryName <- word
   entryVersion <- word
   _ <- scn
 
   pure (ResolvedEntry entryType entryName entryVersion)
 
 word :: Parser Text
-word = T.pack <$> choice
-  [ lexeme (char '\"' *> someTill (satisfy (not . isSpace)) (char '\"'))
-  , lexeme (some (satisfy (not . isSpace)))
-  ]
+word =
+  T.pack
+    <$> choice
+      [ lexeme (char '\"' *> someTill (satisfy (not . isSpace)) (char '\"')),
+        lexeme (some (satisfy (not . isSpace)))
+      ]
 
 scn :: Parser ()
-scn =  L.space space1 empty empty
+scn = L.space space1 empty empty
 
 sc :: Parser ()
-sc =  L.space (void $ some (char ' ')) empty empty
+sc = L.space (void $ some (char ' ')) empty empty
 
 lexeme :: Parser a -> Parser a
 lexeme = L.lexeme sc
@@ -178,10 +186,11 @@ lexeme = L.lexeme sc
 type Parser = Parsec Void Text
 
 data ResolvedEntry = ResolvedEntry
-  { resolvedType    :: EntryType
-  , resolvedName    :: Text
-  , resolvedVersion :: Text
-  } deriving (Eq, Ord, Show)
+  { resolvedType :: EntryType,
+    resolvedName :: Text,
+    resolvedVersion :: Text
+  }
+  deriving (Eq, Ord, Show)
 
 data EntryType = GithubType | GitEntry | BinaryType
   deriving (Eq, Ord, Show)

--- a/src/Strategy/Cocoapods.hs
+++ b/src/Strategy/Cocoapods.hs
@@ -8,13 +8,13 @@ where
 
 import Control.Applicative ((<|>))
 import Control.Effect.Diagnostics (Diagnostics, (<||>))
-import qualified Control.Effect.Diagnostics as Diag
+import Control.Effect.Diagnostics qualified as Diag
 import Discovery.Walk
 import Effect.ReadFS
 import Graphing
 import Path
-import qualified Strategy.Cocoapods.Podfile as Podfile
-import qualified Strategy.Cocoapods.PodfileLock as PodfileLock
+import Strategy.Cocoapods.Podfile qualified as Podfile
+import Strategy.Cocoapods.PodfileLock qualified as PodfileLock
 import Types
 
 discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has ReadFS rsig run, Has Diagnostics rsig run) => Path Abs Dir -> m [DiscoveredProject run]

--- a/src/Strategy/Cocoapods/Podfile.hs
+++ b/src/Strategy/Cocoapods/Podfile.hs
@@ -1,89 +1,92 @@
 {-# LANGUAGE RecordWildCards #-}
 
 module Strategy.Cocoapods.Podfile
-  ( analyze'
-  , buildGraph
-  , parsePodfile
-
-  , Pod (..)
-  , Podfile (..)
-  , PropertyType (..)
-  ) where
+  ( analyze',
+    buildGraph,
+    parsePodfile,
+    Pod (..),
+    Podfile (..),
+    PropertyType (..),
+  )
+where
 
 import Control.Effect.Diagnostics
 import Data.Functor (void)
 import Data.Map.Strict (Map)
-import qualified Data.Map.Strict as M
+import Data.Map.Strict qualified as M
 import Data.Text (Text)
-import qualified Data.Text as T
+import Data.Text qualified as T
 import Data.Void (Void)
 import DepTypes
 import Effect.ReadFS
 import Graphing (Graphing)
-import qualified Graphing
+import Graphing qualified
 import Path
 import Text.Megaparsec hiding (label)
 import Text.Megaparsec.Char
-import qualified Text.Megaparsec.Char.Lexer as L
+import Text.Megaparsec.Char.Lexer qualified as L
 
 analyze' :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs File -> m (Graphing Dependency)
 analyze' file = buildGraph <$> readContentsParser parsePodfile file
 
 buildGraph :: Podfile -> Graphing Dependency
 buildGraph podfile = Graphing.fromList (map toDependency direct)
-    where
+  where
     direct = pods podfile
-    toDependency Pod{..} =
-      Dependency { dependencyType = PodType
-                 , dependencyName = name
-                 , dependencyVersion = CEq <$> version
-                 , dependencyLocations = case M.lookup SourceProperty properties of
-                                            Just repo -> [repo]
-                                            _ -> [source podfile]
-                 , dependencyEnvironments = []
-                 , dependencyTags = M.empty
-                 }
+    toDependency Pod {..} =
+      Dependency
+        { dependencyType = PodType,
+          dependencyName = name,
+          dependencyVersion = CEq <$> version,
+          dependencyLocations = case M.lookup SourceProperty properties of
+            Just repo -> [repo]
+            _ -> [source podfile],
+          dependencyEnvironments = [],
+          dependencyTags = M.empty
+        }
 
 type Parser = Parsec Void Text
 
 data Pod = Pod
-     { name      :: Text
-     , version   :: Maybe Text
-     , properties :: Map PropertyType Text
-     } deriving (Eq, Ord, Show)
+  { name :: Text,
+    version :: Maybe Text,
+    properties :: Map PropertyType Text
+  }
+  deriving (Eq, Ord, Show)
 
 data PropertyType = GitProperty | CommitProperty | SourceProperty | PathProperty
   deriving (Eq, Ord, Show)
 
 data Podfile = Podfile
-      { pods :: [Pod]
-      , source :: Text
-      } deriving (Eq, Ord, Show)
+  { pods :: [Pod],
+    source :: Text
+  }
+  deriving (Eq, Ord, Show)
 
-data Line =
-      PodLine Pod
-      | SourceLine Text
-      deriving (Eq, Ord, Show)
+data Line
+  = PodLine Pod
+  | SourceLine Text
+  deriving (Eq, Ord, Show)
 
 parsePodfile :: Parser Podfile
 parsePodfile = linesToPodfile (Podfile [] "") . concat <$> ((try podParser <|> findSource <|> ignoredLine) `sepBy` eol) <* eof
 
 linesToPodfile :: Podfile -> [Line] -> Podfile
-linesToPodfile file (PodLine pod : xs) = linesToPodfile (file { pods = pod : pods file }) xs
-linesToPodfile file (SourceLine sourceLine : xs) = linesToPodfile (file { source = sourceLine }) xs
+linesToPodfile file (PodLine pod : xs) = linesToPodfile (file {pods = pod : pods file}) xs
+linesToPodfile file (SourceLine sourceLine : xs) = linesToPodfile (file {source = sourceLine}) xs
 linesToPodfile file [] = file
 
 findSource :: Parser [Line]
 findSource = do
-          _ <- chunk "source \'"
-          source <- takeWhileP (Just "source parser") (/= '\'')
-          _ <- char '\''
-          pure [SourceLine source]
+  _ <- chunk "source \'"
+  source <- takeWhileP (Just "source parser") (/= '\'')
+  _ <- char '\''
+  pure [SourceLine source]
 
 podParser :: Parser [Line]
 podParser = do
   sc
-  _   <- symbol "pod"
+  _ <- symbol "pod"
   name <- stringLiteral
   version <- optional (try (comma *> stringLiteral))
   properties <- many property
@@ -96,12 +99,13 @@ comma = () <$ symbol ","
 property :: Parser (PropertyType, Text)
 property = do
   comma
-  propertyType <- choice
-    [ GitProperty    <$ symbol ":git"
-    , CommitProperty <$ symbol ":commit"
-    , SourceProperty <$ symbol ":source"
-    , PathProperty   <$ symbol ":path"
-    ]
+  propertyType <-
+    choice
+      [ GitProperty <$ symbol ":git",
+        CommitProperty <$ symbol ":commit",
+        SourceProperty <$ symbol ":source",
+        PathProperty <$ symbol ":path"
+      ]
   _ <- symbol "=>"
   value <- stringLiteral
   pure (propertyType, value)
@@ -115,11 +119,12 @@ lexeme = L.lexeme sc
 stringLiteral :: Parser Text
 stringLiteral = T.pack <$> go
   where
-  go = (char '"'  *> manyTill L.charLiteral (char '"'))
-   <|> (char '\'' *> manyTill L.charLiteral (char '\''))
+    go =
+      (char '"' *> manyTill L.charLiteral (char '"'))
+        <|> (char '\'' *> manyTill L.charLiteral (char '\''))
 
 sc :: Parser ()
-sc =  L.space (void $ some (char ' ')) (L.skipLineComment "#") empty
+sc = L.space (void $ some (char ' ')) (L.skipLineComment "#") empty
 
 restOfLine :: Parser Text
 restOfLine = takeWhileP (Just "ignored") (not . isEndLine)
@@ -127,7 +132,7 @@ restOfLine = takeWhileP (Just "ignored") (not . isEndLine)
 isEndLine :: Char -> Bool
 isEndLine '\n' = True
 isEndLine '\r' = True
-isEndLine _    = False
+isEndLine _ = False
 
 ignoredLine :: Parser [Line]
 ignoredLine = do

--- a/src/Strategy/Cocoapods/PodfileLock.hs
+++ b/src/Strategy/Cocoapods/PodfileLock.hs
@@ -1,22 +1,22 @@
 module Strategy.Cocoapods.PodfileLock
-  ( analyze'
-  , buildGraph
-  , findSections
-
-  , Dep (..)
-  , Pod (..)
-  , Section (..)
-  ) where
+  ( analyze',
+    buildGraph,
+    findSections,
+    Dep (..),
+    Pod (..),
+    Section (..),
+  )
+where
 
 import Control.Effect.Diagnostics
-import qualified Data.Char as C
+import Data.Char qualified as C
 import Data.Foldable (traverse_)
 import Data.Functor (void)
 import Data.Map.Strict (Map)
-import qualified Data.Map.Strict as M
+import Data.Map.Strict qualified as M
 import Data.Set (Set)
 import Data.Text (Text)
-import qualified Data.Text as T
+import Data.Text qualified as T
 import Data.Void (Void)
 import DepTypes
 import Effect.Grapher
@@ -25,84 +25,89 @@ import Graphing (Graphing)
 import Path
 import Text.Megaparsec hiding (label)
 import Text.Megaparsec.Char
-import qualified Text.Megaparsec.Char.Lexer as L
+import Text.Megaparsec.Char.Lexer qualified as L
 
 analyze' :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs File -> m (Graphing Dependency)
 analyze' file = buildGraph <$> readContentsParser findSections file
 
-newtype PodfilePkg = PodfilePkg { pkgName :: Text }
+newtype PodfilePkg = PodfilePkg {pkgName :: Text}
   deriving (Eq, Ord, Show)
 
 type PodfileGrapher = LabeledGrapher PodfilePkg PodfileLabel
 
-newtype PodfileLabel =
-    PodfileVersion Text
+newtype PodfileLabel
+  = PodfileVersion Text
   deriving (Eq, Ord, Show)
 
 toDependency :: PodfilePkg -> Set PodfileLabel -> Dependency
 toDependency pkg = foldr applyLabel start
   where
+    start :: Dependency
+    start =
+      Dependency
+        { dependencyType = PodType,
+          dependencyName = pkgName pkg,
+          dependencyVersion = Nothing,
+          dependencyLocations = [],
+          dependencyEnvironments = [],
+          dependencyTags = M.empty
+        }
 
-  start :: Dependency
-  start = Dependency
-    { dependencyType = PodType
-    , dependencyName = pkgName pkg
-    , dependencyVersion = Nothing
-    , dependencyLocations = []
-    , dependencyEnvironments = []
-    , dependencyTags = M.empty
-    }
-
-  applyLabel :: PodfileLabel -> Dependency -> Dependency
-  applyLabel (PodfileVersion ver) dep = dep { dependencyVersion = Just (CEq ver) }
+    applyLabel :: PodfileLabel -> Dependency -> Dependency
+    applyLabel (PodfileVersion ver) dep = dep {dependencyVersion = Just (CEq ver)}
 
 buildGraph :: [Section] -> Graphing Dependency
-buildGraph sections = run . withLabeling toDependency $
-  traverse_ addSection sections
+buildGraph sections =
+  run . withLabeling toDependency $
+    traverse_ addSection sections
   where
-  addSection :: Has PodfileGrapher sig m => Section -> m ()
-  addSection (DependencySection deps) = traverse_ (direct . PodfilePkg . depName) deps
-  addSection (PodSection pods) = traverse_ addSpec pods
-  addSection _ = pure ()
+    addSection :: Has PodfileGrapher sig m => Section -> m ()
+    addSection (DependencySection deps) = traverse_ (direct . PodfilePkg . depName) deps
+    addSection (PodSection pods) = traverse_ addSpec pods
+    addSection _ = pure ()
 
-  addSpec :: Has PodfileGrapher sig m => Pod -> m ()
-  addSpec pod = do
-    let pkg = PodfilePkg (podName pod)
-    -- add edges between spec and specdeps
-    traverse_ (edge pkg . PodfilePkg . depName) (podSpecs pod)
-    -- add a label for version
-    label pkg (PodfileVersion (podVersion pod))
+    addSpec :: Has PodfileGrapher sig m => Pod -> m ()
+    addSpec pod = do
+      let pkg = PodfilePkg (podName pod)
+      -- add edges between spec and specdeps
+      traverse_ (edge pkg . PodfilePkg . depName) (podSpecs pod)
+      -- add a label for version
+      label pkg (PodfileVersion (podVersion pod))
 
 type Parser = Parsec Void Text
 
-data Section =
-      PodSection [Pod]
-      | DependencySection [Dep]
-      | SpecRepos [Remote]
-      | ExternalSources [SourceDep]
-      | CheckoutOptions [SourceDep]
-      | UnknownSection Text
-      deriving (Eq, Ord, Show)
+data Section
+  = PodSection [Pod]
+  | DependencySection [Dep]
+  | SpecRepos [Remote]
+  | ExternalSources [SourceDep]
+  | CheckoutOptions [SourceDep]
+  | UnknownSection Text
+  deriving (Eq, Ord, Show)
 
 newtype Dep = Dep
-      { depName :: Text
-      } deriving (Eq, Ord, Show)
+  { depName :: Text
+  }
+  deriving (Eq, Ord, Show)
 
 data SourceDep = SourceDep
-      { sDepName :: Text
-      , tags     :: Map Text Text
-      } deriving (Eq, Ord, Show)
+  { sDepName :: Text,
+    tags :: Map Text Text
+  }
+  deriving (Eq, Ord, Show)
 
 data Pod = Pod
-     { podName    :: Text
-     , podVersion :: Text
-     , podSpecs   :: [Dep]
-     } deriving (Eq, Ord, Show)
+  { podName :: Text,
+    podVersion :: Text,
+    podSpecs :: [Dep]
+  }
+  deriving (Eq, Ord, Show)
 
 data Remote = Remote
-     { remoteLocation :: Text
-     , remoteDeps     :: [Dep]
-     } deriving (Eq, Ord, Show)
+  { remoteLocation :: Text,
+    remoteDeps :: [Dep]
+  }
+  deriving (Eq, Ord, Show)
 
 findSections :: Parser [Section]
 findSections = manyTill (try podSectionParser <|> try dependenciesSectionParser <|> try specRepoParser <|> try externalSourcesParser <|> try checkoutOptionsParser <|> unknownSection) eof
@@ -129,9 +134,10 @@ checkoutOptionsParser :: Parser Section
 checkoutOptionsParser = sectionParser "CHECKOUT OPTIONS:" CheckoutOptions externalDepsParser
 
 sectionParser :: Text -> ([a] -> Section) -> Parser a -> Parser Section
-sectionParser sectionName lambda parser = nonIndented $ indentBlock $ do
-  _ <- chunk sectionName
-  return (L.IndentMany Nothing (pure . lambda) parser)
+sectionParser sectionName lambda parser = nonIndented $
+  indentBlock $ do
+    _ <- chunk sectionName
+    return (L.IndentMany Nothing (pure . lambda) parser)
 
 externalDepsParser :: Parser SourceDep
 externalDepsParser = indentBlock $ do
@@ -150,7 +156,7 @@ tagParser = do
 remoteParser :: Parser Remote
 remoteParser = indentBlock $ do
   location <- restOfLine
-  pure (L.IndentMany Nothing (\deps -> pure $ Remote (T.dropWhileEnd (==':') location) deps) depParser)
+  pure (L.IndentMany Nothing (\deps -> pure $ Remote (T.dropWhileEnd (== ':') location) deps) depParser)
 
 podParser :: Parser Pod
 podParser = indentBlock $ do
@@ -179,7 +185,7 @@ restOfLine = takeWhileP (Just "ignored") (not . isEndLine)
 isEndLine :: Char -> Bool
 isEndLine '\n' = True
 isEndLine '\r' = True
-isEndLine _    = False
+isEndLine _ = False
 
 nonIndented :: Parser a -> Parser a
 nonIndented = L.nonIndented scn
@@ -188,10 +194,10 @@ indentBlock :: Parser (L.IndentOpt Parser a b) -> Parser a
 indentBlock = L.indentBlock scn
 
 scn :: Parser ()
-scn =  L.space space1 empty empty
+scn = L.space space1 empty empty
 
 lexeme :: Parser a -> Parser a
 lexeme = L.lexeme sc
 
 sc :: Parser ()
-sc =  L.space (void $ some (char ' ')) empty empty
+sc = L.space (void $ some (char ' ')) empty empty

--- a/src/Strategy/Composer.hs
+++ b/src/Strategy/Composer.hs
@@ -7,13 +7,13 @@ module Strategy.Composer
 where
 
 import Control.Effect.Diagnostics hiding (fromMaybe)
-import Data.Map.Strict (Map)
-import qualified Data.Map.Strict as M
-import Data.Set (Set)
 import Data.Aeson.Types
 import Data.Foldable (traverse_)
-import Data.Text (Text)
+import Data.Map.Strict (Map)
+import Data.Map.Strict qualified as M
 import Data.Maybe (fromMaybe)
+import Data.Set (Set)
+import Data.Text (Text)
 import DepTypes
 import Discovery.Walk
 import Effect.Grapher
@@ -52,9 +52,10 @@ getDeps :: (Has ReadFS sig m, Has Diagnostics sig m) => ComposerProject -> m (Gr
 getDeps project = buildGraph <$> readContentsJson @ComposerLock (composerLock project)
 
 data ComposerProject = ComposerProject
-  { composerDir :: Path Abs Dir
-  , composerLock :: Path Abs File
-  } deriving (Eq, Ord, Show)
+  { composerDir :: Path Abs Dir,
+    composerLock :: Path Abs File
+  }
+  deriving (Eq, Ord, Show)
 
 data ComposerLock = ComposerLock
   { lockPackages :: [CompDep],
@@ -110,15 +111,16 @@ buildGraph lock = run . withLabeling toDependency $ do
     addEdge pkg name _ = edge pkg (CompPkg name)
 
     toDependency :: CompPkg -> Set CompLabel -> Dependency
-    toDependency pkg = foldr addLabel $
-      Dependency
-        { dependencyType = ComposerType,
-          dependencyName = pkgName pkg,
-          dependencyVersion = Nothing,
-          dependencyLocations = [],
-          dependencyEnvironments = [],
-          dependencyTags = M.empty
-        }
+    toDependency pkg =
+      foldr addLabel $
+        Dependency
+          { dependencyType = ComposerType,
+            dependencyName = pkgName pkg,
+            dependencyVersion = Nothing,
+            dependencyLocations = [],
+            dependencyEnvironments = [],
+            dependencyTags = M.empty
+          }
 
     addLabel :: CompLabel -> Dependency -> Dependency
     addLabel (DepVersion ver) dep = dep {dependencyVersion = Just (CEq ver)}

--- a/src/Strategy/Erlang/ConfigParser.hs
+++ b/src/Strategy/Erlang/ConfigParser.hs
@@ -22,19 +22,20 @@ module Strategy.Erlang.ConfigParser
 where
 
 import Data.Aeson.Types (ToJSON (toJSON))
-import qualified Data.Char as C
-import Data.Functor ( ($>) )
+import Data.Char qualified as C
+import Data.Functor (($>))
 import Data.Text (Text)
-import qualified Data.Text as T
+import Data.Text qualified as T
 import Data.Void
 import GHC.Generics (Generic)
 import Text.Megaparsec
 import Text.Megaparsec.Char
-import qualified Text.Megaparsec.Char.Lexer as L
+import Text.Megaparsec.Char.Lexer qualified as L
 
 type Parser = Parsec Void Text
 
 newtype AtomText = AtomText {unAtomText :: Text} deriving (Eq, Ord, Show, ToJSON)
+
 newtype ConfigValues = ConfigValues {unConfigValues :: [ErlValue]} deriving (Eq, Ord, Show)
 
 data ErlValue
@@ -54,7 +55,6 @@ instance ToJSON ErlValue where
     ErlFloat a -> toJSON a
     ErlArray a -> toJSON a
     ErlTuple a -> toJSON a
-
 
 alphaNumSeq :: [Char]
 alphaNumSeq = ['0' .. '9'] <> ['A' .. 'Z']
@@ -106,8 +106,7 @@ alphaNumToInt :: Char -> Int
 alphaNumToInt c =
   if C.isDigit c
     then C.digitToInt c
-    else
-      -- Get ascii code offset from 'A' (65), but start at 10 (A is 10 in hex)
+    else -- Get ascii code offset from 'A' (65), but start at 10 (A is 10 in hex)
       C.ord (C.toUpper c) - C.ord 'A' + 10
 
 {-  Erlang-specific: $char

--- a/src/Strategy/Erlang/Rebar3Tree.hs
+++ b/src/Strategy/Erlang/Rebar3Tree.hs
@@ -2,35 +2,35 @@
 {-# LANGUAGE TemplateHaskell #-}
 
 module Strategy.Erlang.Rebar3Tree
-  ( analyze'
-
-  , buildGraph
-  , rebar3TreeParser
-  , Rebar3Dep(..)
+  ( analyze',
+    buildGraph,
+    rebar3TreeParser,
+    Rebar3Dep (..),
   )
-  where
+where
 
 import Control.Effect.Diagnostics
-import qualified Data.Map.Strict as M
+import Data.Map.Strict qualified as M
 import Data.Maybe (mapMaybe)
 import Data.Text (Text)
-import qualified Data.Text as T
+import Data.Text qualified as T
 import Data.Void (Void)
 import DepTypes
 import Effect.Exec
 import Effect.ReadFS
 import Graphing (Graphing, unfold)
 import Path
-import Strategy.Erlang.ConfigParser (parseConfig, ErlValue (..), ConfigValues (..), AtomText (..))
+import Strategy.Erlang.ConfigParser (AtomText (..), ConfigValues (..), ErlValue (..), parseConfig)
 import Text.Megaparsec
 import Text.Megaparsec.Char
 
 rebar3TreeCmd :: Command
-rebar3TreeCmd = Command
-  { cmdName = "rebar3"
-  , cmdArgs = ["tree", "-v"]
-  , cmdAllowErr = Never
-  }
+rebar3TreeCmd =
+  Command
+    { cmdName = "rebar3",
+      cmdArgs = ["tree", "-v"],
+      cmdAllowErr = Never
+    }
 
 analyze' :: (Has Exec sig m, Has ReadFS sig m, Has Diagnostics sig m) => Path Abs Dir -> m (Graphing Dependency)
 analyze' dir = do
@@ -57,7 +57,6 @@ extractAliasLookup (ConfigValues erls) = foldr extract M.empty erls
           ErlTuple [ErlAtom (AtomText realname), ErlTuple [ErlAtom (AtomText "pkg"), ErlAtom (AtomText alias)]] -> Just (realname, alias)
           _ -> Nothing
 
-
 unaliasDeps :: M.Map Text Text -> [Rebar3Dep] -> [Rebar3Dep]
 unaliasDeps aliasMap = map unalias
   where
@@ -66,74 +65,76 @@ unaliasDeps aliasMap = map unalias
     lookupName :: M.Map Text Text -> Text -> Text
     lookupName map' name = M.findWithDefault name name map'
     changeName :: Rebar3Dep -> Text -> Rebar3Dep
-    changeName dep name = dep { depName = name }
+    changeName dep name = dep {depName = name}
 
 buildGraph :: [Rebar3Dep] -> Graphing Dependency
 buildGraph deps = unfold deps subDeps toDependency
   where
-  toDependency Rebar3Dep{..} =
-    Dependency { dependencyType = if T.isInfixOf "github.com" depLocation then GitType else HexType
-                 , dependencyName = if T.isInfixOf "github.com" depLocation then depLocation else depName
-                 , dependencyVersion = Just (CEq depVersion)
-                 , dependencyLocations = []
-                 , dependencyEnvironments = []
-                 , dependencyTags = M.empty
-                 }
+    toDependency Rebar3Dep {..} =
+      Dependency
+        { dependencyType = if T.isInfixOf "github.com" depLocation then GitType else HexType,
+          dependencyName = if T.isInfixOf "github.com" depLocation then depLocation else depName,
+          dependencyVersion = Just (CEq depVersion),
+          dependencyLocations = [],
+          dependencyEnvironments = [],
+          dependencyTags = M.empty
+        }
 
 data Rebar3Dep = Rebar3Dep
-  { depName     :: Text
-  , depVersion  :: Text
-  , depLocation :: Text
-  , subDeps     :: [Rebar3Dep]
-  } deriving (Eq, Ord, Show)
+  { depName :: Text,
+    depVersion :: Text,
+    depLocation :: Text,
+    subDeps :: [Rebar3Dep]
+  }
+  deriving (Eq, Ord, Show)
 
 type Parser = Parsec Void Text
 
 rebar3TreeParser :: Parser [Rebar3Dep]
 rebar3TreeParser = concat <$> ((try (rebarDep 0) <|> ignoredLine) `sepBy` eol) <* eof
   where
-  isEndLine :: Char -> Bool
-  isEndLine '\n' = True
-  isEndLine '\r' = True
-  isEndLine _    = False
+    isEndLine :: Char -> Bool
+    isEndLine '\n' = True
+    isEndLine '\r' = True
+    isEndLine _ = False
 
-  -- ignore content until the end of the line
-  ignored :: Parser ()
-  ignored = () <$ takeWhileP (Just "ignored") (not . isEndLine)
+    -- ignore content until the end of the line
+    ignored :: Parser ()
+    ignored = () <$ takeWhileP (Just "ignored") (not . isEndLine)
 
-  ignoredLine :: Parser [Rebar3Dep]
-  ignoredLine = do
-    ignored
-    pure []
+    ignoredLine :: Parser [Rebar3Dep]
+    ignoredLine = do
+      ignored
+      pure []
 
-  findName :: Parser Text
-  findName = takeWhileP (Just "dep") (/= '─')
+    findName :: Parser Text
+    findName = takeWhileP (Just "dep") (/= '─')
 
-  findVersion :: Parser Text
-  findVersion = takeWhileP (Just "version") (/= ' ')
+    findVersion :: Parser Text
+    findVersion = takeWhileP (Just "version") (/= ' ')
 
-  findLocation :: Parser Text
-  findLocation = takeWhileP (Just "location") (/= ')')
+    findLocation :: Parser Text
+    findLocation = takeWhileP (Just "location") (/= ')')
 
-  rebarDep :: Int -> Parser [Rebar3Dep]
-  rebarDep depth = do
-    _ <- chunk " "
-    slashCount <- many "  │"
-    _ <- satisfy (\_ -> length slashCount == depth)
+    rebarDep :: Int -> Parser [Rebar3Dep]
+    rebarDep depth = do
+      _ <- chunk " "
+      slashCount <- many "  │"
+      _ <- satisfy (\_ -> length slashCount == depth)
 
-    _ <- chunk "  & " <|> chunk "  ├─ " <|> chunk " ├─ " <|> chunk " └─ "
-    dep <- findName
-    _ <- chunk "─"
-    version <- findVersion
-    _ <- chunk " ("
-    location <- findLocation
-    _ <- chunk ")"
+      _ <- chunk "  & " <|> chunk "  ├─ " <|> chunk " ├─ " <|> chunk " └─ "
+      dep <- findName
+      _ <- chunk "─"
+      version <- findVersion
+      _ <- chunk " ("
+      location <- findLocation
+      _ <- chunk ")"
 
-    deps <- many $ try $ rebarRecurse $ depth + 1
+      deps <- many $ try $ rebarRecurse $ depth + 1
 
-    pure [Rebar3Dep dep version location (concat deps)]
+      pure [Rebar3Dep dep version location (concat deps)]
 
-  rebarRecurse :: Int -> Parser [Rebar3Dep]
-  rebarRecurse depth = do
-    _ <- chunk "\n"
-    rebarDep depth
+    rebarRecurse :: Int -> Parser [Rebar3Dep]
+    rebarRecurse depth = do
+      _ <- chunk "\n"
+      rebarDep depth

--- a/src/Strategy/Glide.hs
+++ b/src/Strategy/Glide.hs
@@ -8,7 +8,7 @@ import Discovery.Walk
 import Effect.ReadFS
 import Graphing
 import Path
-import qualified Strategy.Go.GlideLock as GlideLock
+import Strategy.Go.GlideLock qualified as GlideLock
 import Types
 
 discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has ReadFS rsig run, Has Diagnostics rsig run) => Path Abs Dir -> m [DiscoveredProject run]

--- a/src/Strategy/Go/GlideLock.hs
+++ b/src/Strategy/Go/GlideLock.hs
@@ -1,67 +1,68 @@
 {-# LANGUAGE RecordWildCards #-}
 
 module Strategy.Go.GlideLock
-  ( analyze'
-
-  , GlideLockfile(..)
-  , GlideDep(..)
-
-  , buildGraph
+  ( analyze',
+    GlideLockfile (..),
+    GlideDep (..),
+    buildGraph,
   )
-  where
+where
 
 import Control.Applicative ((<|>))
 import Control.Effect.Diagnostics
 import Data.Aeson
-import qualified Data.Map.Strict as M
+import Data.Map.Strict qualified as M
 import Data.Text (Text)
-import qualified Data.Text as T
+import Data.Text qualified as T
 import DepTypes
 import Effect.ReadFS
 import Graphing (Graphing)
-import qualified Graphing
+import Graphing qualified
 import Path
 
-analyze' :: (Has ReadFS sig m , Has Diagnostics sig m) => Path Abs File -> m (Graphing Dependency)
+analyze' :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs File -> m (Graphing Dependency)
 analyze' file = buildGraph <$> readContentsYaml @GlideLockfile file
 
 buildGraph :: GlideLockfile -> Graphing Dependency
 buildGraph lockfile = Graphing.fromList (map toDependency direct)
   where
-  direct = imports lockfile
-  toDependency GlideDep{..} =
-    Dependency { dependencyType = GoType
-               , dependencyName = depName
-               , dependencyVersion = Just (CEq depVersion)
-               , dependencyLocations = []
-               , dependencyEnvironments = []
-               , dependencyTags = M.empty
-               }
+    direct = imports lockfile
+    toDependency GlideDep {..} =
+      Dependency
+        { dependencyType = GoType,
+          dependencyName = depName,
+          dependencyVersion = Just (CEq depVersion),
+          dependencyLocations = [],
+          dependencyEnvironments = [],
+          dependencyTags = M.empty
+        }
 
 data GlideLockfile = GlideLockfile
-  { hash    :: Text
-  , updated :: Text
-  , imports :: [GlideDep]
-  } deriving (Eq, Ord, Show)
+  { hash :: Text,
+    updated :: Text,
+    imports :: [GlideDep]
+  }
+  deriving (Eq, Ord, Show)
 
 data GlideDep = GlideDep
-  { depName    :: Text
-  , depVersion :: Text
-  , depRepo    :: Maybe Text
-  } deriving (Eq, Ord, Show)
+  { depName :: Text,
+    depVersion :: Text,
+    depRepo :: Maybe Text
+  }
+  deriving (Eq, Ord, Show)
 
 instance FromJSON GlideLockfile where
   parseJSON = withObject "GlideLockfile" $ \obj ->
     GlideLockfile <$> obj .: "hash"
-                  <*> obj .: "updated"
-                  <*> obj .: "imports"
+      <*> obj .: "updated"
+      <*> obj .: "imports"
 
 instance FromJSON GlideDep where
   parseJSON = withObject "GlideDep" $ \obj ->
-    GlideDep <$> obj .:  "name"
-               -- version field can be text or an int (hexadecimal hash)
-               <*> (obj .: "version" <|> (intToText <$> obj .: "version"))
-               <*> obj .:? "repo"
+    GlideDep <$> obj .: "name"
+      -- version field can be text or an int (hexadecimal hash)
+      <*> (obj .: "version" <|> (intToText <$> obj .: "version"))
+      <*> obj .:? "repo"
 
 intToText :: Int -> Text
 intToText = T.pack . show

--- a/src/Strategy/Go/GoList.hs
+++ b/src/Strategy/Go/GoList.hs
@@ -1,18 +1,17 @@
 {-# LANGUAGE RecordWildCards #-}
 
 module Strategy.Go.GoList
-  ( analyze'
-
-  , Require(..)
+  ( analyze',
+    Require (..),
   )
-  where
+where
 
 import Control.Effect.Diagnostics
-import qualified Data.ByteString.Lazy as BL
+import Data.ByteString.Lazy qualified as BL
 import Data.Foldable (traverse_)
 import Data.Maybe (mapMaybe)
 import Data.Text (Text)
-import qualified Data.Text as T
+import Data.Text qualified as T
 import Data.Text.Encoding (decodeUtf8)
 import DepTypes
 import Effect.Exec
@@ -23,22 +22,25 @@ import Strategy.Go.Transitive (fillInTransitive)
 import Strategy.Go.Types
 
 data Require = Require
-  { reqPackage :: Text
-  , reqVersion :: Text
-  } deriving (Eq, Ord, Show)
+  { reqPackage :: Text,
+    reqVersion :: Text
+  }
+  deriving (Eq, Ord, Show)
 
 golistCmd :: Command
-golistCmd = Command
-  { cmdName = "go"
-  , cmdArgs = ["list", "-m", "all"]
-  , cmdAllowErr = Never
-  }
+golistCmd =
+  Command
+    { cmdName = "go",
+      cmdArgs = ["list", "-m", "all"],
+      cmdAllowErr = Never
+    }
 
 analyze' ::
-  ( Has Exec sig m
-  , Has Diagnostics sig m
-  )
-  => Path Abs Dir -> m (Graphing Dependency)
+  ( Has Exec sig m,
+    Has Diagnostics sig m
+  ) =>
+  Path Abs Dir ->
+  m (Graphing Dependency)
 analyze' dir = graphingGolang $ do
   stdout <- execThrow dir golistCmd
 
@@ -59,9 +61,8 @@ analyze' dir = graphingGolang $ do
 buildGraph :: Has GolangGrapher sig m => [Require] -> m ()
 buildGraph = traverse_ go
   where
-
-  go :: Has GolangGrapher sig m => Require -> m ()
-  go Require{..} = do
-    let pkg = mkGolangPackage reqPackage
-    direct pkg
-    label pkg (mkGolangVersion reqVersion)
+    go :: Has GolangGrapher sig m => Require -> m ()
+    go Require {..} = do
+      let pkg = mkGolangPackage reqPackage
+      direct pkg
+      label pkg (mkGolangVersion reqVersion)

--- a/src/Strategy/Go/Gomod.hs
+++ b/src/Strategy/Go/Gomod.hs
@@ -22,12 +22,12 @@ import Data.Char (isSpace)
 import Data.Foldable (traverse_)
 import Data.Functor (void)
 import Data.Map.Strict (Map)
-import qualified Data.Map.Strict as M
+import Data.Map.Strict qualified as M
 import Data.Maybe (fromMaybe)
-import qualified Data.SemVer as SemVer
+import Data.SemVer qualified as SemVer
 import Data.SemVer.Internal (Identifier (..), Version (..))
 import Data.Text (Text)
-import qualified Data.Text as T
+import Data.Text qualified as T
 import Data.Void (Void)
 import DepTypes (Dependency)
 import Effect.Exec (Exec)
@@ -56,7 +56,7 @@ import Text.Megaparsec
     (<|>),
   )
 import Text.Megaparsec.Char (alphaNumChar, char, numberChar, space1)
-import qualified Text.Megaparsec.Char.Lexer as L
+import Text.Megaparsec.Char.Lexer qualified as L
 
 -- For the file's grammar, see https://golang.org/ref/mod#go-mod-file-grammar.
 --

--- a/src/Strategy/Go/GopkgLock.hs
+++ b/src/Strategy/Go/GopkgLock.hs
@@ -1,15 +1,13 @@
 {-# LANGUAGE RecordWildCards #-}
 
 module Strategy.Go.GopkgLock
-  ( analyze'
-
-  , GoLock(..)
-  , Project(..)
-
-  , buildGraph
-  , golockCodec
+  ( analyze',
+    GoLock (..),
+    Project (..),
+    buildGraph,
+    golockCodec,
   )
-  where
+where
 
 import Control.Effect.Diagnostics
 import Data.Foldable (traverse_)
@@ -24,34 +22,39 @@ import Path
 import Strategy.Go.Transitive (fillInTransitive)
 import Strategy.Go.Types
 import Toml (TomlCodec, (.=))
-import qualified Toml
+import Toml qualified
 
 golockCodec :: TomlCodec GoLock
-golockCodec = GoLock
-  <$> Toml.list projectCodec "projects" .= lockProjects
+golockCodec =
+  GoLock
+    <$> Toml.list projectCodec "projects" .= lockProjects
 
 projectCodec :: TomlCodec Project
-projectCodec = Project
-  <$> Toml.text "name" .= projectName
-  <*> Toml.dioptional (Toml.text "source") .= projectSource
-  <*> Toml.text "revision" .= projectRevision
+projectCodec =
+  Project
+    <$> Toml.text "name" .= projectName
+    <*> Toml.dioptional (Toml.text "source") .= projectSource
+    <*> Toml.text "revision" .= projectRevision
 
 newtype GoLock = GoLock
   { lockProjects :: [Project]
-  } deriving (Eq, Ord, Show)
+  }
+  deriving (Eq, Ord, Show)
 
 data Project = Project
-  { projectName     :: Text
-  , projectSource   :: Maybe Text
-  , projectRevision :: Text
-  } deriving (Eq, Ord, Show)
+  { projectName :: Text,
+    projectSource :: Maybe Text,
+    projectRevision :: Text
+  }
+  deriving (Eq, Ord, Show)
 
 analyze' ::
-  ( Has ReadFS sig m
-  , Has Exec sig m
-  , Has Diagnostics sig m
-  )
-  => Path Abs File -> m (Graphing Dependency)
+  ( Has ReadFS sig m,
+    Has Exec sig m,
+    Has Diagnostics sig m
+  ) =>
+  Path Abs File ->
+  m (Graphing Dependency)
 analyze' file = graphingGolang $ do
   golock <- readContentsToml golockCodec file
   buildGraph (lockProjects golock)
@@ -61,12 +64,12 @@ analyze' file = graphingGolang $ do
 buildGraph :: Has GolangGrapher sig m => [Project] -> m ()
 buildGraph = void . traverse_ go
   where
-  go :: Has GolangGrapher sig m => Project -> m ()
-  go Project{..} = do
-    let pkg = mkGolangPackage projectName
+    go :: Has GolangGrapher sig m => Project -> m ()
+    go Project {..} = do
+      let pkg = mkGolangPackage projectName
 
-    direct pkg
-    label pkg (mkGolangVersion projectRevision)
+      direct pkg
+      label pkg (mkGolangVersion projectRevision)
 
-    -- label location when it exists
-    traverse_ (label pkg . GolangLabelLocation) projectSource
+      -- label location when it exists
+      traverse_ (label pkg . GolangLabelLocation) projectSource

--- a/src/Strategy/Go/GopkgToml.hs
+++ b/src/Strategy/Go/GopkgToml.hs
@@ -1,22 +1,20 @@
 {-# LANGUAGE RecordWildCards #-}
 
 module Strategy.Go.GopkgToml
-  ( Gopkg(..)
-  , PkgConstraint(..)
-
-  , analyze'
-  , buildGraph
-
-  , gopkgCodec
+  ( Gopkg (..),
+    PkgConstraint (..),
+    analyze',
+    buildGraph,
+    gopkgCodec,
   )
-  where
+where
 
 import Control.Applicative ((<|>))
 import Control.Effect.Diagnostics
 import Data.Foldable (traverse_)
 import Data.Functor (void)
 import Data.Map.Strict (Map)
-import qualified Data.Map.Strict as M
+import Data.Map.Strict qualified as M
 import Data.Text (Text)
 import DepTypes
 import Effect.Exec
@@ -27,41 +25,45 @@ import Path
 import Strategy.Go.Transitive (fillInTransitive)
 import Strategy.Go.Types
 import Toml (TomlCodec, (.=))
-import qualified Toml
+import Toml qualified
 
 gopkgCodec :: TomlCodec Gopkg
-gopkgCodec = Gopkg
-  <$> Toml.list constraintCodec "constraint" .= pkgConstraints
-  <*> Toml.list constraintCodec "override" .= pkgOverrides
+gopkgCodec =
+  Gopkg
+    <$> Toml.list constraintCodec "constraint" .= pkgConstraints
+    <*> Toml.list constraintCodec "override" .= pkgOverrides
 
 constraintCodec :: TomlCodec PkgConstraint
-constraintCodec = PkgConstraint
-  <$> Toml.text "name" .= constraintName
-  <*> Toml.dioptional (Toml.text "source") .= constraintSource
-  <*> Toml.dioptional (Toml.text "version") .= constraintVersion
-  <*> Toml.dioptional (Toml.text "branch") .= constraintBranch
-  <*> Toml.dioptional (Toml.text "revision") .= constraintRevision
+constraintCodec =
+  PkgConstraint
+    <$> Toml.text "name" .= constraintName
+    <*> Toml.dioptional (Toml.text "source") .= constraintSource
+    <*> Toml.dioptional (Toml.text "version") .= constraintVersion
+    <*> Toml.dioptional (Toml.text "branch") .= constraintBranch
+    <*> Toml.dioptional (Toml.text "revision") .= constraintRevision
 
 data Gopkg = Gopkg
-  { pkgConstraints :: [PkgConstraint]
-  , pkgOverrides   :: [PkgConstraint]
-  } deriving (Eq, Ord, Show)
+  { pkgConstraints :: [PkgConstraint],
+    pkgOverrides :: [PkgConstraint]
+  }
+  deriving (Eq, Ord, Show)
 
 data PkgConstraint = PkgConstraint
-  { constraintName     :: Text
-  , constraintSource   :: Maybe Text
-  , constraintVersion  :: Maybe Text
-  , constraintBranch   :: Maybe Text
-  , constraintRevision :: Maybe Text
+  { constraintName :: Text,
+    constraintSource :: Maybe Text,
+    constraintVersion :: Maybe Text,
+    constraintBranch :: Maybe Text,
+    constraintRevision :: Maybe Text
   }
   deriving (Eq, Ord, Show)
 
 analyze' ::
-  ( Has ReadFS sig m
-  , Has Exec sig m
-  , Has Diagnostics sig m
-  )
-  => Path Abs File -> m (Graphing Dependency)
+  ( Has ReadFS sig m,
+    Has Exec sig m,
+    Has Diagnostics sig m
+  ) =>
+  Path Abs File ->
+  m (Graphing Dependency)
 analyze' file = graphingGolang $ do
   gopkg <- readContentsToml gopkgCodec file
   buildGraph gopkg
@@ -72,25 +74,26 @@ analyze' file = graphingGolang $ do
 buildGraph :: Has GolangGrapher sig m => Gopkg -> m ()
 buildGraph = void . M.traverseWithKey go . resolve
   where
-  go :: Has GolangGrapher sig m => Text -> PkgConstraint -> m ()
-  go name PkgConstraint{..} = do
-    let pkg = mkGolangPackage name
+    go :: Has GolangGrapher sig m => Text -> PkgConstraint -> m ()
+    go name PkgConstraint {..} = do
+      let pkg = mkGolangPackage name
 
-    direct pkg
+      direct pkg
 
-    -- label version when it exists
-    traverse_ (label pkg . mkGolangVersion)
-              (constraintVersion <|> constraintBranch <|> constraintRevision)
+      -- label version when it exists
+      traverse_
+        (label pkg . mkGolangVersion)
+        (constraintVersion <|> constraintBranch <|> constraintRevision)
 
-    -- label location when it exists
-    traverse_ (label pkg . GolangLabelLocation) constraintSource
+      -- label location when it exists
+      traverse_ (label pkg . GolangLabelLocation) constraintSource
 
 -- TODO: handling version constraints
 resolve :: Gopkg -> Map Text PkgConstraint -- Map Package (Maybe Version)
 resolve gopkg = overridden
   where
-  overridden = foldr inserting constraints (pkgOverrides gopkg)
-  constraints = foldr inserting M.empty (pkgConstraints gopkg)
+    overridden = foldr inserting constraints (pkgOverrides gopkg)
+    constraints = foldr inserting M.empty (pkgConstraints gopkg)
 
-  inserting :: PkgConstraint -> Map Text PkgConstraint -> Map Text PkgConstraint
-  inserting constraint = M.insert (constraintName constraint) constraint
+    inserting :: PkgConstraint -> Map Text PkgConstraint -> Map Text PkgConstraint
+    inserting constraint = M.insert (constraintName constraint) constraint

--- a/src/Strategy/Go/Transitive.hs
+++ b/src/Strategy/Go/Transitive.hs
@@ -1,62 +1,66 @@
-module Strategy.Go.Transitive (
-  fillInTransitive,
-  graphTransitive,
-  normalizeImportsToModules,
-  Module (..),
-  Package (..),
-) where
+module Strategy.Go.Transitive
+  ( fillInTransitive,
+    graphTransitive,
+    normalizeImportsToModules,
+    Module (..),
+    Package (..),
+  )
+where
 
 import Control.Algebra
 import Control.Applicative (many)
-import Control.Monad (unless)
 import Control.Effect.Diagnostics
+import Control.Monad (unless)
 import Data.Aeson
 import Data.Aeson.Internal (formatError, iparse)
 import Data.Aeson.Parser
-import qualified Data.Attoparsec.ByteString as A
-import qualified Data.ByteString.Lazy as BL
+import Data.Attoparsec.ByteString qualified as A
+import Data.ByteString.Lazy qualified as BL
 import Data.Foldable (traverse_)
 import Data.Functor (void)
+import Data.Map.Strict qualified as M
 import Data.Maybe qualified as Maybe
 import Data.Text (Text)
-import qualified Data.Text as T
-import qualified Data.Vector as V
+import Data.Text qualified as T
+import Data.Vector qualified as V
 import Effect.Exec
 import Effect.Grapher
 import Path
 import Strategy.Go.Types
-import qualified Data.Map.Strict as M
 
 goListCmd :: Command
-goListCmd = Command
-  { cmdName = "go"
-  , cmdArgs = ["list", "-json", "all"]
-  , cmdAllowErr = NonEmptyStdout
-  }
+goListCmd =
+  Command
+    { cmdName = "go",
+      cmdArgs = ["list", "-json", "all"],
+      cmdAllowErr = NonEmptyStdout
+    }
 
 data Package = Package
-  { packageImportPath :: Text
-  , packageModule     :: Maybe Module
-  , packageImports    :: Maybe [Text]
-  , packageSystem     :: Maybe Bool
-  } deriving (Eq, Ord, Show)
+  { packageImportPath :: Text,
+    packageModule :: Maybe Module,
+    packageImports :: Maybe [Text],
+    packageSystem :: Maybe Bool
+  }
+  deriving (Eq, Ord, Show)
 
 data Module = Module
-  { modPath    :: Text
-  , modVersion :: Maybe Text
-  } deriving (Eq, Ord, Show)
+  { modPath :: Text,
+    modVersion :: Maybe Text
+  }
+  deriving (Eq, Ord, Show)
 
 instance FromJSON Package where
   parseJSON = withObject "Package" $ \obj ->
-    Package <$> obj .:  "ImportPath"
-            <*> obj .:? "Module"
-            <*> obj .:? "Imports"
-            <*> obj .:? "Standard"
+    Package <$> obj .: "ImportPath"
+      <*> obj .:? "Module"
+      <*> obj .:? "Imports"
+      <*> obj .:? "Standard"
 
 instance FromJSON Module where
   parseJSON = withObject "Module" $ \obj ->
-    Module <$> obj .:  "Path"
-           <*> obj .:? "Version"
+    Module <$> obj .: "Path"
+      <*> obj .:? "Version"
 
 -- `go list -json` is dumb: it outputs a bunch of raw json objects:
 --     {
@@ -71,37 +75,37 @@ instance FromJSON Module where
 decodeMany :: FromJSON a => BL.ByteString -> Either (JSONPath, String) [a]
 decodeMany = eitherDecodeWith parser (iparse parseJSON)
   where
-  -- skipSpace is lifted from Data.Aeson.Parser.Internal
-  skipSpace = A.skipWhile $ \w -> w == 0x20 || w == 0x0a || w == 0x0d || w == 0x09
+    -- skipSpace is lifted from Data.Aeson.Parser.Internal
+    skipSpace = A.skipWhile $ \w -> w == 0x20 || w == 0x0a || w == 0x0d || w == 0x09
 
-  parser = do
-    (objects :: [Value]) <- many json <* skipSpace <* A.endOfInput
-    pure (Array (V.fromList objects))
+    parser = do
+      (objects :: [Value]) <- many json <* skipSpace <* A.endOfInput
+      pure (Array (V.fromList objects))
 
 graphTransitive :: Has GolangGrapher sig m => [Package] -> m ()
 graphTransitive = void . traverse_ go
   where
-  go :: Has GolangGrapher sig m => Package -> m ()
-  go package = unless (packageSystem package == Just True) $ do
-    let -- when a gomod field is present, use that for the package import path
-        -- otherwise use the top-level package import path
-        path :: Text
-        path = maybe (packageImportPath package) modPath (packageModule package)
+    go :: Has GolangGrapher sig m => Package -> m ()
+    go package = unless (packageSystem package == Just True) $ do
+      let -- when a gomod field is present, use that for the package import path
+          -- otherwise use the top-level package import path
+          path :: Text
+          path = maybe (packageImportPath package) modPath (packageModule package)
 
-        pkg :: GolangPackage
-        pkg = mkGolangPackage path
+          pkg :: GolangPackage
+          pkg = mkGolangPackage path
 
-    traverse_ (traverse_ (edge pkg . mkGolangPackage)) (packageImports package)
+      traverse_ (traverse_ (edge pkg . mkGolangPackage)) (packageImports package)
 
-    -- when we have a gomod, and that gomod has a version, add label for version
-    case modVersion =<< packageModule package of
-      Nothing -> pure ()
-      Just ver -> label pkg (mkGolangVersion ver)
+      -- when we have a gomod, and that gomod has a version, add label for version
+      case modVersion =<< packageModule package of
+        Nothing -> pure ()
+        Just ver -> label pkg (mkGolangVersion ver)
 
 fillInTransitive ::
-  ( Has GolangGrapher sig m
-  , Has Exec sig m
-  , Has Diagnostics sig m
+  ( Has GolangGrapher sig m,
+    Has Exec sig m,
+    Has Diagnostics sig m
   ) =>
   Path x Dir ->
   m ()
@@ -120,18 +124,18 @@ fillInTransitive dir = do
 -- in the final dependency graph.
 normalizeImportsToModules :: [Package] -> [Package]
 normalizeImportsToModules packages = map normalizeSingle packages
- where
-  normalizeSingle :: Package -> Package
-  normalizeSingle package = package{packageImports = map replaceImport <$> packageImports package}
+  where
+    normalizeSingle :: Package -> Package
+    normalizeSingle package = package {packageImports = map replaceImport <$> packageImports package}
 
-  -- If a package doesn't have an associated module, use the package name instead
-  replaceImport :: Text -> Text
-  replaceImport package = Maybe.fromMaybe package (M.lookup package packageNameToModule)
+    -- If a package doesn't have an associated module, use the package name instead
+    replaceImport :: Text -> Text
+    replaceImport package = Maybe.fromMaybe package (M.lookup package packageNameToModule)
 
-  packageNameToModule :: M.Map Text Text
-  packageNameToModule =
-    M.fromList
-      [ (packageImportPath package, modPath gomod)
-      | package <- packages
-      , Just gomod <- [packageModule package]
-      ]
+    packageNameToModule :: M.Map Text Text
+    packageNameToModule =
+      M.fromList
+        [ (packageImportPath package, modPath gomod)
+          | package <- packages,
+            Just gomod <- [packageModule package]
+        ]

--- a/src/Strategy/Go/Types.hs
+++ b/src/Strategy/Go/Types.hs
@@ -1,24 +1,23 @@
 module Strategy.Go.Types
-  ( GolangPackage -- don't export GolangPackage; export the smart constructor instead
-  , mkGolangPackage
-  , GolangGrapher
-  , GolangLabel(..)
-  , mkGolangVersion
-
-  , graphingGolang
+  ( GolangPackage, -- don't export GolangPackage; export the smart constructor instead
+    mkGolangPackage,
+    GolangGrapher,
+    GolangLabel (..),
+    mkGolangVersion,
+    graphingGolang,
   )
-  where
+where
 
-import qualified Data.Map.Strict as M
+import Data.Map.Strict qualified as M
 import Data.Set (Set)
 import Data.Text (Text)
-import qualified Data.Text as T
+import Data.Text qualified as T
 import DepTypes
 import Effect.Grapher
 import Graphing
 
 -- | A golang package is uniquely identified by its import path
-newtype GolangPackage = GolangPackage { goImportPath :: Text } deriving (Eq, Ord, Show)
+newtype GolangPackage = GolangPackage {goImportPath :: Text} deriving (Eq, Ord, Show)
 
 -- | Smart constructor for @GolangPackage@. Applies 'unvendor' to the value
 mkGolangPackage :: Text -> GolangPackage
@@ -26,8 +25,8 @@ mkGolangPackage = GolangPackage . unvendor
 
 type GolangGrapher = LabeledGrapher GolangPackage GolangLabel
 
-data GolangLabel =
-    GolangLabelVersion Text
+data GolangLabel
+  = GolangLabelVersion Text
   | GolangLabelLocation Text
   deriving (Eq, Ord, Show)
 
@@ -42,20 +41,20 @@ graphingGolang = withLabeling golangPackageToDependency
 golangPackageToDependency :: GolangPackage -> Set GolangLabel -> Dependency
 golangPackageToDependency pkg = foldr applyLabel start
   where
+    start :: Dependency
+    start =
+      Dependency
+        { dependencyType = GoType,
+          dependencyName = goImportPath pkg,
+          dependencyVersion = Nothing,
+          dependencyLocations = [],
+          dependencyEnvironments = [],
+          dependencyTags = M.empty
+        }
 
-  start :: Dependency
-  start = Dependency
-    { dependencyType = GoType
-    , dependencyName = goImportPath pkg
-    , dependencyVersion = Nothing
-    , dependencyLocations = []
-    , dependencyEnvironments = []
-    , dependencyTags = M.empty
-    }
-
-  applyLabel :: GolangLabel -> Dependency -> Dependency
-  applyLabel (GolangLabelVersion ver) dep = dep { dependencyVersion = Just (CEq ver) }
-  applyLabel (GolangLabelLocation loc) dep = dep { dependencyLocations = loc : dependencyLocations dep }
+    applyLabel :: GolangLabel -> Dependency -> Dependency
+    applyLabel (GolangLabelVersion ver) dep = dep {dependencyVersion = Just (CEq ver)}
+    applyLabel (GolangLabelLocation loc) dep = dep {dependencyLocations = loc : dependencyLocations dep}
 
 -- Replaces "v0.0.0-20191212000000-abcdef+incompatible" with "abcdef".
 --

--- a/src/Strategy/Godep.hs
+++ b/src/Strategy/Godep.hs
@@ -5,14 +5,14 @@ where
 
 import Control.Applicative ((<|>))
 import Control.Effect.Diagnostics (Diagnostics, (<||>))
-import qualified Control.Effect.Diagnostics as Diag
+import Control.Effect.Diagnostics qualified as Diag
 import Discovery.Walk
 import Effect.Exec
 import Effect.ReadFS
 import Graphing
 import Path
-import qualified Strategy.Go.GopkgLock as GopkgLock
-import qualified Strategy.Go.GopkgToml as GopkgToml
+import Strategy.Go.GopkgLock qualified as GopkgLock
+import Strategy.Go.GopkgToml qualified as GopkgToml
 import Types
 
 discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has ReadFS rsig run, Has Exec rsig run, Has Diagnostics rsig run) => Path Abs Dir -> m [DiscoveredProject run]

--- a/src/Strategy/Gomodules.hs
+++ b/src/Strategy/Gomodules.hs
@@ -12,8 +12,8 @@ import Effect.Exec
 import Effect.ReadFS
 import Graphing
 import Path
-import qualified Strategy.Go.GoList as GoList
-import qualified Strategy.Go.Gomod as Gomod
+import Strategy.Go.GoList qualified as GoList
+import Strategy.Go.Gomod qualified as Gomod
 import Types
 
 discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has ReadFS rsig run, Has Exec rsig run, Has Diagnostics rsig run) => Path Abs Dir -> m [DiscoveredProject run]

--- a/src/Strategy/Googlesource/RepoManifest.hs
+++ b/src/Strategy/Googlesource/RepoManifest.hs
@@ -1,47 +1,45 @@
-{-# language LambdaCase #-}
-{-# language QuasiQuotes #-}
-{-# language RecordWildCards #-}
-{-# language ScopedTypeVariables #-}
-{-# language TemplateHaskell #-}
-{-# language TypeApplications #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeApplications #-}
 
 module Strategy.Googlesource.RepoManifest
-  ( discover
-  , buildGraph
-  , validateProject
-  , validateProjects
-  , nestedValidatedProjects
-  , ManifestGitConfigError
-  , RepoManifest(..)
-  , ManifestRemote(..)
-  , ManifestDefault(..)
-  , ManifestProject(..)
-  , ValidatedProject(..)
+  ( discover,
+    buildGraph,
+    validateProject,
+    validateProjects,
+    nestedValidatedProjects,
+    ManifestGitConfigError,
+    RepoManifest (..),
+    ManifestRemote (..),
+    ManifestDefault (..),
+    ManifestProject (..),
+    ValidatedProject (..),
+  )
+where
 
-  ) where
-
-import Prelude
-
+import Control.Applicative (optional, (<|>))
 import Control.Effect.Diagnostics
-import qualified Data.Map.Strict as M
-import qualified Data.Text as T
-
-import Control.Applicative ((<|>), optional)
 import Control.Monad (unless)
-import DepTypes
-import Data.Text (Text)
-import Data.Text.Prettyprint.Doc (pretty)
 import Data.Foldable (find)
+import Data.HashMap.Strict qualified as HM
+import Data.Map.Strict qualified as M
+import Data.Text (Text)
+import Data.Text qualified as T
+import Data.Text.Prettyprint.Doc (pretty)
+import DepTypes
 import Discovery.Walk
 import Effect.ReadFS
 import Graphing (Graphing, unfold)
 import Parse.XML
 import Path
-import Types
-import Text.URI
-import Text.GitConfig.Parser (Section(..), parseConfig)
-import qualified Data.HashMap.Strict as HM
+import Text.GitConfig.Parser (Section (..), parseConfig)
 import Text.Megaparsec (errorBundlePretty)
+import Text.URI
+import Types
+import Prelude
 
 discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has ReadFS rsig run, Has Diagnostics rsig run) => Path Abs Dir -> m [DiscoveredProject run]
 discover dir = map mkProject <$> findProjects dir
@@ -113,16 +111,16 @@ fixRemote rootDir remote = do
         remoteUrl <- maybeToEither "url lookup failed in git remote" (HM.lookup "url" properties)
         rUrl <- maybeToEither "mkURI failed on rUrl" $ mkURI remoteUrl
         fUrl <- maybeToEither "mkURI failed on remote fetch URL" $ mkURI $ remoteFetch remote
-        maybeToEither ("relativeTo failed for URLs remoteUrl = " <> remoteUrl <> " and remoteFetch remote = " <> remoteFetch remote)
-                      (fUrl `relativeTo` rUrl)
+        maybeToEither
+          ("relativeTo failed for URLs remoteUrl = " <> remoteUrl <> " and remoteFetch remote = " <> remoteFetch remote)
+          (fUrl `relativeTo` rUrl)
 
   url <- tagError InvalidRemote fixedUri
-  pure $ remote { remoteFetch = render url }
-
+  pure $ remote {remoteFetch = render url}
   where
-  isOrigin :: Section -> Bool
-  isOrigin (Section ["remote", "origin"] _) = True
-  isOrigin _ = False
+    isOrigin :: Section -> Bool
+    isOrigin (Section ["remote", "origin"] _) = True
+    isOrigin _ = False
 
 -- If a manifest has an include tag, the included manifest will be found in "manifests/<name attribute>" relative
 -- to the original manifest file.
@@ -134,58 +132,63 @@ fixRemote rootDir remote = do
 -- be a sibling to the original manifest you were parsing.
 validatedProjectsFromIncludes :: (Has ReadFS sig m, Has Diagnostics sig m) => RepoManifest -> Path Abs Dir -> Path Abs Dir -> m [ValidatedProject]
 validatedProjectsFromIncludes manifest parentDir rootDir = do
-    let manifestIncludeFiles :: [Text]
-        manifestIncludeFiles = map includeName $ manifestIncludes manifest
-        pathRelativeToManifestDir :: Text -> Maybe (Path Abs File)
-        pathRelativeToManifestDir file = (parentDir </>) <$> parseRelFile ("manifests/" ++ T.unpack file)
-        manifestFiles :: Maybe [Path Abs File]
-        manifestFiles = traverse pathRelativeToManifestDir manifestIncludeFiles
-    case manifestFiles of
-      Nothing -> fatalText "Error"
-      (Just (fs :: [Path Abs File])) -> concat <$> traverse (nestedValidatedProjects rootDir) fs
+  let manifestIncludeFiles :: [Text]
+      manifestIncludeFiles = map includeName $ manifestIncludes manifest
+      pathRelativeToManifestDir :: Text -> Maybe (Path Abs File)
+      pathRelativeToManifestDir file = (parentDir </>) <$> parseRelFile ("manifests/" ++ T.unpack file)
+      manifestFiles :: Maybe [Path Abs File]
+      manifestFiles = traverse pathRelativeToManifestDir manifestIncludeFiles
+  case manifestFiles of
+    Nothing -> fatalText "Error"
+    (Just (fs :: [Path Abs File])) -> concat <$> traverse (nestedValidatedProjects rootDir) fs
 
 -- DTD for the Repo manifest.xml file: https://gerrit.googlesource.com/git-repo/+/master/docs/manifest-format.md
 -- Note that the DTD is only "roughly adhered to" according to the documentation. For example, the DTD says that
 -- there will be zero or more project and remote tags (it uses a `*`), but the documentation specifies at least one
 -- for both of these tags (which should be denoted by a `+` in the DTD).
 data RepoManifest = RepoManifest
-  { manifestDefault  :: Maybe ManifestDefault
-  , manifestRemotes  :: [ManifestRemote]
-  , manifestProjects :: [ManifestProject]
-  , manifestIncludes :: [ManifestInclude]
-  } deriving (Eq, Ord, Show)
+  { manifestDefault :: Maybe ManifestDefault,
+    manifestRemotes :: [ManifestRemote],
+    manifestProjects :: [ManifestProject],
+    manifestIncludes :: [ManifestInclude]
+  }
+  deriving (Eq, Ord, Show)
 
 data ManifestRemote = ManifestRemote
-  { remoteName     :: Text
-  , remoteFetch    :: Text
-  , remoteRevision :: Maybe Text
-  } deriving (Eq, Ord, Show)
+  { remoteName :: Text,
+    remoteFetch :: Text,
+    remoteRevision :: Maybe Text
+  }
+  deriving (Eq, Ord, Show)
 
 data ManifestDefault = ManifestDefault
-  { defaultRemote   :: Maybe Text
-  , defaultRevision :: Maybe Text
-  } deriving (Eq, Ord, Show)
+  { defaultRemote :: Maybe Text,
+    defaultRevision :: Maybe Text
+  }
+  deriving (Eq, Ord, Show)
 
 data ManifestProject = ManifestProject
-  { projectName     :: Text
-  , projectPath     :: Maybe Text
-  , projectRemote   :: Maybe Text
-  , projectRevision :: Maybe Text
-  } deriving (Eq, Ord, Show)
+  { projectName :: Text,
+    projectPath :: Maybe Text,
+    projectRemote :: Maybe Text,
+    projectRevision :: Maybe Text
+  }
+  deriving (Eq, Ord, Show)
 
-data ManifestInclude = ManifestInclude { includeName :: Text } deriving (Eq, Ord, Show)
+data ManifestInclude = ManifestInclude {includeName :: Text} deriving (Eq, Ord, Show)
 
 data ValidatedProject = ValidatedProject
-  { validatedProjectName     :: Text
-  , validatedProjectPath     :: Text
-  , validatedProjectUrl      :: URI
-  , validatedProjectRevision :: Text
-  } deriving (Eq, Ord, Show)
+  { validatedProjectName :: Text,
+    validatedProjectPath :: Text,
+    validatedProjectUrl :: URI,
+    validatedProjectRevision :: Text
+  }
+  deriving (Eq, Ord, Show)
 
 -- If a project does not have a path, then use its name for the path
 projectPathOrName :: ManifestProject -> Text
-projectPathOrName ManifestProject { projectPath = Nothing, projectName = name } = name
-projectPathOrName ManifestProject { projectPath = Just path } = path
+projectPathOrName ManifestProject {projectPath = Nothing, projectName = name} = name
+projectPathOrName ManifestProject {projectPath = Just path} = path
 
 -- A project's revision comes from the first of these that we encounter:
 --   * If the project has a revision attribute, then use that
@@ -197,9 +200,9 @@ projectPathOrName ManifestProject { projectPath = Just path } = path
 --   * If the project does not have a revision and there is no default revision from either its remote or the default, then blow up
 revisionForProject :: RepoManifest -> ManifestProject -> Maybe Text
 revisionForProject manifest project =
-      projectRevision project
-  <|> (remoteForProject manifest project >>= remoteRevision)
-  <|> (manifestDefault manifest >>= defaultRevision)
+  projectRevision project
+    <|> (remoteForProject manifest project >>= remoteRevision)
+    <|> (manifestDefault manifest >>= defaultRevision)
 
 -- The URL for a project is the project's name appended to the fetch attribute of the project's remote
 urlForProject :: RepoManifest -> ManifestProject -> Maybe URI
@@ -221,7 +224,7 @@ remoteByName manifest remoteNameString =
 
 validateProjects :: RepoManifest -> Maybe [ValidatedProject]
 validateProjects manifest =
-    traverse (validateProject manifest) (manifestProjects manifest)
+  traverse (validateProject manifest) (manifestProjects manifest)
 
 validateProject :: RepoManifest -> ManifestProject -> Maybe ValidatedProject
 validateProject manifest project = do
@@ -232,27 +235,27 @@ validateProject manifest project = do
 instance FromXML RepoManifest where
   parseElement el =
     RepoManifest <$> optional (child "default" el)
-                 <*> children "remote" el
-                 <*> children "project" el
-                 <*> children "include" el
+      <*> children "remote" el
+      <*> children "project" el
+      <*> children "include" el
 
 instance FromXML ManifestDefault where
   parseElement el =
     ManifestDefault <$> optional (attr "remote" el)
-                    <*> optional (attr "revision" el)
+      <*> optional (attr "revision" el)
 
 instance FromXML ManifestRemote where
   parseElement el =
     ManifestRemote <$> attr "name" el
-                   <*> attr "fetch" el
-                   <*> optional (attr "revision" el)
+      <*> attr "fetch" el
+      <*> optional (attr "revision" el)
 
 instance FromXML ManifestProject where
   parseElement el =
     ManifestProject <$> attr "name" el
-                    <*> optional (attr "path" el)
-                    <*> optional (attr "remote" el)
-                    <*> optional (attr "revision" el)
+      <*> optional (attr "path" el)
+      <*> optional (attr "remote" el)
+      <*> optional (attr "revision" el)
 
 instance FromXML ManifestInclude where
   parseElement el =
@@ -260,18 +263,19 @@ instance FromXML ManifestInclude where
 
 buildGraph :: [ValidatedProject] -> Graphing Dependency
 buildGraph projects = unfold projects (const []) toDependency
-    where
-    toDependency ValidatedProject{..} =
-      Dependency { dependencyType = GooglesourceType
-                 , dependencyName = validatedProjectName
-                 , dependencyVersion = Just (CEq validatedProjectRevision)
-                 , dependencyLocations = [render validatedProjectUrl]
-                 , dependencyTags = M.empty
-                 , dependencyEnvironments = [EnvProduction]
-                 }
+  where
+    toDependency ValidatedProject {..} =
+      Dependency
+        { dependencyType = GooglesourceType,
+          dependencyName = validatedProjectName,
+          dependencyVersion = Just (CEq validatedProjectRevision),
+          dependencyLocations = [render validatedProjectUrl],
+          dependencyTags = M.empty,
+          dependencyEnvironments = [EnvProduction]
+        }
 
-data ManifestGitConfigError =
-    InvalidRemote Text
+data ManifestGitConfigError
+  = InvalidRemote Text
   | GitConfigParse Text
   | MissingGitConfig Text
   deriving (Eq, Ord, Show)

--- a/src/Strategy/Gradle.hs
+++ b/src/Strategy/Gradle.hs
@@ -2,13 +2,13 @@
 {-# LANGUAGE TemplateHaskell #-}
 
 module Strategy.Gradle
-  ( discover
-
-  , buildGraph
-  , JsonDep(..)
-  , PackageName (..)
-  , ConfigName (..)
-  ) where
+  ( discover,
+    buildGraph,
+    JsonDep (..),
+    PackageName (..),
+    ConfigName (..),
+  )
+where
 
 import Control.Carrier.Diagnostics hiding (fromMaybe)
 import Control.Effect.Exception
@@ -17,18 +17,18 @@ import Control.Effect.Path (withSystemTempDir)
 import Data.Aeson
 import Data.Aeson.Types (Parser, unexpected)
 import Data.ByteString (ByteString)
-import qualified Data.ByteString as BS
-import qualified Data.ByteString.Lazy as BL
+import Data.ByteString qualified as BS
+import Data.ByteString.Lazy qualified as BL
 import Data.FileEmbed (embedFile)
 import Data.Foldable (find, for_)
 import Data.List (isPrefixOf)
 import Data.Map.Strict (Map)
-import qualified Data.Map.Strict as M
+import Data.Map.Strict qualified as M
 import Data.Maybe (fromMaybe, mapMaybe)
 import Data.Set (Set)
-import qualified Data.Set as S
+import Data.Set qualified as S
 import Data.Text (Text)
-import qualified Data.Text as T
+import Data.Text qualified as T
 import Data.Text.Encoding (decodeUtf8, encodeUtf8)
 import DepTypes
 import Discovery.Walk
@@ -38,20 +38,22 @@ import Effect.Logger (Logger, logWarn)
 import Effect.ReadFS (ReadFS)
 import Graphing (Graphing)
 import Path
-import qualified System.FilePath as FP
+import System.FilePath qualified as FP
 import Types
 
+newtype ConfigName = ConfigName {unConfigName :: Text} deriving (Eq, Ord, Show, FromJSON)
 
-newtype ConfigName = ConfigName { unConfigName :: Text } deriving (Eq, Ord, Show, FromJSON)
 newtype GradleLabel = Env DepEnvironment deriving (Eq, Ord, Show)
-newtype PackageName = PackageName { unPackageName :: Text } deriving (Eq, Ord, Show, FromJSON)
+
+newtype PackageName = PackageName {unPackageName :: Text} deriving (Eq, Ord, Show, FromJSON)
 
 gradleJsonDepsCmd :: Text -> FP.FilePath -> Set BuildTarget -> Command
-gradleJsonDepsCmd baseCmd initScriptFilepath targets = Command
-  { cmdName = baseCmd
-  , cmdArgs = ["-I", T.pack initScriptFilepath] ++ map (\target -> unBuildTarget target <> ":jsonDeps") (S.toList targets)
-  , cmdAllowErr = Never
-  }
+gradleJsonDepsCmd baseCmd initScriptFilepath targets =
+  Command
+    { cmdName = baseCmd,
+      cmdArgs = ["-I", T.pack initScriptFilepath] ++ map (\target -> unBuildTarget target <> ":jsonDeps") (S.toList targets),
+      cmdAllowErr = Never
+    }
 
 discover ::
   ( Has (Lift IO) sig m,
@@ -59,7 +61,6 @@ discover ::
     Has Diagnostics sig m,
     Has Exec sig m,
     Has Logger sig m,
-
     Has (Lift IO) rsig run,
     Has Exec rsig run,
     Has Diagnostics rsig run
@@ -76,12 +77,12 @@ findProjects = walk' $ \dir _ files -> do
   case find (\f -> "build.gradle" `isPrefixOf` fileName f) files of
     Nothing -> pure ([], WalkContinue)
     Just _ -> do
-
       projectsStdout <-
-        runDiagnostics $ context ("getting gradle projects rooted at " <> pathToText dir) $
-          execThrow dir (gradleProjectsCmd (pathToText dir <> "gradlew"))
-            <||> execThrow dir (gradleProjectsCmd (pathToText dir <> "gradlew.bat"))
-            <||> execThrow dir (gradleProjectsCmd "gradle")
+        runDiagnostics $
+          context ("getting gradle projects rooted at " <> pathToText dir) $
+            execThrow dir (gradleProjectsCmd (pathToText dir <> "gradlew"))
+              <||> execThrow dir (gradleProjectsCmd (pathToText dir <> "gradlew.bat"))
+              <||> execThrow dir (gradleProjectsCmd "gradle")
 
       case projectsStdout of
         Left err -> do
@@ -99,17 +100,18 @@ findProjects = walk' $ \dir _ files -> do
           pure ([project], WalkSkipAll)
 
 data GradleProject = GradleProject
-  { gradleDir :: Path Abs Dir
-  , gradleProjects :: Set Text
-  } deriving (Eq, Ord, Show)
+  { gradleDir :: Path Abs Dir,
+    gradleProjects :: Set Text
+  }
+  deriving (Eq, Ord, Show)
 
 gradleProjectsCmd :: Text -> Command
-gradleProjectsCmd baseCmd = Command
-  { cmdName = baseCmd
-  , cmdArgs = ["projects"]
-  , cmdAllowErr = Never
-  }
-
+gradleProjectsCmd baseCmd =
+  Command
+    { cmdName = baseCmd,
+      cmdArgs = ["projects"],
+      cmdAllowErr = Never
+    }
 
 -- we use a single empty-string target when no subprojects exist. gradle uses an
 -- empty string to denote the root project when invoking tasks, e.g., ":task"
@@ -164,17 +166,20 @@ initScript :: ByteString
 initScript = $(embedFile "scripts/jsondeps.gradle")
 
 analyze' ::
-  ( Has (Lift IO) sig m
-  , Has Exec sig m
-  , Has Diagnostics sig m
-  )
-  => Set BuildTarget -> Path Abs Dir -> m (Graphing Dependency)
+  ( Has (Lift IO) sig m,
+    Has Exec sig m,
+    Has Diagnostics sig m
+  ) =>
+  Set BuildTarget ->
+  Path Abs Dir ->
+  m (Graphing Dependency)
 analyze' targets dir = withSystemTempDir "fossa-gradle" $ \tmpDir -> do
   let initScriptFilepath = fromAbsDir tmpDir FP.</> "jsondeps.gradle"
   sendIO (BS.writeFile initScriptFilepath initScript)
-  stdout <- execThrow dir (gradleJsonDepsCmd (pathToText dir <> "gradlew") initScriptFilepath targets)
-              <||> execThrow dir (gradleJsonDepsCmd (pathToText dir <> "gradlew.bat") initScriptFilepath targets)
-              <||> execThrow dir (gradleJsonDepsCmd "gradle" initScriptFilepath targets)
+  stdout <-
+    execThrow dir (gradleJsonDepsCmd (pathToText dir <> "gradlew") initScriptFilepath targets)
+      <||> execThrow dir (gradleJsonDepsCmd (pathToText dir <> "gradlew.bat") initScriptFilepath targets)
+      <||> execThrow dir (gradleJsonDepsCmd "gradle" initScriptFilepath targets)
 
   let text = decodeUtf8 $ BL.toStrict stdout
       textLines :: [Text]
@@ -185,7 +190,7 @@ analyze' targets dir = withSystemTempDir "fossa-gradle" $ \tmpDir -> do
       jsonDepsLines = mapMaybe (T.stripPrefix "JSONDEPS_") textLines
 
       packagePathsWithJson :: [(PackageName, Text)]
-      packagePathsWithJson = map (\line -> let (x,y) = T.breakOn "_" line in (PackageName x, T.drop 1 y {- drop the underscore; break doesn't remove it -})) jsonDepsLines
+      packagePathsWithJson = map (\line -> let (x, y) = T.breakOn "_" line in (PackageName x, T.drop 1 y {- drop the underscore; break doesn't remove it -})) jsonDepsLines
 
       packagePathsWithDecoded :: [((PackageName, ConfigName), [JsonDep])]
       packagePathsWithDecoded = do
@@ -203,62 +208,63 @@ analyze' targets dir = withSystemTempDir "fossa-gradle" $ \tmpDir -> do
 buildGraph :: Map (PackageName, ConfigName) [JsonDep] -> Graphing Dependency
 buildGraph projectsAndDeps = run . withLabeling toDependency $ M.traverseWithKey addProject projectsAndDeps
   where
-  -- add top-level projects from the output
-  addProject :: Has (LabeledGrapher JsonDep GradleLabel) sig m => (PackageName, ConfigName) -> [JsonDep] -> m ()
-  addProject (projName, configName) projDeps = do
-    let projAsDep = ProjectDep $ unPackageName projName
-        envLabel = configNameToLabel configName
-    direct projAsDep
-    label projAsDep envLabel
-    for_ projDeps $ \dep -> do
-      edge projAsDep dep
-      mkRecursiveEdges dep envLabel
+    -- add top-level projects from the output
+    addProject :: Has (LabeledGrapher JsonDep GradleLabel) sig m => (PackageName, ConfigName) -> [JsonDep] -> m ()
+    addProject (projName, configName) projDeps = do
+      let projAsDep = ProjectDep $ unPackageName projName
+          envLabel = configNameToLabel configName
+      direct projAsDep
+      label projAsDep envLabel
+      for_ projDeps $ \dep -> do
+        edge projAsDep dep
+        mkRecursiveEdges dep envLabel
 
-  configNameToLabel :: ConfigName -> GradleLabel
-  configNameToLabel conf = case unConfigName conf of
-    "compileOnly" -> Env EnvDevelopment
-    x | x `elem` ["testImplementation", "testCompileOnly", "testRuntimeOnly"] -> Env EnvTesting
-    x -> Env $ EnvOther x
+    configNameToLabel :: ConfigName -> GradleLabel
+    configNameToLabel conf = case unConfigName conf of
+      "compileOnly" -> Env EnvDevelopment
+      x | x `elem` ["testImplementation", "testCompileOnly", "testRuntimeOnly"] -> Env EnvTesting
+      x -> Env $ EnvOther x
 
-  toDependency :: JsonDep -> S.Set GradleLabel -> Dependency
-  toDependency dep = foldr applyLabel $ jsonDepToDep dep
+    toDependency :: JsonDep -> S.Set GradleLabel -> Dependency
+    toDependency dep = foldr applyLabel $ jsonDepToDep dep
 
-  applyLabel :: GradleLabel -> Dependency -> Dependency
-  applyLabel lbl dep = case lbl of
-    Env env -> insertEnvironment env dep
+    applyLabel :: GradleLabel -> Dependency -> Dependency
+    applyLabel lbl dep = case lbl of
+      Env env -> insertEnvironment env dep
 
-  -- build edges between deps, recursively
-  mkRecursiveEdges :: Has (LabeledGrapher JsonDep GradleLabel) sig m => JsonDep -> GradleLabel -> m ()
-  mkRecursiveEdges (ProjectDep x) envLabel = label (ProjectDep x) envLabel
-  mkRecursiveEdges jsondep@(PackageDep _ _ deps) envLabel = do
-    label jsondep envLabel
-    for_ deps $ \child -> do
-      edge jsondep child
-      mkRecursiveEdges child envLabel
+    -- build edges between deps, recursively
+    mkRecursiveEdges :: Has (LabeledGrapher JsonDep GradleLabel) sig m => JsonDep -> GradleLabel -> m ()
+    mkRecursiveEdges (ProjectDep x) envLabel = label (ProjectDep x) envLabel
+    mkRecursiveEdges jsondep@(PackageDep _ _ deps) envLabel = do
+      label jsondep envLabel
+      for_ deps $ \child -> do
+        edge jsondep child
+        mkRecursiveEdges child envLabel
 
-  jsonDepToDep :: JsonDep -> Dependency
-  jsonDepToDep (ProjectDep name) = projectToDep name
-  jsonDepToDep (PackageDep name version _) =
-    Dependency
-      { dependencyType = MavenType
-      , dependencyName = name
-      , dependencyVersion = Just (CEq version)
-      , dependencyLocations = []
-      , dependencyEnvironments = []
-      , dependencyTags = M.empty
-      }
+    jsonDepToDep :: JsonDep -> Dependency
+    jsonDepToDep (ProjectDep name) = projectToDep name
+    jsonDepToDep (PackageDep name version _) =
+      Dependency
+        { dependencyType = MavenType,
+          dependencyName = name,
+          dependencyVersion = Just (CEq version),
+          dependencyLocations = [],
+          dependencyEnvironments = [],
+          dependencyTags = M.empty
+        }
 
-  projectToDep name = Dependency
-    { dependencyType = SubprojectType
-    , dependencyName = name
-    , dependencyVersion = Nothing
-    , dependencyLocations = []
-    , dependencyEnvironments = []
-    , dependencyTags = M.empty
-    }
+    projectToDep name =
+      Dependency
+        { dependencyType = SubprojectType,
+          dependencyName = name,
+          dependencyVersion = Nothing,
+          dependencyLocations = [],
+          dependencyEnvironments = [],
+          dependencyTags = M.empty
+        }
 
-data JsonDep =
-    ProjectDep Text -- name
+data JsonDep
+  = ProjectDep Text -- name
   | PackageDep Text Text [JsonDep] -- name version deps
   deriving (Eq, Ord, Show)
 
@@ -268,4 +274,4 @@ instance FromJSON JsonDep where
     case ty of
       "project" -> ProjectDep <$> obj .: "name"
       "package" -> PackageDep <$> obj .: "name" <*> obj .: "version" <*> obj .: "dependencies"
-      _         -> unexpected (String ty)
+      _ -> unexpected (String ty)

--- a/src/Strategy/Haskell/Cabal.hs
+++ b/src/Strategy/Haskell/Cabal.hs
@@ -21,34 +21,35 @@ import Data.Aeson.Types
 import Data.Foldable (for_)
 import Data.List (isSuffixOf)
 import Data.Map.Strict (Map)
-import qualified Data.Map.Strict as M
+import Data.Map.Strict qualified as M
 import Data.Set (Set)
-import qualified Data.Set as S
+import Data.Set qualified as S
 import Data.Text (Text)
-import qualified Data.Text as T
+import Data.Text qualified as T
 import Discovery.Walk
 import Effect.Exec
 import Effect.Grapher
 import Effect.ReadFS
 import Graphing (Graphing)
-import qualified Graphing as G
+import Graphing qualified as G
 import Path
 import Types
 
 newtype BuildPlan = BuildPlan {installPlans :: [InstallPlan]} deriving (Eq, Ord, Show)
+
 newtype Component = Component {componentDeps :: Set PlanId} deriving (Eq, Ord, Show)
+
 newtype PlanId = PlanId {unPlanId :: Text} deriving (FromJSON, Eq, Ord, Show)
 
-data InstallPlan
-  = InstallPlan
-      { planType :: PlanType,
-        planId :: PlanId,
-        planName :: Text,
-        planVersion :: Text,
-        planDepends :: Set PlanId,
-        planStyle :: Maybe PlanStyle,
-        planComponents :: Set PlanId
-      }
+data InstallPlan = InstallPlan
+  { planType :: PlanType,
+    planId :: PlanId,
+    planName :: Text,
+    planVersion :: Text,
+    planDepends :: Set PlanId,
+    planStyle :: Maybe PlanStyle,
+    planComponents :: Set PlanId
+  }
   deriving (Eq, Ord, Show)
 
 data PlanStyle
@@ -147,7 +148,8 @@ getDeps = analyze . cabalDir
 
 data CabalProject = CabalProject
   { cabalDir :: Path Abs Dir
-  } deriving (Eq, Ord, Show)
+  }
+  deriving (Eq, Ord, Show)
 
 doGraph :: Has (MappedGrapher PlanId InstallPlan) sig m => InstallPlan -> m ()
 doGraph plan = do

--- a/src/Strategy/Haskell/Stack.hs
+++ b/src/Strategy/Haskell/Stack.hs
@@ -2,6 +2,7 @@
 
 module Strategy.Haskell.Stack
   ( discover,
+
     -- * Testing
     buildGraph,
     PackageName (..),
@@ -11,20 +12,20 @@ module Strategy.Haskell.Stack
 where
 
 import Control.Effect.Diagnostics
+import Control.Monad (when)
 import Data.Aeson.Types
 import Data.Foldable (for_)
-import qualified Data.Map.Strict as M
+import Data.Map.Strict qualified as M
 import Data.Text (Text)
-import qualified Data.Text as T
+import Data.Text qualified as T
 import Discovery.Walk
 import Effect.Exec
 import Effect.Grapher
-import qualified Graphing as G
+import Effect.ReadFS (ReadFS)
+import Graphing qualified as G
 import Path
 import Types
 import Prelude
-import Control.Monad (when)
-import Effect.ReadFS (ReadFS)
 
 newtype PackageName = PackageName {unPackageName :: Text} deriving (FromJSON, Eq, Ord, Show)
 
@@ -87,7 +88,8 @@ getDeps = analyze . stackDir
 
 data StackProject = StackProject
   { stackDir :: Path Abs Dir
-  } deriving (Eq, Ord, Show)
+  }
+  deriving (Eq, Ord, Show)
 
 stackJSONDepsCmd :: Command
 stackJSONDepsCmd =

--- a/src/Strategy/Leiningen.hs
+++ b/src/Strategy/Leiningen.hs
@@ -23,25 +23,25 @@ where
 
 import Control.Applicative (optional)
 import Control.Effect.Diagnostics
-import qualified Data.EDN as EDN
+import Data.EDN qualified as EDN
 import Data.EDN.Class.Parser (Parser)
 import Data.Foldable (traverse_)
 import Data.Functor (($>))
 import Data.Map.Strict (Map)
-import qualified Data.Map.Strict as M
+import Data.Map.Strict qualified as M
 import Data.Set (Set)
 import Data.Text (Text)
-import qualified Data.Text as T
-import qualified Data.Text.Lazy as TL
+import Data.Text qualified as T
+import Data.Text.Lazy qualified as TL
 import Data.Text.Lazy.Encoding (decodeUtf8)
-import qualified Data.Vector as V
+import Data.Vector qualified as V
 import Discovery.Walk
 import Effect.Exec
 import Effect.Grapher
+import Effect.ReadFS (ReadFS)
 import Graphing (Graphing)
 import Path
 import Types
-import Effect.ReadFS (ReadFS)
 
 leinDepsCmd :: Command
 leinDepsCmd =
@@ -81,9 +81,10 @@ getDeps :: (Has Exec sig m, Has Diagnostics sig m) => LeiningenProject -> m (Gra
 getDeps = analyze . leinProjectClj
 
 data LeiningenProject = LeiningenProject
-  { leinDir :: Path Abs Dir
-  , leinProjectClj :: Path Abs File
-  } deriving (Eq, Ord, Show)
+  { leinDir :: Path Abs Dir,
+    leinProjectClj :: Path Abs File
+  }
+  deriving (Eq, Ord, Show)
 
 analyze :: (Has Exec sig m, Has Diagnostics sig m) => Path Abs File -> m (Graphing Dependency)
 analyze file = do

--- a/src/Strategy/Maven.hs
+++ b/src/Strategy/Maven.hs
@@ -12,9 +12,9 @@ import Effect.Exec
 import Effect.ReadFS
 import Graphing (Graphing)
 import Path
-import qualified Strategy.Maven.PluginStrategy as Plugin
-import qualified Strategy.Maven.Pom as Pom
-import qualified Strategy.Maven.Pom.Closure as PomClosure
+import Strategy.Maven.PluginStrategy qualified as Plugin
+import Strategy.Maven.Pom qualified as Pom
+import Strategy.Maven.Pom.Closure qualified as PomClosure
 import Types
 
 discover ::
@@ -34,7 +34,9 @@ discover dir = map (mkProject dir) <$> PomClosure.findProjects dir
 mkProject ::
   (Has ReadFS sig n, Has Exec sig n, Has (Lift IO) sig n, Has Diagnostics sig n) =>
   -- | basedir; required for licenses
-  Path Abs Dir -> PomClosure.MavenProjectClosure -> DiscoveredProject n
+  Path Abs Dir ->
+  PomClosure.MavenProjectClosure ->
+  DiscoveredProject n
 mkProject basedir closure =
   DiscoveredProject
     { projectType = "maven",

--- a/src/Strategy/Maven/Plugin.hs
+++ b/src/Strategy/Maven/Plugin.hs
@@ -1,15 +1,15 @@
-{-# language TemplateHaskell #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 module Strategy.Maven.Plugin
-  ( withUnpackedPlugin
-  , installPlugin
-  , execPlugin
-  , parsePluginOutput
-
-  , PluginOutput(..)
-  , Artifact(..)
-  , Edge(..)
-  ) where
+  ( withUnpackedPlugin,
+    installPlugin,
+    execPlugin,
+    parsePluginOutput,
+    PluginOutput (..),
+    Artifact (..),
+    Edge (..),
+  )
+where
 
 import Control.Algebra
 import Control.Effect.Diagnostics
@@ -17,16 +17,16 @@ import Control.Effect.Exception
 import Control.Effect.Lift (sendIO)
 import Data.Aeson
 import Data.ByteString (ByteString)
-import qualified Data.ByteString as BS
+import Data.ByteString qualified as BS
 import Data.FileEmbed (embedFile)
 import Data.Functor (void)
 import Data.Text (Text)
-import qualified Data.Text as T
+import Data.Text qualified as T
 import Effect.Exec
 import Effect.ReadFS
 import Path
 import Path.IO (createTempDir, getTempDir, removeDirRecur)
-import qualified System.FilePath as FP
+import System.FilePath qualified as FP
 
 pluginGroup :: Text
 pluginGroup = "com.github.ferstl"
@@ -42,20 +42,20 @@ pluginJar = $(embedFile "scripts/depgraph-maven-plugin-3.3.0.jar")
 
 withUnpackedPlugin ::
   ( Has (Lift IO) sig m
-  )
-  => (FP.FilePath -> m a) -> m a
+  ) =>
+  (FP.FilePath -> m a) ->
+  m a
 withUnpackedPlugin act =
-  bracket (sendIO (getTempDir >>= \tmp -> createTempDir tmp "fossa-maven"))
-          (sendIO . removeDirRecur)
-          go
-
+  bracket
+    (sendIO (getTempDir >>= \tmp -> createTempDir tmp "fossa-maven"))
+    (sendIO . removeDirRecur)
+    go
   where
+    go tmpDir = do
+      let pluginJarFilepath = fromAbsDir tmpDir FP.</> "plugin.jar"
+      sendIO (BS.writeFile pluginJarFilepath pluginJar)
 
-  go tmpDir = do
-    let pluginJarFilepath = fromAbsDir tmpDir FP.</> "plugin.jar"
-    sendIO (BS.writeFile pluginJarFilepath pluginJar)
-
-    act pluginJarFilepath
+      act pluginJarFilepath
 
 installPlugin :: (Has Exec sig m, Has Diagnostics sig m) => Path Abs Dir -> FP.FilePath -> m ()
 installPlugin dir path = void $ execThrow dir (mavenInstallPluginCmd path)
@@ -70,70 +70,74 @@ parsePluginOutput :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs Dir -
 parsePluginOutput dir = readContentsJson (dir </> outputFile)
 
 mavenInstallPluginCmd :: FP.FilePath -> Command
-mavenInstallPluginCmd pluginFilePath = Command
-  { cmdName = "mvn"
-  , cmdArgs =
-    [ "install:install-file"
-    , "-DgroupId=" <> pluginGroup
-    , "-DartifactId=" <> pluginArtifact
-    , "-Dversion=" <> pluginVersion
-    , "-Dpackaging=jar"
-    , "-Dfile=" <> T.pack pluginFilePath
-    ]
-  , cmdAllowErr = Never
-  }
+mavenInstallPluginCmd pluginFilePath =
+  Command
+    { cmdName = "mvn",
+      cmdArgs =
+        [ "install:install-file",
+          "-DgroupId=" <> pluginGroup,
+          "-DartifactId=" <> pluginArtifact,
+          "-Dversion=" <> pluginVersion,
+          "-Dpackaging=jar",
+          "-Dfile=" <> T.pack pluginFilePath
+        ],
+      cmdAllowErr = Never
+    }
 
 mavenPluginDependenciesCmd :: Command
-mavenPluginDependenciesCmd = Command
-  { cmdName = "mvn"
-  , cmdArgs =
-    [ pluginGroup <> ":" <> pluginArtifact <> ":" <> pluginVersion <> ":aggregate"
-    , "-DgraphFormat=json"
-    , "-DmergeScopes"
-    , "-DreduceEdges=false"
-    ]
-  , cmdAllowErr = Never
-  }
+mavenPluginDependenciesCmd =
+  Command
+    { cmdName = "mvn",
+      cmdArgs =
+        [ pluginGroup <> ":" <> pluginArtifact <> ":" <> pluginVersion <> ":aggregate",
+          "-DgraphFormat=json",
+          "-DmergeScopes",
+          "-DreduceEdges=false"
+        ],
+      cmdAllowErr = Never
+    }
 
 data PluginOutput = PluginOutput
-  { outArtifacts :: [Artifact]
-  , outEdges     :: [Edge]
-  } deriving (Eq, Ord, Show)
+  { outArtifacts :: [Artifact],
+    outEdges :: [Edge]
+  }
+  deriving (Eq, Ord, Show)
 
 -- NOTE: artifact numeric IDs are 1-indexed, whereas edge numeric references are 0-indexed.
 -- the json parser for artifacts converts them to be 0-indexed.
 data Artifact = Artifact
-  { artifactNumericId  :: Int
-  , artifactGroupId    :: Text
-  , artifactArtifactId :: Text
-  , artifactVersion    :: Text
-  , artifactOptional   :: Bool
-  , artifactScopes     :: [Text]
-  } deriving (Eq, Ord, Show)
+  { artifactNumericId :: Int,
+    artifactGroupId :: Text,
+    artifactArtifactId :: Text,
+    artifactVersion :: Text,
+    artifactOptional :: Bool,
+    artifactScopes :: [Text]
+  }
+  deriving (Eq, Ord, Show)
 
 data Edge = Edge
-  { edgeFrom :: Int
-  , edgeTo   :: Int
-  } deriving (Eq, Ord, Show)
+  { edgeFrom :: Int,
+    edgeTo :: Int
+  }
+  deriving (Eq, Ord, Show)
 
 instance FromJSON PluginOutput where
   parseJSON = withObject "PluginOutput" $ \obj ->
-    PluginOutput <$> obj .:? "artifacts"    .!= []
-                 <*> obj .:? "dependencies" .!= []
+    PluginOutput <$> obj .:? "artifacts" .!= []
+      <*> obj .:? "dependencies" .!= []
 
 instance FromJSON Artifact where
   parseJSON = withObject "Artifact" $ \obj ->
     Artifact <$> (offset <$> obj .: "numericId")
-             <*> obj .: "groupId"
-             <*> obj .: "artifactId"
-             <*> obj .: "version"
-             <*> obj .: "optional"
-             <*> obj .: "scopes"
+      <*> obj .: "groupId"
+      <*> obj .: "artifactId"
+      <*> obj .: "version"
+      <*> obj .: "optional"
+      <*> obj .: "scopes"
     where
-
-    offset = subtract 1
+      offset = subtract 1
 
 instance FromJSON Edge where
   parseJSON = withObject "Edge" $ \obj ->
     Edge <$> obj .: "numericFrom"
-         <*> obj .: "numericTo"
+      <*> obj .: "numericTo"

--- a/src/Strategy/Maven/PluginStrategy.hs
+++ b/src/Strategy/Maven/PluginStrategy.hs
@@ -1,15 +1,16 @@
 {-# LANGUAGE RecordWildCards #-}
 
 module Strategy.Maven.PluginStrategy
-  ( analyze'
-  , buildGraph
-  ) where
+  ( analyze',
+    buildGraph,
+  )
+where
 
 import Control.Effect.Diagnostics
 import Control.Effect.Lift
 import Data.Foldable (traverse_)
 import Data.Map.Strict (Map)
-import qualified Data.Map.Strict as M
+import Data.Map.Strict qualified as M
 import DepTypes
 import Effect.Exec
 import Effect.Grapher hiding (Edge)
@@ -19,12 +20,13 @@ import Path
 import Strategy.Maven.Plugin
 
 analyze' ::
-  ( Has (Lift IO) sig m
-  , Has ReadFS sig m
-  , Has Exec sig m
-  , Has Diagnostics sig m
-  )
-  => Path Abs Dir -> m (Graphing Dependency)
+  ( Has (Lift IO) sig m,
+    Has ReadFS sig m,
+    Has Exec sig m,
+    Has Diagnostics sig m
+  ) =>
+  Path Abs Dir ->
+  m (Graphing Dependency)
 analyze' dir = withUnpackedPlugin $ \filepath -> do
   installPlugin dir filepath
   execPlugin dir
@@ -32,37 +34,38 @@ analyze' dir = withUnpackedPlugin $ \filepath -> do
   pure (buildGraph pluginOutput)
 
 buildGraph :: PluginOutput -> Graphing Dependency
-buildGraph PluginOutput{..} = run $ evalGrapher $ do
-  let byNumeric :: Map Int Artifact
-      byNumeric = indexBy artifactNumericId outArtifacts
+buildGraph PluginOutput {..} = run $
+  evalGrapher $ do
+    let byNumeric :: Map Int Artifact
+        byNumeric = indexBy artifactNumericId outArtifacts
 
-  let depsByNumeric :: Map Int Dependency
-      depsByNumeric = M.map toDependency byNumeric
+    let depsByNumeric :: Map Int Dependency
+        depsByNumeric = M.map toDependency byNumeric
 
-  traverse_ (visitEdge depsByNumeric) outEdges
-
+    traverse_ (visitEdge depsByNumeric) outEdges
   where
+    toDependency :: Artifact -> Dependency
+    toDependency Artifact {..} =
+      Dependency
+        { dependencyType = MavenType,
+          dependencyName = artifactGroupId <> ":" <> artifactArtifactId,
+          dependencyVersion = Just (CEq artifactVersion),
+          dependencyLocations = [],
+          dependencyEnvironments = if "test" `elem` artifactScopes then [EnvTesting] else [],
+          dependencyTags =
+            M.fromList $
+              ("scopes", artifactScopes) :
+                [("optional", ["true"]) | artifactOptional]
+        }
 
-  toDependency :: Artifact -> Dependency
-  toDependency Artifact{..} = Dependency
-    { dependencyType = MavenType
-    , dependencyName = artifactGroupId <> ":" <> artifactArtifactId
-    , dependencyVersion = Just (CEq artifactVersion)
-    , dependencyLocations = []
-    , dependencyEnvironments = if "test" `elem` artifactScopes then [EnvTesting] else []
-    , dependencyTags = M.fromList $
-      ("scopes", artifactScopes) :
-      [("optional", ["true"]) | artifactOptional]
-    }
+    visitEdge :: Has (Grapher Dependency) sig m => Map Int Dependency -> Edge -> m ()
+    visitEdge refsByNumeric Edge {..} = do
+      let refs = do
+            parentRef <- M.lookup edgeFrom refsByNumeric
+            childRef <- M.lookup edgeTo refsByNumeric
+            Just (parentRef, childRef)
 
-  visitEdge :: Has (Grapher Dependency) sig m => Map Int Dependency -> Edge -> m ()
-  visitEdge refsByNumeric Edge{..} = do
-    let refs = do
-          parentRef <- M.lookup edgeFrom refsByNumeric
-          childRef <- M.lookup edgeTo refsByNumeric
-          Just (parentRef, childRef)
+      traverse_ (uncurry edge) refs
 
-    traverse_ (uncurry edge) refs
-
-  indexBy :: Ord k => (v -> k) -> [v] -> Map k v
-  indexBy f = M.fromList . map (\v -> (f v, v))
+    indexBy :: Ord k => (v -> k) -> [v] -> Map k v
+    indexBy f = M.fromList . map (\v -> (f v, v))

--- a/src/Strategy/Maven/Pom/Closure.hs
+++ b/src/Strategy/Maven/Pom/Closure.hs
@@ -1,25 +1,26 @@
 module Strategy.Maven.Pom.Closure
-  ( findProjects
-  , MavenProjectClosure(..)
-  , buildProjectClosures
-  ) where
+  ( findProjects,
+    MavenProjectClosure (..),
+    buildProjectClosures,
+  )
+where
 
-import qualified Algebra.Graph.AdjacencyMap as AM
-import qualified Algebra.Graph.AdjacencyMap.Algorithm as AM
+import Algebra.Graph.AdjacencyMap qualified as AM
+import Algebra.Graph.AdjacencyMap.Algorithm qualified as AM
 import Control.Algebra
 import Control.Carrier.State.Strict
 import Control.Effect.Diagnostics
 import Data.Foldable (traverse_)
 import Data.List (isSuffixOf)
 import Data.Map.Strict (Map)
-import qualified Data.Map.Strict as M
+import Data.Map.Strict qualified as M
 import Data.Maybe (mapMaybe)
 import Data.Set (Set)
-import qualified Data.Set as S
+import Data.Set qualified as S
 import Discovery.Walk
 import Effect.ReadFS
 import Path
-import qualified Path.IO as PIO
+import Path.IO qualified as PIO
 import Strategy.Maven.Pom.PomFile
 import Strategy.Maven.Pom.Resolver
 
@@ -40,20 +41,20 @@ findPomFiles dir = execState @[Path Abs File] [] $
 buildProjectClosures :: Path Abs Dir -> GlobalClosure -> [MavenProjectClosure]
 buildProjectClosures basedir global = closures
   where
-  closures = map (\(path, (coord, pom)) -> toClosure path coord pom) (M.toList projectRoots)
+    closures = map (\(path, (coord, pom)) -> toClosure path coord pom) (M.toList projectRoots)
 
-  toClosure :: Path Abs File -> MavenCoordinate -> Pom -> MavenProjectClosure
-  toClosure path coord pom = MavenProjectClosure path coord pom reachableGraph reachablePomMap
-    where
-      reachableGraph = AM.induce (`S.member` reachablePoms) $ globalGraph global
-      reachablePomMap = M.filterWithKey (\k _ -> S.member k reachablePoms) $ globalPoms global
-      reachablePoms = bidirectionalReachable coord (globalGraph global)
+    toClosure :: Path Abs File -> MavenCoordinate -> Pom -> MavenProjectClosure
+    toClosure path coord pom = MavenProjectClosure path coord pom reachableGraph reachablePomMap
+      where
+        reachableGraph = AM.induce (`S.member` reachablePoms) $ globalGraph global
+        reachablePomMap = M.filterWithKey (\k _ -> S.member k reachablePoms) $ globalPoms global
+        reachablePoms = bidirectionalReachable coord (globalGraph global)
 
-  projectRoots :: Map (Path Abs File) (MavenCoordinate, Pom)
-  projectRoots = determineProjectRoots basedir global graphRoots
+    projectRoots :: Map (Path Abs File) (MavenCoordinate, Pom)
+    projectRoots = determineProjectRoots basedir global graphRoots
 
-  graphRoots :: [MavenCoordinate]
-  graphRoots = sourceVertices (globalGraph global)
+    graphRoots :: [MavenCoordinate]
+    graphRoots = sourceVertices (globalGraph global)
 
 -- Find reachable nodes both below (children, grandchildren, ...) and above (parents, grandparents) the node
 bidirectionalReachable :: Ord a => a -> AM.AdjacencyMap a -> S.Set a
@@ -65,36 +66,40 @@ sourceVertices graph = [v | v <- AM.vertexList graph, S.null (AM.preSet v graph)
 determineProjectRoots :: Path Abs Dir -> GlobalClosure -> [MavenCoordinate] -> Map (Path Abs File) (MavenCoordinate, Pom)
 determineProjectRoots rootDir closure = go . S.fromList
   where
-  go :: Set MavenCoordinate -> Map (Path Abs File) (MavenCoordinate, Pom)
-  go coordRoots
-    | S.null coordRoots = M.empty
-    | otherwise = M.union projects (go frontier)
-    where
-    inRoot :: Set (MavenCoordinate, Path Abs File, Pom)
-    inRoot = S.fromList $
-      mapMaybe (\coord -> do
-                   (abspath, pom) <- M.lookup coord (globalPoms closure)
-                   -- This ensures that the absolute path is relative to the root directory
-                   _ <- PIO.makeRelative rootDir abspath
-                   Just (coord, abspath, pom)) (S.toList coordRoots)
+    go :: Set MavenCoordinate -> Map (Path Abs File) (MavenCoordinate, Pom)
+    go coordRoots
+      | S.null coordRoots = M.empty
+      | otherwise = M.union projects (go frontier)
+      where
+        inRoot :: Set (MavenCoordinate, Path Abs File, Pom)
+        inRoot =
+          S.fromList $
+            mapMaybe
+              ( \coord -> do
+                  (abspath, pom) <- M.lookup coord (globalPoms closure)
+                  -- This ensures that the absolute path is relative to the root directory
+                  _ <- PIO.makeRelative rootDir abspath
+                  Just (coord, abspath, pom)
+              )
+              (S.toList coordRoots)
 
-    inRootCoords :: Set MavenCoordinate
-    inRootCoords = S.map (\(c,_,_) -> c) inRoot
+        inRootCoords :: Set MavenCoordinate
+        inRootCoords = S.map (\(c, _, _) -> c) inRoot
 
-    remainingCoords :: Set MavenCoordinate
-    remainingCoords = coordRoots S.\\ inRootCoords
+        remainingCoords :: Set MavenCoordinate
+        remainingCoords = coordRoots S.\\ inRootCoords
 
-    projects :: Map (Path Abs File) (MavenCoordinate, Pom)
-    projects = M.fromList $ S.toList $ S.map (\(coord,path,pom) -> (path, (coord, pom))) inRoot
+        projects :: Map (Path Abs File) (MavenCoordinate, Pom)
+        projects = M.fromList $ S.toList $ S.map (\(coord, path, pom) -> (path, (coord, pom))) inRoot
 
-    frontier :: Set MavenCoordinate
-    frontier = S.unions $ S.map (\coord -> AM.postSet coord (globalGraph closure)) remainingCoords
-
+        frontier :: Set MavenCoordinate
+        frontier = S.unions $ S.map (\coord -> AM.postSet coord (globalGraph closure)) remainingCoords
 
 data MavenProjectClosure = MavenProjectClosure
-  { closurePath      :: Path Abs File
-  , closureRootCoord :: MavenCoordinate
-  , closureRootPom   :: Pom
-  , closureGraph     :: AM.AdjacencyMap MavenCoordinate
-  , closurePoms      :: Map MavenCoordinate (Path Abs File, Pom)
-  } deriving (Eq, Ord, Show)
+  { closurePath :: Path Abs File,
+    closureRootCoord :: MavenCoordinate,
+    closureRootPom :: Pom,
+    closureGraph :: AM.AdjacencyMap MavenCoordinate,
+    closurePoms :: Map MavenCoordinate (Path Abs File, Pom)
+  }
+  deriving (Eq, Ord, Show)

--- a/src/Strategy/Maven/Pom/PomFile.hs
+++ b/src/Strategy/Maven/Pom/PomFile.hs
@@ -1,25 +1,24 @@
 {-# LANGUAGE RecordWildCards #-}
 
 module Strategy.Maven.Pom.PomFile
-  -- TODO: sort
-  ( Pom(..)
-  , RawDependency(..)
-  , RawParent(..)
-  , RawPom(..)
-  , MavenCoordinate(..)
-  , MvnDepBody(..)
-  , PomLicense(..)
+-- TODO: sort
+  ( Pom (..),
+    RawDependency (..),
+    RawParent (..),
+    RawPom (..),
+    MavenCoordinate (..),
+    MvnDepBody (..),
+    PomLicense (..),
+    Group,
+    Artifact,
+    validatePom,
+  )
+where
 
-  , Group
-  , Artifact
-
-  , validatePom
-  ) where
-
-import Control.Applicative ((<|>), optional)
-import Data.Text (Text)
+import Control.Applicative (optional, (<|>))
 import Data.Map.Strict (Map)
-import qualified Data.Map.Strict as M
+import Data.Map.Strict qualified as M
+import Data.Text (Text)
 import Parse.XML
 
 ----- Validating POM files
@@ -39,16 +38,17 @@ validatePom raw = do
 rawDepsToDeps :: [RawDependency] -> Map (Group, Artifact) MvnDepBody
 rawDepsToDeps = M.fromList . map (\dep -> (depToKey dep, depToBody dep))
   where
-  depToKey :: RawDependency -> (Group, Artifact)
-  depToKey raw = (rawDependencyGroup raw, rawDependencyArtifact raw)
+    depToKey :: RawDependency -> (Group, Artifact)
+    depToKey raw = (rawDependencyGroup raw, rawDependencyArtifact raw)
 
-  depToBody :: RawDependency -> MvnDepBody
-  depToBody RawDependency{..} = MvnDepBody
-    { depVersion = rawDependencyVersion
-    , depClassifier = rawDependencyClassifier
-    , depScope = rawDependencyScope
-    , depOptional = rawDependencyOptional
-    }
+    depToBody :: RawDependency -> MvnDepBody
+    depToBody RawDependency {..} =
+      MvnDepBody
+        { depVersion = rawDependencyVersion,
+          depClassifier = rawDependencyClassifier,
+          depScope = rawDependencyScope,
+          depOptional = rawDependencyOptional
+        }
 
 -- Build a full coordinate from a pom, falling back to the group/version from
 -- the parent
@@ -57,44 +57,50 @@ rawDepsToDeps = M.fromList . map (\dep -> (depToKey dep, depToBody dep))
 -- "although, groupId and version need not be explicitly defined if they are inherited from a parent"
 -- https://maven.apache.org/pom.html#Maven_Coordinates
 validateCoordinate :: RawPom -> Maybe MavenCoordinate
-validateCoordinate RawPom{..} = MavenCoordinate <$> group <*> artifact <*> version
+validateCoordinate RawPom {..} = MavenCoordinate <$> group <*> artifact <*> version
   where
-  group, artifact, version :: Maybe Text
-  group = rawPomGroup <|> (rawParentGroup <$> rawPomParent)
-  artifact = pure rawPomArtifact
-  version = rawPomVersion <|> (rawParentVersion <$> rawPomParent)
+    group, artifact, version :: Maybe Text
+    group = rawPomGroup <|> (rawParentGroup <$> rawPomParent)
+    artifact = pure rawPomArtifact
+    version = rawPomVersion <|> (rawParentVersion <$> rawPomParent)
 
 parentToCoordinate :: RawParent -> MavenCoordinate
-parentToCoordinate RawParent{..} = MavenCoordinate
-  { coordGroup    = rawParentGroup
-  , coordArtifact = rawParentArtifact
-  , coordVersion  = rawParentVersion
-  }
+parentToCoordinate RawParent {..} =
+  MavenCoordinate
+    { coordGroup = rawParentGroup,
+      coordArtifact = rawParentArtifact,
+      coordVersion = rawParentVersion
+    }
 
 -- TODO: newtypes?
 type Group = Text
+
 type Artifact = Text
+
 data Pom = Pom
-  { pomCoord                :: MavenCoordinate
-  , pomParentCoord          :: Maybe MavenCoordinate
-  , pomProperties           :: Map Text Text
-  , pomDependencyManagement :: Map (Group, Artifact) MvnDepBody
-  , pomDependencies         :: Map (Group, Artifact) MvnDepBody
-  , pomLicenses             :: [PomLicense]
-  } deriving (Eq, Ord, Show)
+  { pomCoord :: MavenCoordinate,
+    pomParentCoord :: Maybe MavenCoordinate,
+    pomProperties :: Map Text Text,
+    pomDependencyManagement :: Map (Group, Artifact) MvnDepBody,
+    pomDependencies :: Map (Group, Artifact) MvnDepBody,
+    pomLicenses :: [PomLicense]
+  }
+  deriving (Eq, Ord, Show)
 
 data MavenCoordinate = MavenCoordinate
-  { coordGroup    :: Text
-  , coordArtifact :: Text
-  , coordVersion  :: Text
-  } deriving (Eq, Ord, Show)
+  { coordGroup :: Text,
+    coordArtifact :: Text,
+    coordVersion :: Text
+  }
+  deriving (Eq, Ord, Show)
 
 data MvnDepBody = MvnDepBody
-  { depVersion    :: Maybe Text
-  , depClassifier :: Maybe Text
-  , depScope      :: Maybe Text
-  , depOptional   :: Maybe Text
-  } deriving (Eq, Ord, Show)
+  { depVersion :: Maybe Text,
+    depClassifier :: Maybe Text,
+    depScope :: Maybe Text,
+    depOptional :: Maybe Text
+  }
+  deriving (Eq, Ord, Show)
 
 instance Semigroup Pom where
   -- left-biased, similar to M.union
@@ -104,72 +110,77 @@ instance Semigroup Pom where
   --
   -- we overlay dependencyManagement and dependencies with MvnDepBody's
   -- Semigroup instance
-  childPom <> parentPom = Pom
-    { pomCoord = pomCoord childPom
-    , pomParentCoord = pomParentCoord childPom
-    , pomProperties = M.union (pomProperties childPom) (pomProperties parentPom)
-    , pomDependencyManagement = M.unionWith (<>) (pomDependencyManagement childPom) (pomDependencyManagement parentPom)
-    , pomDependencies = M.unionWith (<>) (pomDependencies childPom) (pomDependencies parentPom)
-    , pomLicenses = pomLicenses childPom
-    }
-
+  childPom <> parentPom =
+    Pom
+      { pomCoord = pomCoord childPom,
+        pomParentCoord = pomParentCoord childPom,
+        pomProperties = M.union (pomProperties childPom) (pomProperties parentPom),
+        pomDependencyManagement = M.unionWith (<>) (pomDependencyManagement childPom) (pomDependencyManagement parentPom),
+        pomDependencies = M.unionWith (<>) (pomDependencies childPom) (pomDependencies parentPom),
+        pomLicenses = pomLicenses childPom
+      }
 
 instance Semigroup MvnDepBody where
   -- left-biased, similar to M.union
-  left <> right = MvnDepBody
-    { depVersion = depVersion left <|> depVersion right
-    , depClassifier = depClassifier left <|> depClassifier right
-    , depScope = depScope left <|> depScope right
-    , depOptional = depOptional left <|> depOptional right
-    }
+  left <> right =
+    MvnDepBody
+      { depVersion = depVersion left <|> depVersion right,
+        depClassifier = depClassifier left <|> depClassifier right,
+        depScope = depScope left <|> depScope right,
+        depOptional = depOptional left <|> depOptional right
+      }
 
 ----- Raw POM files + deserialization
 
 -- a POM file as found in the filesystem
 data RawPom = RawPom
-  { rawPomParent               :: Maybe RawParent
-  , rawPomGroup                :: Maybe Text
-  , rawPomArtifact             :: Text
-  , rawPomVersion              :: Maybe Text
-  , rawPomProperties           :: Map Text Text
-  , rawPomModules              :: [Text]
-  , rawPomDependencyManagement :: [RawDependency]
-  , rawPomDependencies         :: [RawDependency]
-  , rawPomLicenses             :: [PomLicense]
-  } deriving (Eq, Ord, Show)
+  { rawPomParent :: Maybe RawParent,
+    rawPomGroup :: Maybe Text,
+    rawPomArtifact :: Text,
+    rawPomVersion :: Maybe Text,
+    rawPomProperties :: Map Text Text,
+    rawPomModules :: [Text],
+    rawPomDependencyManagement :: [RawDependency],
+    rawPomDependencies :: [RawDependency],
+    rawPomLicenses :: [PomLicense]
+  }
+  deriving (Eq, Ord, Show)
 
 data RawParent = RawParent
-  { rawParentGroup        :: Text
-  , rawParentArtifact     :: Text
-  , rawParentVersion      :: Text
-  , rawParentRelativePath :: Maybe Text
-  } deriving (Eq, Ord, Show)
+  { rawParentGroup :: Text,
+    rawParentArtifact :: Text,
+    rawParentVersion :: Text,
+    rawParentRelativePath :: Maybe Text
+  }
+  deriving (Eq, Ord, Show)
 
 data RawDependency = RawDependency
-  { rawDependencyGroup      :: Text
-  , rawDependencyArtifact   :: Text
-  , rawDependencyVersion    :: Maybe Text
-  , rawDependencyClassifier :: Maybe Text
-  , rawDependencyScope      :: Maybe Text
-  , rawDependencyOptional   :: Maybe Text
-  } deriving (Eq, Ord, Show)
+  { rawDependencyGroup :: Text,
+    rawDependencyArtifact :: Text,
+    rawDependencyVersion :: Maybe Text,
+    rawDependencyClassifier :: Maybe Text,
+    rawDependencyScope :: Maybe Text,
+    rawDependencyOptional :: Maybe Text
+  }
+  deriving (Eq, Ord, Show)
 
 data PomLicense = PomLicense
-  { pomLicenseName :: Maybe Text
-  , pomLicenseUrl :: Maybe Text
-  } deriving (Eq, Ord, Show)
+  { pomLicenseName :: Maybe Text,
+    pomLicenseUrl :: Maybe Text
+  }
+  deriving (Eq, Ord, Show)
 
 instance FromXML RawPom where
   parseElement el =
     RawPom <$> optional (child "parent" el)
-           <*> optional (child "groupId" el)
-           <*> child "artifactId" el
-           <*> optional (child "version" el)
-           <*> optional (child "properties" el) `defaultsTo` M.empty
-           <*> optional (child "modules" el >>= children "module") `defaultsTo` []
-           <*> optional (child "dependencyManagement" el >>= children "dependency") `defaultsTo` []
-           <*> optional (child "dependencies" el >>= children "dependency") `defaultsTo` []
-           <*> optional (child "licenses" el >>= children "license") `defaultsTo` []
+      <*> optional (child "groupId" el)
+      <*> child "artifactId" el
+      <*> optional (child "version" el)
+      <*> optional (child "properties" el) `defaultsTo` M.empty
+      <*> optional (child "modules" el >>= children "module") `defaultsTo` []
+      <*> optional (child "dependencyManagement" el >>= children "dependency") `defaultsTo` []
+      <*> optional (child "dependencies" el >>= children "dependency") `defaultsTo` []
+      <*> optional (child "licenses" el >>= children "license") `defaultsTo` []
 
 instance FromXML RawParent where
   -- TODO: move this documentation
@@ -178,20 +189,20 @@ instance FromXML RawParent where
   -- https://maven.apache.org/pom.html#Inheritance
   parseElement el =
     RawParent <$> child "groupId" el
-              <*> child "artifactId" el
-              <*> child "version" el
-              <*> optional (child "relativePath" el)
+      <*> child "artifactId" el
+      <*> child "version" el
+      <*> optional (child "relativePath" el)
 
 instance FromXML RawDependency where
   parseElement el =
     RawDependency <$> child "groupId" el
-                  <*> child "artifactId" el
-                  <*> optional (child "version" el)
-                  <*> optional (child "classifier" el)
-                  <*> optional (child "scope" el)
-                  <*> optional (child "optional" el)
+      <*> child "artifactId" el
+      <*> optional (child "version" el)
+      <*> optional (child "classifier" el)
+      <*> optional (child "scope" el)
+      <*> optional (child "optional" el)
 
 instance FromXML PomLicense where
   parseElement el =
     PomLicense <$> optional (child "name" el)
-               <*> optional (child "url" el)
+      <*> optional (child "url" el)

--- a/src/Strategy/Maven/Pom/Resolver.hs
+++ b/src/Strategy/Maven/Pom/Resolver.hs
@@ -1,18 +1,19 @@
-{-# language TemplateHaskell #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 module Strategy.Maven.Pom.Resolver
-  ( GlobalClosure(..)
-  , buildGlobalClosure
-  ) where
+  ( GlobalClosure (..),
+    buildGlobalClosure,
+  )
+where
 
-import qualified Algebra.Graph.AdjacencyMap as AM
+import Algebra.Graph.AdjacencyMap qualified as AM
 import Control.Algebra
 import Control.Carrier.State.Strict
 import Control.Effect.Diagnostics hiding (fromMaybe)
 import Control.Monad (unless)
 import Data.Foldable (traverse_)
 import Data.Map.Strict (Map)
-import qualified Data.Map.Strict as M
+import Data.Map.Strict qualified as M
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import Effect.ReadFS
@@ -20,35 +21,39 @@ import Path
 import Strategy.Maven.Pom.PomFile
 
 data GlobalClosure = GlobalClosure
-  { globalGraph :: AM.AdjacencyMap MavenCoordinate
-  , globalPoms  :: Map MavenCoordinate (Path Abs File, Pom)
-  } deriving (Eq, Ord, Show)
+  { globalGraph :: AM.AdjacencyMap MavenCoordinate,
+    globalPoms :: Map MavenCoordinate (Path Abs File, Pom)
+  }
+  deriving (Eq, Ord, Show)
 
 buildGlobalClosure :: (Has ReadFS sig m, Has Diagnostics sig m) => [Path Abs File] -> m GlobalClosure
 buildGlobalClosure files = do
-  (loadResults,()) <- runState @LoadResults M.empty $ traverse_ recursiveLoadPom files
+  (loadResults, ()) <- runState @LoadResults M.empty $ traverse_ recursiveLoadPom files
 
   -- TODO: diagnostics/warnings?
   let validated :: Map (Path Abs File) Pom
       validated = M.mapMaybe (validatePom =<<) loadResults
 
   pure (buildClosure validated)
-
   where
-  -- notably, we're not building edges based on <relativePath> from poms.
-  --
-  -- From the docs:
-  -- "However, the group ID, artifact ID and version are still required, and must match the file in the location given or it will revert to the repository for the POM."
-  --
-  -- Because the group/artifact/version are required to match, we can just build edges between _coordinates_, rather than between _pom files_
-  buildClosure :: Map (Path Abs File) Pom -> GlobalClosure
-  buildClosure cache = GlobalClosure
-    { globalGraph = AM.vertices (map pomCoord (M.elems cache)) `AM.overlay` AM.edges
-        [(parentCoord,pomCoord pom)
-          | pom <- M.elems cache
-          , Just parentCoord <- [pomParentCoord pom]]
-    , globalPoms = indexBy (pomCoord . snd) (M.toList cache)
-    }
+    -- notably, we're not building edges based on <relativePath> from poms.
+    --
+    -- From the docs:
+    -- "However, the group ID, artifact ID and version are still required, and must match the file in the location given or it will revert to the repository for the POM."
+    --
+    -- Because the group/artifact/version are required to match, we can just build edges between _coordinates_, rather than between _pom files_
+    buildClosure :: Map (Path Abs File) Pom -> GlobalClosure
+    buildClosure cache =
+      GlobalClosure
+        { globalGraph =
+            AM.vertices (map pomCoord (M.elems cache))
+              `AM.overlay` AM.edges
+                [ (parentCoord, pomCoord pom)
+                  | pom <- M.elems cache,
+                    Just parentCoord <- [pomParentCoord pom]
+                ],
+          globalPoms = indexBy (pomCoord . snd) (M.toList cache)
+        }
 
 -- TODO: reuse this in other strategies
 indexBy :: Ord k => (v -> k) -> [v] -> Map k v
@@ -68,26 +73,24 @@ recursiveLoadPom path = do
       (res :: Maybe RawPom) <- recover (readContentsXML path)
       modify @LoadResults (M.insert path res)
       traverse_ loadAdjacent res
-
   where
+    loadAdjacent :: RawPom -> m ()
+    loadAdjacent raw = loadParent raw *> loadSubmodules raw
 
-  loadAdjacent :: RawPom -> m ()
-  loadAdjacent raw = loadParent raw *> loadSubmodules raw
+    loadParent pom = case rawPomParent pom of
+      Nothing -> pure ()
+      -- the default relative path is "../pom.xml"
+      --
+      -- from the docs:
+      -- "The relative path of the parent <code>pom.xml</code> file within the check out. If not specified, it defaults to <code>../pom.xml</code>"
+      Just mvnParent -> recurseRelative (fromMaybe "../pom.xml" (rawParentRelativePath mvnParent))
 
-  loadParent pom = case rawPomParent pom of
-    Nothing -> pure ()
-    -- the default relative path is "../pom.xml"
-    --
-    -- from the docs:
-    -- "The relative path of the parent <code>pom.xml</code> file within the check out. If not specified, it defaults to <code>../pom.xml</code>"
-    Just mvnParent -> recurseRelative (fromMaybe "../pom.xml" (rawParentRelativePath mvnParent))
+    loadSubmodules raw = traverse_ recurseRelative (rawPomModules raw)
 
-  loadSubmodules raw = traverse_ recurseRelative (rawPomModules raw)
-
-  recurseRelative :: Text {- relative filepath -} -> m ()
-  recurseRelative rel = do
-    (resolvedPath :: Maybe (Path Abs File)) <- recover (resolvePath (parent path) rel)
-    traverse_ recursiveLoadPom resolvedPath
+    recurseRelative :: Text {- relative filepath -} -> m ()
+    recurseRelative rel = do
+      (resolvedPath :: Maybe (Path Abs File)) <- recover (resolvePath (parent path) rel)
+      traverse_ recursiveLoadPom resolvedPath
 
 -- resolve a Filepath (in Text) that may either point to a directory or an exact
 -- pom file. when it's a directory, we default to pointing at the "pom.xml" in

--- a/src/Strategy/Node/NpmLock.hs
+++ b/src/Strategy/Node/NpmLock.hs
@@ -1,20 +1,19 @@
 {-# LANGUAGE RecordWildCards #-}
 
 module Strategy.Node.NpmLock
-  ( analyze'
-  , buildGraph
-
-  , NpmPackageJson(..)
-  , NpmDep(..)
+  ( analyze',
+    buildGraph,
+    NpmPackageJson (..),
+    NpmDep (..),
   )
-  where
+where
 
 import Control.Effect.Diagnostics
 import Data.Aeson
 import Data.Foldable (traverse_)
 import Data.Functor (void)
 import Data.Map.Strict (Map)
-import qualified Data.Map.Strict as M
+import Data.Map.Strict qualified as M
 import Data.Set (Set)
 import Data.Text (Text)
 import DepTypes
@@ -24,40 +23,44 @@ import Graphing (Graphing)
 import Path
 
 data NpmPackageJson = NpmPackageJson
-  { packageName         :: Text
-  , packageVersion      :: Text
-  , packageDependencies :: Map Text NpmDep
-  } deriving (Eq, Ord, Show)
+  { packageName :: Text,
+    packageVersion :: Text,
+    packageDependencies :: Map Text NpmDep
+  }
+  deriving (Eq, Ord, Show)
 
 data NpmDep = NpmDep
-  { depVersion      :: Text
-  , depDev          :: Maybe Bool
-  , depResolved     :: Maybe Text
-  , depRequires     :: Maybe (Map Text Text) -- ^ name to version spec
-  , depDependencies :: Maybe (Map Text NpmDep)
-  } deriving (Eq, Ord, Show)
+  { depVersion :: Text,
+    depDev :: Maybe Bool,
+    depResolved :: Maybe Text,
+    -- | name to version spec
+    depRequires :: Maybe (Map Text Text),
+    depDependencies :: Maybe (Map Text NpmDep)
+  }
+  deriving (Eq, Ord, Show)
 
 instance FromJSON NpmPackageJson where
   parseJSON = withObject "NpmPackageJson" $ \obj ->
     NpmPackageJson <$> obj .: "name"
-                   <*> obj .: "version"
-                   <*> obj .: "dependencies"
+      <*> obj .: "version"
+      <*> obj .: "dependencies"
 
 instance FromJSON NpmDep where
   parseJSON = withObject "NpmDep" $ \obj ->
-    NpmDep <$> obj .:  "version"
-           <*> obj .:? "dev"
-           <*> obj .:? "resolved"
-           <*> obj .:? "requires"
-           <*> obj .:? "dependencies"
+    NpmDep <$> obj .: "version"
+      <*> obj .:? "dev"
+      <*> obj .:? "resolved"
+      <*> obj .:? "requires"
+      <*> obj .:? "dependencies"
 
 analyze' :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs File -> m (Graphing Dependency)
 analyze' file = buildGraph <$> readContentsJson @NpmPackageJson file
 
 data NpmPackage = NpmPackage
-  { pkgName    :: Text
-  , pkgVersion :: Text
-  } deriving (Eq, Ord, Show)
+  { pkgName :: Text,
+    pkgVersion :: Text
+  }
+  deriving (Eq, Ord, Show)
 
 type NpmGrapher = LabeledGrapher NpmPackage NpmPackageLabel
 
@@ -69,46 +72,46 @@ buildGraph packageJson = run . withLabeling toDependency $ do
   _ <- M.traverseWithKey addDirect (packageDependencies packageJson)
   _ <- M.traverseWithKey addDep (packageDependencies packageJson)
   pure ()
-
   where
-  addDirect :: Has NpmGrapher sig m => Text -> NpmDep -> m ()
-  addDirect name NpmDep{depVersion} = direct (NpmPackage name depVersion)
+    addDirect :: Has NpmGrapher sig m => Text -> NpmDep -> m ()
+    addDirect name NpmDep {depVersion} = direct (NpmPackage name depVersion)
 
-  addDep :: Has NpmGrapher sig m => Text -> NpmDep -> m ()
-  addDep name NpmDep{..} = do
-    let pkg = NpmPackage name depVersion
+    addDep :: Has NpmGrapher sig m => Text -> NpmDep -> m ()
+    addDep name NpmDep {..} = do
+      let pkg = NpmPackage name depVersion
 
-    case depDev of
-      Just True -> label pkg (NpmPackageEnv EnvDevelopment)
-      _         -> label pkg (NpmPackageEnv EnvProduction)
+      case depDev of
+        Just True -> label pkg (NpmPackageEnv EnvDevelopment)
+        _ -> label pkg (NpmPackageEnv EnvProduction)
 
-    traverse_ (label pkg . NpmPackageLocation) depResolved
+      traverse_ (label pkg . NpmPackageLocation) depResolved
 
-    -- add edges to required packages
-    case depRequires of
-      Nothing -> pure ()
-      Just required ->
-        void $ M.traverseWithKey (\reqName reqVer -> edge pkg (NpmPackage reqName reqVer)) required
+      -- add edges to required packages
+      case depRequires of
+        Nothing -> pure ()
+        Just required ->
+          void $ M.traverseWithKey (\reqName reqVer -> edge pkg (NpmPackage reqName reqVer)) required
 
-    -- add dependency nodes
-    case depDependencies of
-      Nothing -> pure ()
-      Just deps ->
-        void $ M.traverseWithKey addDep deps
+      -- add dependency nodes
+      case depDependencies of
+        Nothing -> pure ()
+        Just deps ->
+          void $ M.traverseWithKey addDep deps
 
-  toDependency :: NpmPackage -> Set NpmPackageLabel -> Dependency
-  toDependency pkg = foldr addLabel (start pkg)
+    toDependency :: NpmPackage -> Set NpmPackageLabel -> Dependency
+    toDependency pkg = foldr addLabel (start pkg)
 
-  addLabel :: NpmPackageLabel -> Dependency -> Dependency
-  addLabel (NpmPackageEnv env) dep = dep { dependencyEnvironments = env : dependencyEnvironments dep }
-  addLabel (NpmPackageLocation loc) dep = dep { dependencyLocations = loc : dependencyLocations dep }
+    addLabel :: NpmPackageLabel -> Dependency -> Dependency
+    addLabel (NpmPackageEnv env) dep = dep {dependencyEnvironments = env : dependencyEnvironments dep}
+    addLabel (NpmPackageLocation loc) dep = dep {dependencyLocations = loc : dependencyLocations dep}
 
-  start :: NpmPackage -> Dependency
-  start NpmPackage{..} = Dependency
-    { dependencyType = NodeJSType
-    , dependencyName = pkgName
-    , dependencyVersion = Just $ CEq pkgVersion
-    , dependencyLocations = []
-    , dependencyEnvironments = []
-    , dependencyTags = M.empty
-    }
+    start :: NpmPackage -> Dependency
+    start NpmPackage {..} =
+      Dependency
+        { dependencyType = NodeJSType,
+          dependencyName = pkgName,
+          dependencyVersion = Just $ CEq pkgVersion,
+          dependencyLocations = [],
+          dependencyEnvironments = [],
+          dependencyTags = M.empty
+        }

--- a/src/Strategy/Node/YarnLock.hs
+++ b/src/Strategy/Node/YarnLock.hs
@@ -1,21 +1,22 @@
 module Strategy.Node.YarnLock
-  ( analyze'
-  , buildGraph
-  ) where
+  ( analyze',
+    buildGraph,
+  )
+where
 
 import Control.Effect.Diagnostics
 import Data.Bifunctor (first)
 import Data.Foldable (for_)
-import qualified Data.List.NonEmpty as NE
-import qualified Data.Map.Strict as M
-import qualified Data.MultiKeyedMap as MKM
+import Data.List.NonEmpty qualified as NE
+import Data.Map.Strict qualified as M
+import Data.MultiKeyedMap qualified as MKM
 import DepTypes
 import Effect.Grapher
 import Effect.ReadFS
 import Graphing (Graphing)
 import Path
-import qualified Yarn.Lock as YL
-import qualified Yarn.Lock.Types as YL
+import Yarn.Lock qualified as YL
+import Yarn.Lock.Types qualified as YL
 
 analyze' :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs File -> m (Graphing Dependency)
 analyze' lockfile = do
@@ -27,29 +28,31 @@ analyze' lockfile = do
     Right parsed -> pure (buildGraph parsed)
 
 buildGraph :: YL.Lockfile -> Graphing Dependency
-buildGraph lockfile = run . evalGrapher $
-  traverse (add . first NE.head) (MKM.toList lockfile)
+buildGraph lockfile =
+  run . evalGrapher $
+    traverse (add . first NE.head) (MKM.toList lockfile)
   where
-  add :: Has (Grapher Dependency) sig m => (YL.PackageKey, YL.Package) -> m ()
-  add parentPkg@(_, package) =
-    for_ (YL.dependencies package) $ \childKey -> do
-      let childPkg = (childKey, MKM.at lockfile childKey)
-      edge (toDependency parentPkg) (toDependency childPkg)
+    add :: Has (Grapher Dependency) sig m => (YL.PackageKey, YL.Package) -> m ()
+    add parentPkg@(_, package) =
+      for_ (YL.dependencies package) $ \childKey -> do
+        let childPkg = (childKey, MKM.at lockfile childKey)
+        edge (toDependency parentPkg) (toDependency childPkg)
 
-  toDependency (key,package) =
-    Dependency { dependencyType = NodeJSType
-               , dependencyName =
-                   case YL.name key of
-                     YL.SimplePackageKey name -> name
-                     YL.ScopedPackageKey scope name -> "@" <> scope <> "/" <> name
-               , dependencyVersion = Just (CEq (YL.version package))
-               , dependencyLocations =
-                   case YL.remote package of
-                     YL.FileLocal _ _ -> [] -- FUTURE: upload this for analysis?
-                     YL.FileLocalNoIntegrity _ -> [] -- FUTURE: upload this for analysis?
-                     YL.FileRemote url _ -> [url]
-                     YL.FileRemoteNoIntegrity url -> [url]
-                     YL.GitRemote url rev -> [url <> "@" <> rev]
-               , dependencyEnvironments = []
-               , dependencyTags = M.empty
-               }
+    toDependency (key, package) =
+      Dependency
+        { dependencyType = NodeJSType,
+          dependencyName =
+            case YL.name key of
+              YL.SimplePackageKey name -> name
+              YL.ScopedPackageKey scope name -> "@" <> scope <> "/" <> name,
+          dependencyVersion = Just (CEq (YL.version package)),
+          dependencyLocations =
+            case YL.remote package of
+              YL.FileLocal _ _ -> [] -- FUTURE: upload this for analysis?
+              YL.FileLocalNoIntegrity _ -> [] -- FUTURE: upload this for analysis?
+              YL.FileRemote url _ -> [url]
+              YL.FileRemoteNoIntegrity url -> [url]
+              YL.GitRemote url rev -> [url <> "@" <> rev],
+          dependencyEnvironments = [],
+          dependencyTags = M.empty
+        }

--- a/src/Strategy/Npm.hs
+++ b/src/Strategy/Npm.hs
@@ -1,18 +1,18 @@
 module Strategy.Npm
-  ( discover
+  ( discover,
   )
 where
 
-import Control.Effect.Diagnostics ((<||>), Diagnostics)
-import qualified Control.Effect.Diagnostics as Diag
+import Control.Effect.Diagnostics (Diagnostics, (<||>))
+import Control.Effect.Diagnostics qualified as Diag
 import Discovery.Walk
 import Effect.Exec
 import Effect.ReadFS
 import Graphing
 import Path
-import qualified Strategy.Node.NpmList as NpmList
-import qualified Strategy.Node.NpmLock as NpmLock
-import qualified Strategy.Node.PackageJson as PackageJson
+import Strategy.Node.NpmList qualified as NpmList
+import Strategy.Node.NpmLock qualified as NpmLock
+import Strategy.Node.PackageJson qualified as PackageJson
 import Types
 
 discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has ReadFS rsig run, Has Exec rsig run, Has Diagnostics rsig run) => Path Abs Dir -> m [DiscoveredProject run]

--- a/src/Strategy/NuGet/Nuspec.hs
+++ b/src/Strategy/NuGet/Nuspec.hs
@@ -6,25 +6,25 @@ module Strategy.NuGet.Nuspec
     getDeps,
     mkProject,
     buildGraph,
-
-    Nuspec(..),
-    Group(..),
-    NuGetDependency(..),
-    NuspecLicense(..),
-  ) where
+    Nuspec (..),
+    Group (..),
+    NuGetDependency (..),
+    NuspecLicense (..),
+  )
+where
 
 import Control.Applicative (optional)
 import Control.Effect.Diagnostics
 import Data.Foldable (find)
-import qualified Data.List as L
-import qualified Data.Map.Strict as M
+import Data.List qualified as L
+import Data.Map.Strict qualified as M
 import Data.Text (Text)
-import qualified Data.Text as T
+import Data.Text qualified as T
 import DepTypes
 import Discovery.Walk
 import Effect.ReadFS
 import Graphing (Graphing)
-import qualified Graphing
+import Graphing qualified
 import Parse.XML
 import Path
 import Types
@@ -66,49 +66,53 @@ analyzeLicenses file = do
 
 nuspecLicenses :: Nuspec -> [License]
 nuspecLicenses nuspec = url ++ licenseField
-          where
-            url = case licenseUrl nuspec of
-              Just location -> [License LicenseURL location]
-              Nothing -> []
-            licenseField = foldr (\a b -> b ++ [License (parseLicenseType $ nuspecLicenseType a) (nuspecLicenseValue a)]) [] (license nuspec)
+  where
+    url = case licenseUrl nuspec of
+      Just location -> [License LicenseURL location]
+      Nothing -> []
+    licenseField = foldr (\a b -> b ++ [License (parseLicenseType $ nuspecLicenseType a) (nuspecLicenseValue a)]) [] (license nuspec)
 
 parseLicenseType :: Text -> LicenseType
 parseLicenseType rawType = case T.unpack rawType of
-                            "expression" -> LicenseSPDX
-                            "file" -> LicenseFile
-                            _ -> UnknownType
+  "expression" -> LicenseSPDX
+  "file" -> LicenseFile
+  _ -> UnknownType
 
 data Nuspec = Nuspec
-  { groups        :: [Group]
-  , license       :: [NuspecLicense]
-  , licenseUrl    :: Maybe Text
-  } deriving (Eq, Ord, Show)
+  { groups :: [Group],
+    license :: [NuspecLicense],
+    licenseUrl :: Maybe Text
+  }
+  deriving (Eq, Ord, Show)
 
 data NuspecLicense = NuspecLicense
-  { nuspecLicenseType  :: Text
-  , nuspecLicenseValue :: Text
-  } deriving (Eq, Ord, Show)
+  { nuspecLicenseType :: Text,
+    nuspecLicenseValue :: Text
+  }
+  deriving (Eq, Ord, Show)
 
 newtype Group = Group
-  { dependencies  :: [NuGetDependency]
-  } deriving (Eq, Ord, Show)
+  { dependencies :: [NuGetDependency]
+  }
+  deriving (Eq, Ord, Show)
 
 data NuGetDependency = NuGetDependency
-  { depID      :: Text
-  , depVersion :: Text
-  } deriving (Eq, Ord, Show)
+  { depID :: Text,
+    depVersion :: Text
+  }
+  deriving (Eq, Ord, Show)
 
 instance FromXML Nuspec where
   parseElement el = do
-    metadata     <- child "metadata" el
+    metadata <- child "metadata" el
     Nuspec <$> optional (child "dependencies" metadata >>= children "group") `defaultsTo` []
-           <*> children "license" metadata
-           <*> optional (child "licenseUrl" metadata)
+      <*> children "license" metadata
+      <*> optional (child "licenseUrl" metadata)
 
 instance FromXML NuspecLicense where
   parseElement el =
     NuspecLicense <$> optional (attr "type" el) `defaultsTo` ""
-                  <*> content el
+      <*> content el
 
 instance FromXML Group where
   parseElement el = Group <$> children "dependency" el
@@ -116,17 +120,18 @@ instance FromXML Group where
 instance FromXML NuGetDependency where
   parseElement el =
     NuGetDependency <$> attr "id" el
-                    <*> attr "version" el
+      <*> attr "version" el
 
 buildGraph :: Nuspec -> Graphing Dependency
 buildGraph project = Graphing.fromList (map toDependency direct)
-    where
+  where
     direct = concatMap dependencies (groups project)
-    toDependency NuGetDependency{..} =
-      Dependency { dependencyType = NuGetType
-                 , dependencyName = depID
-                 , dependencyVersion = Just (CEq depVersion)
-                 , dependencyLocations = []
-                 , dependencyEnvironments = []
-                 , dependencyTags = M.empty
-                 }
+    toDependency NuGetDependency {..} =
+      Dependency
+        { dependencyType = NuGetType,
+          dependencyName = depID,
+          dependencyVersion = Just (CEq depVersion),
+          dependencyLocations = [],
+          dependencyEnvironments = [],
+          dependencyTags = M.empty
+        }

--- a/src/Strategy/NuGet/PackagesConfig.hs
+++ b/src/Strategy/NuGet/PackagesConfig.hs
@@ -1,25 +1,25 @@
 {-# LANGUAGE RecordWildCards #-}
 
 module Strategy.NuGet.PackagesConfig
-  ( discover
-  , findProjects
-  , getDeps
-  , mkProject
-  , buildGraph
-
-  , PackagesConfig(..)
-  , NuGetDependency(..)
-  ) where
+  ( discover,
+    findProjects,
+    getDeps,
+    mkProject,
+    buildGraph,
+    PackagesConfig (..),
+    NuGetDependency (..),
+  )
+where
 
 import Control.Effect.Diagnostics
 import Data.Foldable (find)
-import qualified Data.Map.Strict as M
+import Data.Map.Strict qualified as M
 import Data.Text (Text)
 import DepTypes
 import Discovery.Walk
 import Effect.ReadFS
 import Graphing (Graphing)
-import qualified Graphing
+import Graphing qualified
 import Parse.XML
 import Path
 import Types
@@ -60,25 +60,28 @@ instance FromXML PackagesConfig where
 instance FromXML NuGetDependency where
   parseElement el =
     NuGetDependency <$> attr "id" el
-                    <*> attr "version" el
+      <*> attr "version" el
 
 newtype PackagesConfig = PackagesConfig
   { deps :: [NuGetDependency]
-  } deriving (Eq, Ord, Show)
+  }
+  deriving (Eq, Ord, Show)
 
 data NuGetDependency = NuGetDependency
-  { depID      :: Text
-  , depVersion :: Text
-  } deriving (Eq, Ord, Show)
+  { depID :: Text,
+    depVersion :: Text
+  }
+  deriving (Eq, Ord, Show)
 
 buildGraph :: PackagesConfig -> Graphing Dependency
 buildGraph = Graphing.fromList . map toDependency . deps
-    where
-    toDependency NuGetDependency{..} =
-      Dependency { dependencyType = NuGetType
-               , dependencyName = depID
-               , dependencyVersion = Just (CEq depVersion)
-               , dependencyLocations = []
-               , dependencyEnvironments = []
-               , dependencyTags = M.empty
-               }
+  where
+    toDependency NuGetDependency {..} =
+      Dependency
+        { dependencyType = NuGetType,
+          dependencyName = depID,
+          dependencyVersion = Just (CEq depVersion),
+          dependencyLocations = [],
+          dependencyEnvironments = [],
+          dependencyTags = M.empty
+        }

--- a/src/Strategy/NuGet/Paket.hs
+++ b/src/Strategy/NuGet/Paket.hs
@@ -1,25 +1,25 @@
 module Strategy.NuGet.Paket
-  ( discover
-  , findProjects
-  , getDeps
-  , mkProject
-  , findSections
-  , buildGraph
-
-  , PaketDep(..)
-  , Section(..)
-  , Remote(..)
-  ) where
+  ( discover,
+    findProjects,
+    getDeps,
+    mkProject,
+    findSections,
+    buildGraph,
+    PaketDep (..),
+    Section (..),
+    Remote (..),
+  )
+where
 
 import Control.Effect.Diagnostics
 import Control.Monad (guard)
-import qualified Data.Char as C
+import Data.Char qualified as C
 import Data.Foldable (traverse_)
 import Data.Functor (void)
-import qualified Data.Map.Strict as M
+import Data.Map.Strict qualified as M
 import Data.Set (Set)
 import Data.Text (Text)
-import qualified Data.Text as T
+import Data.Text qualified as T
 import Data.Void (Void)
 import DepTypes
 import Discovery.Walk
@@ -29,7 +29,7 @@ import Graphing (Graphing)
 import Path
 import Text.Megaparsec hiding (label)
 import Text.Megaparsec.Char
-import qualified Text.Megaparsec.Char.Lexer as L
+import Text.Megaparsec.Char.Lexer qualified as L
 import Types
 
 type Parser = Parsec Void Text
@@ -64,13 +64,13 @@ getDeps = analyze' . paketLock
 analyze' :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs File -> m (Graphing Dependency)
 analyze' file = buildGraph <$> readContentsParser findSections file
 
-newtype PaketPkg = PaketPkg { pkgName :: Text }
+newtype PaketPkg = PaketPkg {pkgName :: Text}
   deriving (Eq, Ord, Show)
 
 type PaketGrapher = LabeledGrapher PaketPkg PaketLabel
 
-data PaketLabel =
-    PaketVersion Text
+data PaketLabel
+  = PaketVersion Text
   | PaketRemote Text
   | GroupName Text
   | DepLocation Text
@@ -79,106 +79,111 @@ data PaketLabel =
 toDependency :: PaketPkg -> Set PaketLabel -> Dependency
 toDependency pkg = foldr applyLabel start
   where
+    start :: Dependency
+    start =
+      Dependency
+        { dependencyType = NuGetType,
+          dependencyName = pkgName pkg,
+          dependencyVersion = Nothing,
+          dependencyLocations = [],
+          dependencyEnvironments = [],
+          dependencyTags = M.empty
+        }
 
-  start :: Dependency
-  start = Dependency
-    { dependencyType = NuGetType
-    , dependencyName = pkgName pkg
-    , dependencyVersion = Nothing
-    , dependencyLocations = []
-    , dependencyEnvironments = []
-    , dependencyTags = M.empty
-    }
-
-  applyLabel :: PaketLabel -> Dependency -> Dependency
-  applyLabel (PaketVersion ver) dep = dep { dependencyVersion = Just (CEq ver) }
-  applyLabel (GroupName name) dep = dep { dependencyTags = M.insertWith (++) "group" [name] (dependencyTags dep) }
-  applyLabel (DepLocation loc) dep = dep { dependencyTags = M.insertWith (++) "location" [loc] (dependencyTags dep) }
-  applyLabel (PaketRemote repo) dep = dep { dependencyLocations = repo : dependencyLocations dep }
+    applyLabel :: PaketLabel -> Dependency -> Dependency
+    applyLabel (PaketVersion ver) dep = dep {dependencyVersion = Just (CEq ver)}
+    applyLabel (GroupName name) dep = dep {dependencyTags = M.insertWith (++) "group" [name] (dependencyTags dep)}
+    applyLabel (DepLocation loc) dep = dep {dependencyTags = M.insertWith (++) "location" [loc] (dependencyTags dep)}
+    applyLabel (PaketRemote repo) dep = dep {dependencyLocations = repo : dependencyLocations dep}
 
 buildGraph :: [Section] -> Graphing Dependency
-buildGraph sections = run . withLabeling toDependency $
-      traverse_ (addSection "MAIN") sections
-      where
-            addSection :: Has PaketGrapher sig m => Text -> Section -> m ()
-            addSection group (StandardSection location remotes) = traverse_ (addRemote group location) remotes
-            addSection _ (GroupSection group gSections) = traverse_ (addSection group) gSections
-            addSection _ (UnknownSection _) = pure ()
+buildGraph sections =
+  run . withLabeling toDependency $
+    traverse_ (addSection "MAIN") sections
+  where
+    addSection :: Has PaketGrapher sig m => Text -> Section -> m ()
+    addSection group (StandardSection location remotes) = traverse_ (addRemote group location) remotes
+    addSection _ (GroupSection group gSections) = traverse_ (addSection group) gSections
+    addSection _ (UnknownSection _) = pure ()
 
-            addRemote :: Has PaketGrapher sig m => Text -> Text -> Remote -> m ()
-            addRemote group loc remote = traverse_ (addSpec (DepLocation loc) (PaketRemote $ remoteLocation remote) (GroupName group)) (remoteDependencies remote)
+    addRemote :: Has PaketGrapher sig m => Text -> Text -> Remote -> m ()
+    addRemote group loc remote = traverse_ (addSpec (DepLocation loc) (PaketRemote $ remoteLocation remote) (GroupName group)) (remoteDependencies remote)
 
-            addSpec :: Has PaketGrapher sig m => PaketLabel -> PaketLabel -> PaketLabel -> PaketDep -> m ()
-            addSpec loc remote group dep = do
-              -- add edges, labels, and direct deps
-              let pkg = PaketPkg (depName dep)
-              traverse_ (edge pkg . PaketPkg) (transitive dep)
-              label pkg (PaketVersion (depVersion dep))
-              label pkg remote
-              label pkg group
-              label pkg loc
-              direct pkg
+    addSpec :: Has PaketGrapher sig m => PaketLabel -> PaketLabel -> PaketLabel -> PaketDep -> m ()
+    addSpec loc remote group dep = do
+      -- add edges, labels, and direct deps
+      let pkg = PaketPkg (depName dep)
+      traverse_ (edge pkg . PaketPkg) (transitive dep)
+      label pkg (PaketVersion (depVersion dep))
+      label pkg remote
+      label pkg group
+      label pkg loc
+      direct pkg
 
 type Name = Text
+
 type Location = Text
 
-data Section =
-       StandardSection Location [Remote]
-      | UnknownSection Text
-      | GroupSection Name [Section]
-      deriving (Eq, Ord, Show)
+data Section
+  = StandardSection Location [Remote]
+  | UnknownSection Text
+  | GroupSection Name [Section]
+  deriving (Eq, Ord, Show)
 
 data Remote = Remote
-     { remoteLocation :: Text
-     , remoteDependencies  :: [PaketDep]
-     } deriving (Eq, Ord, Show)
+  { remoteLocation :: Text,
+    remoteDependencies :: [PaketDep]
+  }
+  deriving (Eq, Ord, Show)
 
 data PaketDep = PaketDep
-     { depName    :: Text
-     , depVersion    :: Text
-     , transitive :: [Text]
-     } deriving (Eq, Ord, Show)
+  { depName :: Text,
+    depVersion :: Text,
+    transitive :: [Text]
+  }
+  deriving (Eq, Ord, Show)
 
 data Group = Group
-     { groupName    :: Text
-     , groupSections :: [Section]
-     } deriving (Eq, Ord, Show)
-
+  { groupName :: Text,
+    groupSections :: [Section]
+  }
+  deriving (Eq, Ord, Show)
 
 findSections :: Parser [Section]
 findSections = many (try standardSectionParser <|> try groupSection <|> try unknownSection) <* eof
 
 groupSection :: Parser Section
 groupSection = do
-          _ <- chunk "GROUP"
-          name <- textValue
-          sections <- many (try standardSectionParser <|>  try unknownSection)
-          pure $ GroupSection name sections
+  _ <- chunk "GROUP"
+  name <- textValue
+  sections <- many (try standardSectionParser <|> try unknownSection)
+  pure $ GroupSection name sections
 
 unknownSection :: Parser Section
 unknownSection = do
-      emptyLine <- restOfLine
-      guard $ not $ "GROUP" `T.isPrefixOf` emptyLine
-      _ <- eol
-      pure $ UnknownSection emptyLine
+  emptyLine <- restOfLine
+  guard $ not $ "GROUP" `T.isPrefixOf` emptyLine
+  _ <- eol
+  pure $ UnknownSection emptyLine
 
 standardSectionParser :: Parser Section
-standardSectionParser = L.nonIndented scn $ L.indentBlock scn $ do
-          location <- chunk "HTTP" <|> "GITHUB" <|> "NUGET"
-          return $ L.IndentMany Nothing (pure . StandardSection location) remoteParser
+standardSectionParser = L.nonIndented scn $
+  L.indentBlock scn $ do
+    location <- chunk "HTTP" <|> "GITHUB" <|> "NUGET"
+    return $ L.IndentMany Nothing (pure . StandardSection location) remoteParser
 
 remoteParser :: Parser Remote
 remoteParser = L.indentBlock scn $ do
-      _ <- chunk "remote:"
-      value <- textValue
-      pure $ L.IndentMany Nothing (pure . Remote value) specParser
+  _ <- chunk "remote:"
+  value <- textValue
+  pure $ L.IndentMany Nothing (pure . Remote value) specParser
 
 specParser :: Parser PaketDep
 specParser = L.indentBlock scn $ do
-        name <- findDep
-        version <- findVersion
-        _ <- restOfLine
-        pure $ L.IndentMany Nothing (pure . PaketDep name version) specsParser
+  name <- findDep
+  version <- findVersion
+  _ <- restOfLine
+  pure $ L.IndentMany Nothing (pure . PaketDep name version) specsParser
 
 specsParser :: Parser Text
 specsParser = findDep <* restOfLine
@@ -198,13 +203,13 @@ restOfLine = takeWhileP (Just "ignored") (not . isEndLine)
 isEndLine :: Char -> Bool
 isEndLine '\n' = True
 isEndLine '\r' = True
-isEndLine _    = False
+isEndLine _ = False
 
 scn :: Parser ()
-scn =  L.space space1 empty empty
+scn = L.space space1 empty empty
 
 lexeme :: Parser a -> Parser a
 lexeme = L.lexeme sc
 
 sc :: Parser ()
-sc =  L.space (void $ some (char ' ')) empty empty
+sc = L.space (void $ some (char ' ')) empty empty

--- a/src/Strategy/NuGet/ProjectJson.hs
+++ b/src/Strategy/NuGet/ProjectJson.hs
@@ -1,27 +1,27 @@
 {-# LANGUAGE RecordWildCards #-}
 
 module Strategy.NuGet.ProjectJson
-  ( discover
-  , findProjects
-  , getDeps
-  , mkProject
-  , buildGraph
-
-  , ProjectJson(..)
-  ) where
+  ( discover,
+    findProjects,
+    getDeps,
+    mkProject,
+    buildGraph,
+    ProjectJson (..),
+  )
+where
 
 import Control.Applicative ((<|>))
 import Control.Effect.Diagnostics
 import Data.Aeson.Types
 import Data.Map.Strict (Map)
-import qualified Data.Map.Strict as M
+import Data.Map.Strict qualified as M
 import Data.Text (Text)
-import qualified Data.Text as T
+import Data.Text qualified as T
 import DepTypes
 import Discovery.Walk
 import Effect.ReadFS
 import Graphing (Graphing)
-import qualified Graphing
+import Graphing qualified
 import Path
 import Types
 
@@ -56,13 +56,15 @@ analyze' :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs File -> m (Gra
 analyze' file = buildGraph <$> readContentsJson @ProjectJson file
 
 newtype ProjectJson = ProjectJson
-  { dependencies     :: Map Text DependencyInfo
-  } deriving Show
+  { dependencies :: Map Text DependencyInfo
+  }
+  deriving (Show)
 
 data DependencyInfo = DependencyInfo
-  { depVersion    :: Text
-  , depType       :: Maybe Text
-  } deriving Show
+  { depVersion :: Text,
+    depType :: Maybe Text
+  }
+  deriving (Show)
 
 instance FromJSON ProjectJson where
   parseJSON = withObject "ProjectJson" $ \obj ->
@@ -71,34 +73,36 @@ instance FromJSON ProjectJson where
 instance FromJSON DependencyInfo where
   parseJSON val = parseJSONObject val <|> parseJSONText val
     where
-    parseJSONObject :: Value -> Parser DependencyInfo
-    parseJSONObject = withObject "DependencyInfo" $ \obj ->
+      parseJSONObject :: Value -> Parser DependencyInfo
+      parseJSONObject = withObject "DependencyInfo" $ \obj ->
         DependencyInfo <$> obj .: "version"
-                        <*> obj .:? "type"
+          <*> obj .:? "type"
 
-    parseJSONText :: Value -> Parser DependencyInfo
-    parseJSONText = withText "DependencyVersion" $ \text ->
+      parseJSONText :: Value -> Parser DependencyInfo
+      parseJSONText = withText "DependencyVersion" $ \text ->
         pure $ DependencyInfo text Nothing
 
 data NuGetDependency = NuGetDependency
-  { name            :: Text
-  , version         :: Text
-  , dependencyType  :: Maybe Text
-  } deriving Show
+  { name :: Text,
+    version :: Text,
+    dependencyType :: Maybe Text
+  }
+  deriving (Show)
 
 buildGraph :: ProjectJson -> Graphing Dependency
 buildGraph project = Graphing.fromList (map toDependency direct)
-    where
+  where
     direct = (\(name, dep) -> NuGetDependency name (depVersion dep) (depType dep)) <$> M.toList (dependencies project)
-    toDependency NuGetDependency{..} =
-      Dependency { dependencyType = NuGetType
-               , dependencyName = name
-               , dependencyVersion = case T.find ('*' ==) version of
-                  Just '*' -> Just (CCompatible version)
-                  _ -> Just (CEq version)
-               , dependencyLocations = []
-               , dependencyEnvironments = []
-               , dependencyTags = case dependencyType of
-                  Nothing -> M.empty
-                  Just depType -> M.insert "type" [depType]  M.empty
-               }
+    toDependency NuGetDependency {..} =
+      Dependency
+        { dependencyType = NuGetType,
+          dependencyName = name,
+          dependencyVersion = case T.find ('*' ==) version of
+            Just '*' -> Just (CCompatible version)
+            _ -> Just (CEq version),
+          dependencyLocations = [],
+          dependencyEnvironments = [],
+          dependencyTags = case dependencyType of
+            Nothing -> M.empty
+            Just depType -> M.insert "type" [depType] M.empty
+        }

--- a/src/Strategy/Python/Pipenv.hs
+++ b/src/Strategy/Python/Pipenv.hs
@@ -1,28 +1,27 @@
 {-# LANGUAGE RecordWildCards #-}
 
 module Strategy.Python.Pipenv
-  ( discover
-  , findProjects
-  , getDeps
-  , mkProject
-
-  , PipenvGraphDep(..)
-  , PipfileLock(..)
-  , PipfileMeta(..)
-  , PipfileSource(..)
-  , PipfileDep(..)
-  , buildGraph
+  ( discover,
+    findProjects,
+    getDeps,
+    mkProject,
+    PipenvGraphDep (..),
+    PipfileLock (..),
+    PipfileMeta (..),
+    PipfileSource (..),
+    PipfileDep (..),
+    buildGraph,
   )
-  where
+where
 
 import Control.Effect.Diagnostics
 import Data.Aeson
 import Data.Foldable (for_, traverse_)
 import Data.Map.Strict (Map)
-import qualified Data.Map.Strict as M
+import Data.Map.Strict qualified as M
 import Data.Set (Set)
 import Data.Text (Text)
-import qualified Data.Text as T
+import Data.Text qualified as T
 import DepTypes
 import Discovery.Walk
 import Effect.Exec
@@ -42,11 +41,12 @@ findProjects = walk' $ \_ _ files -> do
     Just file -> pure ([PipenvProject file], WalkContinue)
 
 getDeps ::
-  ( Has ReadFS sig m
-  , Has Exec sig m
-  , Has Diagnostics sig m
-  )
-  => PipenvProject -> m (Graphing Dependency)
+  ( Has ReadFS sig m,
+    Has Exec sig m,
+    Has Diagnostics sig m
+  ) =>
+  PipenvProject ->
+  m (Graphing Dependency)
 getDeps project = do
   lock <- readContentsJson (pipenvLockfile project)
   maybeDeps <- recover $ execJson (parent (pipenvLockfile project)) pipenvGraphCmd
@@ -54,13 +54,14 @@ getDeps project = do
   pure (buildGraph lock maybeDeps)
 
 mkProject :: (Has ReadFS sig n, Has Exec sig n, Has Diagnostics sig n) => PipenvProject -> DiscoveredProject n
-mkProject project = DiscoveredProject
-  { projectType = "pipenv"
-  , projectBuildTargets = mempty
-  , projectDependencyGraph = const $ getDeps project
-  , projectPath = parent $ pipenvLockfile project
-  , projectLicenses = pure []
-  }
+mkProject project =
+  DiscoveredProject
+    { projectType = "pipenv",
+      projectBuildTargets = mempty,
+      projectDependencyGraph = const $ getDeps project,
+      projectPath = parent $ pipenvLockfile project,
+      projectLicenses = pure []
+    }
 
 newtype PipenvProject = PipenvProject
   { pipenvLockfile :: Path Abs File
@@ -68,11 +69,12 @@ newtype PipenvProject = PipenvProject
   deriving (Eq, Ord, Show)
 
 pipenvGraphCmd :: Command
-pipenvGraphCmd = Command
-  { cmdName = "pipenv"
-  , cmdArgs = ["graph", "--json-tree"]
-  , cmdAllowErr = Never
-  }
+pipenvGraphCmd =
+  Command
+    { cmdName = "pipenv",
+      cmdArgs = ["graph", "--json-tree"],
+      cmdAllowErr = Never
+    }
 
 buildGraph :: PipfileLock -> Maybe [PipenvGraphDep] -> Graphing Dependency
 buildGraph lock maybeDeps = run . withLabeling toDependency $ do
@@ -80,38 +82,39 @@ buildGraph lock maybeDeps = run . withLabeling toDependency $ do
   case maybeDeps of
     Just deps -> buildEdges deps
     Nothing -> pure ()
-
   where
-  toDependency :: PipPkg -> Set PipLabel -> Dependency
-  toDependency pkg = foldr applyLabel start
-    where
-    applyLabel :: PipLabel -> Dependency -> Dependency
-    applyLabel (PipSource loc) dep = dep { dependencyLocations = loc : dependencyLocations dep }
-    applyLabel (PipEnvironment env) dep = dep { dependencyEnvironments = env : dependencyEnvironments dep }
+    toDependency :: PipPkg -> Set PipLabel -> Dependency
+    toDependency pkg = foldr applyLabel start
+      where
+        applyLabel :: PipLabel -> Dependency -> Dependency
+        applyLabel (PipSource loc) dep = dep {dependencyLocations = loc : dependencyLocations dep}
+        applyLabel (PipEnvironment env) dep = dep {dependencyEnvironments = env : dependencyEnvironments dep}
 
-    start = Dependency
-      { dependencyType = PipType
-      , dependencyName = pipPkgName pkg
-      , dependencyVersion = CEq <$> pipPkgVersion pkg
-      , dependencyLocations = []
-      , dependencyEnvironments = []
-      , dependencyTags = M.empty
-      }
+        start =
+          Dependency
+            { dependencyType = PipType,
+              dependencyName = pipPkgName pkg,
+              dependencyVersion = CEq <$> pipPkgVersion pkg,
+              dependencyLocations = [],
+              dependencyEnvironments = [],
+              dependencyTags = M.empty
+            }
 
 data PipPkg = PipPkg
-  { pipPkgName    :: Text
-  , pipPkgVersion :: Maybe Text
-  } deriving (Eq, Ord, Show)
+  { pipPkgName :: Text,
+    pipPkgVersion :: Maybe Text
+  }
+  deriving (Eq, Ord, Show)
 
 type PipGrapher = LabeledGrapher PipPkg PipLabel
 
-data PipLabel =
-    PipSource Text -- location
+data PipLabel
+  = PipSource Text -- location
   | PipEnvironment DepEnvironment
   deriving (Eq, Ord, Show)
 
 buildNodes :: forall sig m. Has PipGrapher sig m => PipfileLock -> m ()
-buildNodes PipfileLock{..} = do
+buildNodes PipfileLock {..} = do
   let indexBy :: Ord k => (v -> k) -> [v] -> Map k v
       indexBy ix = M.fromList . map (\v -> (ix v, v))
 
@@ -120,74 +123,75 @@ buildNodes PipfileLock{..} = do
   _ <- M.traverseWithKey (addWithEnv EnvDevelopment sourcesMap) fileDevelop
   _ <- M.traverseWithKey (addWithEnv EnvProduction sourcesMap) fileDefault
   pure ()
-
   where
+    addWithEnv ::
+      DepEnvironment ->
+      Map Text PipfileSource ->
+      Text -> -- dep name
+      PipfileDep ->
+      m ()
+    addWithEnv env sourcesMap depName dep = do
+      let pkg = PipPkg depName (T.drop 2 <$> fileDepVersion dep)
+      -- TODO: reachable instead of direct
+      direct pkg
+      label pkg (PipEnvironment env)
 
-  addWithEnv :: DepEnvironment
-               -> Map Text PipfileSource
-               -> Text -- dep name
-               -> PipfileDep
-               -> m ()
-  addWithEnv env sourcesMap depName dep = do
-    let pkg = PipPkg depName (T.drop 2 <$> fileDepVersion dep)
-    -- TODO: reachable instead of direct
-    direct pkg
-    label pkg (PipEnvironment env)
-
-    -- add label for source when it exists
-    for_ (fileDepIndex dep) $ \index ->
-      case M.lookup index sourcesMap of
-        Just source -> label pkg (PipSource (sourceUrl source))
-        Nothing -> pure ()
+      -- add label for source when it exists
+      for_ (fileDepIndex dep) $ \index ->
+        case M.lookup index sourcesMap of
+          Just source -> label pkg (PipSource (sourceUrl source))
+          Nothing -> pure ()
 
 buildEdges :: Has PipGrapher sig m => [PipenvGraphDep] -> m ()
 buildEdges pipenvDeps = do
   traverse_ (direct . mkPkg) pipenvDeps
   traverse_ mkEdges pipenvDeps
-
   where
+    mkPkg :: PipenvGraphDep -> PipPkg
+    mkPkg dep = PipPkg (depName dep) $ Just (depInstalled dep)
 
-  mkPkg :: PipenvGraphDep -> PipPkg
-  mkPkg dep = PipPkg (depName dep) $ Just (depInstalled dep)
-
-  mkEdges :: Has PipGrapher sig m => PipenvGraphDep -> m ()
-  mkEdges parentDep =
-    for_ (depDependencies parentDep) $ \childDep -> do
-      edge (mkPkg parentDep) (mkPkg childDep)
-      mkEdges childDep
+    mkEdges :: Has PipGrapher sig m => PipenvGraphDep -> m ()
+    mkEdges parentDep =
+      for_ (depDependencies parentDep) $ \childDep -> do
+        edge (mkPkg parentDep) (mkPkg childDep)
+        mkEdges childDep
 
 ---------- Pipfile.lock
 
 data PipfileLock = PipfileLock
-  { fileMeta    :: PipfileMeta
-  , fileDefault :: Map Text PipfileDep
-  , fileDevelop :: Map Text PipfileDep
-  } deriving (Eq, Ord, Show)
+  { fileMeta :: PipfileMeta,
+    fileDefault :: Map Text PipfileDep,
+    fileDevelop :: Map Text PipfileDep
+  }
+  deriving (Eq, Ord, Show)
 
 newtype PipfileMeta = PipfileMeta
   { fileSources :: [PipfileSource]
-  } deriving (Eq, Ord, Show)
+  }
+  deriving (Eq, Ord, Show)
 
 data PipfileSource = PipfileSource
-  { sourceName :: Text
-  , sourceUrl  :: Text
-  } deriving (Eq, Ord, Show)
+  { sourceName :: Text,
+    sourceUrl :: Text
+  }
+  deriving (Eq, Ord, Show)
 
 data PipfileDep = PipfileDep
-  { fileDepVersion :: Maybe Text
-  , fileDepIndex   :: Maybe Text
-  } deriving (Eq, Ord, Show)
+  { fileDepVersion :: Maybe Text,
+    fileDepIndex :: Maybe Text
+  }
+  deriving (Eq, Ord, Show)
 
 instance FromJSON PipfileLock where
   parseJSON = withObject "PipfileLock" $ \obj ->
     PipfileLock <$> obj .: "_meta"
-                <*> obj .: "default"
-                <*> obj .: "develop"
+      <*> obj .: "default"
+      <*> obj .: "develop"
 
 instance FromJSON PipfileDep where
   parseJSON = withObject "PipfileDep" $ \obj ->
     PipfileDep <$> obj .:? "version"
-               <*> obj .:? "index"
+      <*> obj .:? "index"
 
 instance FromJSON PipfileMeta where
   parseJSON = withObject "PipfileMeta" $ \obj ->
@@ -196,20 +200,21 @@ instance FromJSON PipfileMeta where
 instance FromJSON PipfileSource where
   parseJSON = withObject "PipfileSource" $ \obj ->
     PipfileSource <$> obj .: "name"
-                  <*> obj .: "url"
+      <*> obj .: "url"
 
 ---------- pipenv graph
 
 data PipenvGraphDep = PipenvGraphDep
-  { depName         :: Text
-  , depInstalled    :: Text
-  , depRequired     :: Text
-  , depDependencies :: [PipenvGraphDep]
-  } deriving (Eq, Ord, Show)
+  { depName :: Text,
+    depInstalled :: Text,
+    depRequired :: Text,
+    depDependencies :: [PipenvGraphDep]
+  }
+  deriving (Eq, Ord, Show)
 
 instance FromJSON PipenvGraphDep where
   parseJSON = withObject "PipenvGraphDep" $ \obj ->
     PipenvGraphDep <$> obj .: "package_name"
-                   <*> obj .: "installed_version"
-                   <*> obj .: "required_version"
-                   <*> obj .: "dependencies"
+      <*> obj .: "installed_version"
+      <*> obj .: "required_version"
+      <*> obj .: "dependencies"

--- a/src/Strategy/Python/ReqTxt.hs
+++ b/src/Strategy/Python/ReqTxt.hs
@@ -1,8 +1,8 @@
 module Strategy.Python.ReqTxt
-  ( analyze'
-  , requirementsTxtParser
+  ( analyze',
+    requirementsTxtParser,
   )
-  where
+where
 
 import Control.Effect.Diagnostics
 import Data.Foldable (asum)
@@ -26,28 +26,28 @@ type Parser = Parsec Void Text
 
 -- https://pip.pypa.io/en/stable/reference/pip_install/#requirements-file-format
 requirementsTxtParser :: Parser [Req]
-requirementsTxtParser =  concat <$> manyTill reqParser eof
+requirementsTxtParser = concat <$> manyTill reqParser eof
 
 reqParser :: Parser [Req]
-reqParser = [] <$ char '-' <* ignored -- pip options
-     <|> [] <$ char '.' <* ignored -- relative path
-     <|> [] <$ char '/' <* ignored -- absolute path
-     <|> [] <$ oneOfS ["http:", "https:", "git+", "hg+", "svn+", "bzr+"] <* ignored -- URLs
-     <|> [] <$ comment
-     <|> (pure <$> try requirementParser <* ignored)
-     <|> [] <$ ignored -- something else we're not able to parse
-
+reqParser =
+  [] <$ char '-' <* ignored -- pip options
+    <|> [] <$ char '.' <* ignored -- relative path
+    <|> [] <$ char '/' <* ignored -- absolute path
+    <|> [] <$ oneOfS ["http:", "https:", "git+", "hg+", "svn+", "bzr+"] <* ignored -- URLs
+    <|> [] <$ comment
+    <|> (pure <$> try requirementParser <* ignored)
+    <|> [] <$ ignored -- something else we're not able to parse
   where
-  isEndLine :: Char -> Bool
-  isEndLine '\n' = True
-  isEndLine '\r' = True
-  isEndLine _    = False
+    isEndLine :: Char -> Bool
+    isEndLine '\n' = True
+    isEndLine '\r' = True
+    isEndLine _ = False
 
-  -- ignore content until the end of the line
-  ignored :: Parser ()
-  ignored = () <$ takeWhileP (Just "ignored") (not . isEndLine) <* takeWhileP (Just "end of line") isEndLine
+    -- ignore content until the end of the line
+    ignored :: Parser ()
+    ignored = () <$ takeWhileP (Just "ignored") (not . isEndLine) <* takeWhileP (Just "end of line") isEndLine
 
-  comment :: Parser ()
-  comment = char '#' *> ignored
+    comment :: Parser ()
+    comment = char '#' *> ignored
 
-  oneOfS = asum . map string
+    oneOfS = asum . map string

--- a/src/Strategy/Python/SetupPy.hs
+++ b/src/Strategy/Python/SetupPy.hs
@@ -1,7 +1,7 @@
 module Strategy.Python.SetupPy
-  ( analyze'
+  ( analyze',
   )
-  where
+where
 
 import Control.Effect.Diagnostics
 import Data.Text (Text)
@@ -12,7 +12,7 @@ import Path
 import Strategy.Python.Util
 import Text.Megaparsec
 import Text.Megaparsec.Char
-import qualified Text.Megaparsec.Char.Lexer as L
+import Text.Megaparsec.Char.Lexer qualified as L
 import Types
 
 analyze' :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs File -> m (Graphing Dependency)
@@ -23,13 +23,13 @@ type Parser = Parsec Void Text
 installRequiresParser :: Parser [Req]
 installRequiresParser = prefix *> entries <* end
   where
-  prefix  = skipManyTill anySingle (symbol "install_requires") *> symbol "=" *> symbol "["
-  entries = (requireSurroundedBy "\"" <|> requireSurroundedBy "\'") `sepEndBy` symbol ","
+    prefix = skipManyTill anySingle (symbol "install_requires") *> symbol "=" *> symbol "["
+    entries = (requireSurroundedBy "\"" <|> requireSurroundedBy "\'") `sepEndBy` symbol ","
 
-  requireSurroundedBy :: Text -> Parser Req
-  requireSurroundedBy quote = between (symbol quote) (symbol quote) requirementParser
+    requireSurroundedBy :: Text -> Parser Req
+    requireSurroundedBy quote = between (symbol quote) (symbol quote) requirementParser
 
-  end     = symbol "]"
+    end = symbol "]"
 
-  symbol :: Text -> Parser Text
-  symbol = L.symbol space
+    symbol :: Text -> Parser Text
+    symbol = L.symbol space

--- a/src/Strategy/Python/Setuptools.hs
+++ b/src/Strategy/Python/Setuptools.hs
@@ -8,14 +8,14 @@ where
 
 import Control.Carrier.Output.IO
 import Control.Effect.Diagnostics (Diagnostics)
-import qualified Control.Effect.Diagnostics as Diag
+import Control.Effect.Diagnostics qualified as Diag
 import Data.List (isInfixOf, isSuffixOf)
 import Discovery.Walk
 import Effect.ReadFS
 import Graphing (Graphing)
 import Path
-import qualified Strategy.Python.ReqTxt as ReqTxt
-import qualified Strategy.Python.SetupPy as SetupPy
+import Strategy.Python.ReqTxt qualified as ReqTxt
+import Strategy.Python.SetupPy qualified as SetupPy
 import Types
 
 discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has ReadFS rsig run, Has Diagnostics rsig run) => Path Abs Dir -> m [DiscoveredProject run]

--- a/src/Strategy/Python/Util.hs
+++ b/src/Strategy/Python/Util.hs
@@ -1,110 +1,119 @@
 {-# LANGUAGE LambdaCase #-}
 
 module Strategy.Python.Util
-  ( requirementParser
-  , buildGraph
-
-  , Version(..)
-  , Marker(..)
-  , MarkerOp(..)
-  , Operator(..)
-  , Req(..)
-  ) where
+  ( requirementParser,
+    buildGraph,
+    Version (..),
+    Marker (..),
+    MarkerOp (..),
+    Operator (..),
+    Req (..),
+  )
+where
 
 import Control.Monad (join)
-import qualified Data.Char as C
+import Data.Char qualified as C
 import Data.Foldable (asum)
-import qualified Data.Map.Strict as M
+import Data.Map.Strict qualified as M
 import Data.Text (Text)
+import Data.Text qualified as T
 import Data.Void (Void)
-import qualified Data.Text as T
 import DepTypes
 import Graphing (Graphing)
-import qualified Graphing
+import Graphing qualified
 import Text.Megaparsec
 import Text.Megaparsec.Char
-import qualified Text.URI as URI
+import Text.URI qualified as URI
 
 buildGraph :: [Req] -> Graphing Dependency
 buildGraph = Graphing.fromList . map toDependency
   where
-  toDependency req =
-    Dependency { dependencyType = PipType
-               , dependencyName = depName req
-               , dependencyVersion = depVersion req
-               , dependencyLocations = []
-               , dependencyEnvironments = []
-               , dependencyTags = maybe M.empty toTags (depMarker req)
-               }
+    toDependency req =
+      Dependency
+        { dependencyType = PipType,
+          dependencyName = depName req,
+          dependencyVersion = depVersion req,
+          dependencyLocations = [],
+          dependencyEnvironments = [],
+          dependencyTags = maybe M.empty toTags (depMarker req)
+        }
 
-  depName (NameReq nm _ _ _) = nm
-  depName (UrlReq nm _ _ _) = nm
+    depName (NameReq nm _ _ _) = nm
+    depName (UrlReq nm _ _ _) = nm
 
-  depVersion (NameReq _ _ versions _) = toConstraint <$> versions
-  depVersion (UrlReq _ _ uri _) = Just (CURI (URI.render uri))
+    depVersion (NameReq _ _ versions _) = toConstraint <$> versions
+    depVersion (UrlReq _ _ uri _) = Just (CURI (URI.render uri))
 
-  depMarker (NameReq _ _ _ marker) = marker
-  depMarker (UrlReq _ _ _ marker) = marker
+    depMarker (NameReq _ _ _ marker) = marker
+    depMarker (UrlReq _ _ _ marker) = marker
 
 -- we pull out tags naively. we don't respect and/or semantics, and ignore operators
 -- FUTURE: more useful tagging? in particular: only pull out sys_platform?
 toTags :: Marker -> M.Map Text [Text]
-toTags = M.fromListWith (++) . map (\(a,b) -> (a, [b])) . go
+toTags = M.fromListWith (++) . map (\(a, b) -> (a, [b])) . go
   where
-  go (MarkerAnd a b) = go a ++ go b
-  go (MarkerOr a b) = go a ++ go b
-  go (MarkerExpr lhs op rhs) =
-    case op of
-      MarkerIn    -> [(lhs, rhs)]
-      MarkerNotIn -> [(lhs, "not (" <> rhs <> ")")]
-      MarkerOperator _ -> [(lhs, rhs)]
+    go (MarkerAnd a b) = go a ++ go b
+    go (MarkerOr a b) = go a ++ go b
+    go (MarkerExpr lhs op rhs) =
+      case op of
+        MarkerIn -> [(lhs, rhs)]
+        MarkerNotIn -> [(lhs, "not (" <> rhs <> ")")]
+        MarkerOperator _ -> [(lhs, rhs)]
 
 toConstraint :: [Version] -> VerConstraint
 toConstraint = foldr1 CAnd . map (\(Version op ver) -> opToConstraint op ver)
   where
-
-  opToConstraint = \case
-    OpCompatible -> CCompatible
-    OpEq -> CEq
-    OpNot -> CNot
-    OpLtEq -> CLessOrEq
-    OpGtEq -> CGreaterOrEq
-    OpLt -> CLess
-    OpGt -> CGreater
-    OpArbitrary -> CEq
+    opToConstraint = \case
+      OpCompatible -> CCompatible
+      OpEq -> CEq
+      OpNot -> CNot
+      OpLtEq -> CLessOrEq
+      OpGtEq -> CGreaterOrEq
+      OpLt -> CLess
+      OpGt -> CGreater
+      OpArbitrary -> CEq
 
 type Parser = Parsec Void Text
 
 data Version = Version
-  { versionOperator :: Operator
-  , versionVersion  :: Text
-  } deriving (Eq, Ord, Show)
+  { versionOperator :: Operator,
+    versionVersion :: Text
+  }
+  deriving (Eq, Ord, Show)
 
-data Marker =
-    MarkerAnd  Marker Marker
-  | MarkerOr   Marker Marker
+data Marker
+  = MarkerAnd Marker Marker
+  | MarkerOr Marker Marker
   | MarkerExpr Text MarkerOp Text -- marker_var marker_op marker_var
   deriving (Eq, Ord, Show)
 
-data MarkerOp =
-    MarkerIn
+data MarkerOp
+  = MarkerIn
   | MarkerNotIn
   | MarkerOperator Operator
   deriving (Eq, Ord, Show)
 
-data Operator =
-    OpCompatible -- ^ @~=@; equivalent to `>= V.N, == V.*`
-  | OpEq  -- ^ @==@
-  | OpNot -- ^ @!=@
-  | OpLtEq -- ^ @<=@
-  | OpGtEq -- ^ @>=@
-  | OpLt -- ^ @<@
-  | OpGt -- ^ @>@
-  | OpArbitrary -- ^ @===@
+data Operator
+  = -- | @~=@; equivalent to `>= V.N, == V.*`
+    OpCompatible
+  | -- | @==@
+    OpEq
+  | -- | @!=@
+    OpNot
+  | -- | @<=@
+    OpLtEq
+  | -- | @>=@
+    OpGtEq
+  | -- | @<@
+    OpLt
+  | -- | @>@
+    OpGt
+  | -- | @===@
+    OpArbitrary
   deriving (Eq, Ord, Show)
 
-data Req =
-    NameReq Text (Maybe [Text]) (Maybe [Version]) (Maybe Marker) -- name, extras, ...
+data Req
+  = NameReq Text (Maybe [Text]) (Maybe [Version]) (Maybe Marker) -- name, extras, ...
   | UrlReq Text (Maybe [Text]) URI.URI (Maybe Marker) -- name, extras, ...
   deriving (Eq, Ord, Show)
 
@@ -112,88 +121,108 @@ data Req =
 requirementParser :: Parser Req
 requirementParser = specification
   where
-  oneOfS = asum . map string
-  isSpace c = c == ' ' || c == '\t'
+    oneOfS = asum . map string
+    isSpace c = c == ' ' || c == '\t'
 
-  whitespace = takeWhileP (Just "whitespace") isSpace :: Parser Text
-  whitespace1 = label "whitespace1" $ takeWhile1P (Just "whitespace1") isSpace :: Parser Text
-  letterOrDigit = label "letterOrDigit" $ satisfy (\c -> C.isLetter c || C.isDigit c)
+    whitespace = takeWhileP (Just "whitespace") isSpace :: Parser Text
+    whitespace1 = label "whitespace1" $ takeWhile1P (Just "whitespace1") isSpace :: Parser Text
+    letterOrDigit = label "letterOrDigit" $ satisfy (\c -> C.isLetter c || C.isDigit c)
 
-  version_cmp = label "version_cmp" $ whitespace *> version_operator
+    version_cmp = label "version_cmp" $ whitespace *> version_operator
 
-  version_operator = label "version_operator" $
+    version_operator =
+      label "version_operator" $
         OpCompatible <$ string "~="
-    <|> OpLtEq       <$ string "<="
-    <|> OpGtEq       <$ string ">="
-    <|> OpNot        <$ string "!="
-    <|> OpArbitrary  <$ string "==="
-    <|> OpEq         <$ string "=="
-    <|> OpLt         <$ string "<"
-    <|> OpGt         <$ string ">"
+          <|> OpLtEq <$ string "<="
+          <|> OpGtEq <$ string ">="
+          <|> OpNot <$ string "!="
+          <|> OpArbitrary <$ string "==="
+          <|> OpEq <$ string "=="
+          <|> OpLt <$ string "<"
+          <|> OpGt <$ string ">"
 
-  version = label "version" $ whitespace *> some (letterOrDigit <|> oneOf ['-', '_', '.', '*', '+', '!'])
-  version_one = label "version_one" $ Version <$> version_cmp <*> (T.pack <$> version) <* whitespace
-  version_many = label "version_many" $ version_one `sepBy1` (whitespace *> char ',')
-  versionspec = label "versionspec" $ between (char '(') (char ')') version_many <|> version_many
-  urlspec = label "urlspec" $ char '@' *> whitespace *> URI.parser
+    version = label "version" $ whitespace *> some (letterOrDigit <|> oneOf ['-', '_', '.', '*', '+', '!'])
+    version_one = label "version_one" $ Version <$> version_cmp <*> (T.pack <$> version) <* whitespace
+    version_many = label "version_many" $ version_one `sepBy1` (whitespace *> char ',')
+    versionspec = label "versionspec" $ between (char '(') (char ')') version_many <|> version_many
+    urlspec = label "urlspec" $ char '@' *> whitespace *> URI.parser
 
-  marker_op = label "marker_op" $
-              MarkerOperator <$> version_cmp
+    marker_op =
+      label "marker_op" $
+        MarkerOperator <$> version_cmp
           <|> MarkerIn <$ whitespace <* string "in"
           <|> MarkerNotIn <$ whitespace <* string "not" <* whitespace1 <* string "in"
-  python_str_c :: Parser Char
-  python_str_c = label "python_str_c" $
-                 satisfy isSpace <|> satisfy C.isLetter <|> satisfy C.isDigit
-             <|> oneOf ("().{}-_*#:;,/?[]!~`@$%^&=+|<>" :: String)
+    python_str_c :: Parser Char
+    python_str_c =
+      label "python_str_c" $
+        satisfy isSpace <|> satisfy C.isLetter <|> satisfy C.isDigit
+          <|> oneOf ("().{}-_*#:;,/?[]!~`@$%^&=+|<>" :: String)
 
-  dquote :: Parser Char
-  dquote = label "dquote" $ char '\"'
-  squote :: Parser Char
-  squote = label "squote" $ char '\''
+    dquote :: Parser Char
+    dquote = label "dquote" $ char '\"'
+    squote :: Parser Char
+    squote = label "squote" $ char '\''
 
-  python_str = label "python_str" $
-               (squote *> many (python_str_c <|> dquote) <* squote)
-           <|> (dquote *> many (python_str_c <|> squote) <* dquote)
+    python_str =
+      label "python_str" $
+        (squote *> many (python_str_c <|> dquote) <* squote)
+          <|> (dquote *> many (python_str_c <|> squote) <* dquote)
 
-  env_var :: Parser Text
-  env_var = label "env_var" $ oneOfS ["python_version", "python_full_version",
-                 "os_name", "sys_platform", "platform_release",
-                 "platform_system", "platform_version",
-                 "platform_machine", "platform_python_implementation",
-                 "implementation_name", "implementation_version", "extra"]
-  marker_var :: Parser Text
-  marker_var = label "marker_var" $ whitespace *> (env_var <|> fmap T.pack python_str)
-  marker_expr = label "marker_expr" $
-                MarkerExpr <$> marker_var <*> marker_op <*> marker_var
-            <|> whitespace *> char '(' *> marker_or <* char ')'
+    env_var :: Parser Text
+    env_var =
+      label "env_var" $
+        oneOfS
+          [ "python_version",
+            "python_full_version",
+            "os_name",
+            "sys_platform",
+            "platform_release",
+            "platform_system",
+            "platform_version",
+            "platform_machine",
+            "platform_python_implementation",
+            "implementation_name",
+            "implementation_version",
+            "extra"
+          ]
+    marker_var :: Parser Text
+    marker_var = label "marker_var" $ whitespace *> (env_var <|> fmap T.pack python_str)
+    marker_expr =
+      label "marker_expr" $
+        MarkerExpr <$> marker_var <*> marker_op <*> marker_var
+          <|> whitespace *> char '(' *> marker_or <* char ')'
 
-  marker_and = label "marker_and" $
-               try (MarkerAnd <$> marker_expr <* whitespace <* string "and" <*> marker_expr)
-           <|> marker_expr
+    marker_and =
+      label "marker_and" $
+        try (MarkerAnd <$> marker_expr <* whitespace <* string "and" <*> marker_expr)
+          <|> marker_expr
 
-  marker_or :: Parser Marker
-  marker_or = label "marker_or" $
-              try (MarkerOr <$> marker_and <* whitespace <* string "or" <*> marker_and)
+    marker_or :: Parser Marker
+    marker_or =
+      label "marker_or" $
+        try (MarkerOr <$> marker_and <* whitespace <* string "or" <*> marker_and)
           <|> marker_and
 
-  marker = label "marker" marker_or
-  quoted_marker = label "quoted_marker" $ char ';' *> whitespace *> marker
+    marker = label "marker" marker_or
+    quoted_marker = label "quoted_marker" $ char ';' *> whitespace *> marker
 
-  identifier_end = label "identifier_end" $
-                   pure <$> letterOrDigit
-               <|> do
-                  special <- many (oneOf ['-', '_', '.'])
-                  lod     <- letterOrDigit
-                  pure (special ++ [lod])
-  identifier = label "identifier" $ (:) <$> letterOrDigit <*> (concat <$> many identifier_end)
-  name = label "name" $ T.pack <$> identifier
-  extras_list :: Parser [Text]
-  extras_list = label "extras_list" $
-                (T.pack <$> identifier)
-                `sepBy` (whitespace *> char ',' <* whitespace)
-  extras = label "extras" $ char '[' *> whitespace *> optional extras_list <* whitespace <* char ']'
+    identifier_end =
+      label "identifier_end" $
+        pure <$> letterOrDigit
+          <|> do
+            special <- many (oneOf ['-', '_', '.'])
+            lod <- letterOrDigit
+            pure (special ++ [lod])
+    identifier = label "identifier" $ (:) <$> letterOrDigit <*> (concat <$> many identifier_end)
+    name = label "name" $ T.pack <$> identifier
+    extras_list :: Parser [Text]
+    extras_list =
+      label "extras_list" $
+        (T.pack <$> identifier)
+          `sepBy` (whitespace *> char ',' <* whitespace)
+    extras = label "extras" $ char '[' *> whitespace *> optional extras_list <* whitespace <* char ']'
 
-  name_req = label "name_req" $ NameReq <$> name <* whitespace <*> (join <$> optional extras) <* whitespace <*> optional versionspec <* whitespace <*> optional quoted_marker
-  url_req = label "url_req" $ UrlReq <$> name <* whitespace <*> (join <$> optional extras) <* whitespace <*> urlspec <* whitespace1 <*> optional quoted_marker
+    name_req = label "name_req" $ NameReq <$> name <* whitespace <*> (join <$> optional extras) <* whitespace <*> optional versionspec <* whitespace <*> optional quoted_marker
+    url_req = label "url_req" $ UrlReq <$> name <* whitespace <*> (join <$> optional extras) <* whitespace <*> urlspec <* whitespace1 <*> optional quoted_marker
 
-  specification = label "specification" $ whitespace *> (try url_req <|> name_req) <* whitespace
+    specification = label "specification" $ whitespace *> (try url_req <|> name_req) <* whitespace

--- a/src/Strategy/RPM.hs
+++ b/src/Strategy/RPM.hs
@@ -15,16 +15,16 @@ where
 import Control.Effect.Diagnostics
 import Control.Monad (when)
 import Data.List (isSuffixOf)
-import qualified Data.Map.Strict as M
-import Data.Maybe (mapMaybe, catMaybes)
+import Data.Map.Strict qualified as M
+import Data.Maybe (catMaybes, mapMaybe)
 import Data.Text (Text)
-import qualified Data.Text as T
+import Data.Text qualified as T
 import Data.Text.Extra (splitOnceOn)
 import DepTypes
 import Discovery.Walk
 import Effect.ReadFS
 import Graphing (Graphing)
-import qualified Graphing as G
+import Graphing qualified as G
 import Path
 import Types
 
@@ -32,11 +32,10 @@ newtype SpecFileLabel
   = RequiresType DepEnvironment
   deriving (Eq, Ord, Show)
 
-data RPMDependency
-  = RPMDependency
-      { rpmDepName :: Text,
-        rpmConstraint :: Maybe VerConstraint
-      }
+data RPMDependency = RPMDependency
+  { rpmDepName :: Text,
+    rpmConstraint :: Maybe VerConstraint
+  }
   deriving (Eq, Ord, Show)
 
 data RequiresType
@@ -44,11 +43,10 @@ data RequiresType
   | RuntimeRequires RPMDependency
   deriving (Eq, Ord, Show)
 
-data Dependencies
-  = Dependencies
-      { depBuildRequires :: [RPMDependency],
-        depRuntimeRequires :: [RPMDependency]
-      }
+data Dependencies = Dependencies
+  { depBuildRequires :: [RPMDependency],
+    depRuntimeRequires :: [RPMDependency]
+  }
   deriving (Eq, Ord, Show)
 
 discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has ReadFS rsig run, Has Diagnostics rsig run) => Path Abs Dir -> m [DiscoveredProject run]
@@ -63,8 +61,8 @@ findProjects = walk' $ \dir _ files -> do
     _ -> pure ([RpmProject dir specs], WalkContinue)
 
 data RpmProject = RpmProject
-  { rpmDir :: Path Abs Dir
-  , rpmFiles :: [Path Abs File]
+  { rpmDir :: Path Abs Dir,
+    rpmFiles :: [Path Abs File]
   }
   deriving (Eq, Ord, Show)
 
@@ -100,14 +98,14 @@ analyzeSingle file = do
 
 toDependency :: RPMDependency -> Dependency
 toDependency pkg =
-    Dependency
-      { dependencyType = RPMType,
-        dependencyName = rpmDepName pkg,
-        dependencyVersion = rpmConstraint pkg,
-        dependencyLocations = [],
-        dependencyEnvironments = [],
-        dependencyTags = M.empty
-      }
+  Dependency
+    { dependencyType = RPMType,
+      dependencyName = rpmDepName pkg,
+      dependencyVersion = rpmConstraint pkg,
+      dependencyLocations = [],
+      dependencyEnvironments = [],
+      dependencyTags = M.empty
+    }
 
 buildGraph :: Dependencies -> Graphing Dependency
 buildGraph Dependencies {..} = G.gmap toDependency $ G.fromList depRuntimeRequires

--- a/src/Strategy/Rebar3.hs
+++ b/src/Strategy/Rebar3.hs
@@ -12,7 +12,7 @@ import Effect.Exec
 import Effect.ReadFS
 import Graphing
 import Path
-import qualified Strategy.Erlang.Rebar3Tree as Rebar3Tree
+import Strategy.Erlang.Rebar3Tree qualified as Rebar3Tree
 import Types
 
 discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has ReadFS rsig run, Has Exec rsig run, Has Diagnostics rsig run) => Path Abs Dir -> m [DiscoveredProject run]

--- a/src/Strategy/Ruby/GemfileLock.hs
+++ b/src/Strategy/Ruby/GemfileLock.hs
@@ -1,23 +1,23 @@
 module Strategy.Ruby.GemfileLock
-  ( analyze'
-  , findSections
-  , buildGraph
-
-  , Spec(..)
-  , SpecDep(..)
-  , DirectDep(..)
-  , Section(..)
-  ) where
+  ( analyze',
+    findSections,
+    buildGraph,
+    Spec (..),
+    SpecDep (..),
+    DirectDep (..),
+    Section (..),
+  )
+where
 
 import Control.Effect.Diagnostics
-import qualified Data.Char as C
+import Data.Char qualified as C
 import Data.Foldable (traverse_)
 import Data.Functor (void)
 import Data.Map.Strict (Map)
-import qualified Data.Map.Strict as M
+import Data.Map.Strict qualified as M
 import Data.Set (Set)
 import Data.Text (Text)
-import qualified Data.Text as T
+import Data.Text qualified as T
 import Data.Void (Void)
 import DepTypes
 import Effect.Grapher
@@ -26,92 +26,100 @@ import Graphing (Graphing)
 import Path
 import Text.Megaparsec hiding (label)
 import Text.Megaparsec.Char
-import qualified Text.Megaparsec.Char.Lexer as L
+import Text.Megaparsec.Char.Lexer qualified as L
 
 type Remote = Text
+
 type Revision = Text
+
 type Branch = Text
 
-data Section =
-      GitSection Remote (Maybe Revision) (Maybe Branch) [Spec]
-      | GemSection Remote [Spec]
-      | PathSection Remote [Spec]
-      | DependencySection [DirectDep]
-      | UnknownSection Text
-        deriving (Eq, Ord, Show)
+data Section
+  = GitSection Remote (Maybe Revision) (Maybe Branch) [Spec]
+  | GemSection Remote [Spec]
+  | PathSection Remote [Spec]
+  | DependencySection [DirectDep]
+  | UnknownSection Text
+  deriving (Eq, Ord, Show)
 
 data Spec = Spec
-      { specVersion :: Text
-      , specName :: Text
-      , specDeps :: [SpecDep]
-      } deriving (Eq, Ord, Show)
+  { specVersion :: Text,
+    specName :: Text,
+    specDeps :: [SpecDep]
+  }
+  deriving (Eq, Ord, Show)
 
 newtype SpecDep = SpecDep
-      { depName :: Text
-      } deriving (Eq, Ord, Show)
+  { depName :: Text
+  }
+  deriving (Eq, Ord, Show)
 
 newtype DirectDep = DirectDep
-      { directName :: Text
-      } deriving (Eq, Ord, Show)
+  { directName :: Text
+  }
+  deriving (Eq, Ord, Show)
 
 analyze' :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs File -> m (Graphing Dependency)
 analyze' file = buildGraph <$> readContentsParser @[Section] findSections file
 
-data GemfilePkg = GemfilePkg { pkgName :: Text }
+data GemfilePkg = GemfilePkg {pkgName :: Text}
   deriving (Eq, Ord, Show)
 
 type GemfileGrapher = LabeledGrapher GemfilePkg GemfileLabel
 
-data GemfileLabel =
-    GemfileVersion Text
-  | GitRemote Text (Maybe Text) -- ^ repo url, revision
-  | OtherRemote Text -- ^ url
+data GemfileLabel
+  = GemfileVersion Text
+  | -- | repo url, revision
+    GitRemote Text (Maybe Text)
+  | -- | url
+    OtherRemote Text
   deriving (Eq, Ord, Show)
 
 toDependency :: GemfilePkg -> Set GemfileLabel -> Dependency
 toDependency pkg = foldr applyLabel start
   where
+    start :: Dependency
+    start =
+      Dependency
+        { dependencyType = GemType,
+          dependencyName = pkgName pkg,
+          dependencyVersion = Nothing,
+          dependencyLocations = [],
+          dependencyEnvironments = [],
+          dependencyTags = M.empty
+        }
 
-  start :: Dependency
-  start = Dependency
-    { dependencyType = GemType
-    , dependencyName = pkgName pkg
-    , dependencyVersion = Nothing
-    , dependencyLocations = []
-    , dependencyEnvironments = []
-    , dependencyTags = M.empty
-    }
-
-  applyLabel :: GemfileLabel -> Dependency -> Dependency
-  applyLabel (GemfileVersion ver) dep = dep { dependencyVersion = Just (CEq ver) }
-  applyLabel (GitRemote repo maybeRevision) dep =
-    dep { dependencyLocations = maybe repo (\revision -> repo <> "@" <> revision) maybeRevision : dependencyLocations dep }
-  applyLabel (OtherRemote loc) dep =
-    dep { dependencyLocations = loc : dependencyLocations dep }
+    applyLabel :: GemfileLabel -> Dependency -> Dependency
+    applyLabel (GemfileVersion ver) dep = dep {dependencyVersion = Just (CEq ver)}
+    applyLabel (GitRemote repo maybeRevision) dep =
+      dep {dependencyLocations = maybe repo (\revision -> repo <> "@" <> revision) maybeRevision : dependencyLocations dep}
+    applyLabel (OtherRemote loc) dep =
+      dep {dependencyLocations = loc : dependencyLocations dep}
 
 buildGraph :: [Section] -> Graphing Dependency
-buildGraph sections = run . withLabeling toDependency $
-  traverse_ addSection sections
+buildGraph sections =
+  run . withLabeling toDependency $
+    traverse_ addSection sections
   where
-  addSection :: Has GemfileGrapher sig m => Section -> m ()
-  addSection (DependencySection deps) = traverse_ (direct . GemfilePkg . directName) deps
-  addSection (GitSection remote revision branch specs) =
-    traverse_ (addSpec (GitRemote remote (revision <|> branch))) specs
-  addSection (PathSection remote specs) =
-    traverse_ (addSpec (OtherRemote remote)) specs
-  addSection (GemSection remote specs) =
-    traverse_ (addSpec (OtherRemote remote)) specs
-  addSection UnknownSection{} = pure ()
+    addSection :: Has GemfileGrapher sig m => Section -> m ()
+    addSection (DependencySection deps) = traverse_ (direct . GemfilePkg . directName) deps
+    addSection (GitSection remote revision branch specs) =
+      traverse_ (addSpec (GitRemote remote (revision <|> branch))) specs
+    addSection (PathSection remote specs) =
+      traverse_ (addSpec (OtherRemote remote)) specs
+    addSection (GemSection remote specs) =
+      traverse_ (addSpec (OtherRemote remote)) specs
+    addSection UnknownSection {} = pure ()
 
-  addSpec :: Has GemfileGrapher sig m => GemfileLabel -> Spec -> m ()
-  addSpec remoteLabel spec = do
-    let pkg = GemfilePkg (specName spec)
-    -- add edges between spec and specdeps
-    traverse_ (edge pkg . GemfilePkg . depName) (specDeps spec)
-    -- add a label for version
-    label pkg (GemfileVersion (specVersion spec))
-    -- add a label for remote
-    label pkg remoteLabel
+    addSpec :: Has GemfileGrapher sig m => GemfileLabel -> Spec -> m ()
+    addSpec remoteLabel spec = do
+      let pkg = GemfilePkg (specName spec)
+      -- add edges between spec and specdeps
+      traverse_ (edge pkg . GemfilePkg . depName) (specDeps spec)
+      -- add a label for version
+      label pkg (GemfileVersion (specVersion spec))
+      -- add a label for remote
+      label pkg remoteLabel
 
 type Parser = Parsec Void Text
 
@@ -152,18 +160,17 @@ gemSectionParser = mkSectionParser "GEM" $ \propertyMap -> do
   pure $ GemSection remote specs
 
 mkSectionParser :: Text -> (Map Text RawField -> Either Text Section) -> Parser Section
-mkSectionParser sectionName toSection = L.nonIndented scn $ L.indentBlock scn $ do
-  _ <- chunk sectionName
-  pure $ L.IndentMany Nothing propertiesToSection (try propertyParser <|> specPropertyParser)
-
+mkSectionParser sectionName toSection = L.nonIndented scn $
+  L.indentBlock scn $ do
+    _ <- chunk sectionName
+    pure $ L.IndentMany Nothing propertiesToSection (try propertyParser <|> specPropertyParser)
   where
     propertiesToSection :: [(Text, RawField)] -> Parser Section
     propertiesToSection properties =
       let propertyMap = M.fromList properties
           result :: Either Text Section
           result = toSection propertyMap
-
-      in case result of
+       in case result of
             Right x -> pure x
             Left y -> fail $ T.unpack $ "could not parse " <> sectionName <> " section: " <> y
 
@@ -192,31 +199,28 @@ propertyParser = do
   _ <- chunk ":"
   value <- textValue
   pure (remote, value)
-
   where
     findFieldName :: Parser Text
     findFieldName = takeWhileP (Just "field name") (/= ':')
 
     textValue :: Parser RawField
     textValue = do
-          _ <- chunk " "
-          RawText <$> restOfLine
+      _ <- chunk " "
+      RawText <$> restOfLine
 
 specPropertyParser :: Parser (Text, RawField)
 specPropertyParser = L.indentBlock scn $ do
   remote <- findFieldName
   _ <- chunk ":"
   pure $ L.IndentMany Nothing (\a -> pure (remote, RawSpecs a)) specParser
-
   where
-
     findFieldName :: Parser Text
     findFieldName = takeWhileP (Just "field name") (/= ':')
 
 isEndLine :: Char -> Bool
 isEndLine '\n' = True
 isEndLine '\r' = True
-isEndLine _    = False
+isEndLine _ = False
 
 specParser :: Parser Spec
 specParser = L.indentBlock scn p
@@ -228,15 +232,15 @@ specParser = L.indentBlock scn p
 
 specDepParser :: Parser SpecDep
 specDepParser = do
-      name <- findDep
-      _ <- ignored
-      pure $ SpecDep name
+  name <- findDep
+  _ <- ignored
+  pure $ SpecDep name
 
 scn :: Parser ()
-scn =  L.space space1 empty empty
+scn = L.space space1 empty empty
 
 sc :: Parser ()
-sc =  L.space (void $ some (char ' ')) empty empty
+sc = L.space (void $ some (char ' ')) empty empty
 
 lexeme :: Parser a -> Parser a
 lexeme = L.lexeme sc
@@ -246,19 +250,19 @@ findDep = lexeme (takeWhile1P (Just "dep") (not . C.isSpace))
 
 findVersion :: Parser Text
 findVersion = do
-      _ <- char '('
-      result <- lexeme (takeWhileP (Just "version") (/= ')'))
-      _ <- char ')'
-      pure result
-
+  _ <- char '('
+  result <- lexeme (takeWhileP (Just "version") (/= ')'))
+  _ <- char ')'
+  pure result
 
 dependenciesSectionParser :: Parser Section
-dependenciesSectionParser = L.nonIndented scn $ L.indentBlock scn $ do
-  _ <- chunk "DEPENDENCIES"
-  pure $ L.IndentMany Nothing (\deps -> pure $ DependencySection deps) findDependency
+dependenciesSectionParser = L.nonIndented scn $
+  L.indentBlock scn $ do
+    _ <- chunk "DEPENDENCIES"
+    pure $ L.IndentMany Nothing (\deps -> pure $ DependencySection deps) findDependency
 
 findDependency :: Parser DirectDep
 findDependency = do
-      dep <- findDep
-      _ <- ignored
-      pure $ DirectDep dep
+  dep <- findDep
+  _ <- ignored
+  pure $ DirectDep dep

--- a/src/Strategy/Scala.hs
+++ b/src/Strategy/Scala.hs
@@ -15,17 +15,17 @@ where
 import Control.Carrier.Diagnostics
 import Data.Maybe (mapMaybe)
 import Data.Text (Text)
-import qualified Data.Text as T
-import qualified Data.Text.Lazy as TL
+import Data.Text qualified as T
+import Data.Text.Lazy qualified as TL
 import Data.Text.Lazy.Encoding (decodeUtf8)
 import Discovery.Walk
 import Effect.Exec
 import Effect.Logger hiding (group)
 import Effect.ReadFS
 import Path
-import qualified Strategy.Maven.Pom as Pom
+import Strategy.Maven.Pom qualified as Pom
 import Strategy.Maven.Pom.Closure (MavenProjectClosure, buildProjectClosures)
-import qualified Strategy.Maven.Pom.Closure as PomClosure
+import Strategy.Maven.Pom.Closure qualified as PomClosure
 import Strategy.Maven.Pom.Resolver (buildGlobalClosure)
 import Types
 

--- a/src/Strategy/UserSpecified/YamlDependencies.hs
+++ b/src/Strategy/UserSpecified/YamlDependencies.hs
@@ -13,12 +13,12 @@ where
 import Control.Effect.Diagnostics
 import Data.Aeson
 import Data.Aeson.Types (Parser)
-import qualified Data.Map.Strict as M
+import Data.Map.Strict qualified as M
 import Data.Text (Text, unpack)
 import DepTypes
 import Effect.ReadFS
 import Graphing (Graphing)
-import qualified Graphing
+import Graphing qualified
 import Path
 import Types
 

--- a/src/Strategy/Yarn.hs
+++ b/src/Strategy/Yarn.hs
@@ -1,15 +1,16 @@
 module Strategy.Yarn
-  ( discover
-  ) where
+  ( discover,
+  )
+where
 
 import Control.Effect.Diagnostics
 import Discovery.Walk
 import Effect.ReadFS
-import qualified Graphing as G
+import Graphing qualified as G
 import Path
+import Strategy.Node.YarnLock qualified as YarnLock
 import Types
 import Prelude
-import qualified Strategy.Node.YarnLock as YarnLock
 
 discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has ReadFS rsig run, Has Diagnostics rsig run) => Path Abs Dir -> m [DiscoveredProject run]
 discover dir = map mkProject <$> findProjects dir
@@ -21,9 +22,9 @@ findProjects = walk' $ \dir _ files -> do
     Just lock -> do
       let project =
             YarnProject
-            { yarnDir = dir
-            , yarnLock = lock
-            }
+              { yarnDir = dir,
+                yarnLock = lock
+              }
 
       pure ([project], WalkSkipSome ["node_modules"])
 
@@ -41,6 +42,7 @@ getDeps :: (Has ReadFS sig m, Has Diagnostics sig m) => YarnProject -> m (G.Grap
 getDeps = YarnLock.analyze' . yarnLock
 
 data YarnProject = YarnProject
-  { yarnDir :: Path Abs Dir
-  , yarnLock :: Path Abs File
-  } deriving (Eq, Ord, Show)
+  { yarnDir :: Path Abs Dir,
+    yarnLock :: Path Abs File
+  }
+  deriving (Eq, Ord, Show)

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -2,15 +2,14 @@
 {-# LANGUAGE RecordWildCards #-}
 
 module Types
-  ( DiscoveredProject(..)
-  , BuildTarget(..)
-
-  , LicenseResult(..)
-  , License(..)
-  , LicenseType(..)
-
-  , module DepTypes
-  ) where
+  ( DiscoveredProject (..),
+    BuildTarget (..),
+    LicenseResult (..),
+    License (..),
+    LicenseType (..),
+    module DepTypes,
+  )
+where
 
 import Data.Aeson
 import Data.Set (Set)
@@ -20,6 +19,7 @@ import Graphing
 import Path
 
 -- TODO: results should be within a graph of build targets && eliminate SubprojectType
+
 -- | A project found during project discovery, parameterized by the monad
 -- used to perform dependency analysis
 data DiscoveredProject m = DiscoveredProject
@@ -30,42 +30,45 @@ data DiscoveredProject m = DiscoveredProject
     projectLicenses :: m [LicenseResult]
   }
 
-newtype BuildTarget = BuildTarget { unBuildTarget :: Text }
+newtype BuildTarget = BuildTarget {unBuildTarget :: Text}
   deriving (Eq, Ord, Show)
 
 data LicenseResult = LicenseResult
-  { licenseFile   :: FilePath
-  , licensesFound :: [License]
-  } deriving (Eq, Ord, Show)
+  { licenseFile :: FilePath,
+    licensesFound :: [License]
+  }
+  deriving (Eq, Ord, Show)
 
 data License = License
-  { licenseType  :: LicenseType
-  , licenseValue :: Text
-  } deriving (Eq, Ord, Show)
+  { licenseType :: LicenseType,
+    licenseValue :: Text
+  }
+  deriving (Eq, Ord, Show)
 
-data LicenseType =
-          LicenseURL
-        | LicenseFile
-        | LicenseSPDX
-        | UnknownType
-          deriving (Eq, Ord, Show)
+data LicenseType
+  = LicenseURL
+  | LicenseFile
+  | LicenseSPDX
+  | UnknownType
+  deriving (Eq, Ord, Show)
 
 instance ToJSON License where
-    toJSON License{..} = object
-      [ "type"   .=  textType licenseType
-      , "value"  .=  licenseValue
+  toJSON License {..} =
+    object
+      [ "type" .= textType licenseType,
+        "value" .= licenseValue
       ]
-
-      where
-        textType :: LicenseType -> Text
-        textType = \case
-          LicenseURL  -> "url"
-          LicenseFile -> "file"
-          LicenseSPDX -> "spdx"
-          UnknownType -> "unknown"
+    where
+      textType :: LicenseType -> Text
+      textType = \case
+        LicenseURL -> "url"
+        LicenseFile -> "file"
+        LicenseSPDX -> "spdx"
+        UnknownType -> "unknown"
 
 instance ToJSON LicenseResult where
-    toJSON LicenseResult{..} = object
-      [ "filepath"  .=  licenseFile
-      , "licenses"  .=  licensesFound
+  toJSON LicenseResult {..} =
+    object
+      [ "filepath" .= licenseFile,
+        "licenses" .= licensesFound
       ]

--- a/src/VCS/Git.hs
+++ b/src/VCS/Git.hs
@@ -5,14 +5,14 @@ module VCS.Git
 where
 
 import App.Fossa.FossaAPIV1 (Contributors (..))
-import qualified Control.Carrier.Diagnostics as Diag
+import Control.Carrier.Diagnostics qualified as Diag
 import Control.Effect.Lift (Lift, sendIO)
 import Data.ByteString.Lazy (toStrict)
-import qualified Data.Map as M
+import Data.Map qualified as M
 import Data.Maybe (mapMaybe)
 import Data.Text (Text)
-import qualified Data.Text as T
-import qualified Data.Text.Encoding as TE
+import Data.Text qualified as T
+import Data.Text.Encoding qualified as TE
 import Data.Text.Extra (splitOnceOn)
 import Data.Time
 import Data.Time.Format.ISO8601 (iso8601Show)

--- a/test/App/Fossa/Configuration/ConfigurationSpec.hs
+++ b/test/App/Fossa/Configuration/ConfigurationSpec.hs
@@ -7,10 +7,10 @@ module App.Fossa.Configuration.ConfigurationSpec
 where
 
 import App.Fossa.Configuration
-import qualified Control.Carrier.Diagnostics as Diag
+import Control.Carrier.Diagnostics qualified as Diag
 import Effect.ReadFS
 import Path
-import qualified Test.Hspec as T
+import Test.Hspec qualified as T
 
 expectedConfigFile :: ConfigFile
 expectedConfigFile =

--- a/test/App/Fossa/Report/AttributionSpec.hs
+++ b/test/App/Fossa/Report/AttributionSpec.hs
@@ -8,8 +8,8 @@ import Control.Applicative (liftA2)
 import Data.Aeson
 import Data.Map.Strict (Map)
 import Data.Text (Text)
-import qualified Hedgehog.Gen as Gen
-import qualified Hedgehog.Range as Range
+import Hedgehog.Gen qualified as Gen
+import Hedgehog.Range qualified as Range
 import Test.Hspec
 import Test.Hspec.Hedgehog
 
@@ -65,13 +65,13 @@ arbitraryText = Gen.text (Range.linear 3 25) Gen.unicodeAll
 
 spec :: Spec
 spec =
-  describe "Attribution ToJSON/FromJSON instances"
-    $ modifyMaxSuccess (const 20)
-    $ it "are roundtrippable"
-    $ hedgehog
-    $ do
-      attr <- forAll genAttribution
-      roundtripJson attr
+  describe "Attribution ToJSON/FromJSON instances" $
+    modifyMaxSuccess (const 20) $
+      it "are roundtrippable" $
+        hedgehog $
+          do
+            attr <- forAll genAttribution
+            roundtripJson attr
 
 roundtripJson :: (MonadTest m, Show a, Eq a, ToJSON a, FromJSON a) => a -> m ()
 roundtripJson a = tripping a toJSON fromJSON

--- a/test/App/Fossa/VPS/NinjaGraphSpec.hs
+++ b/test/App/Fossa/VPS/NinjaGraphSpec.hs
@@ -1,16 +1,16 @@
 module App.Fossa.VPS.NinjaGraphSpec
-  ( spec
-  ) where
+  ( spec,
+  )
+where
 
-import qualified Data.Text.IO as TIO
-import qualified Data.Text as T
-import qualified Data.List as List
 import App.Fossa.VPS.NinjaGraph
 import App.Fossa.VPS.Types
-import Data.Text.Encoding
-import Test.Hspec
 import Control.Carrier.Diagnostics
-
+import Data.List qualified as List
+import Data.Text qualified as T
+import Data.Text.Encoding
+import Data.Text.IO qualified as TIO
+import Test.Hspec
 
 -- out/target/product/coral/obj/STATIC_LIBRARIES/libgptutils_intermediates/gpt-utils.o: #deps 2, deps mtime 1583962189 (VALID)
 --     device/google/coral/gpt-utils/gpt-utils.cpp
@@ -18,107 +18,139 @@ import Control.Carrier.Diagnostics
 --     external/libcxx/include/__config
 
 inputOne :: DepsDependency
-inputOne = DepsDependency { dependencyPath = "device/google/coral/gpt-utils/gpt-utils.cpp"
-                          , dependencyComponentName = Nothing
-                          , hasDependencies = False
-                          }
+inputOne =
+  DepsDependency
+    { dependencyPath = "device/google/coral/gpt-utils/gpt-utils.cpp",
+      dependencyComponentName = Nothing,
+      hasDependencies = False
+    }
 
 dependencyOneA :: DepsDependency
-dependencyOneA = DepsDependency { dependencyPath = "external/libcxx/include/stdio.h"
-                                , dependencyComponentName = Nothing
-                                , hasDependencies = False
-                                }
+dependencyOneA =
+  DepsDependency
+    { dependencyPath = "external/libcxx/include/stdio.h",
+      dependencyComponentName = Nothing,
+      hasDependencies = False
+    }
 
 dependencyOneB :: DepsDependency
-dependencyOneB = DepsDependency { dependencyPath = "external/libcxx/include/__config"
-                                , dependencyComponentName = Nothing
-                                , hasDependencies = False
-                                }
+dependencyOneB =
+  DepsDependency
+    { dependencyPath = "external/libcxx/include/__config",
+      dependencyComponentName = Nothing,
+      hasDependencies = False
+    }
 
 targetOne :: DepsTarget
-targetOne = DepsTarget { targetPath = "out/target/product/coral/obj/STATIC_LIBRARIES/libgptutils_intermediates/gpt-utils.o"
-                       , targetDependencies = [dependencyOneA, dependencyOneB]
-                       , targetInputs = [inputOne]
-                       , targetComponentName = Nothing
-                       }
+targetOne =
+  DepsTarget
+    { targetPath = "out/target/product/coral/obj/STATIC_LIBRARIES/libgptutils_intermediates/gpt-utils.o",
+      targetDependencies = [dependencyOneA, dependencyOneB],
+      targetInputs = [inputOne],
+      targetComponentName = Nothing
+    }
 
 -- out/target/product/coral/obj/APPS/Settings_intermediates/package.apk: #deps 0, deps mtime 1583991062 (VALID)
 targetTwo :: DepsTarget
-targetTwo = DepsTarget { targetPath = "out/target/product/coral/obj/APPS/Settings_intermediates/package.apk"
-                       , targetDependencies = []
-                       , targetInputs = []
-                       , targetComponentName = Nothing
-                       }
+targetTwo =
+  DepsTarget
+    { targetPath = "out/target/product/coral/obj/APPS/Settings_intermediates/package.apk",
+      targetDependencies = [],
+      targetInputs = [],
+      targetComponentName = Nothing
+    }
+
 -- out/target/product/coral/obj/JAVA_LIBRARIES/wifi-service_intermediates/dexpreopt.zip: #deps 2, deps mtime 1583991124 (VALID)
 --     out/soong/host/linux-x86/bin/dex2oatd
 --     out/soong/host/linux-x86/bin/profman
 --     out/soong/host/linux-x86/bin/soong_zip
 
 inputThree :: DepsDependency
-inputThree = DepsDependency { dependencyPath = "out/soong/host/linux-x86/bin/dex2oatd"
-                          , dependencyComponentName = Nothing
-                          , hasDependencies = True
-                          }
+inputThree =
+  DepsDependency
+    { dependencyPath = "out/soong/host/linux-x86/bin/dex2oatd",
+      dependencyComponentName = Nothing,
+      hasDependencies = True
+    }
 
 dependencyThreeA :: DepsDependency
-dependencyThreeA = DepsDependency { dependencyPath = "out/soong/host/linux-x86/bin/profman"
-                                , dependencyComponentName = Nothing
-                                , hasDependencies = True
-                                }
+dependencyThreeA =
+  DepsDependency
+    { dependencyPath = "out/soong/host/linux-x86/bin/profman",
+      dependencyComponentName = Nothing,
+      hasDependencies = True
+    }
 
 dependencyThreeB :: DepsDependency
-dependencyThreeB = DepsDependency { dependencyPath = "out/soong/host/linux-x86/bin/soong_zip"
-                                , dependencyComponentName = Nothing
-                                , hasDependencies = True
-                                }
+dependencyThreeB =
+  DepsDependency
+    { dependencyPath = "out/soong/host/linux-x86/bin/soong_zip",
+      dependencyComponentName = Nothing,
+      hasDependencies = True
+    }
 
 targetThree :: DepsTarget
-targetThree = DepsTarget { targetPath = "out/target/product/coral/obj/JAVA_LIBRARIES/wifi-service_intermediates/dexpreopt.zip"
-                       , targetDependencies = [dependencyThreeA, dependencyThreeB]
-                       , targetInputs = [inputThree]
-                       , targetComponentName = Nothing
-                       }
+targetThree =
+  DepsTarget
+    { targetPath = "out/target/product/coral/obj/JAVA_LIBRARIES/wifi-service_intermediates/dexpreopt.zip",
+      targetDependencies = [dependencyThreeA, dependencyThreeB],
+      targetInputs = [inputThree],
+      targetComponentName = Nothing
+    }
 
 smallNinjaDepsTargets :: [DepsTarget]
-smallNinjaDepsTargets =  [targetOne, targetTwo, targetThree]
+smallNinjaDepsTargets = [targetOne, targetTwo, targetThree]
 
 cfiBlacklistDep :: DepsDependency
-cfiBlacklistDep = DepsDependency { dependencyPath = "external/compiler-rt/lib/cfi/cfi_blacklist.txt"
-                                 , dependencyComponentName = Nothing
-                                 , hasDependencies = False
-                                 }
+cfiBlacklistDep =
+  DepsDependency
+    { dependencyPath = "external/compiler-rt/lib/cfi/cfi_blacklist.txt",
+      dependencyComponentName = Nothing,
+      hasDependencies = False
+    }
 
 integerOverflowBlacklistDep :: DepsDependency
-integerOverflowBlacklistDep = DepsDependency { dependencyPath = "build/soong/cc/config/integer_overflow_blacklist.txt"
-                                             , dependencyComponentName = Nothing
-                                             , hasDependencies = False
-                                             }
+integerOverflowBlacklistDep =
+  DepsDependency
+    { dependencyPath = "build/soong/cc/config/integer_overflow_blacklist.txt",
+      dependencyComponentName = Nothing,
+      hasDependencies = False
+    }
 
 inetDep :: DepsDependency
-inetDep = DepsDependency { dependencyPath = "bionic/libc/include/arpa/inet.h"
-                         , dependencyComponentName = Nothing
-                         , hasDependencies = False
-                         }
+inetDep =
+  DepsDependency
+    { dependencyPath = "bionic/libc/include/arpa/inet.h",
+      dependencyComponentName = Nothing,
+      hasDependencies = False
+    }
 
 bpfLoaderDep :: DepsDependency
-bpfLoaderDep = DepsDependency { dependencyPath = "system/bpf/bpfloader/BpfLoader.cpp"
-                              , dependencyComponentName = Nothing
-                              , hasDependencies = False
-                              }
+bpfLoaderDep =
+  DepsDependency
+    { dependencyPath = "system/bpf/bpfloader/BpfLoader.cpp",
+      dependencyComponentName = Nothing,
+      hasDependencies = False
+    }
 
 targetWithFirstLevelWeirdnessFix :: DepsTarget
-targetWithFirstLevelWeirdnessFix = DepsTarget { targetPath = "out/soong/.intermediates/system/bpf/bpfloader/bpfloader/android_arm64_armv8-a_core/obj/system/bpf/bpfloader/BpfLoader.o"
-                                              , targetDependencies = [integerOverflowBlacklistDep, inetDep]
-                                              , targetInputs = [bpfLoaderDep]
-                                              , targetComponentName = Nothing
-                                              }
+targetWithFirstLevelWeirdnessFix =
+  DepsTarget
+    { targetPath = "out/soong/.intermediates/system/bpf/bpfloader/bpfloader/android_arm64_armv8-a_core/obj/system/bpf/bpfloader/BpfLoader.o",
+      targetDependencies = [integerOverflowBlacklistDep, inetDep],
+      targetInputs = [bpfLoaderDep],
+      targetComponentName = Nothing
+    }
 
 targetWithSecondLevelWeirdnessFix :: DepsTarget
-targetWithSecondLevelWeirdnessFix = DepsTarget { targetPath = "out/soong/.intermediates/system/bpf/bpfloader/bpfloader/android_arm64_armv8-a_core/obj/system/bpf/bpfloader/BpfLoader.o"
-                                               , targetDependencies = [cfiBlacklistDep, integerOverflowBlacklistDep, inetDep]
-                                               , targetInputs = [bpfLoaderDep]
-                                               , targetComponentName = Nothing
-                                               }
+targetWithSecondLevelWeirdnessFix =
+  DepsTarget
+    { targetPath = "out/soong/.intermediates/system/bpf/bpfloader/bpfloader/android_arm64_armv8-a_core/obj/system/bpf/bpfloader/BpfLoader.o",
+      targetDependencies = [cfiBlacklistDep, integerOverflowBlacklistDep, inetDep],
+      targetInputs = [bpfLoaderDep],
+      targetComponentName = Nothing
+    }
+
 spec :: Spec
 spec = do
   smallNinjaDeps <- runIO (TIO.readFile "test/App/Fossa/VPS/testdata/small-ninja-deps")

--- a/test/Cargo/MetadataSpec.hs
+++ b/test/Cargo/MetadataSpec.hs
@@ -1,17 +1,18 @@
 module Cargo.MetadataSpec
-  ( spec
-  ) where
+  ( spec,
+  )
+where
 
 import Data.Aeson
-import qualified Data.ByteString.Lazy as BL
-import qualified Data.Map.Strict as M
+import Data.ByteString.Lazy qualified as BL
+import Data.Map.Strict qualified as M
 import Data.Text (Text)
-import qualified Data.Text as T
+import Data.Text qualified as T
 import DepTypes
 import GraphUtil
 import Graphing
 import Strategy.Cargo
-import qualified Test.Hspec as Test
+import Test.Hspec qualified as Test
 
 expectedMetadata :: CargoMetadata
 expectedMetadata = CargoMetadata [] [jfmtId] $ Resolve expectedResolveNodes

--- a/test/Carthage/CarthageSpec.hs
+++ b/test/Carthage/CarthageSpec.hs
@@ -1,14 +1,15 @@
 {-# LANGUAGE TemplateHaskell #-}
 
 module Carthage.CarthageSpec
-  ( spec
-  ) where
+  ( spec,
+  )
+where
 
 import Control.Carrier.Diagnostics
 import Data.Function ((&))
 import Effect.ReadFS
 import GraphUtil
-import qualified Graphing as G
+import Graphing qualified as G
 import Path
 import Path.IO (makeAbsolute)
 import Strategy.Carthage
@@ -22,9 +23,10 @@ testProjectComplex = $(mkRelFile "test/Carthage/testdata/testproject/Cartfile.re
 
 spec :: Spec
 spec = do
-  let runIt f = analyze f
-        & runReadFSIO
-        & runDiagnostics
+  let runIt f =
+        analyze f
+          & runReadFSIO
+          & runDiagnostics
 
   emptyResult <- runIO $ runIt =<< makeAbsolute testProjectEmpty
   complexResult <- runIO $ runIt =<< makeAbsolute testProjectComplex
@@ -41,19 +43,23 @@ spec = do
         Right result -> do
           let graph = resultValue result
           expectDirect [nimble713, swinject, ocmock] graph
-          expectDeps [ nimble713
-                     , nimble703
-                     , swinject
-                     , ocmock
-                     , quick
-                     , cwlPreconditionTesting
-                     , cwlCatchException
-                     ] graph
-          expectEdges [ (nimble713, cwlPreconditionTesting)
-                      , (nimble713, cwlCatchException)
-                      , (swinject, nimble703)
-                      , (swinject, quick)
-                      ] graph
+          expectDeps
+            [ nimble713,
+              nimble703,
+              swinject,
+              ocmock,
+              quick,
+              cwlPreconditionTesting,
+              cwlCatchException
+            ]
+            graph
+          expectEdges
+            [ (nimble713, cwlPreconditionTesting),
+              (nimble713, cwlCatchException),
+              (swinject, nimble703),
+              (swinject, quick)
+            ]
+            graph
 
 nimble713 :: ResolvedEntry
 nimble713 = ResolvedEntry GithubType "Quick/Nimble" "v7.1.3"

--- a/test/Clojure/ClojureSpec.hs
+++ b/test/Clojure/ClojureSpec.hs
@@ -3,9 +3,9 @@ module Clojure.ClojureSpec
   )
 where
 
-import qualified Data.EDN as EDN
-import qualified Data.Map.Strict as M
-import qualified Data.Text.IO as TIO
+import Data.EDN qualified as EDN
+import Data.Map.Strict qualified as M
+import Data.Text.IO qualified as TIO
 import DepTypes
 import GraphUtil
 import Strategy.Leiningen

--- a/test/Cocoapods/PodfileLockSpec.hs
+++ b/test/Cocoapods/PodfileLockSpec.hs
@@ -1,50 +1,59 @@
 module Cocoapods.PodfileLockSpec
-  ( spec
-  ) where
+  ( spec,
+  )
+where
 
-import qualified Data.Map.Strict as M
-import qualified Data.Text.IO as TIO
+import Data.Map.Strict qualified as M
+import Data.Text.IO qualified as TIO
 import DepTypes
 import GraphUtil
 import Strategy.Cocoapods.PodfileLock
-import qualified Test.Hspec as T
+import Test.Hspec qualified as T
 import Text.Megaparsec
 
 dependencyOne :: Dependency
-dependencyOne = Dependency { dependencyType = PodType
-                           , dependencyName = "one"
-                           , dependencyVersion = Just (CEq "1.0.0")
-                           , dependencyLocations = []
-                           , dependencyEnvironments = []
-                           , dependencyTags = M.empty
-                           }
+dependencyOne =
+  Dependency
+    { dependencyType = PodType,
+      dependencyName = "one",
+      dependencyVersion = Just (CEq "1.0.0"),
+      dependencyLocations = [],
+      dependencyEnvironments = [],
+      dependencyTags = M.empty
+    }
 
 dependencyTwo :: Dependency
-dependencyTwo = Dependency { dependencyType = PodType
-                           , dependencyName = "two"
-                           , dependencyVersion = Just (CEq "2.0.0")
-                           , dependencyLocations = []
-                           , dependencyEnvironments = []
-                           , dependencyTags = M.empty
-                           }
+dependencyTwo =
+  Dependency
+    { dependencyType = PodType,
+      dependencyName = "two",
+      dependencyVersion = Just (CEq "2.0.0"),
+      dependencyLocations = [],
+      dependencyEnvironments = [],
+      dependencyTags = M.empty
+    }
 
 dependencyThree :: Dependency
-dependencyThree = Dependency { dependencyType = PodType
-                             , dependencyName = "three"
-                             , dependencyVersion = Just (CEq "3.0.0")
-                             , dependencyLocations = []
-                             , dependencyEnvironments = []
-                             , dependencyTags = M.empty
-                             }
+dependencyThree =
+  Dependency
+    { dependencyType = PodType,
+      dependencyName = "three",
+      dependencyVersion = Just (CEq "3.0.0"),
+      dependencyLocations = [],
+      dependencyEnvironments = [],
+      dependencyTags = M.empty
+    }
 
 dependencyFour :: Dependency
-dependencyFour = Dependency { dependencyType = PodType
-                            , dependencyName = "four"
-                            , dependencyVersion = Just (CEq "4.0.0")
-                            , dependencyLocations = []
-                            , dependencyEnvironments = []
-                            , dependencyTags = M.empty
-                            }
+dependencyFour =
+  Dependency
+    { dependencyType = PodType,
+      dependencyName = "four",
+      dependencyVersion = Just (CEq "4.0.0"),
+      dependencyLocations = [],
+      dependencyEnvironments = [],
+      dependencyTags = M.empty
+    }
 
 podSection :: Section
 podSection = PodSection [Pod "one" "1.0.0" [Dep "two", Dep "three"], Pod "two" "2.0.0" [], Pod "three" "3.0.0" [Dep "four"], Pod "four" "4.0.0" []]
@@ -60,10 +69,12 @@ spec = do
 
       expectDeps [dependencyOne, dependencyTwo, dependencyThree, dependencyFour] graph
       expectDirect [dependencyOne, dependencyThree] graph
-      expectEdges [ (dependencyOne, dependencyTwo)
-                  , (dependencyOne, dependencyThree)
-                  , (dependencyThree, dependencyFour)
-                  ] graph
+      expectEdges
+        [ (dependencyOne, dependencyTwo),
+          (dependencyOne, dependencyThree),
+          (dependencyThree, dependencyFour)
+        ]
+        graph
 
   podLockFile <- T.runIO (TIO.readFile "test/Cocoapods/testdata/Podfile.lock")
   T.describe "podfile lock parser" $

--- a/test/Cocoapods/PodfileSpec.hs
+++ b/test/Cocoapods/PodfileSpec.hs
@@ -1,50 +1,59 @@
 module Cocoapods.PodfileSpec
-  ( spec
-  ) where
+  ( spec,
+  )
+where
 
-import qualified Data.Map.Strict as M
-import qualified Data.Text.IO as TIO
+import Data.Map.Strict qualified as M
+import Data.Text.IO qualified as TIO
 import DepTypes
 import GraphUtil
 import Strategy.Cocoapods.Podfile
-import qualified Test.Hspec as T
+import Test.Hspec qualified as T
 import Text.Megaparsec
 
 dependencyOne :: Dependency
-dependencyOne = Dependency { dependencyType = PodType
-                           , dependencyName = "one"
-                           , dependencyVersion = Just (CEq "1.0.0")
-                           , dependencyLocations = ["test.repo"]
-                           , dependencyEnvironments = []
-                           , dependencyTags = M.empty
-                           }
+dependencyOne =
+  Dependency
+    { dependencyType = PodType,
+      dependencyName = "one",
+      dependencyVersion = Just (CEq "1.0.0"),
+      dependencyLocations = ["test.repo"],
+      dependencyEnvironments = [],
+      dependencyTags = M.empty
+    }
 
 dependencyTwo :: Dependency
-dependencyTwo = Dependency { dependencyType = PodType
-                           , dependencyName = "two"
-                           , dependencyVersion = Just (CEq "2.0.0")
-                           , dependencyLocations = ["custom.repo"]
-                           , dependencyEnvironments = []
-                           , dependencyTags = M.empty
-                           }
+dependencyTwo =
+  Dependency
+    { dependencyType = PodType,
+      dependencyName = "two",
+      dependencyVersion = Just (CEq "2.0.0"),
+      dependencyLocations = ["custom.repo"],
+      dependencyEnvironments = [],
+      dependencyTags = M.empty
+    }
 
 dependencyThree :: Dependency
-dependencyThree = Dependency { dependencyType = PodType
-                             , dependencyName = "three"
-                             , dependencyVersion = Just (CEq "3.0.0")
-                             , dependencyLocations = ["test.repo"]
-                             , dependencyEnvironments = []
-                             , dependencyTags = M.empty
-                             }
+dependencyThree =
+  Dependency
+    { dependencyType = PodType,
+      dependencyName = "three",
+      dependencyVersion = Just (CEq "3.0.0"),
+      dependencyLocations = ["test.repo"],
+      dependencyEnvironments = [],
+      dependencyTags = M.empty
+    }
 
 dependencyFour :: Dependency
-dependencyFour = Dependency { dependencyType = PodType
-                             , dependencyName = "four"
-                             , dependencyVersion = Nothing
-                             , dependencyLocations = ["test.repo"]
-                             , dependencyEnvironments = []
-                             , dependencyTags = M.empty
-                             }
+dependencyFour =
+  Dependency
+    { dependencyType = PodType,
+      dependencyName = "four",
+      dependencyVersion = Nothing,
+      dependencyLocations = ["test.repo"],
+      dependencyEnvironments = [],
+      dependencyTags = M.empty
+    }
 
 podOne :: Pod
 podOne = Pod "one" (Just "1.0.0") M.empty
@@ -80,5 +89,5 @@ spec = do
       case runParser parsePodfile "" podLockFile of
         Left _ -> T.expectationFailure "failed to parse"
         Right result -> do
-            pods result `T.shouldMatchList` testPods
-            source result `T.shouldBe` "test.repo"
+          pods result `T.shouldMatchList` testPods
+          source result `T.shouldBe` "test.repo"

--- a/test/Composer/ComposerLockSpec.hs
+++ b/test/Composer/ComposerLockSpec.hs
@@ -3,9 +3,9 @@ module Composer.ComposerLockSpec
   )
 where
 
-import qualified Data.ByteString as BS
-import qualified Data.Map.Strict as M
 import Data.Aeson
+import Data.ByteString qualified as BS
+import Data.Map.Strict qualified as M
 import DepTypes
 import GraphUtil
 import Strategy.Composer

--- a/test/Discovery/FiltersSpec.hs
+++ b/test/Discovery/FiltersSpec.hs
@@ -5,7 +5,7 @@ module Discovery.FiltersSpec
   )
 where
 
-import qualified Data.Set as S
+import Data.Set qualified as S
 import Discovery.Filters
 import Path
 import Test.Hspec

--- a/test/Erlang/ConfigParserSpec.hs
+++ b/test/Erlang/ConfigParserSpec.hs
@@ -3,10 +3,10 @@ module Erlang.ConfigParserSpec
   )
 where
 
-import qualified Data.Char as C
-import Data.Text ( Text )
-import qualified Data.Text.IO as TIO
-import Data.Void ( Void )
+import Data.Char qualified as C
+import Data.Text (Text)
+import Data.Text.IO qualified as TIO
+import Data.Void (Void)
 import Strategy.Erlang.ConfigParser
 import Test.Hspec
 import Test.Hspec.Megaparsec
@@ -47,7 +47,6 @@ spec = do
       "\"\\n\"" `shouldParseInto` ErlString "\n"
       "\"\\\"\"" `shouldParseInto` ErlString "\"" -- in source, LHS would appear as -> "\""
       "\"a\" \"b\"" `shouldParseInto` ErlString "ab" -- run-on strings -> "a" "b"
-
     it "should parse an array" $ do
       let shouldParseInto input = parseMatch parseErlArray input
 
@@ -100,21 +99,22 @@ spec = do
       parse parseRadixLiteral "" `shouldFailOn` "-2#10"
 
     it "should parse everything at once" $
-      parse parseConfig "stresstest.config" oneWithEverything `shouldParse`
-        ConfigValues
-          [ErlTuple [
-            atom "rawAtom",
-            atom "quotedAtom",
-            ErlString "Regular String",
-            ErlString "Escaped \" String",
-            ErlInt 1234, -- Literal
-            ErlFloat 3.14159,
-            ErlInt 120, -- '$x'
-            ErlInt 35338, -- 'wes' in base 33
-            ErlArray [atom "arr1"],
-            ErlArray [ErlTuple [atom "key", ErlString "value"]],
-            ErlTuple [atom "number", ErlInt 5678] -- Literal
-          ]]
+      parse parseConfig "stresstest.config" oneWithEverything
+        `shouldParse` ConfigValues
+          [ ErlTuple
+              [ atom "rawAtom",
+                atom "quotedAtom",
+                ErlString "Regular String",
+                ErlString "Escaped \" String",
+                ErlInt 1234, -- Literal
+                ErlFloat 3.14159,
+                ErlInt 120, -- '$x'
+                ErlInt 35338, -- 'wes' in base 33
+                ErlArray [atom "arr1"],
+                ErlArray [ErlTuple [atom "key", ErlString "value"]],
+                ErlTuple [atom "number", ErlInt 5678] -- Literal
+              ]
+          ]
 
   describe "radix parser" $
     it "should parse number strings correctly" $ do
@@ -123,7 +123,6 @@ spec = do
       intLiteralInBase 10 "1234" `shouldBe` 1234
       intLiteralInBase 16 "abcd" `shouldBe` 0xabcd
       intLiteralInBase 36 "1z" `shouldBe` 71 -- (36 * 2 - 1)
-
   describe "alphaNumToInt" $
     it "should provide the correct value for chars" $ do
       alphaNumToInt 'a' `shouldBe` 10

--- a/test/Erlang/Rebar3TreeSpec.hs
+++ b/test/Erlang/Rebar3TreeSpec.hs
@@ -1,101 +1,116 @@
 module Erlang.Rebar3TreeSpec
-  ( spec
-  ) where
+  ( spec,
+  )
+where
 
-import qualified Data.Map.Strict as M
-import qualified Data.Text.IO as TIO
+import Data.Map.Strict qualified as M
+import Data.Text.IO qualified as TIO
+import DepTypes
+import GraphUtil
+import Graphing ()
+import Strategy.Erlang.Rebar3Tree
+import Test.Hspec
 import Text.Megaparsec
 
-import DepTypes
-import Graphing()
-import Strategy.Erlang.Rebar3Tree
-import GraphUtil
-
-import Test.Hspec
-
 dependencyOne :: Dependency
-dependencyOne = Dependency { dependencyType = GitType
-                      , dependencyName = "https://github.com/dep/one"
-                      , dependencyVersion = Just (CEq "1.0.0")
-                      , dependencyLocations = []
-                      , dependencyEnvironments = []
-                      , dependencyTags = M.empty
-                      }
+dependencyOne =
+  Dependency
+    { dependencyType = GitType,
+      dependencyName = "https://github.com/dep/one",
+      dependencyVersion = Just (CEq "1.0.0"),
+      dependencyLocations = [],
+      dependencyEnvironments = [],
+      dependencyTags = M.empty
+    }
 
 dependencyTwo :: Dependency
-dependencyTwo = Dependency { dependencyType = HexType
-                      , dependencyName = "two"
-                      , dependencyVersion = Just (CEq "2.0.0")
-                      , dependencyLocations = []
-                      , dependencyEnvironments = []
-                      , dependencyTags = M.empty
-                      }
+dependencyTwo =
+  Dependency
+    { dependencyType = HexType,
+      dependencyName = "two",
+      dependencyVersion = Just (CEq "2.0.0"),
+      dependencyLocations = [],
+      dependencyEnvironments = [],
+      dependencyTags = M.empty
+    }
+
 dependencyThree :: Dependency
-dependencyThree = Dependency { dependencyType = HexType
-                      , dependencyName = "three"
-                      , dependencyVersion = Just (CEq "3.0.0")
-                      , dependencyLocations = []
-                      , dependencyEnvironments = []
-                      , dependencyTags = M.empty
-                      }
+dependencyThree =
+  Dependency
+    { dependencyType = HexType,
+      dependencyName = "three",
+      dependencyVersion = Just (CEq "3.0.0"),
+      dependencyLocations = [],
+      dependencyEnvironments = [],
+      dependencyTags = M.empty
+    }
 
 dependencyFour :: Dependency
-dependencyFour = Dependency { dependencyType = GitType
-                      , dependencyName = "https://github.com/dep/four"
-                      , dependencyVersion = Just (CEq "4.0.0")
-                      , dependencyLocations = []
-                      , dependencyEnvironments = []
-                      , dependencyTags = M.empty
-                      }
+dependencyFour =
+  Dependency
+    { dependencyType = GitType,
+      dependencyName = "https://github.com/dep/four",
+      dependencyVersion = Just (CEq "4.0.0"),
+      dependencyLocations = [],
+      dependencyEnvironments = [],
+      dependencyTags = M.empty
+    }
 
 dependencyFive :: Dependency
-dependencyFive = Dependency { dependencyType = HexType
-                      , dependencyName = "five"
-                      , dependencyVersion = Just (CEq "5.0.0")
-                      , dependencyLocations = []
-                      , dependencyEnvironments = []
-                      , dependencyTags = M.empty
-                      }
+dependencyFive =
+  Dependency
+    { dependencyType = HexType,
+      dependencyName = "five",
+      dependencyVersion = Just (CEq "5.0.0"),
+      dependencyLocations = [],
+      dependencyEnvironments = [],
+      dependencyTags = M.empty
+    }
 
 depOne :: Rebar3Dep
-depOne = Rebar3Dep
-          { depName = "one"
-          , depVersion = "1.0.0"
-          , depLocation = "https://github.com/dep/one"
-          , subDeps = [depTwo, depFour]
-          }
+depOne =
+  Rebar3Dep
+    { depName = "one",
+      depVersion = "1.0.0",
+      depLocation = "https://github.com/dep/one",
+      subDeps = [depTwo, depFour]
+    }
 
 depTwo :: Rebar3Dep
-depTwo = Rebar3Dep
-          { depName = "two"
-          , depVersion = "2.0.0"
-          , depLocation = "hex package"
-          , subDeps = [depThree]
-          }
+depTwo =
+  Rebar3Dep
+    { depName = "two",
+      depVersion = "2.0.0",
+      depLocation = "hex package",
+      subDeps = [depThree]
+    }
 
 depThree :: Rebar3Dep
-depThree = Rebar3Dep
-          { depName = "three"
-          , depVersion = "3.0.0"
-          , depLocation = "hex package"
-          , subDeps = []
-          }
+depThree =
+  Rebar3Dep
+    { depName = "three",
+      depVersion = "3.0.0",
+      depLocation = "hex package",
+      subDeps = []
+    }
 
 depFour :: Rebar3Dep
-depFour = Rebar3Dep
-          { depName = "four"
-          , depVersion = "4.0.0"
-          , depLocation = "https://github.com/dep/four"
-          , subDeps = []
-          }
+depFour =
+  Rebar3Dep
+    { depName = "four",
+      depVersion = "4.0.0",
+      depLocation = "https://github.com/dep/four",
+      subDeps = []
+    }
 
 depFive :: Rebar3Dep
-depFive = Rebar3Dep
-          { depName = "five"
-          , depVersion = "5.0.0"
-          , depLocation = "hex package"
-          , subDeps = []
-          }
+depFive =
+  Rebar3Dep
+    { depName = "five",
+      depVersion = "5.0.0",
+      depLocation = "hex package",
+      subDeps = []
+    }
 
 spec :: Spec
 spec = do

--- a/test/Extra/TextSpec.hs
+++ b/test/Extra/TextSpec.hs
@@ -1,10 +1,11 @@
-module Extra.TextSpec (
-    spec
-) where
+module Extra.TextSpec
+  ( spec,
+  )
+where
 
-import qualified Test.Hspec as Test
-import Prelude
 import Data.Text.Extra
+import Test.Hspec qualified as Test
+import Prelude
 
 spec :: Test.Spec
 spec = do

--- a/test/Fossa/API/TypesSpec.hs
+++ b/test/Fossa/API/TypesSpec.hs
@@ -1,10 +1,10 @@
 module Fossa.API.TypesSpec (spec) where
 
-import Fossa.API.Types (Issue (..), IssueRule (..), IssueType (..), Issues (..))
 import Data.Aeson (FromJSON, ToJSON, fromJSON, toJSON)
 import Data.Text (Text)
-import qualified Hedgehog.Gen as Gen
-import qualified Hedgehog.Range as Range
+import Fossa.API.Types (Issue (..), IssueRule (..), IssueType (..), Issues (..))
+import Hedgehog.Gen qualified as Gen
+import Hedgehog.Range qualified as Range
 import Test.Hspec
 import Test.Hspec.Hedgehog
 import Prelude
@@ -12,9 +12,10 @@ import Prelude
 spec :: Spec
 spec = do
   describe "Issues ToJSON/FromJSON instances" $ do
-    it "are roundtrippable" $ hedgehog $ do
-      issues <- forAll genIssues
-      roundtripJson issues
+    it "are roundtrippable" $
+      hedgehog $ do
+        issues <- forAll genIssues
+        roundtripJson issues
 
 genIssues :: Gen Issues
 genIssues =

--- a/test/Go/GlideLockSpec.hs
+++ b/test/Go/GlideLockSpec.hs
@@ -1,55 +1,57 @@
 module Go.GlideLockSpec
-  ( spec
-  ) where
-
-import qualified Data.Map.Strict as M
-import qualified Data.ByteString as BS
-import Data.Yaml
+  ( spec,
+  )
+where
 
 import Control.Algebra
+import Data.ByteString qualified as BS
+import Data.Map.Strict qualified as M
+import Data.Yaml
 import DepTypes
 import Effect.Grapher
 import Graphing (Graphing)
 import Strategy.Go.GlideLock
-
 import Test.Hspec
 
 expected :: Graphing Dependency
 expected = run . evalGrapher $ do
-  direct $ Dependency
-               { dependencyType = GoType
-               , dependencyName = "github.com/pkg/one"
-               , dependencyVersion = Just (CEq "1234")
-               , dependencyLocations = []
-               , dependencyEnvironments = []
-               , dependencyTags = M.empty
-               }
-  direct $ Dependency
-               { dependencyType = GoType
-               , dependencyName = "github.com/pkg/three/v3"
-               , dependencyVersion = Just (CEq "4bd8")
-               , dependencyLocations = []
-               , dependencyEnvironments = []
-               , dependencyTags = M.empty
-               }
+  direct $
+    Dependency
+      { dependencyType = GoType,
+        dependencyName = "github.com/pkg/one",
+        dependencyVersion = Just (CEq "1234"),
+        dependencyLocations = [],
+        dependencyEnvironments = [],
+        dependencyTags = M.empty
+      }
+  direct $
+    Dependency
+      { dependencyType = GoType,
+        dependencyName = "github.com/pkg/three/v3",
+        dependencyVersion = Just (CEq "4bd8"),
+        dependencyLocations = [],
+        dependencyEnvironments = [],
+        dependencyTags = M.empty
+      }
 
 glideLockfile :: GlideLockfile
 glideLockfile =
-  GlideLockfile { hash = "123"
-  , updated = "now"
-  , imports =
-    [ GlideDep
-        { depName = "github.com/pkg/one"
-        , depVersion = "1234"
-        , depRepo = Just "testRepo"
+  GlideLockfile
+    { hash = "123",
+      updated = "now",
+      imports =
+        [ GlideDep
+            { depName = "github.com/pkg/one",
+              depVersion = "1234",
+              depRepo = Just "testRepo"
+            },
+          GlideDep
+            { depName = "github.com/pkg/three/v3",
+              depVersion = "4bd8",
+              depRepo = Just "testRepo"
+            }
+        ]
     }
-    , GlideDep
-        { depName = "github.com/pkg/three/v3"
-        , depVersion = "4bd8"
-        , depRepo = Just "testRepo"
-    }
-  ]
-  }
 
 spec :: Spec
 spec = do

--- a/test/Go/GoListSpec.hs
+++ b/test/Go/GoListSpec.hs
@@ -3,15 +3,16 @@
 {-# LANGUAGE UndecidableInstances #-}
 
 module Go.GoListSpec
-  ( spec
-  ) where
+  ( spec,
+  )
+where
 
 import Control.Algebra
 import Control.Carrier.Diagnostics
 import Control.Carrier.Reader
-import qualified Data.ByteString.Lazy as BL
+import Data.ByteString.Lazy qualified as BL
 import Data.Function ((&))
-import qualified Data.Map.Strict as M
+import Data.Map.Strict qualified as M
 import DepTypes
 import Effect.Exec
 import Effect.Grapher
@@ -23,7 +24,7 @@ import Test.Hspec
 runConstExec :: BL.ByteString -> ConstExecC m a -> m a
 runConstExec output = runReader output . runConstExecC
 
-newtype ConstExecC m a = ConstExecC { runConstExecC :: ReaderC (BL.ByteString) m a }
+newtype ConstExecC m a = ConstExecC {runConstExecC :: ReaderC (BL.ByteString) m a}
   deriving (Functor, Applicative, Monad)
 
 instance Algebra sig m => Algebra (Exec :+: sig) (ConstExecC m) where
@@ -35,20 +36,24 @@ instance Algebra sig m => Algebra (Exec :+: sig) (ConstExecC m) where
 
 expected :: Graphing Dependency
 expected = run . evalGrapher $ do
-  direct $ Dependency { dependencyType = GoType
-                      , dependencyName = "github.com/pkg/one"
-                      , dependencyVersion = Just (CEq "commithash")
-                      , dependencyLocations = []
-                      , dependencyEnvironments = []
-                      , dependencyTags = M.empty
-                      }
-  direct $ Dependency { dependencyType = GoType
-                      , dependencyName = "github.com/pkg/two"
-                      , dependencyVersion = Just (CEq "v2.0.0")
-                      , dependencyLocations = []
-                      , dependencyEnvironments = []
-                      , dependencyTags = M.empty
-                      }
+  direct $
+    Dependency
+      { dependencyType = GoType,
+        dependencyName = "github.com/pkg/one",
+        dependencyVersion = Just (CEq "commithash"),
+        dependencyLocations = [],
+        dependencyEnvironments = [],
+        dependencyTags = M.empty
+      }
+  direct $
+    Dependency
+      { dependencyType = GoType,
+        dependencyName = "github.com/pkg/two",
+        dependencyVersion = Just (CEq "v2.0.0"),
+        dependencyLocations = [],
+        dependencyEnvironments = [],
+        dependencyTags = M.empty
+      }
 
 spec :: Spec
 spec = do
@@ -75,5 +80,5 @@ spec = do
               & run
 
       case result of
-          Left err -> fail $ "failed to build graph" <> show (renderFailureBundle err)
-          Right graph -> length (graphingDirect (resultValue graph)) `shouldBe` 12
+        Left err -> fail $ "failed to build graph" <> show (renderFailureBundle err)
+        Right graph -> length (graphingDirect (resultValue graph)) `shouldBe` 12

--- a/test/Go/GomodSpec.hs
+++ b/test/Go/GomodSpec.hs
@@ -2,11 +2,11 @@ module Go.GomodSpec (spec) where
 
 import Control.Algebra (run)
 import Data.Function ((&))
-import qualified Data.Map.Strict as M
+import Data.Map.Strict qualified as M
 import Data.SemVer (version)
 import Data.SemVer.Internal (Identifier (..))
 import Data.Text (Text)
-import qualified Data.Text.IO as TIO
+import Data.Text.IO qualified as TIO
 import DepTypes (DepType (GoType), Dependency (..), VerConstraint (CEq))
 import Effect.Grapher (direct, evalGrapher)
 import Graphing (Graphing (..))
@@ -53,7 +53,6 @@ trivialGraph = run . evalGrapher $ do
   direct $ dep "github.com/pkg/one" "v1.0.0"
   direct $ dep "github.com/pkg/overridden" "overridden"
   direct $ dep "github.com/pkg/three/v3" "v3.0.0"
-
 
 localReplaceGomod :: Gomod
 localReplaceGomod =

--- a/test/Go/GopkgLockSpec.hs
+++ b/test/Go/GopkgLockSpec.hs
@@ -1,63 +1,67 @@
 module Go.GopkgLockSpec
-  ( spec
-  ) where
+  ( spec,
+  )
+where
 
 import Data.Function ((&))
-import qualified Data.Map.Strict as M
-import qualified Data.Text.IO as TIO
+import Data.Map.Strict qualified as M
+import Data.Text.IO qualified as TIO
 import DepTypes
 import Effect.Grapher
 import Graphing (Graphing)
 import Strategy.Go.GopkgLock
 import Strategy.Go.Types (graphingGolang)
 import Test.Hspec
-import qualified Toml
+import Toml qualified
 
 projects :: [Project]
 projects =
   [ Project
-      { projectName = "repo/name/A"
-      , projectSource = Nothing
-      , projectRevision = "3012a1dbe2e4bd1391d42b32f0577cb7bbc7f005"
-      }
-  , Project
-      { projectName = "repo/name/B"
-      , projectSource = Nothing
-      , projectRevision = "12345"
-      }
-  , Project
-      { projectName = "repo/name/C"
-      , projectSource = Just "https://someotherlocation/"
-      , projectRevision = "12345"
+      { projectName = "repo/name/A",
+        projectSource = Nothing,
+        projectRevision = "3012a1dbe2e4bd1391d42b32f0577cb7bbc7f005"
+      },
+    Project
+      { projectName = "repo/name/B",
+        projectSource = Nothing,
+        projectRevision = "12345"
+      },
+    Project
+      { projectName = "repo/name/C",
+        projectSource = Just "https://someotherlocation/",
+        projectRevision = "12345"
       }
   ]
 
 expected :: Graphing Dependency
 expected = run . evalGrapher $ do
-  direct $ Dependency
-             { dependencyType = GoType
-             , dependencyName = "repo/name/A"
-             , dependencyVersion = Just (CEq "3012a1dbe2e4bd1391d42b32f0577cb7bbc7f005")
-             , dependencyLocations = []
-             , dependencyEnvironments = []
-             , dependencyTags = M.empty
-             }
-  direct $ Dependency
-             { dependencyType = GoType
-             , dependencyName = "repo/name/B"
-             , dependencyVersion = Just (CEq "12345")
-             , dependencyLocations = []
-             , dependencyEnvironments = []
-             , dependencyTags = M.empty
-             }
-  direct $ Dependency
-             { dependencyType = GoType
-             , dependencyName = "repo/name/C"
-             , dependencyVersion = Just (CEq "12345")
-             , dependencyLocations = ["https://someotherlocation/"]
-             , dependencyEnvironments = []
-             , dependencyTags = M.empty
-             }
+  direct $
+    Dependency
+      { dependencyType = GoType,
+        dependencyName = "repo/name/A",
+        dependencyVersion = Just (CEq "3012a1dbe2e4bd1391d42b32f0577cb7bbc7f005"),
+        dependencyLocations = [],
+        dependencyEnvironments = [],
+        dependencyTags = M.empty
+      }
+  direct $
+    Dependency
+      { dependencyType = GoType,
+        dependencyName = "repo/name/B",
+        dependencyVersion = Just (CEq "12345"),
+        dependencyLocations = [],
+        dependencyEnvironments = [],
+        dependencyTags = M.empty
+      }
+  direct $
+    Dependency
+      { dependencyType = GoType,
+        dependencyName = "repo/name/C",
+        dependencyVersion = Just (CEq "12345"),
+        dependencyLocations = ["https://someotherlocation/"],
+        dependencyEnvironments = [],
+        dependencyTags = M.empty
+      }
 
 spec :: Spec
 spec = do

--- a/test/Go/GopkgTomlSpec.hs
+++ b/test/Go/GopkgTomlSpec.hs
@@ -1,95 +1,101 @@
 module Go.GopkgTomlSpec
-  ( spec
-  ) where
+  ( spec,
+  )
+where
 
 import Data.Function ((&))
-import qualified Data.Map.Strict as M
-import qualified Data.Text.IO as TIO
+import Data.Map.Strict qualified as M
+import Data.Text.IO qualified as TIO
 import DepTypes
 import Effect.Grapher
 import Graphing (Graphing)
 import Strategy.Go.GopkgToml
 import Strategy.Go.Types (graphingGolang)
 import Test.Hspec
-import qualified Toml
+import Toml qualified
 
 gopkg :: Gopkg
-gopkg = Gopkg
-  { pkgConstraints =
-      [ PkgConstraint
-          { constraintName = "cat/fossa"
-          , constraintSource = Just "https://someotherlocation/"
-          , constraintVersion = Just "v3.0.0"
-          , constraintBranch = Nothing
-          , constraintRevision = Nothing
-          }
-      , PkgConstraint
-          { constraintName = "repo/name/A"
-          , constraintSource = Nothing
-          , constraintVersion = Just "v1.0.0"
-          , constraintBranch = Nothing
-          , constraintRevision = Nothing
-          }
-      , PkgConstraint
-          { constraintName = "repo/name/B"
-          , constraintSource = Nothing
-          , constraintVersion = Nothing
-          , constraintBranch = Nothing
-          , constraintRevision = Just "12345"
-          }
-      , PkgConstraint
-          { constraintName = "repo/name/C"
-          , constraintSource = Nothing
-          , constraintVersion = Nothing
-          , constraintBranch = Just "branchname"
-          , constraintRevision = Nothing
-          }
-      ]
-  , pkgOverrides =
-    [ PkgConstraint
-        { constraintName = "repo/name/B"
-        , constraintSource = Nothing
-        , constraintVersion = Nothing
-        , constraintBranch = Just "overridebranch"
-        , constraintRevision = Nothing
-        }
-    ]
-  }
+gopkg =
+  Gopkg
+    { pkgConstraints =
+        [ PkgConstraint
+            { constraintName = "cat/fossa",
+              constraintSource = Just "https://someotherlocation/",
+              constraintVersion = Just "v3.0.0",
+              constraintBranch = Nothing,
+              constraintRevision = Nothing
+            },
+          PkgConstraint
+            { constraintName = "repo/name/A",
+              constraintSource = Nothing,
+              constraintVersion = Just "v1.0.0",
+              constraintBranch = Nothing,
+              constraintRevision = Nothing
+            },
+          PkgConstraint
+            { constraintName = "repo/name/B",
+              constraintSource = Nothing,
+              constraintVersion = Nothing,
+              constraintBranch = Nothing,
+              constraintRevision = Just "12345"
+            },
+          PkgConstraint
+            { constraintName = "repo/name/C",
+              constraintSource = Nothing,
+              constraintVersion = Nothing,
+              constraintBranch = Just "branchname",
+              constraintRevision = Nothing
+            }
+        ],
+      pkgOverrides =
+        [ PkgConstraint
+            { constraintName = "repo/name/B",
+              constraintSource = Nothing,
+              constraintVersion = Nothing,
+              constraintBranch = Just "overridebranch",
+              constraintRevision = Nothing
+            }
+        ]
+    }
 
 expected :: Graphing Dependency
 expected = run . evalGrapher $ do
-  direct $ Dependency
-             { dependencyType = GoType
-             , dependencyName = "cat/fossa"
-             , dependencyVersion = Just (CEq "v3.0.0")
-             , dependencyLocations = ["https://someotherlocation/"]
-             , dependencyEnvironments = []
-             , dependencyTags = M.empty
-             }
-  direct $ Dependency
-             { dependencyType = GoType
-             , dependencyName = "repo/name/A"
-             , dependencyVersion = Just (CEq "v1.0.0")
-             , dependencyLocations = []
-             , dependencyEnvironments = []
-             , dependencyTags = M.empty
-             }
-  direct $ Dependency
-             { dependencyType = GoType
-             , dependencyName = "repo/name/B"
-             , dependencyVersion = Just (CEq "overridebranch")
-             , dependencyLocations = []
-             , dependencyEnvironments = []
-             , dependencyTags = M.empty
-             }
-  direct $ Dependency
-             { dependencyType = GoType
-             , dependencyName = "repo/name/C"
-             , dependencyVersion = Just (CEq "branchname")
-             , dependencyLocations = []
-             , dependencyEnvironments = []
-             , dependencyTags = M.empty
-             }
+  direct $
+    Dependency
+      { dependencyType = GoType,
+        dependencyName = "cat/fossa",
+        dependencyVersion = Just (CEq "v3.0.0"),
+        dependencyLocations = ["https://someotherlocation/"],
+        dependencyEnvironments = [],
+        dependencyTags = M.empty
+      }
+  direct $
+    Dependency
+      { dependencyType = GoType,
+        dependencyName = "repo/name/A",
+        dependencyVersion = Just (CEq "v1.0.0"),
+        dependencyLocations = [],
+        dependencyEnvironments = [],
+        dependencyTags = M.empty
+      }
+  direct $
+    Dependency
+      { dependencyType = GoType,
+        dependencyName = "repo/name/B",
+        dependencyVersion = Just (CEq "overridebranch"),
+        dependencyLocations = [],
+        dependencyEnvironments = [],
+        dependencyTags = M.empty
+      }
+  direct $
+    Dependency
+      { dependencyType = GoType,
+        dependencyName = "repo/name/C",
+        dependencyVersion = Just (CEq "branchname"),
+        dependencyLocations = [],
+        dependencyEnvironments = [],
+        dependencyTags = M.empty
+      }
 
 spec :: Spec
 spec = do

--- a/test/Go/TransitiveSpec.hs
+++ b/test/Go/TransitiveSpec.hs
@@ -32,151 +32,151 @@ spec_packageToModule =
 nonModulePackages :: [Package]
 nonModulePackages =
   [ Package
-      { packageImportPath = "github.com/example/foo"
-      , packageModule = Nothing
-      , packageImports =
+      { packageImportPath = "github.com/example/foo",
+        packageModule = Nothing,
+        packageImports =
           Just
             [ "github.com/example/nonmodule/foo"
-            ]
-      , packageSystem = Nothing
-      }
-  , Package
-      { packageImportPath = "github.com/example/nonmodule/foo"
-      , packageModule = Nothing
-      , packageImports = Nothing
-      , packageSystem = Nothing
+            ],
+        packageSystem = Nothing
+      },
+    Package
+      { packageImportPath = "github.com/example/nonmodule/foo",
+        packageModule = Nothing,
+        packageImports = Nothing,
+        packageSystem = Nothing
       }
   ]
 
 testPackages :: [Package]
 testPackages =
   [ Package
-      { packageImportPath = "github.com/example/foo"
-      , packageModule = Nothing
-      , packageImports =
+      { packageImportPath = "github.com/example/foo",
+        packageModule = Nothing,
+        packageImports =
           Just
             [ "github.com/example/bar/some/package"
-            ]
-      , packageSystem = Nothing
-      }
-  , Package
-      { packageImportPath = "github.com/example/bar/some/package"
-      , packageModule =
+            ],
+        packageSystem = Nothing
+      },
+    Package
+      { packageImportPath = "github.com/example/bar/some/package",
+        packageModule =
           Just
             Module
-              { modPath = "github.com/example/bar"
-              , modVersion = Nothing
-              }
-      , packageImports =
+              { modPath = "github.com/example/bar",
+                modVersion = Nothing
+              },
+        packageImports =
           Just
-            [ "github.com/example/baz"
-            , "github.com/example/baz/other"
-            ]
-      , packageSystem = Nothing
-      }
-  , Package
-      { packageImportPath = "github.com/example/baz/other"
-      , packageModule =
-          Just
-            Module
-              { modPath = "github.com/example/baz"
-              , modVersion = Nothing
-              }
-      , packageImports = Nothing
-      , packageSystem = Nothing
-      }
-  , Package
-      { packageImportPath = "github.com/example/baz"
-      , packageModule =
+            [ "github.com/example/baz",
+              "github.com/example/baz/other"
+            ],
+        packageSystem = Nothing
+      },
+    Package
+      { packageImportPath = "github.com/example/baz/other",
+        packageModule =
           Just
             Module
-              { modPath = "github.com/example/baz"
-              , modVersion = Nothing
-              }
-      , packageImports = Nothing
-      , packageSystem = Nothing
+              { modPath = "github.com/example/baz",
+                modVersion = Nothing
+              },
+        packageImports = Nothing,
+        packageSystem = Nothing
+      },
+    Package
+      { packageImportPath = "github.com/example/baz",
+        packageModule =
+          Just
+            Module
+              { modPath = "github.com/example/baz",
+                modVersion = Nothing
+              },
+        packageImports = Nothing,
+        packageSystem = Nothing
       }
   ]
 
 normalizedPackages :: [Package]
 normalizedPackages =
   [ Package
-      { packageImportPath = "github.com/example/foo"
-      , packageModule = Nothing
-      , packageImports =
+      { packageImportPath = "github.com/example/foo",
+        packageModule = Nothing,
+        packageImports =
           Just
             [ "github.com/example/bar"
-            ]
-      , packageSystem = Nothing
-      }
-  , Package
-      { packageImportPath = "github.com/example/bar/some/package"
-      , packageModule =
+            ],
+        packageSystem = Nothing
+      },
+    Package
+      { packageImportPath = "github.com/example/bar/some/package",
+        packageModule =
           Just
             Module
-              { modPath = "github.com/example/bar"
-              , modVersion = Nothing
-              }
-      , packageImports =
+              { modPath = "github.com/example/bar",
+                modVersion = Nothing
+              },
+        packageImports =
           Just
-            [ "github.com/example/baz"
-            , "github.com/example/baz"
-            ]
-      , packageSystem = Nothing
-      }
-  , Package
-      { packageImportPath = "github.com/example/baz/other"
-      , packageModule =
-          Just
-            Module
-              { modPath = "github.com/example/baz"
-              , modVersion = Nothing
-              }
-      , packageImports = Nothing
-      , packageSystem = Nothing
-      }
-  , Package
-      { packageImportPath = "github.com/example/baz"
-      , packageModule =
+            [ "github.com/example/baz",
+              "github.com/example/baz"
+            ],
+        packageSystem = Nothing
+      },
+    Package
+      { packageImportPath = "github.com/example/baz/other",
+        packageModule =
           Just
             Module
-              { modPath = "github.com/example/baz"
-              , modVersion = Nothing
-              }
-      , packageImports = Nothing
-      , packageSystem = Nothing
+              { modPath = "github.com/example/baz",
+                modVersion = Nothing
+              },
+        packageImports = Nothing,
+        packageSystem = Nothing
+      },
+    Package
+      { packageImportPath = "github.com/example/baz",
+        packageModule =
+          Just
+            Module
+              { modPath = "github.com/example/baz",
+                modVersion = Nothing
+              },
+        packageImports = Nothing,
+        packageSystem = Nothing
       }
   ]
 
 fooDep :: Dependency
 fooDep =
   Dependency
-    { dependencyType = GoType
-    , dependencyName = "github.com/example/foo"
-    , dependencyVersion = Nothing
-    , dependencyLocations = []
-    , dependencyEnvironments = []
-    , dependencyTags = mempty
+    { dependencyType = GoType,
+      dependencyName = "github.com/example/foo",
+      dependencyVersion = Nothing,
+      dependencyLocations = [],
+      dependencyEnvironments = [],
+      dependencyTags = mempty
     }
 
 barDep :: Dependency
 barDep =
   Dependency
-    { dependencyType = GoType
-    , dependencyName = "github.com/example/bar"
-    , dependencyVersion = Nothing
-    , dependencyLocations = []
-    , dependencyEnvironments = []
-    , dependencyTags = mempty
+    { dependencyType = GoType,
+      dependencyName = "github.com/example/bar",
+      dependencyVersion = Nothing,
+      dependencyLocations = [],
+      dependencyEnvironments = [],
+      dependencyTags = mempty
     }
 
 bazDep :: Dependency
 bazDep =
   Dependency
-    { dependencyType = GoType
-    , dependencyName = "github.com/example/baz"
-    , dependencyVersion = Nothing
-    , dependencyLocations = []
-    , dependencyEnvironments = []
-    , dependencyTags = mempty
+    { dependencyType = GoType,
+      dependencyName = "github.com/example/baz",
+      dependencyVersion = Nothing,
+      dependencyLocations = [],
+      dependencyEnvironments = [],
+      dependencyTags = mempty
     }

--- a/test/Googlesource/RepoManifestSpec.hs
+++ b/test/Googlesource/RepoManifestSpec.hs
@@ -2,13 +2,14 @@
 {-# LANGUAGE TemplateHaskell #-}
 
 module Googlesource.RepoManifestSpec
-  ( spec
-  ) where
+  ( spec,
+  )
+where
 
 import Control.Carrier.Diagnostics hiding (withResult)
-import qualified Data.Map.Strict as M
-import qualified Data.Text as T
-import qualified Data.Text.IO as TIO
+import Data.Map.Strict qualified as M
+import Data.Text qualified as T
+import Data.Text.IO qualified as TIO
 import DepTypes
 import Effect.ReadFS
 import GraphUtil
@@ -21,17 +22,21 @@ import Text.URI.QQ
 
 -- <remote name="aosp" fetch="https://android.googlesource.com" />
 remoteOne :: ManifestRemote
-remoteOne = ManifestRemote { remoteName     = "aosp"
-                           , remoteFetch    = "https://android.googlesource.com"
-                           , remoteRevision = Nothing
-                           }
+remoteOne =
+  ManifestRemote
+    { remoteName = "aosp",
+      remoteFetch = "https://android.googlesource.com",
+      remoteRevision = Nothing
+    }
 
 -- <remote fetch="https://android.othersource.com" name="othersource" revision="google/android-6.0.1_r74" />
 remoteTwo :: ManifestRemote
-remoteTwo = ManifestRemote { remoteName     = "othersource"
-                           , remoteFetch    = "https://android.othersource.com"
-                           , remoteRevision = Just "google/android-6.0.1_r74"
-                           }
+remoteTwo =
+  ManifestRemote
+    { remoteName = "othersource",
+      remoteFetch = "https://android.othersource.com",
+      remoteRevision = Just "google/android-6.0.1_r74"
+    }
 
 basicRemoteList :: [ManifestRemote]
 basicRemoteList = [remoteOne, remoteTwo]
@@ -40,135 +45,174 @@ basicRemoteList = [remoteOne, remoteTwo]
 --          remote="aosp"
 --          sync-j="4" />
 basicDefault :: ManifestDefault
-basicDefault = ManifestDefault { defaultRemote   = Just "aosp"
-                               , defaultRevision = Just "refs/tags/android-10.0.0_r29"
-                               }
+basicDefault =
+  ManifestDefault
+    { defaultRemote = Just "aosp",
+      defaultRevision = Just "refs/tags/android-10.0.0_r29"
+    }
 
 -- <project path="art" name="platform/art" groups="pdk" />
 projectOne :: ManifestProject
-projectOne = ManifestProject { projectName     = "platform/art"
-                             , projectPath     = Just "art"
-                             , projectRevision = Nothing
-                             , projectRemote   = Just "aosp"
-                             }
+projectOne =
+  ManifestProject
+    { projectName = "platform/art",
+      projectPath = Just "art",
+      projectRevision = Nothing,
+      projectRemote = Just "aosp"
+    }
+
 -- <project path="bionic" name="platform/bionic" groups="pdk" revision="57b7d1574276f5e7f895c884df29f45859da74b6" />
 projectTwo :: ManifestProject
-projectTwo = ManifestProject { projectName     = "platform/bionic"
-                             , projectPath     = Just "bionic"
-                             , projectRevision = Just "57b7d1574276f5e7f895c884df29f45859da74b6"
-                             , projectRemote   = Nothing
-                             }
+projectTwo =
+  ManifestProject
+    { projectName = "platform/bionic",
+      projectPath = Just "bionic",
+      projectRevision = Just "57b7d1574276f5e7f895c884df29f45859da74b6",
+      projectRemote = Nothing
+    }
+
 -- <project path="bionic" name="platform/bionic" groups="pdk" revision="57b7d1574276f5e7f895c884df29f45859da74b6" remote="aosp" />
 projectTwoWithRemote :: ManifestProject
-projectTwoWithRemote = ManifestProject { projectName     = "platform/bionic"
-                             , projectPath     = Just "bionic"
-                             , projectRevision = Just "57b7d1574276f5e7f895c884df29f45859da74b6"
-                             , projectRemote   = Just "aosp"
-                             }
+projectTwoWithRemote =
+  ManifestProject
+    { projectName = "platform/bionic",
+      projectPath = Just "bionic",
+      projectRevision = Just "57b7d1574276f5e7f895c884df29f45859da74b6",
+      projectRemote = Just "aosp"
+    }
+
 -- <project path="bootable/recovery" name="platform/bootable/recovery" groups="pdk" remote="othersource" />
 projectThree :: ManifestProject
-projectThree = ManifestProject { projectName     = "platform/bootable/recovery"
-                               , projectPath     = Just "bootable/recovery"
-                               , projectRevision = Nothing
-                               , projectRemote   = Just "othersource"
-                               }
+projectThree =
+  ManifestProject
+    { projectName = "platform/bootable/recovery",
+      projectPath = Just "bootable/recovery",
+      projectRevision = Nothing,
+      projectRemote = Just "othersource"
+    }
+
 -- <project path="cts" name="platform/cts" groups="cts,pdk-cw-fs,pdk-fs" remote="othersource" revision="1111"/>
 projectFour :: ManifestProject
-projectFour = ManifestProject { projectName    = "platform/cts"
-                             , projectPath     = Just "cts"
-                             , projectRevision = Just "1111"
-                             , projectRemote   = Just "othersource"
-                             }
+projectFour =
+  ManifestProject
+    { projectName = "platform/cts",
+      projectPath = Just "cts",
+      projectRevision = Just "1111",
+      projectRemote = Just "othersource"
+    }
+
 -- <project path="dalvik" name="platform/dalvik" groups="pdk-cw-fs,pdk-fs" />
 projectFive :: ManifestProject
-projectFive = ManifestProject { projectName    = "platform/dalvik"
-                             , projectPath     = Just "dalvik"
-                             , projectRevision = Nothing
-                             , projectRemote   = Nothing
-                             }
+projectFive =
+  ManifestProject
+    { projectName = "platform/dalvik",
+      projectPath = Just "dalvik",
+      projectRevision = Nothing,
+      projectRemote = Nothing
+    }
 
 basicProjectList :: [ManifestProject]
 basicProjectList = [projectOne, projectTwo, projectThree, projectFour, projectFive]
 
 dependencyOne :: Dependency
-dependencyOne = Dependency { dependencyType = GooglesourceType
-                           , dependencyName = "platform/art"
-                           , dependencyVersion = Just (CEq "refs/tags/android-10.0.0_r29")
-                           , dependencyLocations = ["https://android.googlesource.com/platform/art"]
-                           , dependencyTags = M.empty
-                           , dependencyEnvironments = [EnvProduction]
-                           }
+dependencyOne =
+  Dependency
+    { dependencyType = GooglesourceType,
+      dependencyName = "platform/art",
+      dependencyVersion = Just (CEq "refs/tags/android-10.0.0_r29"),
+      dependencyLocations = ["https://android.googlesource.com/platform/art"],
+      dependencyTags = M.empty,
+      dependencyEnvironments = [EnvProduction]
+    }
 
 dependencyTwo :: Dependency
-dependencyTwo = Dependency { dependencyType = GooglesourceType
-                           , dependencyName = "platform/bionic"
-                           , dependencyVersion = Just (CEq "57b7d1574276f5e7f895c884df29f45859da74b6")
-                           , dependencyLocations = ["https://android.googlesource.com/platform/bionic"]
-                           , dependencyTags = M.empty
-                           , dependencyEnvironments = [EnvProduction]
-                           }
+dependencyTwo =
+  Dependency
+    { dependencyType = GooglesourceType,
+      dependencyName = "platform/bionic",
+      dependencyVersion = Just (CEq "57b7d1574276f5e7f895c884df29f45859da74b6"),
+      dependencyLocations = ["https://android.googlesource.com/platform/bionic"],
+      dependencyTags = M.empty,
+      dependencyEnvironments = [EnvProduction]
+    }
 
 dependencyThree :: Dependency
-dependencyThree = Dependency { dependencyType = GooglesourceType
-                             , dependencyName = "platform/bootable/recovery"
-                             , dependencyVersion = Just (CEq "google/android-6.0.1_r74")
-                             , dependencyLocations = ["https://android.othersource.com/platform/bootable/recovery"]
-                             , dependencyTags = M.empty
-                             , dependencyEnvironments = [EnvProduction]
-                             }
+dependencyThree =
+  Dependency
+    { dependencyType = GooglesourceType,
+      dependencyName = "platform/bootable/recovery",
+      dependencyVersion = Just (CEq "google/android-6.0.1_r74"),
+      dependencyLocations = ["https://android.othersource.com/platform/bootable/recovery"],
+      dependencyTags = M.empty,
+      dependencyEnvironments = [EnvProduction]
+    }
 
 dependencyFour :: Dependency
-dependencyFour = Dependency { dependencyType = GooglesourceType
-                            , dependencyName = "platform/cts"
-                            , dependencyVersion = Just (CEq "1111")
-                            , dependencyLocations = ["https://android.othersource.com/platform/cts"]
-                            , dependencyTags = M.empty
-                            , dependencyEnvironments = [EnvProduction]
-                            }
+dependencyFour =
+  Dependency
+    { dependencyType = GooglesourceType,
+      dependencyName = "platform/cts",
+      dependencyVersion = Just (CEq "1111"),
+      dependencyLocations = ["https://android.othersource.com/platform/cts"],
+      dependencyTags = M.empty,
+      dependencyEnvironments = [EnvProduction]
+    }
 
 dependencyFive :: Dependency
-dependencyFive = Dependency { dependencyType = GooglesourceType
-                            , dependencyName = "platform/dalvik"
-                            , dependencyVersion = Just (CEq "refs/tags/android-10.0.0_r29")
-                            , dependencyLocations = ["https://android.googlesource.com/platform/dalvik"]
-                            , dependencyTags = M.empty
-                            , dependencyEnvironments = [EnvProduction]
-                            }
+dependencyFive =
+  Dependency
+    { dependencyType = GooglesourceType,
+      dependencyName = "platform/dalvik",
+      dependencyVersion = Just (CEq "refs/tags/android-10.0.0_r29"),
+      dependencyLocations = ["https://android.googlesource.com/platform/dalvik"],
+      dependencyTags = M.empty,
+      dependencyEnvironments = [EnvProduction]
+    }
 
 validatedProjectOne :: ValidatedProject
-validatedProjectOne = ValidatedProject { validatedProjectName = "platform/art"
-                                       , validatedProjectPath = "art"
-                                       , validatedProjectUrl = [uri|https://android.googlesource.com/platform/art|]
-                                       , validatedProjectRevision = "refs/tags/android-10.0.0_r29"
-                                       }
+validatedProjectOne =
+  ValidatedProject
+    { validatedProjectName = "platform/art",
+      validatedProjectPath = "art",
+      validatedProjectUrl = [uri|https://android.googlesource.com/platform/art|],
+      validatedProjectRevision = "refs/tags/android-10.0.0_r29"
+    }
 
 validatedProjectTwo :: ValidatedProject
-validatedProjectTwo = ValidatedProject { validatedProjectName = "platform/bionic"
-                                       , validatedProjectPath = "bionic"
-                                       , validatedProjectUrl = [uri|https://android.googlesource.com/platform/bionic|]
-                                       , validatedProjectRevision = "57b7d1574276f5e7f895c884df29f45859da74b6"
-                                       }
+validatedProjectTwo =
+  ValidatedProject
+    { validatedProjectName = "platform/bionic",
+      validatedProjectPath = "bionic",
+      validatedProjectUrl = [uri|https://android.googlesource.com/platform/bionic|],
+      validatedProjectRevision = "57b7d1574276f5e7f895c884df29f45859da74b6"
+    }
 
 validatedProjectThree :: ValidatedProject
-validatedProjectThree = ValidatedProject { validatedProjectName = "platform/bootable/recovery"
-                                       , validatedProjectPath = "bootable/recovery"
-                                       , validatedProjectUrl = [uri|https://android.othersource.com/platform/bootable/recovery|]
-                                       , validatedProjectRevision = "google/android-6.0.1_r74"
-                                       }
+validatedProjectThree =
+  ValidatedProject
+    { validatedProjectName = "platform/bootable/recovery",
+      validatedProjectPath = "bootable/recovery",
+      validatedProjectUrl = [uri|https://android.othersource.com/platform/bootable/recovery|],
+      validatedProjectRevision = "google/android-6.0.1_r74"
+    }
 
 validatedProjectFour :: ValidatedProject
-validatedProjectFour = ValidatedProject { validatedProjectName = "platform/cts"
-                                       , validatedProjectPath = "cts"
-                                       , validatedProjectUrl = [uri|https://android.othersource.com/platform/cts|]
-                                       , validatedProjectRevision = "1111"
-                                       }
+validatedProjectFour =
+  ValidatedProject
+    { validatedProjectName = "platform/cts",
+      validatedProjectPath = "cts",
+      validatedProjectUrl = [uri|https://android.othersource.com/platform/cts|],
+      validatedProjectRevision = "1111"
+    }
 
 validatedProjectFive :: ValidatedProject
-validatedProjectFive = ValidatedProject { validatedProjectName = "platform/dalvik"
-                                       , validatedProjectPath = "dalvik"
-                                       , validatedProjectUrl = [uri|https://android.googlesource.com/platform/dalvik|]
-                                       , validatedProjectRevision = "refs/tags/android-10.0.0_r29"
-                                       }
+validatedProjectFive =
+  ValidatedProject
+    { validatedProjectName = "platform/dalvik",
+      validatedProjectPath = "dalvik",
+      validatedProjectUrl = [uri|https://android.googlesource.com/platform/dalvik|],
+      validatedProjectRevision = "refs/tags/android-10.0.0_r29"
+    }
 
 validatedProjectList :: [ValidatedProject]
 validatedProjectList = [validatedProjectOne, validatedProjectTwo, validatedProjectThree, validatedProjectFour, validatedProjectFive]
@@ -213,8 +257,8 @@ spec = do
         case parseXML basicManifest of
           Right manifest -> do
             let projects = case validateProjects manifest of
-                        Nothing -> []
-                        (Just ps) -> ps
+                  Nothing -> []
+                  (Just ps) -> ps
             let graph = buildGraph projects
             let vps = validateProject manifest <$> manifestProjects manifest
             vps `shouldMatchList` [Just validatedProjectOne, Just validatedProjectTwo, Just validatedProjectThree, Just validatedProjectFour, Just validatedProjectFive]
@@ -227,7 +271,6 @@ spec = do
           Right manifest -> do
             let vps = validateProject manifest <$> manifestProjects manifest
             vps `shouldMatchList` [Just validatedProjectOne, Just validatedProjectTwo, Just validatedProjectThree, Just validatedProjectFour, Nothing]
-
           Left err -> expectationFailure (T.unpack ("could not parse repo manifest file: " <> xmlErrorPretty err))
 
     describe "for a manifest with no default revision" $

--- a/test/Gradle/GradleSpec.hs
+++ b/test/Gradle/GradleSpec.hs
@@ -1,72 +1,79 @@
 module Gradle.GradleSpec
-  ( spec
-  ) where
+  ( spec,
+  )
+where
 
 import Data.Map.Strict (Map)
-import qualified Data.Map.Strict as M
+import Data.Map.Strict qualified as M
 import Data.Text (Text)
 import DepTypes
 import GraphUtil
 import Graphing (Graphing, empty)
-import Strategy.Gradle (JsonDep (..), buildGraph, PackageName(..), ConfigName(..))
+import Strategy.Gradle (ConfigName (..), JsonDep (..), PackageName (..), buildGraph)
 import Test.Hspec
 
 projectOne :: Dependency
-projectOne = Dependency
-  { dependencyType = SubprojectType
-  , dependencyName = ":projectOne"
-  , dependencyVersion = Nothing
-  , dependencyLocations = []
-  , dependencyEnvironments = [EnvOther "config"]
-  , dependencyTags = M.empty
-  }
+projectOne =
+  Dependency
+    { dependencyType = SubprojectType,
+      dependencyName = ":projectOne",
+      dependencyVersion = Nothing,
+      dependencyLocations = [],
+      dependencyEnvironments = [EnvOther "config"],
+      dependencyTags = M.empty
+    }
 
 projectTwo :: Dependency
-projectTwo = Dependency
-  { dependencyType = SubprojectType
-  , dependencyName = ":projectTwo"
-  , dependencyVersion = Nothing
-  , dependencyLocations = []
-  , dependencyEnvironments = [EnvDevelopment, EnvOther "config"]
-  , dependencyTags = M.empty
-  }
+projectTwo =
+  Dependency
+    { dependencyType = SubprojectType,
+      dependencyName = ":projectTwo",
+      dependencyVersion = Nothing,
+      dependencyLocations = [],
+      dependencyEnvironments = [EnvDevelopment, EnvOther "config"],
+      dependencyTags = M.empty
+    }
 
 projectThree :: Dependency
-projectThree = Dependency
-  { dependencyType = SubprojectType
-  , dependencyName = ":projectThree"
-  , dependencyVersion = Nothing
-  , dependencyLocations = []
-  , dependencyEnvironments = [EnvDevelopment, EnvTesting]
-  , dependencyTags = M.empty
-  }
+projectThree =
+  Dependency
+    { dependencyType = SubprojectType,
+      dependencyName = ":projectThree",
+      dependencyVersion = Nothing,
+      dependencyLocations = [],
+      dependencyEnvironments = [EnvDevelopment, EnvTesting],
+      dependencyTags = M.empty
+    }
 
 packageOne :: Dependency
-packageOne = Dependency
-  { dependencyType = MavenType
-  , dependencyName = "mygroup:packageOne"
-  , dependencyVersion = Just (CEq "1.0.0")
-  , dependencyLocations = []
-  , dependencyEnvironments = [EnvDevelopment]
-  , dependencyTags = M.empty
-  }
+packageOne =
+  Dependency
+    { dependencyType = MavenType,
+      dependencyName = "mygroup:packageOne",
+      dependencyVersion = Just (CEq "1.0.0"),
+      dependencyLocations = [],
+      dependencyEnvironments = [EnvDevelopment],
+      dependencyTags = M.empty
+    }
 
 packageTwo :: Dependency
-packageTwo = Dependency
-  { dependencyType = MavenType
-  , dependencyName = "mygroup:packageTwo"
-  , dependencyVersion = Just (CEq "2.0.0")
-  , dependencyLocations = []
-  , dependencyEnvironments = [EnvTesting]
-  , dependencyTags = M.empty
-  }
+packageTwo =
+  Dependency
+    { dependencyType = MavenType,
+      dependencyName = "mygroup:packageTwo",
+      dependencyVersion = Just (CEq "2.0.0"),
+      dependencyLocations = [],
+      dependencyEnvironments = [EnvTesting],
+      dependencyTags = M.empty
+    }
 
 gradleOutput :: Map (Text, Text) [JsonDep]
-gradleOutput = M.fromList
-  [ ((":projectOne", "config"), [ProjectDep ":projectTwo"])
-  , ((":projectTwo", "compileOnly"), [ProjectDep ":projectThree", PackageDep "mygroup:packageOne" "1.0.0" []])
-  , ((":projectThree", "testCompileOnly"), [PackageDep "mygroup:packageTwo" "2.0.0" []])
-  ]
+gradleOutput =
+  M.fromList
+    [ ((":projectOne", "config"), [ProjectDep ":projectTwo"]),
+      ((":projectTwo", "compileOnly"), [ProjectDep ":projectThree", PackageDep "mygroup:packageOne" "1.0.0" []]),
+      ((":projectThree", "testCompileOnly"), [PackageDep "mygroup:packageTwo" "2.0.0" []])
+    ]
 
 wrapKeys :: (Text, Text) -> (PackageName, ConfigName)
 wrapKeys (a, b) = (PackageName a, ConfigName b)
@@ -82,8 +89,10 @@ spec = do
       let graph = buildGraph $ M.mapKeys wrapKeys gradleOutput
       expectDeps [projectOne, projectTwo, projectThree, packageOne, packageTwo] graph
       expectDirect [projectOne, projectTwo, projectThree] graph
-      expectEdges [ (projectOne, projectTwo)
-                  , (projectTwo, projectThree)
-                  , (projectTwo, packageOne)
-                  , (projectThree, packageTwo)
-                  ] graph
+      expectEdges
+        [ (projectOne, projectTwo),
+          (projectTwo, projectThree),
+          (projectTwo, packageOne),
+          (projectThree, packageTwo)
+        ]
+        graph

--- a/test/GraphUtil.hs
+++ b/test/GraphUtil.hs
@@ -1,24 +1,27 @@
 module GraphUtil
-  ( expectDeps
-  , expectDirect
-  , expectEdges
-  ) where
+  ( expectDeps,
+    expectDirect,
+    expectEdges,
+  )
+where
 
-import qualified Algebra.Graph.AdjacencyMap as AM
+import Algebra.Graph.AdjacencyMap qualified as AM
 import Algebra.Graph.ToGraph (vertexSet)
 import Data.Foldable (toList, traverse_)
 import Graphing
 import Test.Hspec
 
 -- TODO: expectReachable instead?
+
 -- | Expect the given dependencies to be the deps in the graph
 expectDeps :: (Ord a, Show a) => [a] -> Graphing a -> Expectation
 expectDeps deps graph = toList (vertexSet (graphingAdjacent graph)) `shouldMatchList` deps
 
 -- TODO: I expect the shouldSatisfy will produce poor test failure messages
+
 -- | Expect only the given edges between @[(parent,child)]@ dependencies to be present in the graph
-expectEdges :: (Ord a, Show a) => [(a,a)] -> Graphing a -> Expectation
-expectEdges edges graph = (length edges `shouldBe` AM.edgeCount (graphingAdjacent graph)) *> traverse_ (`shouldSatisfy` \(from,to) -> AM.hasEdge from to (graphingAdjacent graph)) edges
+expectEdges :: (Ord a, Show a) => [(a, a)] -> Graphing a -> Expectation
+expectEdges edges graph = (length edges `shouldBe` AM.edgeCount (graphingAdjacent graph)) *> traverse_ (`shouldSatisfy` \(from, to) -> AM.hasEdge from to (graphingAdjacent graph)) edges
 
 -- | Expect the given dependencies to be the direct deps in the graph
 expectDirect :: (Eq a, Show a) => [a] -> Graphing a -> Expectation

--- a/test/GraphingSpec.hs
+++ b/test/GraphingSpec.hs
@@ -1,20 +1,20 @@
 module GraphingSpec
-  ( spec
+  ( spec,
   )
-  where
+where
 
+import GraphUtil
+import Graphing
 import Test.Hspec
 import Prelude
-import Graphing
-import GraphUtil
 
 spec :: Spec
 spec = do
   describe "unfold" $ do
     it "should unfold deeply" $ do
       let graph :: Graphing Int
-          graph = unfold [10] (\x -> if x > 0 then [x-2] else []) id
+          graph = unfold [10] (\x -> if x > 0 then [x -2] else []) id
 
       expectDirect [10] graph
       expectDeps [10, 8, 6, 4, 2, 0] graph
-      expectEdges [(10,8), (8,6), (6,4), (4,2), (2,0)] graph
+      expectEdges [(10, 8), (8, 6), (6, 4), (4, 2), (2, 0)] graph

--- a/test/Haskell/CabalSpec.hs
+++ b/test/Haskell/CabalSpec.hs
@@ -7,13 +7,13 @@ where
 
 import Control.Carrier.Diagnostics
 import Data.Aeson
-import qualified Data.ByteString.Lazy as BL
-import qualified Data.Set as S
+import Data.ByteString.Lazy qualified as BL
+import Data.Set qualified as S
 import DepTypes
 import GraphUtil
 import Graphing
 import Strategy.Haskell.Cabal
-import qualified Test.Hspec as Test
+import Test.Hspec qualified as Test
 
 buildPlan :: [InstallPlan]
 buildPlan = [aesonPlan, basePlan, deepDepPlan, rtsPlan, spectrometerFossaPlan, spectrometerLibPlan, withCompPlan]

--- a/test/Haskell/StackSpec.hs
+++ b/test/Haskell/StackSpec.hs
@@ -5,16 +5,16 @@ module Haskell.StackSpec
   )
 where
 
-import Data.Aeson
-import qualified Data.ByteString.Lazy as BL
-import Data.Text (Text)
-import qualified Graphing as G
-import qualified Test.Hspec as Test
-import Prelude
-import Strategy.Haskell.Stack
 import Control.Carrier.Diagnostics
-import Types
+import Data.Aeson
+import Data.ByteString.Lazy qualified as BL
+import Data.Text (Text)
 import GraphUtil
+import Graphing qualified as G
+import Strategy.Haskell.Stack
+import Test.Hspec qualified as Test
+import Types
+import Prelude
 
 allDeps :: [StackDep]
 allDeps = [builtinDep, deepDep, localDep, remoteDep]
@@ -24,10 +24,13 @@ mkDep name deps = StackDep (PackageName name) (name <> "-ver") (map PackageName 
 
 builtinDep :: StackDep
 builtinDep = mkDep "builtin" [] BuiltIn
+
 deepDep :: StackDep
 deepDep = mkDep "deep" [] Remote
+
 localDep :: StackDep
 localDep = mkDep "local" ["remote", "builtin"] Local
+
 remoteDep :: StackDep
 remoteDep = mkDep "remote" ["deep"] Remote
 

--- a/test/Maven/PluginStrategySpec.hs
+++ b/test/Maven/PluginStrategySpec.hs
@@ -1,8 +1,9 @@
 module Maven.PluginStrategySpec
-  ( spec
-  ) where
+  ( spec,
+  )
+where
 
-import qualified Data.Map.Strict as M
+import Data.Map.Strict qualified as M
 import DepTypes
 import GraphUtil
 import Strategy.Maven.Plugin
@@ -10,52 +11,55 @@ import Strategy.Maven.PluginStrategy
 import Test.Hspec
 
 packageOne :: Dependency
-packageOne = Dependency
-  { dependencyType = MavenType
-  , dependencyName = "mygroup:packageOne"
-  , dependencyVersion = Just (CEq "1.0.0")
-  , dependencyLocations = []
-  , dependencyEnvironments = [EnvTesting]
-  , dependencyTags = M.fromList [("scopes", ["compile", "test"])]
-  }
+packageOne =
+  Dependency
+    { dependencyType = MavenType,
+      dependencyName = "mygroup:packageOne",
+      dependencyVersion = Just (CEq "1.0.0"),
+      dependencyLocations = [],
+      dependencyEnvironments = [EnvTesting],
+      dependencyTags = M.fromList [("scopes", ["compile", "test"])]
+    }
 
 packageTwo :: Dependency
-packageTwo = Dependency
-  { dependencyType = MavenType
-  , dependencyName = "mygroup:packageTwo"
-  , dependencyVersion = Just (CEq "2.0.0")
-  , dependencyLocations = []
-  , dependencyEnvironments = []
-  , dependencyTags = M.fromList [("scopes", ["compile"]), ("optional", ["true"])]
-  }
+packageTwo =
+  Dependency
+    { dependencyType = MavenType,
+      dependencyName = "mygroup:packageTwo",
+      dependencyVersion = Just (CEq "2.0.0"),
+      dependencyLocations = [],
+      dependencyEnvironments = [],
+      dependencyTags = M.fromList [("scopes", ["compile"]), ("optional", ["true"])]
+    }
 
 mavenOutput :: PluginOutput
-mavenOutput = PluginOutput
-  { outArtifacts =
-    [ Artifact
-        { artifactNumericId = 0
-        , artifactGroupId = "mygroup"
-        , artifactArtifactId = "packageOne"
-        , artifactVersion = "1.0.0"
-        , artifactOptional = False
-        , artifactScopes = ["compile", "test"]
-        }
-    , Artifact
-        { artifactNumericId = 1
-        , artifactGroupId = "mygroup"
-        , artifactArtifactId = "packageTwo"
-        , artifactVersion = "2.0.0"
-        , artifactOptional = True
-        , artifactScopes = ["compile"]
-        }
-    ]
-  , outEdges =
-    [ Edge
-        { edgeFrom = 0
-        , edgeTo = 1
-        }
-    ]
-  }
+mavenOutput =
+  PluginOutput
+    { outArtifacts =
+        [ Artifact
+            { artifactNumericId = 0,
+              artifactGroupId = "mygroup",
+              artifactArtifactId = "packageOne",
+              artifactVersion = "1.0.0",
+              artifactOptional = False,
+              artifactScopes = ["compile", "test"]
+            },
+          Artifact
+            { artifactNumericId = 1,
+              artifactGroupId = "mygroup",
+              artifactArtifactId = "packageTwo",
+              artifactVersion = "2.0.0",
+              artifactOptional = True,
+              artifactScopes = ["compile"]
+            }
+        ],
+      outEdges =
+        [ Edge
+            { edgeFrom = 0,
+              edgeTo = 1
+            }
+        ]
+    }
 
 spec :: Spec
 spec = do
@@ -63,6 +67,6 @@ spec = do
     it "should produce expected output" $ do
       let graph = buildGraph mavenOutput
 
-      expectDeps [ packageOne, packageTwo ] graph
+      expectDeps [packageOne, packageTwo] graph
       expectDirect [] graph
       expectEdges [(packageOne, packageTwo)] graph

--- a/test/Maven/PomStrategySpec.hs
+++ b/test/Maven/PomStrategySpec.hs
@@ -3,7 +3,7 @@ module Maven.PomStrategySpec
   )
 where
 
-import qualified Data.Map.Strict as M
+import Data.Map.Strict qualified as M
 import Strategy.Maven.Pom (interpolateProperties)
 import Strategy.Maven.Pom.PomFile
 import Test.Hspec
@@ -18,7 +18,7 @@ spec = do
       interpolateProperties pom "${project.version}" `shouldBe` "MYVERSION"
 
     it "should prefer user-specified properties over computed ones" $ do
-      let pom' = pom { pomProperties = M.singleton "project.groupId" "OTHERGROUP" }
+      let pom' = pom {pomProperties = M.singleton "project.groupId" "OTHERGROUP"}
       interpolateProperties pom' "${project.groupId}" `shouldBe` "OTHERGROUP"
 
     it "should work in the middle of strings" $ do

--- a/test/Node/NpmLockSpec.hs
+++ b/test/Node/NpmLockSpec.hs
@@ -1,72 +1,87 @@
 module Node.NpmLockSpec
-  ( spec
-  ) where
+  ( spec,
+  )
+where
 
-import qualified Data.Map.Strict as M
+import Data.Map.Strict qualified as M
 import DepTypes
 import GraphUtil
 import Strategy.Node.NpmLock
 import Test.Hspec
 
 mockInput :: NpmPackageJson
-mockInput = NpmPackageJson
-  { packageName = "example"
-  , packageVersion = "1.0.0"
-  , packageDependencies = M.fromList
-    [ ("packageOne", NpmDep
-        { depVersion = "1.0.0"
-        , depDev = Nothing
-        , depResolved = Just "https://example.com/one.tgz"
-        , depRequires = Just (M.fromList [("packageTwo", "2.0.0")])
-        , depDependencies = Just (M.fromList
-            [ ("packageTwo", NpmDep
-                { depVersion = "2.0.0"
-                , depDev = Just True
-                , depResolved = Just "https://example.com/two.tgz"
-                , depRequires = Just (M.fromList [("packageThree", "3.0.0")])
-                , depDependencies = Nothing
-                })
-            ])
-        })
-    , ("packageThree", NpmDep
-        { depVersion = "3.0.0"
-        , depDev = Just True
-        , depResolved = Nothing
-        , depRequires = Just (M.fromList [("packageOne", "1.0.0")])
-        , depDependencies = Nothing
-        })
-    ]
-  }
+mockInput =
+  NpmPackageJson
+    { packageName = "example",
+      packageVersion = "1.0.0",
+      packageDependencies =
+        M.fromList
+          [ ( "packageOne",
+              NpmDep
+                { depVersion = "1.0.0",
+                  depDev = Nothing,
+                  depResolved = Just "https://example.com/one.tgz",
+                  depRequires = Just (M.fromList [("packageTwo", "2.0.0")]),
+                  depDependencies =
+                    Just
+                      ( M.fromList
+                          [ ( "packageTwo",
+                              NpmDep
+                                { depVersion = "2.0.0",
+                                  depDev = Just True,
+                                  depResolved = Just "https://example.com/two.tgz",
+                                  depRequires = Just (M.fromList [("packageThree", "3.0.0")]),
+                                  depDependencies = Nothing
+                                }
+                            )
+                          ]
+                      )
+                }
+            ),
+            ( "packageThree",
+              NpmDep
+                { depVersion = "3.0.0",
+                  depDev = Just True,
+                  depResolved = Nothing,
+                  depRequires = Just (M.fromList [("packageOne", "1.0.0")]),
+                  depDependencies = Nothing
+                }
+            )
+          ]
+    }
 
 packageOne :: Dependency
-packageOne = Dependency
-  { dependencyType = NodeJSType
-  , dependencyName = "packageOne"
-  , dependencyVersion = Just (CEq "1.0.0")
-  , dependencyLocations = ["https://example.com/one.tgz"]
-  , dependencyEnvironments = [EnvProduction]
-  , dependencyTags = M.empty
-  }
+packageOne =
+  Dependency
+    { dependencyType = NodeJSType,
+      dependencyName = "packageOne",
+      dependencyVersion = Just (CEq "1.0.0"),
+      dependencyLocations = ["https://example.com/one.tgz"],
+      dependencyEnvironments = [EnvProduction],
+      dependencyTags = M.empty
+    }
 
 packageTwo :: Dependency
-packageTwo = Dependency
-  { dependencyType = NodeJSType
-  , dependencyName = "packageTwo"
-  , dependencyVersion = Just (CEq "2.0.0")
-  , dependencyLocations = ["https://example.com/two.tgz"]
-  , dependencyEnvironments = [EnvDevelopment]
-  , dependencyTags = M.empty
-  }
+packageTwo =
+  Dependency
+    { dependencyType = NodeJSType,
+      dependencyName = "packageTwo",
+      dependencyVersion = Just (CEq "2.0.0"),
+      dependencyLocations = ["https://example.com/two.tgz"],
+      dependencyEnvironments = [EnvDevelopment],
+      dependencyTags = M.empty
+    }
 
 packageThree :: Dependency
-packageThree = Dependency
-  { dependencyType = NodeJSType
-  , dependencyName = "packageThree"
-  , dependencyVersion = Just (CEq "3.0.0")
-  , dependencyLocations = []
-  , dependencyEnvironments = [EnvDevelopment]
-  , dependencyTags = M.empty
-  }
+packageThree =
+  Dependency
+    { dependencyType = NodeJSType,
+      dependencyName = "packageThree",
+      dependencyVersion = Just (CEq "3.0.0"),
+      dependencyLocations = [],
+      dependencyEnvironments = [EnvDevelopment],
+      dependencyTags = M.empty
+    }
 
 spec :: Spec
 spec = do
@@ -75,7 +90,9 @@ spec = do
       let graph = buildGraph mockInput
       expectDeps [packageOne, packageTwo, packageThree] graph
       expectDirect [packageOne, packageThree] graph
-      expectEdges [ (packageOne, packageTwo)
-                  , (packageTwo, packageThree)
-                  , (packageThree, packageOne)
-                  ] graph
+      expectEdges
+        [ (packageOne, packageTwo),
+          (packageTwo, packageThree),
+          (packageThree, packageOne)
+        ]
+        graph

--- a/test/Node/PackageJsonSpec.hs
+++ b/test/Node/PackageJsonSpec.hs
@@ -1,38 +1,42 @@
 module Node.PackageJsonSpec
-  ( spec
-  ) where
+  ( spec,
+  )
+where
 
-import qualified Data.Map.Strict as M
+import Data.Map.Strict qualified as M
 import DepTypes
 import GraphUtil
 import Strategy.Node.PackageJson
 import Test.Hspec
 
 mockInput :: PackageJson
-mockInput = PackageJson
-  { packageDeps = M.fromList [("packageOne", "^1.0.0")]
-  , packageDevDeps = M.fromList [("packageTwo", "^2.0.0")]
-  }
+mockInput =
+  PackageJson
+    { packageDeps = M.fromList [("packageOne", "^1.0.0")],
+      packageDevDeps = M.fromList [("packageTwo", "^2.0.0")]
+    }
 
 packageOne :: Dependency
-packageOne = Dependency
-  { dependencyType = NodeJSType
-  , dependencyName = "packageOne"
-  , dependencyVersion = Just (CCompatible "^1.0.0")
-  , dependencyLocations = []
-  , dependencyEnvironments = [EnvProduction]
-  , dependencyTags = M.empty
-  }
+packageOne =
+  Dependency
+    { dependencyType = NodeJSType,
+      dependencyName = "packageOne",
+      dependencyVersion = Just (CCompatible "^1.0.0"),
+      dependencyLocations = [],
+      dependencyEnvironments = [EnvProduction],
+      dependencyTags = M.empty
+    }
 
 packageTwo :: Dependency
-packageTwo = Dependency
-  { dependencyType = NodeJSType
-  , dependencyName = "packageTwo"
-  , dependencyVersion = Just (CCompatible "^2.0.0")
-  , dependencyLocations = []
-  , dependencyEnvironments = [EnvDevelopment]
-  , dependencyTags = M.empty
-  }
+packageTwo =
+  Dependency
+    { dependencyType = NodeJSType,
+      dependencyName = "packageTwo",
+      dependencyVersion = Just (CCompatible "^2.0.0"),
+      dependencyLocations = [],
+      dependencyEnvironments = [EnvDevelopment],
+      dependencyTags = M.empty
+    }
 
 spec :: Spec
 spec = do

--- a/test/Node/YarnLockSpec.hs
+++ b/test/Node/YarnLockSpec.hs
@@ -1,45 +1,49 @@
 module Node.YarnLockSpec
-  ( spec
-  ) where
+  ( spec,
+  )
+where
 
-import qualified Data.Map.Strict as M
+import Data.ByteString qualified as BS
+import Data.Map.Strict qualified as M
 import Data.Text.Encoding
 import DepTypes
 import GraphUtil
 import Strategy.Node.YarnLock
-import qualified Data.ByteString as BS
 import Test.Hspec
-import qualified Yarn.Lock as YL
+import Yarn.Lock qualified as YL
 
 packageOne :: Dependency
-packageOne = Dependency
-  { dependencyType = NodeJSType
-  , dependencyName = "packageOne"
-  , dependencyVersion = Just (CEq "1.0.0")
-  , dependencyLocations = ["https://registry.npmjs.org/packageOne"]
-  , dependencyEnvironments = []
-  , dependencyTags = M.empty
-  }
+packageOne =
+  Dependency
+    { dependencyType = NodeJSType,
+      dependencyName = "packageOne",
+      dependencyVersion = Just (CEq "1.0.0"),
+      dependencyLocations = ["https://registry.npmjs.org/packageOne"],
+      dependencyEnvironments = [],
+      dependencyTags = M.empty
+    }
 
 packageTwo :: Dependency
-packageTwo = Dependency
-  { dependencyType = NodeJSType
-  , dependencyName = "packageTwo"
-  , dependencyVersion = Just (CEq "2.0.0")
-  , dependencyLocations = ["https://registry.npmjs.org/packageTwo"]
-  , dependencyEnvironments = []
-  , dependencyTags = M.empty
-  }
+packageTwo =
+  Dependency
+    { dependencyType = NodeJSType,
+      dependencyName = "packageTwo",
+      dependencyVersion = Just (CEq "2.0.0"),
+      dependencyLocations = ["https://registry.npmjs.org/packageTwo"],
+      dependencyEnvironments = [],
+      dependencyTags = M.empty
+    }
 
 packageThree :: Dependency
-packageThree = Dependency
-  { dependencyType = NodeJSType
-  , dependencyName = "packageThree"
-  , dependencyVersion = Just (CEq "3.0.0")
-  , dependencyLocations = ["https://registry.npmjs.org/packageThree"]
-  , dependencyEnvironments = []
-  , dependencyTags = M.empty
-  }
+packageThree =
+  Dependency
+    { dependencyType = NodeJSType,
+      dependencyName = "packageThree",
+      dependencyVersion = Just (CEq "3.0.0"),
+      dependencyLocations = ["https://registry.npmjs.org/packageThree"],
+      dependencyEnvironments = [],
+      dependencyTags = M.empty
+    }
 
 spec :: Spec
 spec = do
@@ -52,6 +56,8 @@ spec = do
           let graph = buildGraph lockfile
           expectDeps [packageOne, packageTwo, packageThree] graph
           expectDirect [] graph
-          expectEdges [ (packageOne, packageTwo)
-                      , (packageTwo, packageThree)
-                      ] graph
+          expectEdges
+            [ (packageOne, packageTwo),
+              (packageTwo, packageThree)
+            ]
+            graph

--- a/test/NuGet/NuspecSpec.hs
+++ b/test/NuGet/NuspecSpec.hs
@@ -1,10 +1,11 @@
 module NuGet.NuspecSpec
-  ( spec
-  ) where
+  ( spec,
+  )
+where
 
-import qualified Data.Map.Strict as M
-import qualified Data.Text as T
-import qualified Data.Text.IO as TIO
+import Data.Map.Strict qualified as M
+import Data.Text qualified as T
+import Data.Text.IO qualified as TIO
 import DepTypes
 import GraphUtil
 import Parse.XML
@@ -12,31 +13,37 @@ import Strategy.NuGet.Nuspec
 import Test.Hspec
 
 dependencyOne :: Dependency
-dependencyOne = Dependency { dependencyType = NuGetType
-                        , dependencyName = "one"
-                        , dependencyVersion = Just (CEq "1.0.0")
-                        , dependencyLocations = []
-                        , dependencyEnvironments = []
-                        , dependencyTags = M.empty
-                        }
+dependencyOne =
+  Dependency
+    { dependencyType = NuGetType,
+      dependencyName = "one",
+      dependencyVersion = Just (CEq "1.0.0"),
+      dependencyLocations = [],
+      dependencyEnvironments = [],
+      dependencyTags = M.empty
+    }
 
 dependencyTwo :: Dependency
-dependencyTwo = Dependency { dependencyType = NuGetType
-                        , dependencyName = "two"
-                        , dependencyVersion = Just (CEq "2.0.0")
-                        , dependencyLocations = []
-                        , dependencyEnvironments = []
-                        , dependencyTags = M.empty
-                        }
+dependencyTwo =
+  Dependency
+    { dependencyType = NuGetType,
+      dependencyName = "two",
+      dependencyVersion = Just (CEq "2.0.0"),
+      dependencyLocations = [],
+      dependencyEnvironments = [],
+      dependencyTags = M.empty
+    }
 
 dependencyThree :: Dependency
-dependencyThree = Dependency { dependencyType = NuGetType
-                        , dependencyName = "three"
-                        , dependencyVersion = Just (CEq "3.0.0")
-                        , dependencyLocations = []
-                        , dependencyEnvironments = []
-                        , dependencyTags = M.empty
-                        }
+dependencyThree =
+  Dependency
+    { dependencyType = NuGetType,
+      dependencyName = "three",
+      dependencyVersion = Just (CEq "3.0.0"),
+      dependencyLocations = [],
+      dependencyEnvironments = [],
+      dependencyTags = M.empty
+    }
 
 nuspec :: Nuspec
 nuspec = Nuspec groupList licenses (Just "test.com")
@@ -88,7 +95,7 @@ spec = do
         Left err -> expectationFailure (T.unpack ("could not parse nuspec file: " <> xmlErrorPretty err))
 
     it "constructs an accurate graph" $ do
-          let graph = buildGraph nuspec
-          expectDeps [dependencyOne, dependencyTwo, dependencyThree] graph
-          expectDirect [dependencyOne, dependencyTwo, dependencyThree] graph
-          expectEdges [] graph
+      let graph = buildGraph nuspec
+      expectDeps [dependencyOne, dependencyTwo, dependencyThree] graph
+      expectDirect [dependencyOne, dependencyTwo, dependencyThree] graph
+      expectEdges [] graph

--- a/test/NuGet/PackageReferenceSpec.hs
+++ b/test/NuGet/PackageReferenceSpec.hs
@@ -1,10 +1,11 @@
 module NuGet.PackageReferenceSpec
-  ( spec
-  ) where
+  ( spec,
+  )
+where
 
-import qualified Data.Map.Strict as M
-import qualified Data.Text as T
-import qualified Data.Text.IO as TIO
+import Data.Map.Strict qualified as M
+import Data.Text qualified as T
+import Data.Text.IO qualified as TIO
 import DepTypes
 import GraphUtil
 import Parse.XML
@@ -12,40 +13,48 @@ import Strategy.NuGet.PackageReference
 import Test.Hspec
 
 dependencyOne :: Dependency
-dependencyOne = Dependency { dependencyType = NuGetType
-                           , dependencyName = "one"
-                           , dependencyVersion = Just (CEq "1.0.0")
-                           , dependencyLocations = []
-                           , dependencyEnvironments = []
-                           , dependencyTags = M.empty
-                           }
+dependencyOne =
+  Dependency
+    { dependencyType = NuGetType,
+      dependencyName = "one",
+      dependencyVersion = Just (CEq "1.0.0"),
+      dependencyLocations = [],
+      dependencyEnvironments = [],
+      dependencyTags = M.empty
+    }
 
 dependencyTwo :: Dependency
-dependencyTwo = Dependency { dependencyType = NuGetType
-                           , dependencyName = "two"
-                           , dependencyVersion = Just (CEq "2.0.0")
-                           , dependencyLocations = []
-                           , dependencyEnvironments = []
-                           , dependencyTags = M.empty
-                           }
+dependencyTwo =
+  Dependency
+    { dependencyType = NuGetType,
+      dependencyName = "two",
+      dependencyVersion = Just (CEq "2.0.0"),
+      dependencyLocations = [],
+      dependencyEnvironments = [],
+      dependencyTags = M.empty
+    }
 
 dependencyThree :: Dependency
-dependencyThree = Dependency { dependencyType = NuGetType
-                             , dependencyName = "three"
-                             , dependencyVersion = Just (CEq "3.0.0")
-                             , dependencyLocations = []
-                             , dependencyEnvironments = []
-                             , dependencyTags = M.empty
-                             }
+dependencyThree =
+  Dependency
+    { dependencyType = NuGetType,
+      dependencyName = "three",
+      dependencyVersion = Just (CEq "3.0.0"),
+      dependencyLocations = [],
+      dependencyEnvironments = [],
+      dependencyTags = M.empty
+    }
 
 dependencyFour :: Dependency
-dependencyFour = Dependency { dependencyType = NuGetType
-                            , dependencyName = "four"
-                            , dependencyVersion = Nothing
-                            , dependencyLocations = []
-                            , dependencyEnvironments = []
-                            , dependencyTags = M.empty
-                            }
+dependencyFour =
+  Dependency
+    { dependencyType = NuGetType,
+      dependencyName = "four",
+      dependencyVersion = Nothing,
+      dependencyLocations = [],
+      dependencyEnvironments = [],
+      dependencyTags = M.empty
+    }
 
 packageReference :: PackageReference
 packageReference = PackageReference itemGroupList
@@ -76,7 +85,7 @@ spec = do
         Left err -> expectationFailure (T.unpack ("could not parse package reference file" <> xmlErrorPretty err))
 
     it "constructs an accurate graph" $ do
-          let graph = buildGraph packageReference
-          expectDeps [dependencyOne, dependencyTwo, dependencyThree, dependencyFour] graph
-          expectDirect [dependencyOne, dependencyTwo, dependencyThree, dependencyFour] graph
-          expectEdges [] graph
+      let graph = buildGraph packageReference
+      expectDeps [dependencyOne, dependencyTwo, dependencyThree, dependencyFour] graph
+      expectDirect [dependencyOne, dependencyTwo, dependencyThree, dependencyFour] graph
+      expectEdges [] graph

--- a/test/NuGet/PackagesConfigSpec.hs
+++ b/test/NuGet/PackagesConfigSpec.hs
@@ -1,33 +1,38 @@
 module NuGet.PackagesConfigSpec
-  ( spec
-  ) where
+  ( spec,
+  )
+where
 
-import qualified Data.Map.Strict as M
-import qualified Data.Text as T
-import qualified Data.Text.IO as TIO
+import Data.Map.Strict qualified as M
+import Data.Text qualified as T
+import Data.Text.IO qualified as TIO
 import DepTypes
 import GraphUtil
-import Strategy.NuGet.PackagesConfig
 import Parse.XML
+import Strategy.NuGet.PackagesConfig
 import Test.Hspec
 
 dependencyOne :: Dependency
-dependencyOne = Dependency { dependencyType = NuGetType
-                        , dependencyName = "one"
-                        , dependencyVersion = Just (CEq "1.0.0")
-                        , dependencyLocations = []
-                        , dependencyEnvironments = []
-                        , dependencyTags = M.empty
-                        }
+dependencyOne =
+  Dependency
+    { dependencyType = NuGetType,
+      dependencyName = "one",
+      dependencyVersion = Just (CEq "1.0.0"),
+      dependencyLocations = [],
+      dependencyEnvironments = [],
+      dependencyTags = M.empty
+    }
 
 dependencyTwo :: Dependency
-dependencyTwo = Dependency { dependencyType = NuGetType
-                        , dependencyName = "two"
-                        , dependencyVersion = Just (CEq "2.0.0")
-                        , dependencyLocations = []
-                        , dependencyEnvironments = []
-                        , dependencyTags = M.empty
-                        }
+dependencyTwo =
+  Dependency
+    { dependencyType = NuGetType,
+      dependencyName = "two",
+      dependencyVersion = Just (CEq "2.0.0"),
+      dependencyLocations = [],
+      dependencyEnvironments = [],
+      dependencyTags = M.empty
+    }
 
 packagesConfig :: PackagesConfig
 packagesConfig = PackagesConfig depList
@@ -46,7 +51,7 @@ spec = do
         Left err -> expectationFailure (T.unpack ("could not parse packages.config file" <> xmlErrorPretty err))
 
     it "constructs an accurate graph" $ do
-          let graph = buildGraph packagesConfig
-          expectDeps [dependencyOne, dependencyTwo] graph
-          expectDirect [dependencyOne, dependencyTwo] graph
-          expectEdges [] graph
+      let graph = buildGraph packagesConfig
+      expectDeps [dependencyOne, dependencyTwo] graph
+      expectDirect [dependencyOne, dependencyTwo] graph
+      expectEdges [] graph

--- a/test/NuGet/PaketSpec.hs
+++ b/test/NuGet/PaketSpec.hs
@@ -1,88 +1,110 @@
 module NuGet.PaketSpec
-  ( spec
-  ) where
+  ( spec,
+  )
+where
 
-import qualified Data.Map.Strict as M
-import qualified Data.Text.IO as TIO
+import Data.Map.Strict qualified as M
+import Data.Text.IO qualified as TIO
 import DepTypes
 import GraphUtil
 import Strategy.NuGet.Paket
-import qualified Test.Hspec as T
+import Test.Hspec qualified as T
 import Text.Megaparsec
 
 dependencyOne :: Dependency
-dependencyOne = Dependency { dependencyType = NuGetType
-                           , dependencyName = "one"
-                           , dependencyVersion = Just (CEq "1.0.0")
-                           , dependencyLocations = ["nuget.com"]
-                           , dependencyEnvironments = []
-                           , dependencyTags = M.fromList [("location", ["NUGET"]), ("group", ["MAIN"])]
-                           }
+dependencyOne =
+  Dependency
+    { dependencyType = NuGetType,
+      dependencyName = "one",
+      dependencyVersion = Just (CEq "1.0.0"),
+      dependencyLocations = ["nuget.com"],
+      dependencyEnvironments = [],
+      dependencyTags = M.fromList [("location", ["NUGET"]), ("group", ["MAIN"])]
+    }
 
 dependencyTwo :: Dependency
-dependencyTwo = Dependency { dependencyType = NuGetType
-                           , dependencyName = "two"
-                           , dependencyVersion = Just (CEq "2.0.0")
-                           , dependencyLocations = ["nuget-v2.com", "nuget.com"]
-                           , dependencyEnvironments = []
-                           , dependencyTags = M.fromList [("location", ["NUGET"]), ("group", ["MAIN", "TEST"])]
-                           }
+dependencyTwo =
+  Dependency
+    { dependencyType = NuGetType,
+      dependencyName = "two",
+      dependencyVersion = Just (CEq "2.0.0"),
+      dependencyLocations = ["nuget-v2.com", "nuget.com"],
+      dependencyEnvironments = [],
+      dependencyTags = M.fromList [("location", ["NUGET"]), ("group", ["MAIN", "TEST"])]
+    }
 
 dependencyThree :: Dependency
-dependencyThree = Dependency { dependencyType = NuGetType
-                             , dependencyName = "three"
-                             , dependencyVersion = Just (CEq "3.0.0")
-                             , dependencyLocations = ["custom-site.com"]
-                             , dependencyEnvironments = []
-                             , dependencyTags = M.fromList [("location", ["HTTP"]), ("group", ["MAIN"])]
-                             }
+dependencyThree =
+  Dependency
+    { dependencyType = NuGetType,
+      dependencyName = "three",
+      dependencyVersion = Just (CEq "3.0.0"),
+      dependencyLocations = ["custom-site.com"],
+      dependencyEnvironments = [],
+      dependencyTags = M.fromList [("location", ["HTTP"]), ("group", ["MAIN"])]
+    }
 
 dependencyFour :: Dependency
-dependencyFour = Dependency { dependencyType = NuGetType
-                            , dependencyName = "four"
-                            , dependencyVersion = Just (CEq "4.0.0")
-                            , dependencyLocations = ["nuget-v2.com"]
-                            , dependencyEnvironments = []
-                            , dependencyTags = M.fromList [("location", ["NUGET"]), ("group", ["TEST"])]
-                            }
+dependencyFour =
+  Dependency
+    { dependencyType = NuGetType,
+      dependencyName = "four",
+      dependencyVersion = Just (CEq "4.0.0"),
+      dependencyLocations = ["nuget-v2.com"],
+      dependencyEnvironments = [],
+      dependencyTags = M.fromList [("location", ["NUGET"]), ("group", ["TEST"])]
+    }
 
 dependencyFive :: Dependency
-dependencyFive = Dependency { dependencyType = NuGetType
-                            , dependencyName = "five"
-                            , dependencyVersion = Just (CEq "5.0.0")
-                            , dependencyLocations = ["nuget-v2.com"]
-                            , dependencyEnvironments = []
-                            , dependencyTags = M.fromList [("location", ["NUGET"]), ("group", ["TEST"])]
-                            }
+dependencyFive =
+  Dependency
+    { dependencyType = NuGetType,
+      dependencyName = "five",
+      dependencyVersion = Just (CEq "5.0.0"),
+      dependencyLocations = ["nuget-v2.com"],
+      dependencyEnvironments = [],
+      dependencyTags = M.fromList [("location", ["NUGET"]), ("group", ["TEST"])]
+    }
 
 dependencySix :: Dependency
-dependencySix = Dependency { dependencyType = NuGetType
-                           , dependencyName = "six"
-                           , dependencyVersion = Just (CEq "6.0.0")
-                           , dependencyLocations = ["github.com"]
-                           , dependencyEnvironments = []
-                           , dependencyTags = M.fromList [("location", ["GITHUB"]), ("group", ["TEST"])]
-                           }
+dependencySix =
+  Dependency
+    { dependencyType = NuGetType,
+      dependencyName = "six",
+      dependencyVersion = Just (CEq "6.0.0"),
+      dependencyLocations = ["github.com"],
+      dependencyEnvironments = [],
+      dependencyTags = M.fromList [("location", ["GITHUB"]), ("group", ["TEST"])]
+    }
 
 nugetSection :: Section
-nugetSection = StandardSection "NUGET" [Remote "nuget.com" [PaketDep "one" "1.0.0" ["two"]
-                                                , PaketDep "two" "2.0.0" []
-                                                ]]
+nugetSection =
+  StandardSection
+    "NUGET"
+    [ Remote
+        "nuget.com"
+        [ PaketDep "one" "1.0.0" ["two"],
+          PaketDep "two" "2.0.0" []
+        ]
+    ]
 
 httpSection :: Section
 httpSection = StandardSection "HTTP" [Remote "custom-site.com" [PaketDep "three" "3.0.0" []]]
 
 nugetGroupRemote :: Remote
-nugetGroupRemote = Remote "nuget-v2.com" [PaketDep "four" "4.0.0" ["five"]
-                                         , PaketDep "five" "5.0.0" []
-                                         , PaketDep "two" "2.0.0" []
-                                         ]
+nugetGroupRemote =
+  Remote
+    "nuget-v2.com"
+    [ PaketDep "four" "4.0.0" ["five"],
+      PaketDep "five" "5.0.0" [],
+      PaketDep "two" "2.0.0" []
+    ]
 
 gitGroupRemote :: Remote
 gitGroupRemote = Remote "github.com" [PaketDep "six" "6.0.0" []]
 
 groupSection :: Section
-groupSection = GroupSection "TEST" [ StandardSection "NUGET" [nugetGroupRemote], StandardSection "GITHUB" [gitGroupRemote] ]
+groupSection = GroupSection "TEST" [StandardSection "NUGET" [nugetGroupRemote], StandardSection "GITHUB" [gitGroupRemote]]
 
 paketLockSections :: [Section]
 paketLockSections = [nugetSection, httpSection, groupSection]
@@ -95,9 +117,11 @@ spec = do
 
       expectDeps [dependencyOne, dependencyTwo, dependencyThree, dependencyFour, dependencyFive, dependencySix] graph
       expectDirect [dependencyOne, dependencyTwo, dependencyThree, dependencyFour, dependencyFive, dependencySix] graph
-      expectEdges [ (dependencyOne, dependencyTwo)
-                  , (dependencyFour, dependencyFive)
-                  ] graph
+      expectEdges
+        [ (dependencyOne, dependencyTwo),
+          (dependencyFour, dependencyFive)
+        ]
+        graph
 
   paketLockFile <- T.runIO (TIO.readFile "test/NuGet/testdata/paket.lock")
   T.describe "paket lock parser" $
@@ -105,6 +129,6 @@ spec = do
       case runParser findSections "" paketLockFile of
         Left _ -> T.expectationFailure "failed to parse"
         Right result -> do
-            result `T.shouldContain` [nugetSection]
-            result `T.shouldContain` [httpSection]
-            result `T.shouldContain` [groupSection]
+          result `T.shouldContain` [nugetSection]
+          result `T.shouldContain` [httpSection]
+          result `T.shouldContain` [groupSection]

--- a/test/NuGet/ProjectAssetsJsonSpec.hs
+++ b/test/NuGet/ProjectAssetsJsonSpec.hs
@@ -1,50 +1,59 @@
 module NuGet.ProjectAssetsJsonSpec
-  ( spec
-  ) where
+  ( spec,
+  )
+where
 
 import Data.Aeson
-import qualified Data.ByteString as BS
-import qualified Data.Map.Strict as M
+import Data.ByteString qualified as BS
+import Data.Map.Strict qualified as M
 import DepTypes
 import GraphUtil
 import Strategy.NuGet.ProjectAssetsJson
 import Test.Hspec
 
 dependencyOne :: Dependency
-dependencyOne = Dependency { dependencyType = NuGetType
-                        , dependencyName = "one"
-                        , dependencyVersion = Just (CEq "1.0.0")
-                        , dependencyLocations = []
-                        , dependencyEnvironments = []
-                        , dependencyTags = M.empty
-                        }
+dependencyOne =
+  Dependency
+    { dependencyType = NuGetType,
+      dependencyName = "one",
+      dependencyVersion = Just (CEq "1.0.0"),
+      dependencyLocations = [],
+      dependencyEnvironments = [],
+      dependencyTags = M.empty
+    }
 
 dependencyTwo :: Dependency
-dependencyTwo = Dependency { dependencyType = NuGetType
-                        , dependencyName = "two"
-                        , dependencyVersion = Just (CEq "2.0.0")
-                        , dependencyLocations = []
-                        , dependencyEnvironments = []
-                        , dependencyTags = M.empty
-                        }
+dependencyTwo =
+  Dependency
+    { dependencyType = NuGetType,
+      dependencyName = "two",
+      dependencyVersion = Just (CEq "2.0.0"),
+      dependencyLocations = [],
+      dependencyEnvironments = [],
+      dependencyTags = M.empty
+    }
 
 dependencyThree :: Dependency
-dependencyThree = Dependency { dependencyType = NuGetType
-                        , dependencyName = "three"
-                        , dependencyVersion = Just (CEq "3.0.0")
-                        , dependencyLocations = []
-                        , dependencyEnvironments = []
-                        , dependencyTags = M.empty
-                        }
+dependencyThree =
+  Dependency
+    { dependencyType = NuGetType,
+      dependencyName = "three",
+      dependencyVersion = Just (CEq "3.0.0"),
+      dependencyLocations = [],
+      dependencyEnvironments = [],
+      dependencyTags = M.empty
+    }
 
 dependencyFour :: Dependency
-dependencyFour = Dependency { dependencyType = NuGetType
-                        , dependencyName = "four"
-                        , dependencyVersion = Just (CEq "4.0.0")
-                        , dependencyLocations = []
-                        , dependencyEnvironments = []
-                        , dependencyTags = M.empty
-                        }
+dependencyFour =
+  Dependency
+    { dependencyType = NuGetType,
+      dependencyName = "four",
+      dependencyVersion = Just (CEq "4.0.0"),
+      dependencyLocations = [],
+      dependencyEnvironments = [],
+      dependencyTags = M.empty
+    }
 
 spec :: Spec
 spec = do
@@ -54,8 +63,8 @@ spec = do
     it "reads a file and constructs an accurate graph" $ do
       case eitherDecodeStrict testFile of
         Right res -> do
-              let graph = buildGraph res
-              expectDeps [dependencyOne, dependencyTwo, dependencyThree, dependencyFour] graph
-              expectDirect [dependencyOne, dependencyTwo, dependencyFour] graph
-              expectEdges [ (dependencyOne, dependencyThree) ] graph
+          let graph = buildGraph res
+          expectDeps [dependencyOne, dependencyTwo, dependencyThree, dependencyFour] graph
+          expectDirect [dependencyOne, dependencyTwo, dependencyFour] graph
+          expectEdges [(dependencyOne, dependencyThree)] graph
         Left _ -> expectationFailure "failed to parse"

--- a/test/NuGet/ProjectJsonSpec.hs
+++ b/test/NuGet/ProjectJsonSpec.hs
@@ -1,41 +1,48 @@
 module NuGet.ProjectJsonSpec
-  ( spec
-  ) where
+  ( spec,
+  )
+where
 
 import Data.Aeson
-import qualified Data.ByteString as BS
-import qualified Data.Map.Strict as M
+import Data.ByteString qualified as BS
+import Data.Map.Strict qualified as M
 import DepTypes
 import GraphUtil
 import Strategy.NuGet.ProjectJson
 import Test.Hspec
 
 dependencyOne :: Dependency
-dependencyOne = Dependency { dependencyType = NuGetType
-                        , dependencyName = "one"
-                        , dependencyVersion = Just (CEq "1.0.0")
-                        , dependencyLocations = []
-                        , dependencyEnvironments = []
-                        , dependencyTags = M.empty
-                        }
+dependencyOne =
+  Dependency
+    { dependencyType = NuGetType,
+      dependencyName = "one",
+      dependencyVersion = Just (CEq "1.0.0"),
+      dependencyLocations = [],
+      dependencyEnvironments = [],
+      dependencyTags = M.empty
+    }
 
 dependencyTwo :: Dependency
-dependencyTwo = Dependency { dependencyType = NuGetType
-                        , dependencyName = "two"
-                        , dependencyVersion = Just (CCompatible "2.*")
-                        , dependencyLocations = []
-                        , dependencyEnvironments = []
-                        , dependencyTags = M.empty
-                        }
+dependencyTwo =
+  Dependency
+    { dependencyType = NuGetType,
+      dependencyName = "two",
+      dependencyVersion = Just (CCompatible "2.*"),
+      dependencyLocations = [],
+      dependencyEnvironments = [],
+      dependencyTags = M.empty
+    }
 
 dependencyThree :: Dependency
-dependencyThree = Dependency { dependencyType = NuGetType
-                        , dependencyName = "three"
-                        , dependencyVersion = Just (CEq "3.0.0")
-                        , dependencyLocations = []
-                        , dependencyEnvironments = []
-                        , dependencyTags = M.fromList [ ("type", ["sometype"]) ]
-                        }
+dependencyThree =
+  Dependency
+    { dependencyType = NuGetType,
+      dependencyName = "three",
+      dependencyVersion = Just (CEq "3.0.0"),
+      dependencyLocations = [],
+      dependencyEnvironments = [],
+      dependencyTags = M.fromList [("type", ["sometype"])]
+    }
 
 spec :: Spec
 spec = do
@@ -45,8 +52,8 @@ spec = do
     it "reads a file and constructs an accurate graph" $ do
       case eitherDecodeStrict testFile of
         Right res -> do
-              let graph = buildGraph res
-              expectDeps [dependencyOne, dependencyTwo, dependencyThree] graph
-              expectDirect [dependencyOne, dependencyTwo, dependencyThree] graph
-              expectEdges [] graph
+          let graph = buildGraph res
+          expectDeps [dependencyOne, dependencyTwo, dependencyThree] graph
+          expectDirect [dependencyOne, dependencyTwo, dependencyThree] graph
+          expectEdges [] graph
         Left _ -> expectationFailure "failed to parse"

--- a/test/Python/PipenvSpec.hs
+++ b/test/Python/PipenvSpec.hs
@@ -1,101 +1,124 @@
 module Python.PipenvSpec
-  ( spec
-  ) where
+  ( spec,
+  )
+where
 
-import qualified Data.Map.Strict as M
+import Data.Aeson (eitherDecodeStrict)
+import Data.ByteString qualified as BS
+import Data.Map.Strict qualified as M
 import DepTypes
 import GraphUtil
 import Strategy.Python.Pipenv
 import Test.Hspec hiding (xit)
-import Data.Aeson (eitherDecodeStrict)
-import qualified Data.ByteString as BS
 
 pipfileLock :: PipfileLock
-pipfileLock = PipfileLock
-  { fileMeta    = PipfileMeta
-    [ PipfileSource { sourceName = "package-index"
-                    , sourceUrl  = "https://my-package-index/"
-                    }
-    ]
-
-  , fileDefault = M.fromList
-    [ ("pkgTwo", PipfileDep { fileDepVersion = Just "==2.0.0"
-                            , fileDepIndex = Just "package-index"
-                            })
-    , ("pkgThree", PipfileDep { fileDepVersion = Just "==3.0.0"
-                              , fileDepIndex = Nothing
-                              })
-    , ("pkgFour", PipfileDep { fileDepVersion = Nothing
-                              , fileDepIndex = Nothing
-                              })
-    ]
-
-  , fileDevelop = M.fromList
-    [ ("pkgOne", PipfileDep { fileDepVersion = Just "==1.0.0"
-                            , fileDepIndex = Nothing
-                            })
-    ]
-  }
+pipfileLock =
+  PipfileLock
+    { fileMeta =
+        PipfileMeta
+          [ PipfileSource
+              { sourceName = "package-index",
+                sourceUrl = "https://my-package-index/"
+              }
+          ],
+      fileDefault =
+        M.fromList
+          [ ( "pkgTwo",
+              PipfileDep
+                { fileDepVersion = Just "==2.0.0",
+                  fileDepIndex = Just "package-index"
+                }
+            ),
+            ( "pkgThree",
+              PipfileDep
+                { fileDepVersion = Just "==3.0.0",
+                  fileDepIndex = Nothing
+                }
+            ),
+            ( "pkgFour",
+              PipfileDep
+                { fileDepVersion = Nothing,
+                  fileDepIndex = Nothing
+                }
+            )
+          ],
+      fileDevelop =
+        M.fromList
+          [ ( "pkgOne",
+              PipfileDep
+                { fileDepVersion = Just "==1.0.0",
+                  fileDepIndex = Nothing
+                }
+            )
+          ]
+    }
 
 pipenvOutput :: [PipenvGraphDep]
 pipenvOutput =
-  [ PipenvGraphDep { depName         = "pkgOne"
-                   , depInstalled    = "1.0.0"
-                   , depRequired     = "==1.0.0"
-                   , depDependencies = []
-                   }
-  , PipenvGraphDep { depName = "pkgTwo"
-                   , depInstalled = "2.0.0"
-                   , depRequired = "==2.0.0"
-                   , depDependencies =
-                     [ PipenvGraphDep { depName      = "pkgThree"
-                                      , depInstalled = "3.0.0"
-                                      , depRequired  = "==3.0.0"
-                                      , depDependencies = []
-                                      }
-                     ]
-                   }
+  [ PipenvGraphDep
+      { depName = "pkgOne",
+        depInstalled = "1.0.0",
+        depRequired = "==1.0.0",
+        depDependencies = []
+      },
+    PipenvGraphDep
+      { depName = "pkgTwo",
+        depInstalled = "2.0.0",
+        depRequired = "==2.0.0",
+        depDependencies =
+          [ PipenvGraphDep
+              { depName = "pkgThree",
+                depInstalled = "3.0.0",
+                depRequired = "==3.0.0",
+                depDependencies = []
+              }
+          ]
+      }
   ]
 
 depOne :: Dependency
-depOne = Dependency
-  { dependencyType = PipType
-  , dependencyName = "pkgOne"
-  , dependencyVersion = Just (CEq "1.0.0")
-  , dependencyLocations = []
-  , dependencyEnvironments = [EnvDevelopment]
-  , dependencyTags = M.empty
-  }
+depOne =
+  Dependency
+    { dependencyType = PipType,
+      dependencyName = "pkgOne",
+      dependencyVersion = Just (CEq "1.0.0"),
+      dependencyLocations = [],
+      dependencyEnvironments = [EnvDevelopment],
+      dependencyTags = M.empty
+    }
 
 depTwo :: Dependency
-depTwo = Dependency
-  { dependencyType = PipType
-  , dependencyName = "pkgTwo"
-  , dependencyVersion = Just (CEq "2.0.0")
-  , dependencyLocations = ["https://my-package-index/"]
-  , dependencyEnvironments = [EnvProduction]
-  , dependencyTags = M.empty
-  }
+depTwo =
+  Dependency
+    { dependencyType = PipType,
+      dependencyName = "pkgTwo",
+      dependencyVersion = Just (CEq "2.0.0"),
+      dependencyLocations = ["https://my-package-index/"],
+      dependencyEnvironments = [EnvProduction],
+      dependencyTags = M.empty
+    }
 
 depThree :: Dependency
-depThree = Dependency
-  { dependencyType = PipType
-  , dependencyName = "pkgThree"
-  , dependencyVersion = Just (CEq "3.0.0")
-  , dependencyLocations = []
-  , dependencyEnvironments = [EnvProduction]
-  , dependencyTags = M.empty
-  }
+depThree =
+  Dependency
+    { dependencyType = PipType,
+      dependencyName = "pkgThree",
+      dependencyVersion = Just (CEq "3.0.0"),
+      dependencyLocations = [],
+      dependencyEnvironments = [EnvProduction],
+      dependencyTags = M.empty
+    }
 
 depFour :: Dependency
-depFour = Dependency
-  { dependencyType = PipType
-  , dependencyName = "pkgFour"
-  , dependencyVersion = Nothing
-  , dependencyLocations = []
-  , dependencyEnvironments = [EnvProduction]
-  , dependencyTags = M.empty
-  }
+depFour =
+  Dependency
+    { dependencyType = PipType,
+      dependencyName = "pkgFour",
+      dependencyVersion = Nothing,
+      dependencyLocations = [],
+      dependencyEnvironments = [EnvProduction],
+      dependencyTags = M.empty
+    }
 
 xit :: String -> Expectation -> SpecWith (Arg Expectation)
 xit _ _ = it "is an ignored test" $ () `shouldBe` ()

--- a/test/Python/ReqTxtSpec.hs
+++ b/test/Python/ReqTxtSpec.hs
@@ -1,53 +1,67 @@
 {-# LANGUAGE QuasiQuotes #-}
 
 module Python.ReqTxtSpec
-  ( spec
-  ) where
+  ( spec,
+  )
+where
 
-import qualified Data.Map.Strict as M
-import Text.URI.QQ (uri)
-
+import Data.Map.Strict qualified as M
 import DepTypes
 import Effect.Grapher
 import Graphing (Graphing)
 import Strategy.Python.Util
-
 import Test.Hspec
+import Text.URI.QQ (uri)
 
 setupPyInput :: [Req]
 setupPyInput =
-  [ NameReq "pkgOne" Nothing (Just [ Version OpGtEq "1.0.0"
-                                   , Version OpLt   "2.0.0"
-                                   ]) Nothing
-  , NameReq "pkgTwo" Nothing Nothing Nothing
-  , UrlReq "pkgThree" Nothing [uri|https://example.com|] Nothing
+  [ NameReq
+      "pkgOne"
+      Nothing
+      ( Just
+          [ Version OpGtEq "1.0.0",
+            Version OpLt "2.0.0"
+          ]
+      )
+      Nothing,
+    NameReq "pkgTwo" Nothing Nothing Nothing,
+    UrlReq "pkgThree" Nothing [uri|https://example.com|] Nothing
   ]
 
 expected :: Graphing Dependency
 expected = run . evalGrapher $ do
-  direct $ Dependency { dependencyType = PipType
-                      , dependencyName = "pkgOne"
-                      , dependencyVersion =
-                          Just (CAnd (CGreaterOrEq "1.0.0")
-                                     (CLess "2.0.0"))
-                      , dependencyLocations = []
-                      , dependencyEnvironments = []
-                      , dependencyTags = M.empty
-                      }
-  direct $ Dependency { dependencyType = PipType
-                      , dependencyName = "pkgTwo"
-                      , dependencyVersion = Nothing
-                      , dependencyLocations = []
-                      , dependencyEnvironments = []
-                      , dependencyTags = M.empty
-                      }
-  direct $ Dependency { dependencyType = PipType
-                      , dependencyName = "pkgThree"
-                      , dependencyVersion = Just (CURI "https://example.com")
-                      , dependencyLocations = []
-                      , dependencyEnvironments = []
-                      , dependencyTags = M.empty
-                      }
+  direct $
+    Dependency
+      { dependencyType = PipType,
+        dependencyName = "pkgOne",
+        dependencyVersion =
+          Just
+            ( CAnd
+                (CGreaterOrEq "1.0.0")
+                (CLess "2.0.0")
+            ),
+        dependencyLocations = [],
+        dependencyEnvironments = [],
+        dependencyTags = M.empty
+      }
+  direct $
+    Dependency
+      { dependencyType = PipType,
+        dependencyName = "pkgTwo",
+        dependencyVersion = Nothing,
+        dependencyLocations = [],
+        dependencyEnvironments = [],
+        dependencyTags = M.empty
+      }
+  direct $
+    Dependency
+      { dependencyType = PipType,
+        dependencyName = "pkgThree",
+        dependencyVersion = Just (CURI "https://example.com"),
+        dependencyLocations = [],
+        dependencyEnvironments = [],
+        dependencyTags = M.empty
+      }
 
 spec :: Spec
 spec =

--- a/test/Python/RequirementsSpec.hs
+++ b/test/Python/RequirementsSpec.hs
@@ -3,18 +3,18 @@ module Python.RequirementsSpec
   )
 where
 
-import Data.Foldable ( traverse_ )
+import Data.Foldable (traverse_)
+import Data.Map.Strict qualified as M
 import Data.Text (Text)
-import Strategy.Python.Util (requirementParser, buildGraph)
+import Data.Text.IO qualified as TIO
+import DepTypes
+import GraphUtil (expectDeps)
 import Strategy.Python.ReqTxt (requirementsTxtParser)
+import Strategy.Python.Util (buildGraph, requirementParser)
+import Test.Hspec qualified as T
 import Test.Hspec.Megaparsec
 import Text.Megaparsec
 import Prelude
-import DepTypes
-import qualified Data.Map.Strict as M
-import qualified Data.Text.IO as TIO
-import qualified Test.Hspec as T
-import GraphUtil (expectDeps)
 
 examples :: [Text]
 examples =
@@ -36,46 +36,54 @@ examples =
   ]
 
 depOne :: Dependency
-depOne = Dependency { dependencyType = PipType
-                        , dependencyName = "one"
-                        , dependencyVersion = Just (CEq "1.0")
-                        , dependencyLocations = []
-                        , dependencyEnvironments = []
-                        , dependencyTags = M.empty
-                        }
+depOne =
+  Dependency
+    { dependencyType = PipType,
+      dependencyName = "one",
+      dependencyVersion = Just (CEq "1.0"),
+      dependencyLocations = [],
+      dependencyEnvironments = [],
+      dependencyTags = M.empty
+    }
 
 depTwo :: Dependency
-depTwo = Dependency { dependencyType = PipType
-                        , dependencyName = "two"
-                        , dependencyVersion = Just (CLessOrEq "2.0.0")
-                        , dependencyLocations = []
-                        , dependencyEnvironments = []
-                        , dependencyTags = M.empty
-                        }
+depTwo =
+  Dependency
+    { dependencyType = PipType,
+      dependencyName = "two",
+      dependencyVersion = Just (CLessOrEq "2.0.0"),
+      dependencyLocations = [],
+      dependencyEnvironments = [],
+      dependencyTags = M.empty
+    }
 
 depThree :: Dependency
-depThree = Dependency { dependencyType = PipType
-                        , dependencyName = "three"
-                        , dependencyVersion = Just (CEq "3.0.0")
-                        , dependencyLocations = []
-                        , dependencyEnvironments = []
-                        , dependencyTags = M.empty
-                        }
+depThree =
+  Dependency
+    { dependencyType = PipType,
+      dependencyName = "three",
+      dependencyVersion = Just (CEq "3.0.0"),
+      dependencyLocations = [],
+      dependencyEnvironments = [],
+      dependencyTags = M.empty
+    }
 
 depFour :: Dependency
-depFour = Dependency { dependencyType = PipType
-                        , dependencyName = "four"
-                        , dependencyVersion = Just (CEq "4.0.0")
-                        , dependencyLocations = []
-                        , dependencyEnvironments = []
-                        , dependencyTags = M.empty
-                        }
+depFour =
+  Dependency
+    { dependencyType = PipType,
+      dependencyName = "four",
+      dependencyVersion = Just (CEq "4.0.0"),
+      dependencyLocations = [],
+      dependencyEnvironments = [],
+      dependencyTags = M.empty
+    }
 
 spec :: T.Spec
 spec = do
-  T.describe "requirementParser"
-    $ T.it "can parse the edge case examples"
-    $ traverse_ (\input -> runParser requirementParser "" `shouldSucceedOn` input) examples
+  T.describe "requirementParser" $
+    T.it "can parse the edge case examples" $
+      traverse_ (\input -> runParser requirementParser "" `shouldSucceedOn` input) examples
 
   requirementsTextFile <- T.runIO (TIO.readFile "test/Python/testdata/req.txt")
   T.describe "req file" $

--- a/test/Python/SetupPySpec.hs
+++ b/test/Python/SetupPySpec.hs
@@ -1,53 +1,67 @@
 {-# LANGUAGE QuasiQuotes #-}
 
 module Python.SetupPySpec
-  ( spec
-  ) where
+  ( spec,
+  )
+where
 
-import qualified Data.Map.Strict as M
-import Text.URI.QQ (uri)
-
+import Data.Map.Strict qualified as M
 import DepTypes
 import Effect.Grapher
 import Graphing (Graphing)
 import Strategy.Python.Util
-
 import Test.Hspec
+import Text.URI.QQ (uri)
 
 setupPyInput :: [Req]
 setupPyInput =
-  [ NameReq "pkgOne" Nothing (Just [ Version OpGtEq "1.0.0"
-                                   , Version OpLt   "2.0.0"
-                                   ]) Nothing
-  , NameReq "pkgTwo" Nothing Nothing Nothing
-  , UrlReq "pkgThree" Nothing [uri|https://example.com|] Nothing
+  [ NameReq
+      "pkgOne"
+      Nothing
+      ( Just
+          [ Version OpGtEq "1.0.0",
+            Version OpLt "2.0.0"
+          ]
+      )
+      Nothing,
+    NameReq "pkgTwo" Nothing Nothing Nothing,
+    UrlReq "pkgThree" Nothing [uri|https://example.com|] Nothing
   ]
 
 expected :: Graphing Dependency
 expected = run . evalGrapher $ do
-  direct $ Dependency { dependencyType = PipType
-                      , dependencyName = "pkgOne"
-                      , dependencyVersion =
-                          Just (CAnd (CGreaterOrEq "1.0.0")
-                                     (CLess "2.0.0"))
-                      , dependencyLocations = []
-                      , dependencyEnvironments = []
-                      , dependencyTags = M.empty
-                      }
-  direct $ Dependency { dependencyType = PipType
-                      , dependencyName = "pkgTwo"
-                      , dependencyVersion = Nothing
-                      , dependencyLocations = []
-                      , dependencyEnvironments = []
-                      , dependencyTags = M.empty
-                      }
-  direct $ Dependency { dependencyType = PipType
-                      , dependencyName = "pkgThree"
-                      , dependencyVersion = Just (CURI "https://example.com")
-                      , dependencyLocations = []
-                      , dependencyEnvironments = []
-                      , dependencyTags = M.empty
-                      }
+  direct $
+    Dependency
+      { dependencyType = PipType,
+        dependencyName = "pkgOne",
+        dependencyVersion =
+          Just
+            ( CAnd
+                (CGreaterOrEq "1.0.0")
+                (CLess "2.0.0")
+            ),
+        dependencyLocations = [],
+        dependencyEnvironments = [],
+        dependencyTags = M.empty
+      }
+  direct $
+    Dependency
+      { dependencyType = PipType,
+        dependencyName = "pkgTwo",
+        dependencyVersion = Nothing,
+        dependencyLocations = [],
+        dependencyEnvironments = [],
+        dependencyTags = M.empty
+      }
+  direct $
+    Dependency
+      { dependencyType = PipType,
+        dependencyName = "pkgThree",
+        dependencyVersion = Just (CURI "https://example.com"),
+        dependencyLocations = [],
+        dependencyEnvironments = [],
+        dependencyTags = M.empty
+      }
 
 spec :: Spec
 spec =

--- a/test/RPM/SpecFileSpec.hs
+++ b/test/RPM/SpecFileSpec.hs
@@ -5,11 +5,11 @@ where
 
 import Data.Maybe (listToMaybe)
 import Data.Text (Text)
-import qualified Data.Text.IO as TIO
+import Data.Text.IO qualified as TIO
 import DepTypes
 import GraphUtil
 import Strategy.RPM
-import qualified Test.Hspec as Test
+import Test.Hspec qualified as Test
 
 mkUnVerDep :: Text -> RPMDependency
 mkUnVerDep name = RPMDependency name Nothing
@@ -73,11 +73,11 @@ spec = do
       depBuildRequires deps `Test.shouldMatchList` buildDeps
       listToMaybe (depRuntimeRequires deps) `Test.shouldBe` Just tacpDep
   --
-  Test.describe "line parser"
-    $ Test.it "should parse single lines correctly"
-    $ do
-      getTypeFromLine "BuildRequires: xz = 1" `Test.shouldBe` Just (BuildRequires $ mkVerDep "xz" $ CEq "1")
-      getTypeFromLine "Requires: xz = 1" `Test.shouldBe` Just (RuntimeRequires $ mkVerDep "xz" $ CEq "1")
+  Test.describe "line parser" $
+    Test.it "should parse single lines correctly" $
+      do
+        getTypeFromLine "BuildRequires: xz = 1" `Test.shouldBe` Just (BuildRequires $ mkVerDep "xz" $ CEq "1")
+        getTypeFromLine "Requires: xz = 1" `Test.shouldBe` Just (RuntimeRequires $ mkVerDep "xz" $ CEq "1")
   --
   Test.describe "rpm dependency grapher" $
     Test.it "should produce flat RuntimeRequires" $ do

--- a/test/Ruby/BundleShowSpec.hs
+++ b/test/Ruby/BundleShowSpec.hs
@@ -1,45 +1,48 @@
 module Ruby.BundleShowSpec
-  ( spec
-  ) where
+  ( spec,
+  )
+where
 
-import qualified Data.Map.Strict as M
-import qualified Data.Text.IO as TIO
-import Text.Megaparsec
-
+import Data.Map.Strict qualified as M
+import Data.Text.IO qualified as TIO
 import DepTypes
 import Effect.Grapher
 import Graphing (Graphing)
 import Strategy.Ruby.BundleShow
-
 import Test.Hspec
+import Text.Megaparsec
 
 expected :: Graphing Dependency
 expected = run . evalGrapher $ do
-  direct $ Dependency { dependencyType = GemType
-                      , dependencyName = "pkgOne"
-                      , dependencyVersion = Just (CEq "1.0.0")
-                      , dependencyLocations = []
-                      , dependencyEnvironments = []
-                      , dependencyTags = M.empty
-                      }
-  direct $ Dependency { dependencyType = GemType
-                      , dependencyName = "pkgTwo"
-                      , dependencyVersion = Just (CEq "2.0.0")
-                      , dependencyLocations = []
-                      , dependencyEnvironments = []
-                      , dependencyTags = M.empty
-                      }
+  direct $
+    Dependency
+      { dependencyType = GemType,
+        dependencyName = "pkgOne",
+        dependencyVersion = Just (CEq "1.0.0"),
+        dependencyLocations = [],
+        dependencyEnvironments = [],
+        dependencyTags = M.empty
+      }
+  direct $
+    Dependency
+      { dependencyType = GemType,
+        dependencyName = "pkgTwo",
+        dependencyVersion = Just (CEq "2.0.0"),
+        dependencyLocations = [],
+        dependencyEnvironments = [],
+        dependencyTags = M.empty
+      }
 
 bundleShowOutput :: [BundleShowDep]
 bundleShowOutput =
   [ BundleShowDep
-    { depName = "pkgOne"
-    , depVersion = "1.0.0"
-    }
-  , BundleShowDep
-    { depName = "pkgTwo"
-    , depVersion = "2.0.0"
-    }
+      { depName = "pkgOne",
+        depVersion = "1.0.0"
+      },
+    BundleShowDep
+      { depName = "pkgTwo",
+        depVersion = "2.0.0"
+      }
   ]
 
 spec :: Spec

--- a/test/Ruby/GemfileLockSpec.hs
+++ b/test/Ruby/GemfileLockSpec.hs
@@ -1,69 +1,90 @@
 module Ruby.GemfileLockSpec
-  ( spec
-  ) where
+  ( spec,
+  )
+where
 
-import qualified Data.Map.Strict as M
-import qualified Data.Text.IO as TIO
+import Data.Map.Strict qualified as M
+import Data.Text.IO qualified as TIO
 import DepTypes
 import GraphUtil
 import Strategy.Ruby.GemfileLock
-import qualified Test.Hspec as T
+import Test.Hspec qualified as T
 import Text.Megaparsec
 
 dependencyOne :: Dependency
-dependencyOne = Dependency { dependencyType = GemType
-                        , dependencyName = "dep-one"
-                        , dependencyVersion = Just (CEq "1.0.0")
-                        , dependencyLocations = ["temp@12345"]
-                        , dependencyEnvironments = []
-                        , dependencyTags = M.empty
-                        }
+dependencyOne =
+  Dependency
+    { dependencyType = GemType,
+      dependencyName = "dep-one",
+      dependencyVersion = Just (CEq "1.0.0"),
+      dependencyLocations = ["temp@12345"],
+      dependencyEnvironments = [],
+      dependencyTags = M.empty
+    }
 
 dependencyTwo :: Dependency
-dependencyTwo = Dependency { dependencyType = GemType
-                        , dependencyName = "dep-two"
-                        , dependencyVersion = Just (CEq "2.0.0")
-                        , dependencyLocations = ["remote"]
-                        , dependencyEnvironments = []
-                        , dependencyTags = M.empty
-                        }
+dependencyTwo =
+  Dependency
+    { dependencyType = GemType,
+      dependencyName = "dep-two",
+      dependencyVersion = Just (CEq "2.0.0"),
+      dependencyLocations = ["remote"],
+      dependencyEnvironments = [],
+      dependencyTags = M.empty
+    }
 
 dependencyThree :: Dependency
-dependencyThree = Dependency { dependencyType = GemType
-                        , dependencyName = "dep-three"
-                        , dependencyVersion = Just (CEq "3.0.0")
-                        , dependencyLocations = ["remote"]
-                        , dependencyEnvironments = []
-                        , dependencyTags = M.empty
-                        }
+dependencyThree =
+  Dependency
+    { dependencyType = GemType,
+      dependencyName = "dep-three",
+      dependencyVersion = Just (CEq "3.0.0"),
+      dependencyLocations = ["remote"],
+      dependencyEnvironments = [],
+      dependencyTags = M.empty
+    }
 
 gitSection :: Section
-gitSection = GitSection "temp" (Just "12345") (Just "branch") [ Spec { specVersion = "1.0.0"
-                                                , specName = "dep-one"
-                                                , specDeps = [ SpecDep { depName = "dep-three" }
-                                                            , SpecDep { depName = "dep-two"}
-                                                            ]
-                                                }
-                                             ]
+gitSection =
+  GitSection
+    "temp"
+    (Just "12345")
+    (Just "branch")
+    [ Spec
+        { specVersion = "1.0.0",
+          specName = "dep-one",
+          specDeps =
+            [ SpecDep {depName = "dep-three"},
+              SpecDep {depName = "dep-two"}
+            ]
+        }
+    ]
 
 gemSection :: Section
-gemSection = GemSection "remote" [ Spec { specVersion = "2.0.0"
-                                        , specName = "dep-two"
-                                        , specDeps = [ SpecDep { depName = "dep-three" } ]
-                                        }
-                                 , Spec { specVersion = "3.0.0"
-                                        , specName = "dep-three"
-                                        , specDeps = []
-                                        }
-                                 ]
+gemSection =
+  GemSection
+    "remote"
+    [ Spec
+        { specVersion = "2.0.0",
+          specName = "dep-two",
+          specDeps = [SpecDep {depName = "dep-three"}]
+        },
+      Spec
+        { specVersion = "3.0.0",
+          specName = "dep-three",
+          specDeps = []
+        }
+    ]
 
 dependencySection :: Section
-dependencySection = DependencySection [ DirectDep { directName = "dep-one" }
-                                      , DirectDep { directName = "dep-two" }
-                                      ]
+dependencySection =
+  DependencySection
+    [ DirectDep {directName = "dep-one"},
+      DirectDep {directName = "dep-two"}
+    ]
 
 gemfileLockSection :: [Section]
-gemfileLockSection = [gitSection , gemSection, dependencySection]
+gemfileLockSection = [gitSection, gemSection, dependencySection]
 
 spec :: T.Spec
 spec = do
@@ -75,16 +96,18 @@ spec = do
 
       expectDeps [dependencyOne, dependencyTwo, dependencyThree] graph
       expectDirect [dependencyOne, dependencyTwo] graph
-      expectEdges [ (dependencyOne, dependencyTwo)
-                  , (dependencyOne, dependencyThree)
-                  , (dependencyTwo, dependencyThree)
-                  ] graph
+      expectEdges
+        [ (dependencyOne, dependencyTwo),
+          (dependencyOne, dependencyThree),
+          (dependencyTwo, dependencyThree)
+        ]
+        graph
 
   T.describe "gemfile lock parser" $ do
     T.it "parses error messages into an empty list" $ do
       case runParser findSections "" gemfileLock of
         Left _ -> T.expectationFailure "failed to parse"
         Right result -> do
-            result `T.shouldContain` [gitSection]
-            result `T.shouldContain` [dependencySection]
-            result `T.shouldContain` [gemSection]
+          result `T.shouldContain` [gitSection]
+          result `T.shouldContain` [dependencySection]
+          result `T.shouldContain` [gemSection]

--- a/test/UserSpecified/YamlDependenciesSpec.hs
+++ b/test/UserSpecified/YamlDependenciesSpec.hs
@@ -6,8 +6,8 @@ module UserSpecified.YamlDependenciesSpec
 where
 
 import Control.Algebra
-import qualified Data.ByteString as BS
-import qualified Data.Map.Strict as M
+import Data.ByteString qualified as BS
+import Data.Map.Strict qualified as M
 import Data.Yaml
 import DepTypes
 import Effect.Grapher


### PR DESCRIPTION
_Note: I do not intend to merge this, if we want to do this we can resubmit it later, this will conflict with current work.
You do not need to review this in depth, and doing so is a waste of time.  This is a POC pull request and will not be merged._

Here's what it looks like if we were to reformat the entire codebase using `ormolu`.

A few issues came up when running this naively:
- We use the `TypeApplications` extension everywhere, so many files failed initially.
- We have exactly 1 instance of postpositive qualified import, in `Strategy.Go.Transitive`.
  - postpositive import looks like `import Foo qualified as F` as opposed to the default (prepositive) of `import qualified Foo as F`
  - When we enable this extension to allow ormolu to scan this file, it picks up every prepositive import and converts it to postpositive.
 - `ormolu` DOES NOT pick up extensions from cabal, and may never do so.  We might need to script this in haskell using `cabal-the-library`.
 - `ormolu` DOES NOT currently attempt to recursively scan for files (in any mode), so invoking requires some file-finding scripting.
 - There was one instance of a re-ordered import causing a redundant import warning.

The final invocation which worked:
``` shell
ormolu \
  --check-idempotence \
  --mode inplace \
  --ghc-opt -XTypeApplications \
  --ghc-opt -XImportQualifiedPost \
  $(fd --type f '(src|test|app)/.*\.hs')
```

`fd` is [fd-find](https://github.com/sharkdp/fd), but any find tool can be used.  I was able to accomplish the same file list with shell globbing.

We should make a decision about post-positive vs. pre-positive qualified imports, and then apply that decision by either:
- Fixing the single postpositive import and rerunning with the default import style
- Not fixing it and converting every other import to postpositive (ormolu does it automatically)