### PR TITLE
Display `fossa test`/`fossa report`/etc status updates by default in ansi-incompatible terminals

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - Fixes the dependency version parser for `.csproj`, `.vbproj`, and similar .NET files ([#247](https://github.com/fossas/spectrometer/pull/247))
+- Re-enables status messages for commands like `fossa test` in CI environments ([#248](https://github.com/fossas/spectrometer/pull/248))
 
 # v2.7.0
 

--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -217,7 +217,7 @@ analyze (BaseDir basedir) destination override unpackArchives filters = do
 
   (projectResults, ()) <-
     runOutput @ProjectResult
-      . runStickyLogger
+      . runStickyLogger SevInfo
       . runFinally
       . withTaskPool capabilities updateProgress
       . runAtomicCounter

--- a/src/App/Fossa/Compatibility.hs
+++ b/src/App/Fossa/Compatibility.hs
@@ -29,7 +29,7 @@ compatibilityMain ::
   [Argument] ->
   IO ()
 compatibilityMain args = withDefaultLogger SevInfo . runExecIO . withCLIv1Binary $ \v1Bin -> do
-  cmd <- runStickyLogger $ do
+  cmd <- runStickyLogger SevInfo $ do
     logSticky "[ Waiting for fossa analyze completion ]"
     exec [reldir|.|] $ v1Command v1Bin args
 

--- a/src/App/Fossa/Container/Test.hs
+++ b/src/App/Fossa/Container/Test.hs
@@ -38,7 +38,7 @@ testMain ::
   ImageText ->
   IO ()
 testMain apiOpts logSeverity timeoutSeconds outputType override image = do
-  void . timeout timeoutSeconds . withDefaultLogger logSeverity . runStickyLogger $ do
+  void . timeout timeoutSeconds . withDefaultLogger logSeverity . runStickyLogger SevInfo $ do
     logWithExit_ $ testInner apiOpts outputType override image
 
   hPutStrLn stderr "Timed out while wait for issues"

--- a/src/App/Fossa/ListTargets.hs
+++ b/src/App/Fossa/ListTargets.hs
@@ -29,7 +29,7 @@ listTargetsMain (BaseDir basedir) = do
   capabilities <- getNumCapabilities
 
   withDefaultLogger SevInfo
-    . runStickyLogger
+    . runStickyLogger SevInfo
     . runFinally
     . withTaskPool capabilities updateProgress
     . runReadFSIO

--- a/src/App/Fossa/Report.hs
+++ b/src/App/Fossa/Report.hs
@@ -49,7 +49,7 @@ reportMain (BaseDir basedir) apiOpts logSeverity timeoutSeconds reportType overr
   * Timeout over `IO a` (easy to move, but where do we move it?)
   * CLI command refactoring as laid out in https://github.com/fossas/issues/issues/129
   -}
-  void . timeout timeoutSeconds . withDefaultLogger logSeverity . runStickyLogger $ do
+  void . timeout timeoutSeconds . withDefaultLogger logSeverity . runStickyLogger SevInfo $ do
     result <- runDiagnostics . runReadFSIO $ do
       revision <- mergeOverride override <$> (inferProjectFromVCS basedir <||> inferProjectCached basedir <||> inferProjectDefault basedir)
 

--- a/src/App/Fossa/Test.hs
+++ b/src/App/Fossa/Test.hs
@@ -32,7 +32,7 @@ testMain
   -> OverrideProject
   -> IO ()
 testMain (BaseDir basedir) apiOpts logSeverity timeoutSeconds outputType override = do
-  void . timeout timeoutSeconds . withDefaultLogger logSeverity . runStickyLogger $ do
+  void . timeout timeoutSeconds . withDefaultLogger logSeverity . runStickyLogger SevInfo $ do
     result <- runDiagnostics . runReadFSIO $ do
       revision <- mergeOverride override <$> (inferProjectFromVCS basedir <||> inferProjectCached basedir <||> inferProjectDefault basedir)
 

--- a/src/App/Fossa/VPS/Report.hs
+++ b/src/App/Fossa/VPS/Report.hs
@@ -51,7 +51,7 @@ reportMain (BaseDir basedir) apiOpts logSeverity timeoutSeconds reportType overr
   * Timeout over `IO a` (easy to move, but where do we move it?)
   * CLI command refactoring as laid out in https://github.com/fossas/issues/issues/129
   -}
-  void . timeout timeoutSeconds . withDefaultLogger logSeverity . runStickyLogger $ do
+  void . timeout timeoutSeconds . withDefaultLogger logSeverity . runStickyLogger SevInfo $ do
     result <- runDiagnostics . runReadFSIO $ do
       revision <- mergeOverride override <$> (inferProjectFromVCS basedir <||> inferProjectCached basedir <||> inferProjectDefault basedir)
 

--- a/src/App/Fossa/VPS/Scan/ScotlandYard.hs
+++ b/src/App/Fossa/VPS/Scan/ScotlandYard.hs
@@ -117,7 +117,7 @@ uploadBuildGraph apiOpts syOpts@ScotlandYardNinjaOpts {..} targets = runHTTP $ d
   let chunkUrl = uploadBuildGraphChunkEndpoint baseUrl locator scanId (responseBuildGraphId buildGraphId)
       chunkedTargets = chunkedBySize targets (1024 * 1024)
   capabilities <- liftIO getNumCapabilities
-  _ <- runStickyLogger . withTaskPool capabilities updateProgress $
+  _ <- runStickyLogger SevInfo . withTaskPool capabilities updateProgress $
     traverse_ (forkTask . uploadBuildGraphChunk chunkUrl authenticatedHttpOptions) chunkedTargets
 
   -- mark the build graph as complete

--- a/src/App/Fossa/VPS/Test.hs
+++ b/src/App/Fossa/VPS/Test.hs
@@ -38,7 +38,7 @@ testMain ::
   OverrideProject ->
   IO ()
 testMain (BaseDir basedir) apiOpts logSeverity timeoutSeconds outputType override = do
-  _ <- timeout timeoutSeconds . withDefaultLogger logSeverity . runStickyLogger $ do
+  _ <- timeout timeoutSeconds . withDefaultLogger logSeverity . runStickyLogger SevInfo $ do
     result <- runDiagnostics . runReadFSIO $ do
       revision <- mergeOverride override <$> (inferProjectFromVCS basedir <||> inferProjectCached basedir <||> inferProjectDefault basedir)
 

--- a/src/App/Pathfinder/Scan.hs
+++ b/src/App/Pathfinder/Scan.hs
@@ -64,7 +64,7 @@ scan basedir = runFinally $ do
 
   (projectResults, ()) <-
     runOutput @ProjectLicenseScan
-      . runStickyLogger
+      . runStickyLogger SevInfo
       . runReadFSIO
       . runFinally
       . withTaskPool capabilities updateProgress

--- a/src/Console/Sticky.hs
+++ b/src/Console/Sticky.hs
@@ -13,16 +13,16 @@ import Effect.Logger
 import System.Console.ANSI (hSupportsANSI)
 import System.IO (stdout)
 
-withStickyRegion :: Has (Lift IO) sig m => (StickyRegion -> m a) -> m a
-withStickyRegion f = do
+withStickyRegion :: Has (Lift IO) sig m => Severity -> (StickyRegion -> m a) -> m a
+withStickyRegion sev f = do
   ansiSupported <- sendIO $ hSupportsANSI stdout
   if ansiSupported
     then R.withConsoleRegion R.Linear (f . Sticky)
-    else f NonSticky
+    else f (NonSticky sev)
 
 data StickyRegion
   = -- | Show messages via Logger
-    NonSticky
+    NonSticky Severity
   | -- | Show messages in console region
     Sticky R.ConsoleRegion
 
@@ -30,7 +30,7 @@ setSticky :: (Has (Lift IO) sig m, Has Logger sig m) => StickyRegion -> Text -> 
 setSticky region = setSticky' region . pretty
 
 setSticky' :: (Has (Lift IO) sig m, Has Logger sig m) => StickyRegion -> Doc AnsiStyle -> m ()
-setSticky' NonSticky msg = logDebug msg
+setSticky' (NonSticky sev) msg = Effect.Logger.log sev msg
 setSticky' (Sticky region) msg = logDebug msg *> renderToConsoleRegion region msg
 
 renderToConsoleRegion :: Has (Lift IO) sig m => R.ConsoleRegion -> Doc AnsiStyle -> m ()

--- a/src/Control/Carrier/Diagnostics/StickyContext.hs
+++ b/src/Control/Carrier/Diagnostics/StickyContext.hs
@@ -20,7 +20,7 @@ import Control.Effect.AtomicCounter
 stickyDiag :: (Has AtomicCounter sig m, Has (Lift IO) sig m) => StickyDiagC m a -> m a
 stickyDiag act = do
   taskId <- generateId
-  Sticky.withStickyRegion $ \region ->
+  Sticky.withStickyRegion SevDebug $ \region ->
     runReader (StickyCtx (TaskId taskId) [] region) . runStickyDiagC $ act
 
 data StickyCtx = StickyCtx

--- a/src/Control/Carrier/StickyLogger.hs
+++ b/src/Control/Carrier/StickyLogger.hs
@@ -16,10 +16,15 @@ import Control.Effect.Lift (Lift)
 import Control.Effect.StickyLogger as X
 import Control.Monad.IO.Class (MonadIO)
 import Control.Monad.Trans (MonadTrans)
-import Effect.Logger (Logger)
+import Effect.Logger (Logger, Severity)
 
-runStickyLogger :: Has (Lift IO) sig m => StickyLoggerC m a -> m a
-runStickyLogger act = withStickyRegion $ \region ->
+runStickyLogger ::
+  Has (Lift IO) sig m =>
+  -- | Severity to use for log messages in ansi-incompatible terminals
+  Severity ->
+  StickyLoggerC m a ->
+  m a
+runStickyLogger sev act = withStickyRegion sev $ \region ->
   runReader region (runStickyLoggerC act)
 
 newtype StickyLoggerC m a = StickyLoggerC {runStickyLoggerC :: ReaderC StickyRegion m a}


### PR DESCRIPTION
## Overview

As of https://github.com/fossas/spectrometer/pull/239, `--debug` mode is required to see status updates in `fossa test` and similar commands when running in an ansi-incompatible environment, like CI. This means that, e.g., for `fossa test`, users would see no output until both project- and issue-scans were complete

## Testing plan

- Run `fossa test >/dev/null` -- status messages are still produced while we wait for project and issue scan completion