### PR TITLE
chore: Make grammar in PR template checklist consistent

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -29,5 +29,5 @@ _Example:_ Closes https://github.com/example/repo/issues/123.
 - [] I added tests for this PR's change.
 - [] I linted (`hlint`) and formatted (`ormolu`) any files I touched in this PR.
 - [] If this PR introduced a user-visible change, I added documentation into `docs/`.
-- [] I updated `CHANGELOG.md`. If the PR did not mark a release, update the `#Unreleased section at the top`.
+- [] I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
 - [] I linked this PR to any referenced GitHub issues.


### PR DESCRIPTION
# Overview

This PR makes the PR template more consistent in grammar.

## Acceptance criteria

The PR template is now slightly less annoying to read.

## Testing plan

Read the PR template checklist, and check that it's slightly less annoying.

## Risks

N/A

## References
N/A

## Checklist

- [x] I added tests for this PR's change.
- [x] I linted (`hlint`) and formatted (`ormolu`) any files I touched in this PR.
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] I updated `CHANGELOG.md`. If the PR did not mark a release, update the `#Unreleased section at the top`.
- [x] I noticed that the _current_ PR template apparently is not changed, and is still a bit annoying.
- [x] I linked this PR to any referenced GitHub issues.
