### PR TITLE
Add --depth 1000 to npm ls

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,11 @@
-# Unreleased
+# v2.5.18
+
+- Add --depth 1000 to npm ls #240 ([#240](https://github.com/fossas/spectrometer/pull/240)))
+
+# v2.5.17
+
 - Fix `fossa container analyze` `--project` and `--revision` flags ([#238](https://github.com/fossas/spectrometer/pull/238)))
+
 # v2.5.16
 
 - Support for manually specified dependencies through `fossa-deps.yaml` ([#236](https://github.com/fossas/spectrometer/pull/236))

--- a/src/Strategy/Node/NpmList.hs
+++ b/src/Strategy/Node/NpmList.hs
@@ -15,7 +15,7 @@ import Path
 npmListCmd :: Command
 npmListCmd = Command
   { cmdName = "npm"
-  , cmdArgs = ["ls", "--json", "--production"]
+  , cmdArgs = ["ls", "--json", "--production", "--depth", "1000"]
   , cmdAllowErr = NonEmptyStdout
   }
 


### PR DESCRIPTION
# Overview

`npm ls` has started to only show depth of 0 as late as npm 7.8.0. This breaks standard npm analysis, fortunately adding `--depth 1000` shows the full dependency graph and is backward compatible. 1000 is arbitrary but it is a round number and enforces that we will always get the full dependency graph.

## Acceptance criteria

`npm ls --production --depth 1000` is run and in environments, with newer npm versions we are able to get deep dependencies.

## Testing plan

Set npm to 7.8.0, run spectrometer before updating the npm command, and compare the results to what I get after updating the npm command.

## Risks

I don't see any risks with this.

## Checklist

- [X] I updated `CHANGELOG.md`. If the PR did not mark a release, update the `#Unreleased section at the top`.
