### PR TITLE
PackageReference: parse version from xml attr

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,11 @@
+# Unreleased
+
+- Fixes the dependency version parser for `.csproj`, `.vbproj`, and similar .NET files ([#247](https://github.com/fossas/spectrometer/pull/247))
+
 # v2.7.0
 
 - Adds support for the Conda package manager ([#226](https://github.com/fossas/spectrometer/pull/226))
+
 # v2.6.0
 
 - Improves the output of `fossa analyze` by displaying the status of ongoing Project Discovery and Project Analysis tasks ([#241](https://github.com/fossas/spectrometer/pull/241))

--- a/src/Strategy/NuGet/PackageReference.hs
+++ b/src/Strategy/NuGet/PackageReference.hs
@@ -12,7 +12,7 @@ module Strategy.NuGet.PackageReference
   , Package(..)
   ) where
 
-import Control.Applicative (optional)
+import Control.Applicative (optional, (<|>))
 import Control.Effect.Diagnostics
 import Data.Foldable (find)
 import qualified Data.List as L
@@ -90,7 +90,7 @@ instance FromXML ItemGroup where
 instance FromXML Package where
   parseElement el =
     Package <$> attr "Include" el
-            <*> optional (attr "Version" el)
+            <*> optional (attr "Version" el <|> child "Version" el)
 
 buildGraph :: PackageReference -> Graphing Dependency
 buildGraph project = Graphing.fromList (map toDependency direct)

--- a/src/Strategy/NuGet/PackageReference.hs
+++ b/src/Strategy/NuGet/PackageReference.hs
@@ -83,10 +83,14 @@ instance FromXML PackageReference where
 instance FromXML ItemGroup where
   parseElement el = ItemGroup <$> children "PackageReference" el
 
+-- | A "PackageReference" xml tag
+--
+-- See: https://docs.microsoft.com/en-us/dotnet/core/project-sdk/msbuild-props#packagereference
+-- See: https://cloud.google.com/functions/docs/writing/specifying-dependencies-dotnet
 instance FromXML Package where
   parseElement el =
     Package <$> attr "Include" el
-            <*> optional (child "Version" el)
+            <*> optional (attr "Version" el)
 
 buildGraph :: PackageReference -> Graphing Dependency
 buildGraph project = Graphing.fromList (map toDependency direct)

--- a/test/NuGet/testdata/test.csproj
+++ b/test/NuGet/testdata/test.csproj
@@ -19,7 +19,9 @@
     <PackageReference Include="two" Version="2.0.0" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="three" Version="3.0.0" />
+    <PackageReference Include="three">
+      <Version>3.0.0</Version>
+    </PackageReference>
     <PackageReference Include="four">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/test/NuGet/testdata/test.csproj
+++ b/test/NuGet/testdata/test.csproj
@@ -15,17 +15,11 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="one">
-      <Version>1.0.0</Version>
-    </PackageReference>
-    <PackageReference Include="two">
-      <Version>2.0.0</Version>
-    </PackageReference>
+    <PackageReference Include="one" Version="1.0.0" />
+    <PackageReference Include="two" Version="2.0.0" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="three">
-      <Version>3.0.0</Version>
-    </PackageReference>
+    <PackageReference Include="three" Version="3.0.0" />
     <PackageReference Include="four">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
# Overview

In fossa-cli and here, we're parsing versions incorrectly in `.csproj`/`.vbproj`/etc files

We were looking for `Version` as a child element, when it's actually an attribute:
- https://docs.microsoft.com/en-us/dotnet/core/project-sdk/msbuild-props#packagereference
- https://cloud.google.com/functions/docs/writing/specifying-dependencies-dotnet

## Acceptance criteria

Versions are parsed correctly for packages in `PackageReference` elements

## Testing plan

The relevant test file was updated
