### PR TITLE
Format all files with fourmolu

### DIFF
--- a/src/App/Fossa/API/BuildLink.hs
+++ b/src/App/Fossa/API/BuildLink.hs
@@ -1,12 +1,11 @@
-{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE RecordWildCards #-}
 
-module App.Fossa.API.BuildLink
-  ( getBuildURLWithOrg,
-    getFossaBuildUrl,
-    samlUrlPath,
-  )
-where
+module App.Fossa.API.BuildLink (
+  getBuildURLWithOrg,
+  getFossaBuildUrl,
+  samlUrlPath,
+) where
 
 import App.Fossa.FossaAPIV1 (Organization (..), getOrganization)
 import App.Types
@@ -17,12 +16,12 @@ import Data.Text (Text)
 import Data.Text.Extra (showT)
 import Fossa.API.Types (ApiOpts (..))
 import Srclib.Types (Locator (..))
-import qualified Text.URI as URI
+import Text.URI qualified as URI
 import Text.URI.Builder
 import Text.URI.QQ (uri)
 
 fossaProjectUrlPath :: Locator -> ProjectRevision -> [PathComponent]
-fossaProjectUrlPath Locator {..} ProjectRevision {..} = map PathComponent components
+fossaProjectUrlPath Locator{..} ProjectRevision{..} = map PathComponent components
   where
     components = ["projects", project, "refs", "branch", branch, revision]
     project = locatorFetcher <> "+" <> locatorProject
@@ -54,4 +53,4 @@ samlUrlPair org path = do
   pure (samlUrlPath org, [Pair "next" pathtext])
 
 samlUrlPath :: Organization -> [PathComponent]
-samlUrlPath Organization {organizationId} = map PathComponent ["account", "saml", showT organizationId]
+samlUrlPath Organization{organizationId} = map PathComponent ["account", "saml", showT organizationId]

--- a/src/App/Fossa/API/BuildWait.hs
+++ b/src/App/Fossa/API/BuildWait.hs
@@ -1,20 +1,19 @@
-module App.Fossa.API.BuildWait
-  ( waitForBuild,
-    waitForIssues,
-    waitForSherlockScan,
-    timeout,
-  )
-where
+module App.Fossa.API.BuildWait (
+  waitForBuild,
+  waitForIssues,
+  waitForSherlockScan,
+  timeout,
+) where
 
 import App.Fossa.FossaAPIV1 qualified as Fossa
 import App.Fossa.VPS.Scan.Core qualified as VPSCore
 import App.Fossa.VPS.Scan.ScotlandYard qualified as ScotlandYard
 import App.Types
 import Control.Carrier.Diagnostics
+import Control.Carrier.StickyLogger (StickyLogger, logSticky')
 import Control.Concurrent (threadDelay)
 import Control.Concurrent.Async qualified as Async
 import Control.Effect.Lift (Lift, sendIO)
-import Control.Carrier.StickyLogger (StickyLogger, logSticky')
 import Data.Functor (($>))
 import Data.Text (Text)
 import Effect.Logger

--- a/src/App/Fossa/Analyze/Graph.hs
+++ b/src/App/Fossa/Analyze/Graph.hs
@@ -1,36 +1,36 @@
 {-# LANGUAGE RecordWildCards #-}
 
-module App.Fossa.Analyze.Graph
-  ( Graph()
-  , DepRef()
-
-  , empty
-  , addDirect
-  , addEdge
-  , addNode
-  , graphAssocs
-  , graphDeps
-  , graphDirect
-  ) where
+module App.Fossa.Analyze.Graph (
+  Graph (),
+  DepRef (),
+  empty,
+  addDirect,
+  addEdge,
+  addNode,
+  graphAssocs,
+  graphDeps,
+  graphDirect,
+) where
 
 import Data.Aeson
 import Data.Bifunctor (bimap)
 import Data.Function ((&))
-import qualified Data.IntMap as IM
-import qualified Data.IntSet as IS
-import qualified Data.Sequence as S
+import Data.IntMap qualified as IM
+import Data.IntSet qualified as IS
+import Data.Sequence qualified as S
 
 import DepTypes
 
 -- | Opaque reference to a dependency in the graph. Used for adding edges to the graph (See: 'addEdge')
-newtype DepRef = DepRef { unDepRef :: Int } deriving (Eq, Ord, Show)
+newtype DepRef = DepRef {unDepRef :: Int} deriving (Eq, Ord, Show)
 
 -- | A Graph of dependencies. See 'empty', 'addNode', and 'addEdge'
 data Graph = Graph
-  { _graphDeps   :: S.Seq Dependency
+  { _graphDeps :: S.Seq Dependency
   , _graphAssocs :: IM.IntMap IS.IntSet -- references dependencies by their position in the _graphDeps Seq
   , _graphDirect :: IS.IntSet
-  } deriving (Eq, Ord, Show)
+  }
+  deriving (Eq, Ord, Show)
 
 -- | Retrieve the nodes of the dependency graph
 graphDeps :: Graph -> S.Seq Dependency
@@ -52,37 +52,40 @@ empty = Graph S.empty IM.empty IS.empty
 
 -- | Add a new dependency node to the graph. The returned 'DepRef' can be used to 'addEdge's
 addNode :: Dependency -> Graph -> (Graph, DepRef)
-addNode dep graph = (graph { _graphDeps = curDeps S.|> dep }, DepRef (length curDeps))
+addNode dep graph = (graph{_graphDeps = curDeps S.|> dep}, DepRef (length curDeps))
   where
-  curDeps = _graphDeps graph
+    curDeps = _graphDeps graph
 
 -- | Add an edge to the dependency graph
 addEdge :: DepRef -> DepRef -> Graph -> Graph
-addEdge parent child graph = graph { _graphAssocs = IM.insertWith (<>) (unDepRef parent) (IS.singleton (unDepRef child)) (_graphAssocs graph) }
+addEdge parent child graph = graph{_graphAssocs = IM.insertWith (<>) (unDepRef parent) (IS.singleton (unDepRef child)) (_graphAssocs graph)}
 
 addDirect :: DepRef -> Graph -> Graph
-addDirect dep graph = graph { _graphDirect = IS.insert (unDepRef dep) (_graphDirect graph) }
+addDirect dep graph = graph{_graphDirect = IS.insert (unDepRef dep) (_graphDirect graph)}
 
 -- Graph is a semigroup: dependencies can be combined, with offsets applied to
 -- the assocs and direct deps of the second graph
 instance Semigroup Graph where
   Graph deps1 assocs1 direct1 <> Graph deps2 assocs2 direct2 =
-    Graph (deps1 <> deps2) -- combine deps
-          (IM.union assocs1 offsetAssocs2) -- offset the assocs entries
-          (direct1 <> IS.map (+offset) direct2) -- offset the direct entries
+    Graph
+      (deps1 <> deps2) -- combine deps
+      (IM.union assocs1 offsetAssocs2) -- offset the assocs entries
+      (direct1 <> IS.map (+ offset) direct2) -- offset the direct entries
     where
-    offsetAssocs2 = assocs2
-                  & IM.toList -- [(key, IntSet)]
-                  & map (bimap (+offset) (IS.map (+offset)))
-                  & IM.fromList
-    offset = length deps1
+      offsetAssocs2 =
+        assocs2
+          & IM.toList -- [(key, IntSet)]
+          & map (bimap (+ offset) (IS.map (+ offset)))
+          & IM.fromList
+      offset = length deps1
 
 instance Monoid Graph where
   mempty = empty
 
 instance ToJSON Graph where
-  toJSON Graph{..} = object
-    [ "deps"   .= _graphDeps
-    , "assocs" .= _graphAssocs
-    , "direct" .= _graphDirect
-    ]
+  toJSON Graph{..} =
+    object
+      [ "deps" .= _graphDeps
+      , "assocs" .= _graphAssocs
+      , "direct" .= _graphDirect
+      ]

--- a/src/App/Fossa/Analyze/GraphBuilder.hs
+++ b/src/App/Fossa/Analyze/GraphBuilder.hs
@@ -3,20 +3,19 @@
 {-# LANGUAGE UndecidableInstances #-}
 
 -- | Legacy/deprecated GraphBuilder interface. Kept for compatibility with old code
-module App.Fossa.Analyze.GraphBuilder
-  ( GraphBuilder(..)
-  , addNode
-  , addEdge
-  , addDirect
-  , runGraphBuilder
-  , evalGraphBuilder
-  )
-  where
+module App.Fossa.Analyze.GraphBuilder (
+  GraphBuilder (..),
+  addNode,
+  addEdge,
+  addDirect,
+  runGraphBuilder,
+  evalGraphBuilder,
+) where
 
+import App.Fossa.Analyze.Graph qualified as G
 import Control.Algebra
 import Control.Carrier.State.Strict
 import Control.Monad.IO.Class (MonadIO)
-import qualified App.Fossa.Analyze.Graph as G
 import Data.Kind (Type)
 import DepTypes
 
@@ -43,8 +42,8 @@ runGraphBuilder start = runState start . runGraphBuilderC
 evalGraphBuilder :: Functor m => G.Graph -> GraphBuilderC m a -> m G.Graph
 evalGraphBuilder start = execState start . runGraphBuilderC
 
-newtype GraphBuilderC m a = GraphBuilderC { runGraphBuilderC :: StateC G.Graph m a }
- deriving (Functor, Applicative, Monad, MonadIO)
+newtype GraphBuilderC m a = GraphBuilderC {runGraphBuilderC :: StateC G.Graph m a}
+  deriving (Functor, Applicative, Monad, MonadIO)
 
 instance Algebra sig m => Algebra (GraphBuilder :+: sig) (GraphBuilderC m) where
   alg hdl sig ctx = GraphBuilderC $ case sig of

--- a/src/App/Fossa/Analyze/GraphMangler.hs
+++ b/src/App/Fossa/Analyze/GraphMangler.hs
@@ -1,20 +1,20 @@
-module App.Fossa.Analyze.GraphMangler
-  ( graphingToGraph
-  ) where
+module App.Fossa.Analyze.GraphMangler (
+  graphingToGraph,
+) where
 
 import Algebra.Graph.AdjacencyMap (AdjacencyMap)
-import qualified Algebra.Graph.AdjacencyMap as AM
+import Algebra.Graph.AdjacencyMap qualified as AM
 import Algebra.Graph.ToGraph (dfs)
 import Control.Algebra
 import Data.Foldable (traverse_)
 import Data.Map.Strict (Map)
-import qualified Data.Map.Strict as M
-import qualified Data.Set as S
+import Data.Map.Strict qualified as M
+import Data.Set qualified as S
 
+import App.Fossa.Analyze.Graph qualified as G
 import App.Fossa.Analyze.GraphBuilder
-import qualified App.Fossa.Analyze.Graph as G
 import DepTypes
-import Graphing (Graphing(..))
+import Graphing (Graphing (..))
 
 graphingToGraph :: Graphing Dependency -> G.Graph
 graphingToGraph graphing = run . evalGraphBuilder G.empty $ do
@@ -28,25 +28,23 @@ graphingToGraph graphing = run . evalGraphBuilder G.empty $ do
   traverse_ (visitNode refs depAmap) nodes
 
   traverse_ (\dep -> traverse_ addDirect (M.lookup dep refs)) depDirect
-
   where
+    -- add a node with GraphBuilder
+    addingNode :: Has GraphBuilder sig m => Dependency -> m (Dependency, G.DepRef)
+    addingNode k = do
+      ref <- addNode k
+      pure (k, ref)
 
-  -- add a node with GraphBuilder
-  addingNode :: Has GraphBuilder sig m => Dependency -> m (Dependency, G.DepRef)
-  addingNode k = do
-    ref <- addNode k
-    pure (k, ref)
+    -- visit a node, adding edges between it and all of its dependencies
+    visitNode :: Has GraphBuilder sig m => Map Dependency G.DepRef -> AdjacencyMap Dependency -> Dependency -> m ()
+    visitNode refs amap node = traverse_ (visitEdge refs node) (S.toList $ AM.postSet node amap)
 
-  -- visit a node, adding edges between it and all of its dependencies
-  visitNode :: Has GraphBuilder sig m => Map Dependency G.DepRef -> AdjacencyMap Dependency -> Dependency -> m ()
-  visitNode refs amap node = traverse_ (visitEdge refs node) (S.toList $ AM.postSet node amap)
+    -- visit an edge by adding it to the graph
+    visitEdge :: Has GraphBuilder sig m => Map Dependency G.DepRef -> Dependency -> Dependency -> m ()
+    visitEdge refs parent child = do
+      let edgeRefs = do
+            parentRef <- M.lookup parent refs
+            childRef <- M.lookup child refs
+            pure (parentRef, childRef)
 
-  -- visit an edge by adding it to the graph
-  visitEdge :: Has GraphBuilder sig m => Map Dependency G.DepRef -> Dependency -> Dependency -> m ()
-  visitEdge refs parent child = do
-    let edgeRefs = do
-          parentRef <- M.lookup parent refs
-          childRef <- M.lookup child refs
-          pure (parentRef, childRef)
-
-    traverse_ (uncurry addEdge) edgeRefs
+      traverse_ (uncurry addEdge) edgeRefs

--- a/src/App/Fossa/Analyze/Project.hs
+++ b/src/App/Fossa/Analyze/Project.hs
@@ -1,30 +1,31 @@
-module App.Fossa.Analyze.Project
-  ( ProjectResult(..)
-  , mkResult
-  ) where
+module App.Fossa.Analyze.Project (
+  ProjectResult (..),
+  mkResult,
+) where
 
+import Data.Set qualified as S
 import Data.Text (Text)
 import DepTypes
 import Graphing (Graphing)
-import qualified Graphing
+import Graphing qualified
 import Path
 import Types
-import qualified Data.Set as S
 
 mkResult :: DiscoveredProject n -> Graphing Dependency -> ProjectResult
-mkResult project graph = ProjectResult
-  { projectResultType = projectType project
-  , projectResultPath = projectPath project
-  , projectResultGraph =
-      -- FIXME: this is a hack to work around analyzers that aren't able to
-      -- determine which dependencies are direct. Without this hack, all of
-      -- their dependencies would be filtered out. The real fix to this is to
-      -- have a separate designation for "reachable" vs "direct" on nodes in a
-      -- Graphing, where direct deps are inherently reachable.
-      if S.null (Graphing.graphingDirect graph)
-        then graph
-        else Graphing.pruneUnreachable graph
-  }
+mkResult project graph =
+  ProjectResult
+    { projectResultType = projectType project
+    , projectResultPath = projectPath project
+    , projectResultGraph =
+        -- FIXME: this is a hack to work around analyzers that aren't able to
+        -- determine which dependencies are direct. Without this hack, all of
+        -- their dependencies would be filtered out. The real fix to this is to
+        -- have a separate designation for "reachable" vs "direct" on nodes in a
+        -- Graphing, where direct deps are inherently reachable.
+        if S.null (Graphing.graphingDirect graph)
+          then graph
+          else Graphing.pruneUnreachable graph
+    }
 
 data ProjectResult = ProjectResult
   { projectResultType :: Text

--- a/src/App/Fossa/Analyze/Record.hs
+++ b/src/App/Fossa/Analyze/Record.hs
@@ -1,12 +1,11 @@
 {-# LANGUAGE RecordWildCards #-}
 
-module App.Fossa.Analyze.Record
-  ( AnalyzeJournal (..),
-    AnalyzeEffects (..),
-    saveReplayLog,
-    loadReplayLog,
-  )
-where
+module App.Fossa.Analyze.Record (
+  AnalyzeJournal (..),
+  AnalyzeEffects (..),
+  saveReplayLog,
+  loadReplayLog,
+) where
 
 import App.Version (fullVersionDescription)
 import Control.Effect.Record
@@ -18,16 +17,16 @@ import System.Directory (getCurrentDirectory)
 import System.Environment (getArgs)
 
 data AnalyzeJournal = AnalyzeJournal
-  { analyzeCommit :: Text,
-    analyzeEffects :: AnalyzeEffects,
-    analyzeArgs :: [String],
-    analyzeWorkdir :: FilePath
+  { analyzeCommit :: Text
+  , analyzeEffects :: AnalyzeEffects
+  , analyzeArgs :: [String]
+  , analyzeWorkdir :: FilePath
   }
   deriving (Eq, Ord, Show)
 
 data AnalyzeEffects = AnalyzeEffects
-  { effectsReadFS :: Journal ReadFS,
-    effectsExec :: Journal Exec
+  { effectsReadFS :: Journal ReadFS
+  , effectsExec :: Journal Exec
   }
   deriving (Eq, Ord, Show)
 
@@ -44,19 +43,19 @@ instance FromJSON AnalyzeEffects where
       <*> obj .: "Exec"
 
 instance ToJSON AnalyzeJournal where
-  toJSON AnalyzeJournal {..} =
+  toJSON AnalyzeJournal{..} =
     object
-      [ "commit" .= analyzeCommit,
-        "args" .= analyzeArgs,
-        "workdir" .= analyzeWorkdir,
-        "effects" .= analyzeEffects
+      [ "commit" .= analyzeCommit
+      , "args" .= analyzeArgs
+      , "workdir" .= analyzeWorkdir
+      , "effects" .= analyzeEffects
       ]
 
 instance ToJSON AnalyzeEffects where
-  toJSON AnalyzeEffects {..} =
+  toJSON AnalyzeEffects{..} =
     object
-      [ "ReadFS" .= effectsReadFS,
-        "Exec" .= effectsExec
+      [ "ReadFS" .= effectsReadFS
+      , "Exec" .= effectsExec
       ]
 
 saveReplayLog :: Journal ReadFS -> Journal Exec -> FilePath -> IO ()
@@ -65,16 +64,16 @@ saveReplayLog readFSJournal execJournal path = do
   workdir <- getCurrentDirectory
   let effects =
         AnalyzeEffects
-          { effectsReadFS = readFSJournal,
-            effectsExec = execJournal
+          { effectsReadFS = readFSJournal
+          , effectsExec = execJournal
           }
 
       journal =
         AnalyzeJournal
-          { analyzeCommit = fullVersionDescription,
-            analyzeEffects = effects,
-            analyzeArgs = args,
-            analyzeWorkdir = workdir
+          { analyzeCommit = fullVersionDescription
+          , analyzeEffects = effects
+          , analyzeArgs = args
+          , analyzeWorkdir = workdir
           }
 
   encodeFile path journal

--- a/src/App/Fossa/Compatibility.hs
+++ b/src/App/Fossa/Compatibility.hs
@@ -1,15 +1,13 @@
 {-# LANGUAGE QuasiQuotes #-}
 
-
-module App.Fossa.Compatibility
-  ( compatibilityMain,
-    argumentParser,
-    Argument,
-  )
-where
+module App.Fossa.Compatibility (
+  compatibilityMain,
+  argumentParser,
+  Argument,
+) where
 
 import App.Fossa.EmbeddedBinary (BinaryPaths, toExecutablePath, withCLIv1Binary)
-import Control.Carrier.StickyLogger (runStickyLogger, logSticky)
+import Control.Carrier.StickyLogger (logSticky, runStickyLogger)
 import Control.Effect.Lift (sendIO)
 import Data.ByteString.Lazy.Char8 qualified as BL
 import Data.String.Conversion (decodeUtf8)
@@ -43,7 +41,7 @@ compatibilityMain args = withDefaultLogger SevInfo . runExecIO . withCLIv1Binary
 v1Command :: BinaryPaths -> [Text] -> Command
 v1Command bin args =
   Command
-    { cmdName = pack . toFilePath $ toExecutablePath bin,
-      cmdArgs = "analyze" : args,
-      cmdAllowErr = Never
+    { cmdName = pack . toFilePath $ toExecutablePath bin
+    , cmdArgs = "analyze" : args
+    , cmdAllowErr = Never
     }

--- a/src/App/Fossa/Configuration.hs
+++ b/src/App/Fossa/Configuration.hs
@@ -1,48 +1,47 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeApplications #-}
 
-module App.Fossa.Configuration
-  ( mergeFileCmdMetadata,
-    readConfigFileIO,
-    readConfigFile,
-    ConfigFile (..),
-    ConfigProject (..),
-    ConfigRevision (..),
-  )
-where
+module App.Fossa.Configuration (
+  mergeFileCmdMetadata,
+  readConfigFileIO,
+  readConfigFile,
+  ConfigFile (..),
+  ConfigProject (..),
+  ConfigRevision (..),
+) where
 
 import App.Types
-import qualified Control.Carrier.Diagnostics as Diag
+import Control.Applicative (Alternative ((<|>)))
+import Control.Carrier.Diagnostics qualified as Diag
 import Data.Aeson (FromJSON (parseJSON), withObject, (.:), (.:?))
 import Data.Text (Text)
 import Effect.ReadFS
-import Control.Applicative ( Alternative ((<|>)) )
 import Path
 import System.Exit (die)
 
 data ConfigFile = ConfigFile
-  { configVersion :: Int,
-    configServer :: Maybe Text,
-    configApiKey :: Maybe Text,
-    configProject :: Maybe ConfigProject,
-    configRevision :: Maybe ConfigRevision
+  { configVersion :: Int
+  , configServer :: Maybe Text
+  , configApiKey :: Maybe Text
+  , configProject :: Maybe ConfigProject
+  , configRevision :: Maybe ConfigRevision
   }
   deriving (Eq, Ord, Show)
 
 data ConfigProject = ConfigProject
-  { configProjID :: Maybe Text,
-    configName :: Maybe Text,
-    configLink :: Maybe Text,
-    configTeam :: Maybe Text,
-    configJiraKey :: Maybe Text,
-    configUrl :: Maybe Text,
-    configPolicy :: Maybe Text
+  { configProjID :: Maybe Text
+  , configName :: Maybe Text
+  , configLink :: Maybe Text
+  , configTeam :: Maybe Text
+  , configJiraKey :: Maybe Text
+  , configUrl :: Maybe Text
+  , configPolicy :: Maybe Text
   }
   deriving (Eq, Ord, Show)
 
 data ConfigRevision = ConfigRevision
-  { configCommit :: Maybe Text,
-    configBranch :: Maybe Text
+  { configCommit :: Maybe Text
+  , configBranch :: Maybe Text
   }
   deriving (Eq, Ord, Show)
 
@@ -93,10 +92,10 @@ readConfigFileIO = do
 mergeFileCmdMetadata :: ProjectMetadata -> ConfigFile -> ProjectMetadata
 mergeFileCmdMetadata meta file =
   ProjectMetadata
-    { projectTitle = projectTitle meta <|> (configProject file >>= configName),
-      projectUrl = projectUrl meta <|> (configProject file >>= configUrl),
-      projectJiraKey = projectJiraKey meta <|> (configProject file >>= configJiraKey),
-      projectLink = projectLink meta <|> (configProject file >>= configLink),
-      projectTeam = projectTeam meta <|> (configProject file >>= configTeam),
-      projectPolicy = projectPolicy meta <|> (configProject file >>= configPolicy)
+    { projectTitle = projectTitle meta <|> (configProject file >>= configName)
+    , projectUrl = projectUrl meta <|> (configProject file >>= configUrl)
+    , projectJiraKey = projectJiraKey meta <|> (configProject file >>= configJiraKey)
+    , projectLink = projectLink meta <|> (configProject file >>= configLink)
+    , projectTeam = projectTeam meta <|> (configProject file >>= configTeam)
+    , projectPolicy = projectPolicy meta <|> (configProject file >>= configPolicy)
     }

--- a/src/App/Fossa/Container.hs
+++ b/src/App/Fossa/Container.hs
@@ -1,48 +1,47 @@
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE RecordWildCards #-}
 
-module App.Fossa.Container
-  ( ImageText (..),
-    imageTextArg,
-    Locator (..),
-    SyftResponse (..),
-    ResponseArtifact (..),
-    ResponseSource (..),
-    ResponseDistro (..),
-    SourceTarget (..),
-    ContainerScan (..),
-    ContainerImage (..),
-    ContainerArtifact (..),
-    runSyft,
-    toContainerScan,
-    extractRevision,
-    parseSyftOutput,
-    parseSyftOutputMain,
-    dumpSyftScanMain,
-  )
-where
+module App.Fossa.Container (
+  ImageText (..),
+  imageTextArg,
+  Locator (..),
+  SyftResponse (..),
+  ResponseArtifact (..),
+  ResponseSource (..),
+  ResponseDistro (..),
+  SourceTarget (..),
+  ContainerScan (..),
+  ContainerImage (..),
+  ContainerArtifact (..),
+  runSyft,
+  toContainerScan,
+  extractRevision,
+  parseSyftOutput,
+  parseSyftOutputMain,
+  dumpSyftScanMain,
+) where
 
 import App.Fossa.EmbeddedBinary (BinaryPaths, toExecutablePath, withSyftBinary)
-import App.Types (ProjectRevision (..), OverrideProject (..))
+import App.Types (OverrideProject (..), ProjectRevision (..))
 import Control.Carrier.Diagnostics hiding (fromMaybe)
 import Control.Effect.Lift (Lift, sendIO)
 import Control.Monad.IO.Class
 import Data.Aeson
 import Data.Aeson.Types (parseEither)
-import qualified Data.ByteString.Lazy as BL
+import Data.ByteString.Lazy qualified as BL
 import Data.Functor.Extra ((<$$>))
 import Data.List (nub)
-import qualified Data.Map.Lazy as LMap
+import Data.Map.Lazy qualified as LMap
 import Data.Map.Strict (Map)
-import Data.Maybe (listToMaybe, fromMaybe)
+import Data.Maybe (fromMaybe, listToMaybe)
 import Data.String.Conversion (decodeUtf8)
 import Data.Text (Text, pack)
 import Data.Text.Extra (breakOnAndRemove)
-import Effect.Exec (AllowErr (Never), Command (..), execJson, runExecIO, Exec, execThrow)
+import Effect.Exec (AllowErr (Never), Command (..), Exec, execJson, execThrow, runExecIO)
 import Effect.Logger
-import Effect.ReadFS (ReadFS, readContentsJson, ReadFSIOC (runReadFSIO), resolveFile)
+import Effect.ReadFS (ReadFS, ReadFSIOC (runReadFSIO), readContentsJson, resolveFile)
 import Options.Applicative (Parser, argument, help, metavar, str)
-import Path ( toFilePath, reldir, Dir, Rel )
+import Path (Dir, Rel, reldir, toFilePath)
 import Path.IO (getCurrentDir)
 
 newtype ImageText = ImageText {unImageText :: Text} deriving (Show, Eq, Ord)
@@ -53,12 +52,11 @@ imageTextArg = ImageText . pack <$> argument str (metavar "IMAGE" <> help "The i
 newtype Locator = Locator {unLocator :: Text} deriving (Eq, Ord, Show)
 
 -- | The output of the syft binary
-data SyftResponse
-  = SyftResponse
-      { responseArtifacts :: [ResponseArtifact],
-        responseSource :: ResponseSource,
-        responseDistro :: ResponseDistro
-      }
+data SyftResponse = SyftResponse
+  { responseArtifacts :: [ResponseArtifact]
+  , responseSource :: ResponseSource
+  , responseDistro :: ResponseDistro
+  }
 
 instance FromJSON SyftResponse where
   parseJSON = withObject "SyftResponse" $ \obj ->
@@ -72,16 +70,15 @@ artifactTypeIsOk art = artifactType art `elem` acceptedArtifactTypes
 acceptedArtifactTypes :: [Text]
 acceptedArtifactTypes = ["deb", "rpm", "apk"]
 
-data ResponseArtifact
-  = ResponseArtifact
-      { artifactName :: Text,
-        artifactVersion :: Text,
-        artifactType :: Text,
-        artifactLocations :: [ContainerLocation],
-        artifactPkgUrl :: Text,
-        artifactMetadataType :: Text,
-        artifactMetadata :: Maybe (Map Text Value)
-      }
+data ResponseArtifact = ResponseArtifact
+  { artifactName :: Text
+  , artifactVersion :: Text
+  , artifactType :: Text
+  , artifactLocations :: [ContainerLocation]
+  , artifactPkgUrl :: Text
+  , artifactMetadataType :: Text
+  , artifactMetadata :: Maybe (Map Text Value)
+  }
 
 instance FromJSON ResponseArtifact where
   parseJSON = withObject "ResponseArtifact" $ \obj ->
@@ -98,31 +95,28 @@ instance FromJSON ResponseArtifact where
       -- as well.
       <*> (LMap.delete "files" <$$> obj .:? "metadata")
 
-newtype ResponseSource
-  = ResponseSource
-      {sourceTarget :: SourceTarget}
+newtype ResponseSource = ResponseSource
+  {sourceTarget :: SourceTarget}
 
 instance FromJSON ResponseSource where
   parseJSON = withObject "ResponseSource" $ \obj ->
     ResponseSource <$> obj .: "target"
 
-data ResponseDistro
-  = ResponseDistro
-      { distroName :: Text,
-        distroVersion :: Text
-      }
+data ResponseDistro = ResponseDistro
+  { distroName :: Text
+  , distroVersion :: Text
+  }
 
 instance FromJSON ResponseDistro where
   parseJSON = withObject "ResponseDistro" $ \obj ->
     ResponseDistro <$> obj .: "name"
       <*> obj .: "version"
 
-data SourceTarget
-  = SourceTarget
-      { targetDigest :: Text,
-        targetLayers :: [LayerTarget],
-        targetTags :: [Text]
-      }
+data SourceTarget = SourceTarget
+  { targetDigest :: Text
+  , targetLayers :: [LayerTarget]
+  , targetTags :: [Text]
+  }
 
 instance FromJSON SourceTarget where
   parseJSON = withObject "SourceTarget" $ \obj ->
@@ -132,95 +126,84 @@ instance FromJSON SourceTarget where
 
 -- Capture container layers from target
 -- The digest will correspond to location -> layerId
-newtype LayerTarget
-  = LayerTarget {
-    layerTargetDigest :: Text
-  } deriving (Eq, Show, Ord)
+newtype LayerTarget = LayerTarget {layerTargetDigest :: Text} deriving (Eq, Show, Ord)
 
 instance FromJSON LayerTarget where
   parseJSON = withObject "LayerTarget" $ \obj ->
     LayerTarget <$> obj .: "digest"
 
 instance ToJSON LayerTarget where
-  toJSON LayerTarget {..} =
-    object ["digest" .= layerTargetDigest ]
-
+  toJSON LayerTarget{..} =
+    object ["digest" .= layerTargetDigest]
 
 -- | The reorganized output of syft into a slightly different format
-data ContainerScan
-  = ContainerScan
-      { imageData :: ContainerImage,
-        imageTag :: Text,
-        imageDigest :: Text
-      }
+data ContainerScan = ContainerScan
+  { imageData :: ContainerImage
+  , imageTag :: Text
+  , imageDigest :: Text
+  }
 
 instance ToJSON ContainerScan where
   toJSON scan = object ["image" .= imageData scan]
 
-data ContainerImage
-  = ContainerImage
-      { imageArtifacts :: [ContainerArtifact],
-        imageOs :: Text,
-        imageOsRelease :: Text,
-        imageLayers :: [LayerTarget]
-      }
+data ContainerImage = ContainerImage
+  { imageArtifacts :: [ContainerArtifact]
+  , imageOs :: Text
+  , imageOsRelease :: Text
+  , imageLayers :: [LayerTarget]
+  }
 
 instance ToJSON ContainerImage where
-  toJSON ContainerImage {..} =
+  toJSON ContainerImage{..} =
     object
-      [ "os" .= imageOs,
-        "osRelease" .= imageOsRelease,
-        "layers" .= imageLayers,
-        "artifacts" .= imageArtifacts
+      [ "os" .= imageOs
+      , "osRelease" .= imageOsRelease
+      , "layers" .= imageLayers
+      , "artifacts" .= imageArtifacts
       ]
 
 -- Define Layer/Location type to capture layers in which a dep is found
 -- omitting "path" from the object to reduce noise
-newtype ContainerLocation
-  = ContainerLocation {
-    conLayerId :: Text
-  } deriving (Eq, Show, Ord)
+newtype ContainerLocation = ContainerLocation {conLayerId :: Text} deriving (Eq, Show, Ord)
 
 instance FromJSON ContainerLocation where
   parseJSON = withObject "ContainerLocation" $ \obj ->
     ContainerLocation <$> obj .: "layerID"
 
 instance ToJSON ContainerLocation where
-  toJSON ContainerLocation {..} =
-    object [ "layerId" .= conLayerId ]
+  toJSON ContainerLocation{..} =
+    object ["layerId" .= conLayerId]
 
-data ContainerArtifact
-  = ContainerArtifact
-      { conArtifactName :: Text,
-        conArtifactVersion :: Text,
-        conArtifactType :: Text,
-        conArtifactLocations :: [ContainerLocation],
-        conArtifactPkgUrl :: Text,
-        conArtifactMetadataType :: Text,
-        conArtifactMetadata :: Map Text Value
-      }
+data ContainerArtifact = ContainerArtifact
+  { conArtifactName :: Text
+  , conArtifactVersion :: Text
+  , conArtifactType :: Text
+  , conArtifactLocations :: [ContainerLocation]
+  , conArtifactPkgUrl :: Text
+  , conArtifactMetadataType :: Text
+  , conArtifactMetadata :: Map Text Value
+  }
 
 instance ToJSON ContainerArtifact where
-  toJSON ContainerArtifact {..} =
+  toJSON ContainerArtifact{..} =
     object
-      [ "name" .= conArtifactName,
-        "fullVersion" .= conArtifactVersion,
-        "type" .= conArtifactType,
-        "locations" .= nub conArtifactLocations,
-        "purl" .= conArtifactPkgUrl,
-        "metadataType" .= conArtifactMetadataType,
-        "metadata" .= LMap.delete "files" conArtifactMetadata
+      [ "name" .= conArtifactName
+      , "fullVersion" .= conArtifactVersion
+      , "type" .= conArtifactType
+      , "locations" .= nub conArtifactLocations
+      , "purl" .= conArtifactPkgUrl
+      , "metadataType" .= conArtifactMetadataType
+      , "metadata" .= LMap.delete "files" conArtifactMetadata
       ]
 
 extractRevision :: OverrideProject -> ContainerScan -> ProjectRevision
-extractRevision OverrideProject {..} ContainerScan {..} = ProjectRevision name revision Nothing
+extractRevision OverrideProject{..} ContainerScan{..} = ProjectRevision name revision Nothing
   where
     name = fromMaybe imageTag overrideName
     revision = fromMaybe imageDigest overrideRevision
 
-
 toContainerScan :: Has Diagnostics sig m => SyftResponse -> m ContainerScan
-toContainerScan SyftResponse {..} = do
+toContainerScan SyftResponse{..} = do
   newArts <- context "error while validating system artifacts" $ traverse convertArtifact responseArtifacts
   let image = ContainerImage newArts (distroName responseDistro) (distroVersion responseDistro) (targetLayers $ sourceTarget responseSource)
       target = sourceTarget responseSource
@@ -228,18 +211,19 @@ toContainerScan SyftResponse {..} = do
   pure . ContainerScan image tag $ targetDigest target
 
 convertArtifact :: Has Diagnostics sig m => ResponseArtifact -> m ContainerArtifact
-convertArtifact ResponseArtifact {..} = do
+convertArtifact ResponseArtifact{..} = do
   let errMsg = "No metadata for system package with name: " <> artifactName
   validMetadata <- fromMaybeText errMsg artifactMetadata
-  pure ContainerArtifact
-    { conArtifactName = artifactName,
-      conArtifactVersion = artifactVersion,
-      conArtifactType = artifactType,
-      conArtifactLocations = artifactLocations,
-      conArtifactPkgUrl = artifactPkgUrl,
-      conArtifactMetadataType = artifactMetadataType,
-      conArtifactMetadata = validMetadata
-    }
+  pure
+    ContainerArtifact
+      { conArtifactName = artifactName
+      , conArtifactVersion = artifactVersion
+      , conArtifactType = artifactType
+      , conArtifactLocations = artifactLocations
+      , conArtifactPkgUrl = artifactPkgUrl
+      , conArtifactMetadataType = artifactMetadataType
+      , conArtifactMetadata = validMetadata
+      }
 
 extractTag :: Has Diagnostics sig m => [Text] -> m Text
 extractTag tags = do
@@ -248,9 +232,9 @@ extractTag tags = do
   pure $ fst tagTuple
 
 runSyft ::
-  ( Has Diagnostics sig m,
-    Has (Lift IO) sig m,
-    MonadIO m
+  ( Has Diagnostics sig m
+  , Has (Lift IO) sig m
+  , MonadIO m
   ) =>
   ImageText ->
   m SyftResponse
@@ -262,9 +246,9 @@ runSyft image = runExecIO . withSyftBinary $ \syftBin -> do
 syftCommand :: BinaryPaths -> ImageText -> Command
 syftCommand bin (ImageText image) =
   Command
-    { cmdName = pack . toFilePath $ toExecutablePath bin,
-      cmdArgs = ["--scope", "all-layers", "-o", "json", image],
-      cmdAllowErr = Never
+    { cmdName = pack . toFilePath $ toExecutablePath bin
+    , cmdArgs = ["--scope", "all-layers", "-o", "json", image]
+    , cmdAllowErr = Never
     }
 
 parseSyftOutputMain :: Severity -> FilePath -> IO ()
@@ -291,10 +275,10 @@ dumpSyftScanMain :: Severity -> Maybe FilePath -> ImageText -> IO ()
 dumpSyftScanMain logseverity path image = withDefaultLogger logseverity . logWithExit_ . runExecIO $ dumpSyftScan path image
 
 dumpSyftScan ::
-  ( Has Diagnostics sig m,
-    Has (Lift IO) sig m,
-    Has Exec sig m,
-    MonadIO m
+  ( Has Diagnostics sig m
+  , Has (Lift IO) sig m
+  , Has Exec sig m
+  , MonadIO m
   ) =>
   Maybe FilePath ->
   ImageText ->

--- a/src/App/Fossa/Container/Analyze.hs
+++ b/src/App/Fossa/Container/Analyze.hs
@@ -1,12 +1,11 @@
-module App.Fossa.Container.Analyze
-  ( analyzeMain,
-  )
-where
+module App.Fossa.Container.Analyze (
+  analyzeMain,
+) where
 
-import App.Fossa.Analyze (ScanDestination (..))
 import App.Fossa.API.BuildLink (getFossaBuildUrl)
-import App.Fossa.Container (ImageText (..), runSyft, toContainerScan, extractRevision)
-import App.Fossa.FossaAPIV1 (UploadResponse(uploadError, uploadLocator), uploadContainerScan)
+import App.Fossa.Analyze (ScanDestination (..))
+import App.Fossa.Container (ImageText (..), extractRevision, runSyft, toContainerScan)
+import App.Fossa.FossaAPIV1 (UploadResponse (uploadError, uploadLocator), uploadContainerScan)
 import App.Types (OverrideProject (..), ProjectRevision (..))
 import Control.Carrier.Diagnostics
 import Control.Effect.Lift (Lift)
@@ -25,10 +24,10 @@ analyzeMain scanDestination logSeverity override image = withDefaultLogger logSe
     Right _ -> pure ()
 
 analyze ::
-  ( Has Diagnostics sig m,
-    Has (Lift IO) sig m,
-    Has Logger sig m,
-    MonadIO m
+  ( Has Diagnostics sig m
+  , Has (Lift IO) sig m
+  , Has Logger sig m
+  , MonadIO m
   ) =>
   ScanDestination ->
   OverrideProject ->

--- a/src/App/Fossa/Container/Test.hs
+++ b/src/App/Fossa/Container/Test.hs
@@ -1,10 +1,9 @@
 {-# LANGUAGE BlockArguments #-}
 
-module App.Fossa.Container.Test
-  ( TestOutputType (..),
-    testMain,
-  )
-where
+module App.Fossa.Container.Test (
+  TestOutputType (..),
+  testMain,
+) where
 
 import App.Fossa.API.BuildWait
 import App.Fossa.Container

--- a/src/App/Fossa/EmbeddedBinary.hs
+++ b/src/App/Fossa/EmbeddedBinary.hs
@@ -1,20 +1,19 @@
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TemplateHaskell #-}
 
-module App.Fossa.EmbeddedBinary
-  ( extractEmbeddedBinary,
-    cleanupExtractedBinaries,
-    withEmbeddedBinary,
-    dumpEmbeddedBinary,
-    toExecutablePath,
-    BinaryPaths,
-    withWigginsBinary,
-    withSyftBinary,
-    withCLIv1Binary,
-    allBins,
-    PackagedBinary (..),
-  )
-where
+module App.Fossa.EmbeddedBinary (
+  extractEmbeddedBinary,
+  cleanupExtractedBinaries,
+  withEmbeddedBinary,
+  dumpEmbeddedBinary,
+  toExecutablePath,
+  BinaryPaths,
+  withWigginsBinary,
+  withSyftBinary,
+  withCLIv1Binary,
+  allBins,
+  PackagedBinary (..),
+) where
 
 import Control.Effect.Exception (bracket)
 import Control.Effect.Lift (Has, Lift, sendIO)
@@ -35,40 +34,40 @@ allBins :: [PackagedBinary]
 allBins = enumFromTo minBound maxBound
 
 data BinaryPaths = BinaryPaths
-  { binaryPathContainer :: Path Abs Dir,
-    binaryFilePath :: Path Rel File
+  { binaryPathContainer :: Path Abs Dir
+  , binaryFilePath :: Path Rel File
   }
 
 toExecutablePath :: BinaryPaths -> Path Abs File
-toExecutablePath BinaryPaths {..} = binaryPathContainer </> binaryFilePath
+toExecutablePath BinaryPaths{..} = binaryPathContainer </> binaryFilePath
 
 withSyftBinary ::
-  ( Has (Lift IO) sig m,
-    MonadIO m
+  ( Has (Lift IO) sig m
+  , MonadIO m
   ) =>
   (BinaryPaths -> m c) ->
   m c
 withSyftBinary = withEmbeddedBinary Syft
 
 withWigginsBinary ::
-  ( Has (Lift IO) sig m,
-    MonadIO m
+  ( Has (Lift IO) sig m
+  , MonadIO m
   ) =>
   (BinaryPaths -> m c) ->
   m c
 withWigginsBinary = withEmbeddedBinary Wiggins
 
 withCLIv1Binary ::
-  ( Has (Lift IO) sig m,
-    MonadIO m
+  ( Has (Lift IO) sig m
+  , MonadIO m
   ) =>
   (BinaryPaths -> m c) ->
   m c
 withCLIv1Binary = withEmbeddedBinary CLIv1
 
 withEmbeddedBinary ::
-  ( Has (Lift IO) sig m,
-    MonadIO m
+  ( Has (Lift IO) sig m
+  , MonadIO m
   ) =>
   PackagedBinary ->
   (BinaryPaths -> m c) ->
@@ -121,7 +120,7 @@ extractDir = do
 makeExecutable :: Path Abs File -> IO ()
 makeExecutable path = do
   p <- getPermissions path
-  setPermissions path (p {executable = True})
+  setPermissions path (p{executable = True})
 
 -- The intent with these embedded binaries is that the build system will replace the files with
 -- built binaries of the appropriate architecture.

--- a/src/App/Fossa/ListTargets.hs
+++ b/src/App/Fossa/ListTargets.hs
@@ -1,16 +1,15 @@
 {-# LANGUAGE RecordWildCards #-}
 
-module App.Fossa.ListTargets
-  ( listTargetsMain,
-  )
-where
+module App.Fossa.ListTargets (
+  listTargetsMain,
+) where
 
 import App.Fossa.Analyze (discoverFuncs)
 import App.Types (BaseDir (..))
+import Control.Carrier.AtomicCounter
 import Control.Carrier.Diagnostics qualified as Diag
 import Control.Carrier.Finally
-import Control.Carrier.AtomicCounter
-import Control.Carrier.StickyLogger (runStickyLogger, logSticky', StickyLogger)
+import Control.Carrier.StickyLogger (StickyLogger, logSticky', runStickyLogger)
 import Control.Carrier.TaskPool
 import Control.Concurrent (getNumCapabilities)
 import Data.Foldable (for_)
@@ -58,7 +57,7 @@ listTargetsMain (BaseDir basedir) = do
                   <> pretty (unBuildTarget target)
 
 updateProgress :: Has StickyLogger sig m => Progress -> m ()
-updateProgress Progress {..} =
+updateProgress Progress{..} =
   logSticky'
     ( "[ "
         <> annotate (color Cyan) (pretty pQueued)

--- a/src/App/Fossa/Report.hs
+++ b/src/App/Fossa/Report.hs
@@ -1,7 +1,7 @@
-module App.Fossa.Report
-  ( reportMain
-  , ReportType (..)
-  ) where
+module App.Fossa.Report (
+  reportMain,
+  ReportType (..),
+) where
 
 import App.Fossa.API.BuildWait
 import App.Fossa.FossaAPIV1 qualified as Fossa
@@ -21,21 +21,22 @@ import Fossa.API.Types (ApiOpts)
 import System.Exit (exitFailure, exitSuccess)
 import System.IO (stderr)
 
-data ReportType =
-    AttributionReport
+data ReportType
+  = AttributionReport
 
 reportName :: ReportType -> Text
 reportName r = case r of
   AttributionReport -> "attribution"
 
 reportMain ::
-  BaseDir
-  -> ApiOpts
-  -> Severity
-  -> Int -- ^ timeout (seconds)
-  -> ReportType
-  -> OverrideProject
-  -> IO ()
+  BaseDir ->
+  ApiOpts ->
+  Severity ->
+  -- | timeout (seconds)
+  Int ->
+  ReportType ->
+  OverrideProject ->
+  IO ()
 reportMain (BaseDir basedir) apiOpts logSeverity timeoutSeconds reportType override = do
   -- TODO: refactor this code duplicate from `fossa test`
   {-

--- a/src/App/Fossa/Report/Attribution.hs
+++ b/src/App/Fossa/Report/Attribution.hs
@@ -1,69 +1,62 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE RecordWildCards #-}
 
-module App.Fossa.Report.Attribution
-  ( Attribution (..),
-    Dependency (..),
-    License (..),
-    LicenseContents (..),
-    LicenseName (..),
-    Project (..),
-  )
-where
+module App.Fossa.Report.Attribution (
+  Attribution (..),
+  Dependency (..),
+  License (..),
+  LicenseContents (..),
+  LicenseName (..),
+  Project (..),
+) where
 
 import Data.Aeson
-import Data.Text (Text)
 import Data.Map.Strict (Map)
 import Data.Maybe (catMaybes)
+import Data.Text (Text)
 
-newtype LicenseName
-  = LicenseName {rawName :: Text}
+newtype LicenseName = LicenseName {rawName :: Text}
   deriving (Eq, Ord, Show, FromJSON, FromJSONKey, ToJSON, ToJSONKey)
 
-newtype LicenseContents
-  = LicenseContents {rawContents :: Text}
+newtype LicenseContents = LicenseContents {rawContents :: Text}
   deriving (Eq, Ord, Show, FromJSON, ToJSON)
 
-data Attribution
-  = Attribution
-      { attribProject :: Project,
-        attribDirectDeps :: [Dependency],
-        attribDeepDeps :: [Dependency],
-        attribLicenses :: Map LicenseName LicenseContents
-      }
+data Attribution = Attribution
+  { attribProject :: Project
+  , attribDirectDeps :: [Dependency]
+  , attribDeepDeps :: [Dependency]
+  , attribLicenses :: Map LicenseName LicenseContents
+  }
   deriving (Eq, Show, Ord)
 
-data Dependency
-  = Dependency
-      { depPackage :: Text,
-        depSource :: Text,
-        depVersion :: Maybe Text,
-        depIsGolang :: Maybe Bool,
-        depHash :: Maybe Text,
-        depAuthors :: [Text],
-        depDescription :: Maybe Text,
-        depLicenses :: Maybe [License],
-        depOtherLicenses :: [License],
-        depProjectUrl :: Maybe Text,
-        depDependencyPaths :: [Text],
-        depNotes :: [Text],
-        depDownloadUrl :: Maybe Text,
-        depTitle :: Text
-      }
+data Dependency = Dependency
+  { depPackage :: Text
+  , depSource :: Text
+  , depVersion :: Maybe Text
+  , depIsGolang :: Maybe Bool
+  , depHash :: Maybe Text
+  , depAuthors :: [Text]
+  , depDescription :: Maybe Text
+  , depLicenses :: Maybe [License]
+  , depOtherLicenses :: [License]
+  , depProjectUrl :: Maybe Text
+  , depDependencyPaths :: [Text]
+  , depNotes :: [Text]
+  , depDownloadUrl :: Maybe Text
+  , depTitle :: Text
+  }
   deriving (Eq, Show, Ord)
 
-data License
-  = License
-      { licenseName :: LicenseName,
-        licenseAttribution :: Maybe LicenseContents
-      }
+data License = License
+  { licenseName :: LicenseName
+  , licenseAttribution :: Maybe LicenseContents
+  }
   deriving (Eq, Show, Ord)
 
-data Project
-  = Project
-      { projectName :: Text,
-        projectRevision :: Text
-      }
+data Project = Project
+  { projectName :: Text
+  , projectRevision :: Text
+  }
   deriving (Eq, Show, Ord)
 
 instance FromJSON Attribution where
@@ -75,12 +68,12 @@ instance FromJSON Attribution where
       <*> obj .: "licenses"
 
 instance ToJSON Attribution where
-  toJSON Attribution {..} =
+  toJSON Attribution{..} =
     object
-      [ "project" .= attribProject,
-        "directDependencies" .= attribDirectDeps,
-        "deepDependencies" .= attribDeepDeps,
-        "licenses" .= attribLicenses
+      [ "project" .= attribProject
+      , "directDependencies" .= attribDirectDeps
+      , "deepDependencies" .= attribDeepDeps
+      , "licenses" .= attribLicenses
       ]
 
 instance FromJSON Dependency where
@@ -102,22 +95,22 @@ instance FromJSON Dependency where
       <*> obj .: "title"
 
 instance ToJSON Dependency where
-  toJSON Dependency {..} =
+  toJSON Dependency{..} =
     object
-      [ "package" .= depPackage,
-        "source" .= depSource,
-        "version" .= depVersion,
-        "isGolang" .= depIsGolang,
-        "hash" .= depHash,
-        "authors" .= depAuthors,
-        "description" .= depDescription,
-        "licenses" .= depLicenses,
-        "otherLicenses" .= depOtherLicenses,
-        "projectUrl" .= depProjectUrl,
-        "dependencyPaths" .= depDependencyPaths,
-        "notes" .= depNotes,
-        "downloadUrl" .= depDownloadUrl,
-        "title" .= depTitle
+      [ "package" .= depPackage
+      , "source" .= depSource
+      , "version" .= depVersion
+      , "isGolang" .= depIsGolang
+      , "hash" .= depHash
+      , "authors" .= depAuthors
+      , "description" .= depDescription
+      , "licenses" .= depLicenses
+      , "otherLicenses" .= depOtherLicenses
+      , "projectUrl" .= depProjectUrl
+      , "dependencyPaths" .= depDependencyPaths
+      , "notes" .= depNotes
+      , "downloadUrl" .= depDownloadUrl
+      , "title" .= depTitle
       ]
 
 instance FromJSON License where
@@ -127,10 +120,10 @@ instance FromJSON License where
       <*> obj .:? "attribution"
 
 instance ToJSON License where
-  toJSON License {..} =
+  toJSON License{..} =
     object
-      [ "name" .= licenseName,
-        "attribution" .= licenseAttribution
+      [ "name" .= licenseName
+      , "attribution" .= licenseAttribution
       ]
 
 instance FromJSON Project where
@@ -140,8 +133,8 @@ instance FromJSON Project where
       <*> obj .: "revision"
 
 instance ToJSON Project where
-  toJSON Project {..} =
+  toJSON Project{..} =
     object
-      [ "name" .= projectName,
-        "revision" .= projectRevision
+      [ "name" .= projectName
+      , "revision" .= projectRevision
       ]

--- a/src/App/Fossa/Test.hs
+++ b/src/App/Fossa/Test.hs
@@ -1,13 +1,13 @@
-module App.Fossa.Test
-  ( testMain
-  , TestOutputType(..)
-  ) where
+module App.Fossa.Test (
+  testMain,
+  TestOutputType (..),
+) where
 
 import App.Fossa.API.BuildWait
 import App.Fossa.ProjectInference
 import App.Types
 import Control.Carrier.Diagnostics hiding (fromMaybe)
-import Control.Carrier.StickyLogger (runStickyLogger, logSticky)
+import Control.Carrier.StickyLogger (logSticky, runStickyLogger)
 import Control.Effect.Lift (sendIO)
 import Data.Aeson qualified as Aeson
 import Data.Functor (void)
@@ -20,17 +20,20 @@ import System.Exit (exitFailure, exitSuccess)
 import System.IO (stderr)
 
 data TestOutputType
-  = TestOutputPretty -- ^ pretty output format for issues
-  | TestOutputJson -- ^ use json output for issues
+  = -- | pretty output format for issues
+    TestOutputPretty
+  | -- | use json output for issues
+    TestOutputJson
 
-testMain
-  :: BaseDir
-  -> ApiOpts
-  -> Severity
-  -> Int -- ^ timeout (seconds)
-  -> TestOutputType
-  -> OverrideProject
-  -> IO ()
+testMain ::
+  BaseDir ->
+  ApiOpts ->
+  Severity ->
+  -- | timeout (seconds)
+  Int ->
+  TestOutputType ->
+  OverrideProject ->
+  IO ()
 testMain (BaseDir basedir) apiOpts logSeverity timeoutSeconds outputType override = do
   void . timeout timeoutSeconds . withDefaultLogger logSeverity . runStickyLogger SevInfo $ do
     result <- runDiagnostics . runReadFSIO $ do
@@ -55,10 +58,9 @@ testMain (BaseDir basedir) apiOpts logSeverity timeoutSeconds outputType overrid
           logError $ "Test failed. Number of issues found: " <> pretty n
           if null (issuesIssues issues)
             then logError "Check the webapp for more details, or use a full-access API key (currently using a push-only API key)"
-            else
-              case outputType of
-                TestOutputPretty -> logError $ pretty issues
-                TestOutputJson -> logStdout . decodeUtf8 . Aeson.encode $ issues
+            else case outputType of
+              TestOutputPretty -> logError $ pretty issues
+              TestOutputJson -> logStdout . decodeUtf8 . Aeson.encode $ issues
 
           sendIO exitFailure
 

--- a/src/App/Fossa/VPS/AOSPNotice.hs
+++ b/src/App/Fossa/VPS/AOSPNotice.hs
@@ -1,20 +1,20 @@
-module App.Fossa.VPS.AOSPNotice
-  ( aospNoticeMain,
-  ) where
+module App.Fossa.VPS.AOSPNotice (
+  aospNoticeMain,
+) where
 
-import Control.Effect.Lift (Lift)
 import Control.Carrier.Diagnostics
+import Control.Effect.Lift (Lift)
 import Effect.Exec
 
 import App.Fossa.EmbeddedBinary
+import App.Fossa.ProjectInference
 import App.Fossa.VPS.Scan.RunWiggins
 import App.Fossa.VPS.Types
 import App.Types (BaseDir (..), OverrideProject)
-import Effect.Logger
 import Data.Text (Text)
-import App.Fossa.ProjectInference
-import Fossa.API.Types (ApiOpts(..))
-import Path (Path, Abs, Dir)
+import Effect.Logger
+import Fossa.API.Types (ApiOpts (..))
+import Path (Abs, Dir, Path)
 
 aospNoticeMain :: BaseDir -> Severity -> OverrideProject -> NinjaScanID -> NinjaFilePaths -> ApiOpts -> IO ()
 aospNoticeMain (BaseDir basedir) logSeverity overrideProject ninjaScanId ninjaFilePaths apiOpts = withDefaultLogger logSeverity $ do
@@ -26,7 +26,15 @@ aospNoticeGenerate ::
   ( Has Diagnostics sig m
   , Has Logger sig m
   , Has (Lift IO) sig m
-  ) => Path Abs Dir -> Severity -> OverrideProject -> NinjaScanID -> NinjaFilePaths -> ApiOpts -> BinaryPaths -> m ()
+  ) =>
+  Path Abs Dir ->
+  Severity ->
+  OverrideProject ->
+  NinjaScanID ->
+  NinjaFilePaths ->
+  ApiOpts ->
+  BinaryPaths ->
+  m ()
 aospNoticeGenerate basedir logSeverity overrideProject ninjaScanId ninjaFilePaths apiOpts binaryPaths = do
   projectRevision <- mergeOverride overrideProject <$> (inferProjectFromVCS basedir <||> inferProjectDefault basedir)
 
@@ -36,6 +44,6 @@ aospNoticeGenerate basedir logSeverity overrideProject ninjaScanId ninjaFilePath
   stdout <- runExecIO $ runWiggins binaryPaths wigginsOpts
   logInfo $ pretty stdout
 
-runWiggins :: ( Has Exec sig m, Has Diagnostics sig m) => BinaryPaths -> WigginsOpts -> m Text
+runWiggins :: (Has Exec sig m, Has Diagnostics sig m) => BinaryPaths -> WigginsOpts -> m Text
 runWiggins binaryPaths opts = do
   execWiggins binaryPaths opts

--- a/src/App/Fossa/VPS/Report.hs
+++ b/src/App/Fossa/VPS/Report.hs
@@ -1,7 +1,7 @@
-module App.Fossa.VPS.Report
-  ( reportMain
-  , ReportType (..)
-  ) where
+module App.Fossa.VPS.Report (
+  reportMain,
+  ReportType (..),
+) where
 
 import App.Fossa.API.BuildWait
 import App.Fossa.FossaAPIV1 qualified as Fossa
@@ -10,34 +10,35 @@ import App.Fossa.VPS.Scan.Core qualified as VPSCore
 import App.Fossa.VPS.Scan.ScotlandYard qualified as ScotlandYard
 import App.Types
 import Control.Carrier.Diagnostics
-import Control.Carrier.StickyLogger (runStickyLogger, logSticky)
+import Control.Carrier.StickyLogger (logSticky, runStickyLogger)
 import Control.Effect.Lift (sendIO)
 import Data.Aeson qualified as Aeson
 import Data.Functor (void)
+import Data.String.Conversion (decodeUtf8)
 import Data.Text (Text)
 import Data.Text.IO (hPutStrLn)
 import Effect.Logger
 import Effect.ReadFS
 import Fossa.API.Types (ApiOpts)
-import Data.String.Conversion (decodeUtf8)
 import System.Exit (exitFailure, exitSuccess)
 import System.IO (stderr)
 
-data ReportType =
-    AttributionReport
+data ReportType
+  = AttributionReport
 
 reportName :: ReportType -> Text
 reportName r = case r of
   AttributionReport -> "attribution"
 
 reportMain ::
-  BaseDir
-  -> ApiOpts
-  -> Severity
-  -> Int -- ^ timeout (seconds)
-  -> ReportType
-  -> OverrideProject
-  -> IO ()
+  BaseDir ->
+  ApiOpts ->
+  Severity ->
+  -- | timeout (seconds)
+  Int ->
+  ReportType ->
+  OverrideProject ->
+  IO ()
 reportMain (BaseDir basedir) apiOpts logSeverity timeoutSeconds reportType override = do
   -- TODO: refactor this code duplicate from `fossa test`
   {-

--- a/src/App/Fossa/VPS/Scan.hs
+++ b/src/App/Fossa/VPS/Scan.hs
@@ -1,24 +1,24 @@
-module App.Fossa.VPS.Scan
-  ( scanMain,
-    FollowSymlinks (..),
-    SkipIPRScan (..),
-    LicenseOnlyScan (..)
-  ) where
+module App.Fossa.VPS.Scan (
+  scanMain,
+  FollowSymlinks (..),
+  SkipIPRScan (..),
+  LicenseOnlyScan (..),
+) where
 
-import Control.Effect.Lift (Lift)
 import Control.Carrier.Diagnostics
+import Control.Effect.Lift (Lift)
 import Effect.Exec
 import System.Exit (exitFailure)
 
 import App.Fossa.EmbeddedBinary
+import App.Fossa.ProjectInference
 import App.Fossa.VPS.Scan.RunWiggins
 import App.Fossa.VPS.Types
 import App.Types (BaseDir (..), OverrideProject (..), ProjectMetadata (..))
 import Data.Flag (Flag, fromFlag)
-import Effect.Logger
-import Fossa.API.Types (ApiOpts(..))
-import App.Fossa.ProjectInference
 import Data.Text
+import Effect.Logger
+import Fossa.API.Types (ApiOpts (..))
 
 -- | FollowSymlinks bool flag
 data FollowSymlinks = FollowSymlinks
@@ -29,7 +29,7 @@ data SkipIPRScan = SkipIPRScan
 -- | LicenseOnlyScan bool flag
 data LicenseOnlyScan = LicenseOnlyScan
 
-scanMain :: BaseDir -> ApiOpts -> ProjectMetadata -> Severity -> OverrideProject -> FilterExpressions -> Flag FollowSymlinks -> Flag SkipIPRScan -> Flag LicenseOnlyScan ->  IO ()
+scanMain :: BaseDir -> ApiOpts -> ProjectMetadata -> Severity -> OverrideProject -> FilterExpressions -> Flag FollowSymlinks -> Flag SkipIPRScan -> Flag LicenseOnlyScan -> IO ()
 scanMain basedir apiOpts metadata logSeverity overrideProject fileFilters followSymlinks skipIprFlag licenseOnlyScan = do
   result <- runDiagnostics $ withWigginsBinary $ vpsScan basedir logSeverity overrideProject followSymlinks skipIprFlag licenseOnlyScan fileFilters apiOpts metadata
   case result of
@@ -43,7 +43,18 @@ scanMain basedir apiOpts metadata logSeverity overrideProject fileFilters follow
 vpsScan ::
   ( Has Diagnostics sig m
   , Has (Lift IO) sig m
-  ) => BaseDir -> Severity -> OverrideProject -> Flag FollowSymlinks -> Flag SkipIPRScan -> Flag LicenseOnlyScan -> FilterExpressions -> ApiOpts -> ProjectMetadata -> BinaryPaths -> m ()
+  ) =>
+  BaseDir ->
+  Severity ->
+  OverrideProject ->
+  Flag FollowSymlinks ->
+  Flag SkipIPRScan ->
+  Flag LicenseOnlyScan ->
+  FilterExpressions ->
+  ApiOpts ->
+  ProjectMetadata ->
+  BinaryPaths ->
+  m ()
 vpsScan (BaseDir basedir) logSeverity overrideProject followSymlinks skipIprFlag licenseOnlyScan fileFilters apiOpts metadata binaryPaths = withDefaultLogger logSeverity $ do
   projectRevision <- mergeOverride overrideProject <$> (inferProjectFromVCS basedir <||> inferProjectDefault basedir)
   saveRevision projectRevision
@@ -55,6 +66,6 @@ vpsScan (BaseDir basedir) logSeverity overrideProject followSymlinks skipIprFlag
   stdout <- runExecIO $ runWiggins binaryPaths wigginsOpts
   logInfo $ pretty stdout
 
-runWiggins :: ( Has Exec sig m, Has Diagnostics sig m) => BinaryPaths -> WigginsOpts -> m Text
+runWiggins :: (Has Exec sig m, Has Diagnostics sig m) => BinaryPaths -> WigginsOpts -> m Text
 runWiggins binaryPaths opts = do
   execWiggins binaryPaths opts

--- a/src/App/Fossa/VPS/Scan/Core.hs
+++ b/src/App/Fossa/VPS/Scan/Core.hs
@@ -1,24 +1,23 @@
 {-# LANGUAGE DataKinds #-}
 
-module App.Fossa.VPS.Scan.Core
-  ( createLocator
-  , createRevisionLocator
-  , getSherlockInfo
-  , Locator(..)
-  , RevisionLocator(..)
-  , SherlockInfo(..)
-  )
-where
+module App.Fossa.VPS.Scan.Core (
+  createLocator,
+  createRevisionLocator,
+  getSherlockInfo,
+  Locator (..),
+  RevisionLocator (..),
+  SherlockInfo (..),
+) where
 
 import App.Fossa.VPS.Types
-import Data.Text (pack, Text)
-import Prelude
-import Network.HTTP.Req
 import Control.Carrier.Trace.Printing
 import Control.Effect.Diagnostics
 import Control.Effect.Lift (Lift)
 import Data.Aeson
-import Fossa.API.Types (useApiOpts, ApiOpts(..))
+import Data.Text (Text, pack)
+import Fossa.API.Types (ApiOpts (..), useApiOpts)
+import Network.HTTP.Req
+import Prelude
 
 data SherlockInfo = SherlockInfo
   { sherlockUrl :: Text
@@ -33,12 +32,12 @@ instance FromJSON SherlockInfo where
     auth <- obj .: "auth"
     SherlockInfo <$> obj .: "url" <*> auth .: "clientToken" <*> auth .: "clientId" <*> obj .: "orgId"
 
-newtype Locator = Locator { unLocator :: Text }
+newtype Locator = Locator {unLocator :: Text}
 
 createLocator :: Text -> Int -> Locator
 createLocator projectName organizationId = Locator $ "custom+" <> pack (show organizationId) <> "/" <> projectName
 
-newtype RevisionLocator = RevisionLocator { unRevisionLocator :: Text }
+newtype RevisionLocator = RevisionLocator {unRevisionLocator :: Text}
 
 createRevisionLocator :: Text -> Int -> Text -> RevisionLocator
 createRevisionLocator projectName organizationId revision = do
@@ -52,5 +51,5 @@ sherlockInfoEndpoint baseurl = baseurl /: "api" /: "vendored-package-scan" /: "s
 getSherlockInfo :: (Has (Lift IO) sig m, Has Diagnostics sig m) => ApiOpts -> m SherlockInfo
 getSherlockInfo apiOpts = runHTTP $ do
   (baseUrl, baseOptions) <- useApiOpts apiOpts
-  resp <- req GET (sherlockInfoEndpoint baseUrl) NoReqBody jsonResponse (baseOptions <> header "Content-Type" "application/json" )
+  resp <- req GET (sherlockInfoEndpoint baseUrl) NoReqBody jsonResponse (baseOptions <> header "Content-Type" "application/json")
   pure (responseBody resp)

--- a/src/App/Fossa/VPS/Scan/RunWiggins.hs
+++ b/src/App/Fossa/VPS/Scan/RunWiggins.hs
@@ -1,26 +1,26 @@
 {-# LANGUAGE RecordWildCards #-}
 
-module App.Fossa.VPS.Scan.RunWiggins
-  ( execWiggins,
-    execWigginsJson,
-    generateWigginsScanOpts,
-    generateWigginsAOSPNoticeOpts,
-    generateVSIStandaloneOpts,
-    WigginsOpts (..),
-    ScanType (..),
-  )
-where
+module App.Fossa.VPS.Scan.RunWiggins (
+  execWiggins,
+  execWigginsJson,
+  generateWigginsScanOpts,
+  generateWigginsAOSPNoticeOpts,
+  generateVSIStandaloneOpts,
+  WigginsOpts (..),
+  ScanType (..),
+) where
 
 import App.Fossa.EmbeddedBinary
-import App.Fossa.VPS.Types
-  ( FilterExpressions (FilterExpressions),
-    NinjaFilePaths (unNinjaFilePaths),
-    NinjaScanID (unNinjaScanID),
-    encodeFilterExpressions,
-  )
+import App.Fossa.VPS.Types (
+  FilterExpressions (FilterExpressions),
+  NinjaFilePaths (unNinjaFilePaths),
+  NinjaScanID (unNinjaScanID),
+  encodeFilterExpressions,
+ )
 import App.Types
 import Control.Carrier.Error.Either
 import Control.Effect.Diagnostics
+import Data.Aeson
 import Data.ByteString.Lazy qualified as BL
 import Data.Text (Text)
 import Data.Text qualified as T
@@ -30,17 +30,16 @@ import Effect.Logger
 import Fossa.API.Types
 import Path
 import Text.URI
-import Data.Aeson
 
 data ScanType = ScanType
-  { followSymlinks :: Bool,
-    scanSkipIpr :: Bool,
-    scanLicenseOnly :: Bool
+  { followSymlinks :: Bool
+  , scanSkipIpr :: Bool
+  , scanLicenseOnly :: Bool
   }
 
 data WigginsOpts = WigginsOpts
-  { scanDir :: Path Abs Dir,
-    spectrometerArgs :: [Text]
+  { scanDir :: Path Abs Dir
+  , spectrometerArgs :: [Text]
   }
 
 generateWigginsScanOpts :: Path Abs Dir -> Severity -> ProjectRevision -> ScanType -> FilterExpressions -> ApiOpts -> ProjectMetadata -> WigginsOpts
@@ -55,7 +54,7 @@ generateVSIStandaloneOpts :: Path Abs Dir -> ApiOpts -> WigginsOpts
 generateVSIStandaloneOpts scanDir apiOpts = WigginsOpts scanDir $ generateVSIStandaloneArgs apiOpts
 
 generateSpectrometerAOSPNoticeArgs :: Severity -> ApiOpts -> ProjectRevision -> NinjaScanID -> NinjaFilePaths -> [Text]
-generateSpectrometerAOSPNoticeArgs logSeverity ApiOpts {..} ProjectRevision {..} ninjaScanId ninjaInputFiles =
+generateSpectrometerAOSPNoticeArgs logSeverity ApiOpts{..} ProjectRevision{..} ninjaScanId ninjaInputFiles =
   ["aosp-notice-files"]
     ++ optBool "-debug" (logSeverity == SevDebug)
     ++ optMaybeText "-endpoint" (render <$> apiOptsUri)
@@ -66,14 +65,14 @@ generateSpectrometerAOSPNoticeArgs logSeverity ApiOpts {..} ProjectRevision {..}
     ++ (T.pack . toFilePath <$> unNinjaFilePaths ninjaInputFiles)
 
 generateVSIStandaloneArgs :: ApiOpts -> [Text]
-generateVSIStandaloneArgs ApiOpts {..} =
+generateVSIStandaloneArgs ApiOpts{..} =
   "vsi-direct" :
   optMaybeText "-endpoint" (render <$> apiOptsUri)
     ++ ["-fossa-api-key", unApiKey apiOptsApiKey]
     ++ ["."]
 
 generateSpectrometerScanArgs :: Severity -> ProjectRevision -> ScanType -> FilterExpressions -> ApiOpts -> ProjectMetadata -> [Text]
-generateSpectrometerScanArgs logSeverity ProjectRevision {..} ScanType {..} fileFilters ApiOpts {..} ProjectMetadata {..} =
+generateSpectrometerScanArgs logSeverity ProjectRevision{..} ScanType{..} fileFilters ApiOpts{..} ProjectMetadata{..} =
   "analyze" :
   optMaybeText "-endpoint" (render <$> apiOptsUri)
     ++ ["-fossa-api-key", unApiKey apiOptsApiKey]
@@ -110,9 +109,9 @@ execWigginsJson :: (FromJSON a, Has Exec sig m, Has Diagnostics sig m) => Wiggin
 execWigginsJson opts binaryPaths = execJson (scanDir opts) (wigginsCommand binaryPaths opts)
 
 wigginsCommand :: BinaryPaths -> WigginsOpts -> Command
-wigginsCommand bin WigginsOpts {..} = do
+wigginsCommand bin WigginsOpts{..} = do
   Command
-    { cmdName = T.pack $ fromAbsFile $ toExecutablePath bin,
-      cmdArgs = spectrometerArgs,
-      cmdAllowErr = Never
+    { cmdName = T.pack $ fromAbsFile $ toExecutablePath bin
+    , cmdArgs = spectrometerArgs
+    , cmdAllowErr = Never
     }

--- a/src/App/Fossa/VPS/Scan/ScotlandYard.hs
+++ b/src/App/Fossa/VPS/Scan/ScotlandYard.hs
@@ -1,19 +1,18 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE RecordWildCards #-}
 
-module App.Fossa.VPS.Scan.ScotlandYard
-  ( uploadBuildGraph
-  , getScan
-  , getLatestScan
-  , ScanResponse (..)
-  , ScotlandYardNinjaOpts (..)
-  )
-where
+module App.Fossa.VPS.Scan.ScotlandYard (
+  uploadBuildGraph,
+  getScan,
+  getLatestScan,
+  ScanResponse (..),
+  ScotlandYardNinjaOpts (..),
+) where
 
 import App.Fossa.VPS.Scan.Core
 import App.Fossa.VPS.Types
 import Control.Carrier.Diagnostics hiding (fromMaybe)
-import Control.Carrier.StickyLogger (runStickyLogger, StickyLogger, logSticky')
+import Control.Carrier.StickyLogger (StickyLogger, logSticky', runStickyLogger)
 import Control.Carrier.TaskPool
 import Control.Effect.Lift
 import Control.Monad.IO.Class
@@ -44,7 +43,8 @@ getLatestScanEndpoint baseurl (Locator projectId) = coreProxyPrefix baseurl /: "
 
 newtype CreateScanResponse = CreateScanResponse
   { createScanResponseId :: Text
-  } deriving (Eq, Ord, Show)
+  }
+  deriving (Eq, Ord, Show)
 
 data ScanResponse = ScanResponse
   { responseScanId :: Text
@@ -75,17 +75,19 @@ instance FromJSON CreateBuildGraphResponse where
 getLatestScan :: (Has (Lift IO) sig m, Has Diagnostics sig m) => ApiOpts -> Locator -> Text -> m ScanResponse
 getLatestScan apiOpts locator revisionId = runHTTP $ do
   (baseUrl, baseOptions) <- useApiOpts apiOpts
-  let opts = baseOptions
-        <> header "Content-Type" "application/json"
-        <> "revisionID" =: revisionId
+  let opts =
+        baseOptions
+          <> header "Content-Type" "application/json"
+          <> "revisionID" =: revisionId
   resp <- req GET (getLatestScanEndpoint baseUrl locator) NoReqBody jsonResponse opts
   pure (responseBody resp)
 
 getScan :: (Has (Lift IO) sig m, Has Diagnostics sig m) => ApiOpts -> Locator -> Text -> m ScanResponse
 getScan apiOpts locator scanId = runHTTP $ do
   (baseUrl, baseOptions) <- useApiOpts apiOpts
-  let opts = baseOptions
-        <> header "Content-Type" "application/json"
+  let opts =
+        baseOptions
+          <> header "Content-Type" "application/json"
   resp <- req GET (getScanEndpoint baseUrl locator scanId) NoReqBody jsonResponse opts
   pure (responseBody resp)
 
@@ -94,16 +96,16 @@ createBuildGraphEndpoint :: Url 'Https -> Text -> Text -> Url 'Https
 createBuildGraphEndpoint baseurl projectId scanId = coreProxyPrefix baseurl /: "projects" /: projectId /: "scans" /: scanId /: "build-graphs"
 
 -- /projects/{projectID}/scans/{scanID}/build-graphs/{buildGraphID}/rules
-uploadBuildGraphChunkEndpoint :: Url 'Https -> Text -> Text -> Text ->  Url 'Https
+uploadBuildGraphChunkEndpoint :: Url 'Https -> Text -> Text -> Text -> Url 'Https
 uploadBuildGraphChunkEndpoint baseurl projectId scanId buildGraphId = coreProxyPrefix baseurl /: "projects" /: projectId /: "scans" /: scanId /: "build-graphs" /: buildGraphId /: "rules"
 
 -- /projects/{projectID}/scans/{scanID}/build-graphs/{buildGraphID}/rules/complete
-uploadBuildGraphCompleteEndpoint :: Url 'Https -> Text -> Text -> Text ->  Url 'Https
+uploadBuildGraphCompleteEndpoint :: Url 'Https -> Text -> Text -> Text -> Url 'Https
 uploadBuildGraphCompleteEndpoint baseurl projectId scanId buildGraphId = coreProxyPrefix baseurl /: "projects" /: projectId /: "scans" /: scanId /: "build-graphs" /: buildGraphId /: "rules" /: "complete"
 
 -- create the build graph in SY, upload it in chunks of ~ 1 MB and then complete it.
 uploadBuildGraph :: (Has (Lift IO) sig m, Has Logger sig m, Has Diagnostics sig m) => ApiOpts -> ScotlandYardNinjaOpts -> [DepsTarget] -> m ()
-uploadBuildGraph apiOpts syOpts@ScotlandYardNinjaOpts {..} targets = runHTTP $ do
+uploadBuildGraph apiOpts syOpts@ScotlandYardNinjaOpts{..} targets = runHTTP $ do
   let NinjaGraphOpts{..} = syNinjaOpts
       locator = unLocator syNinjaProjectId
   (baseUrl, baseOptions) <- useApiOpts apiOpts
@@ -117,15 +119,16 @@ uploadBuildGraph apiOpts syOpts@ScotlandYardNinjaOpts {..} targets = runHTTP $ d
   let chunkUrl = uploadBuildGraphChunkEndpoint baseUrl locator scanId (responseBuildGraphId buildGraphId)
       chunkedTargets = chunkedBySize targets (1024 * 1024)
   capabilities <- liftIO getNumCapabilities
-  _ <- runStickyLogger SevInfo . withTaskPool capabilities updateProgress $
-    traverse_ (forkTask . uploadBuildGraphChunk chunkUrl authenticatedHttpOptions) chunkedTargets
+  _ <-
+    runStickyLogger SevInfo . withTaskPool capabilities updateProgress $
+      traverse_ (forkTask . uploadBuildGraphChunk chunkUrl authenticatedHttpOptions) chunkedTargets
 
   -- mark the build graph as complete
   _ <- req PUT (uploadBuildGraphCompleteEndpoint baseUrl locator scanId (responseBuildGraphId buildGraphId)) (ReqBodyJson $ object []) ignoreResponse authenticatedHttpOptions
   pure ()
 
 createBuildGraph :: (Has (Lift IO) sig m, Has Diagnostics sig m) => ScotlandYardNinjaOpts -> Url 'Https -> Option 'Https -> m CreateBuildGraphResponse
-createBuildGraph ScotlandYardNinjaOpts {..} url httpOptions = runHTTP $ do
+createBuildGraph ScotlandYardNinjaOpts{..} url httpOptions = runHTTP $ do
   let NinjaGraphOpts{..} = syNinjaOpts
   let body = object ["display_name" .= buildName]
   resp <- req POST url (ReqBodyJson body) jsonResponse httpOptions
@@ -155,15 +158,14 @@ updateProgress Progress{..} =
 -- greater than maxByteSize.
 chunkedBySize :: (ToJSON a) => [a] -> Int -> [[a]]
 chunkedBySize d maxByteSize =
-    chunked
+  chunked
   where
     (_, chunked) = foldr (addToList maxByteSize) (0, [[]]) d
     addToList :: (ToJSON a) => Int -> a -> (Int, [[a]]) -> (Int, [[a]])
-    addToList maxLength ele (currentLength, first:rest) =
-      if (currentLength + newLength) > maxLength then
-        (newLength, [ele]:first:rest)
-      else
-        (newLength + currentLength, (ele:first):rest)
+    addToList maxLength ele (currentLength, first : rest) =
+      if (currentLength + newLength) > maxLength
+        then (newLength, [ele] : first : rest)
+        else (newLength + currentLength, (ele : first) : rest)
       where
         newLength = fromIntegral $ BS.length $ encode ele
     addToList _ ele (n, []) = (n, [[ele]])

--- a/src/App/Fossa/VPS/Test.hs
+++ b/src/App/Fossa/VPS/Test.hs
@@ -1,8 +1,7 @@
-module App.Fossa.VPS.Test
-  ( testMain,
-    TestOutputType (..),
-  )
-where
+module App.Fossa.VPS.Test (
+  testMain,
+  TestOutputType (..),
+) where
 
 import App.Fossa.API.BuildWait
 import App.Fossa.FossaAPIV1 qualified as Fossa
@@ -11,7 +10,7 @@ import App.Fossa.VPS.Scan.Core qualified as VPSCore
 import App.Fossa.VPS.Scan.ScotlandYard qualified as ScotlandYard
 import App.Types
 import Control.Carrier.Diagnostics hiding (fromMaybe)
-import Control.Carrier.StickyLogger (runStickyLogger, logSticky)
+import Control.Carrier.StickyLogger (logSticky, runStickyLogger)
 import Control.Effect.Lift (sendIO)
 import Data.Aeson qualified as Aeson
 import Data.String.Conversion
@@ -67,10 +66,9 @@ testMain (BaseDir basedir) apiOpts logSeverity timeoutSeconds outputType overrid
           logError $ "Test failed. Number of issues found: " <> pretty n
           if null (issuesIssues issues)
             then logError "Check the webapp for more details, or use a full-access API key (currently using a push-only API key)"
-            else
-              case outputType of
-                TestOutputPretty -> pure ()
-                TestOutputJson -> logStdout . decodeUtf8 . Aeson.encode $ issues
+            else case outputType of
+              TestOutputPretty -> pure ()
+              TestOutputJson -> logStdout . decodeUtf8 . Aeson.encode $ issues
           sendIO exitFailure
 
     case result of

--- a/src/App/Fossa/VPS/Types.hs
+++ b/src/App/Fossa/VPS/Types.hs
@@ -2,37 +2,37 @@
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE UndecidableInstances #-}
 
-module App.Fossa.VPS.Types
-( FilterExpressions(..)
-, DepsTarget(..)
-, DepsDependency(..)
-, runHTTP
-, encodeFilterExpressions
-, HTTP(..)
-, HTTPRequestFailed(..)
-, VPSOpts (..)
-, NinjaGraphOpts (..)
-, NinjaScanID (..)
-, NinjaFilePaths (..)
+module App.Fossa.VPS.Types (
+  FilterExpressions (..),
+  DepsTarget (..),
+  DepsDependency (..),
+  runHTTP,
+  encodeFilterExpressions,
+  HTTP (..),
+  HTTPRequestFailed (..),
+  VPSOpts (..),
+  NinjaGraphOpts (..),
+  NinjaScanID (..),
+  NinjaFilePaths (..),
 ) where
 
-import Control.Monad.IO.Class (MonadIO(..))
 import Control.Carrier.Diagnostics
 import Control.Effect.Lift (Lift, sendIO)
-import Data.Text (Text)
+import Control.Monad.IO.Class (MonadIO (..))
 import Data.Aeson
+import Data.ByteString.Lazy qualified as BSL
+import Data.Text (Text)
+import Data.Text.Encoding (decodeUtf8)
+import Data.Text.Prettyprint.Doc (viaShow)
 import Fossa.API.Types (ApiOpts)
 import Network.HTTP.Req
-import Data.Text.Prettyprint.Doc (viaShow)
-import qualified Data.ByteString.Lazy as BSL
-import Data.Text.Encoding (decodeUtf8)
 import Path
 
-newtype NinjaScanID = NinjaScanID { unNinjaScanID :: Text }
+newtype NinjaScanID = NinjaScanID {unNinjaScanID :: Text}
 
-newtype NinjaFilePaths = NinjaFilePaths { unNinjaFilePaths :: [Path Abs File] }
+newtype NinjaFilePaths = NinjaFilePaths {unNinjaFilePaths :: [Path Abs File]}
 
-newtype FilterExpressions = FilterExpressions { unFilterExpressions :: [Text] }
+newtype FilterExpressions = FilterExpressions {unFilterExpressions :: [Text]}
 
 encodeFilterExpressions :: FilterExpressions -> Text
 encodeFilterExpressions filters = decodeUtf8 $ BSL.toStrict $ encode (unFilterExpressions filters)
@@ -47,10 +47,11 @@ instance ToJSON FilterExpressions where
 -- VPSOpts in particular is used as a God type, and is very unwieldy in the merged CLI form.
 data VPSOpts = VPSOpts
   { vpsProjectName :: Text
-  , userProvidedRevision :: Maybe Text  -- FIXME: Since we can now infer a revision, we should rename this field.
+  , userProvidedRevision :: Maybe Text -- FIXME: Since we can now infer a revision, we should rename this field.
   , skipIprScan :: Bool
   , fileFilter :: FilterExpressions
   }
+
 -- end FIXME
 
 data DepsTarget = DepsTarget
@@ -58,28 +59,32 @@ data DepsTarget = DepsTarget
   , targetDependencies :: [DepsDependency]
   , targetInputs :: [DepsDependency]
   , targetComponentName :: Maybe Text
-  } deriving (Eq, Ord, Show)
+  }
+  deriving (Eq, Ord, Show)
 
 instance ToJSON DepsTarget where
-  toJSON DepsTarget{..} = object
-    [ "path" .= targetPath
-    , "dependencies" .= targetDependencies
-    , "inputs" .= targetInputs
-    , "componentName" .=  targetComponentName
-    ]
+  toJSON DepsTarget{..} =
+    object
+      [ "path" .= targetPath
+      , "dependencies" .= targetDependencies
+      , "inputs" .= targetInputs
+      , "componentName" .= targetComponentName
+      ]
 
 data DepsDependency = DepsDependency
   { dependencyPath :: Text
   , dependencyComponentName :: Maybe Text
   , hasDependencies :: Bool
-  } deriving (Eq, Ord, Show)
+  }
+  deriving (Eq, Ord, Show)
 
 instance ToJSON DepsDependency where
-  toJSON DepsDependency{..} = object
-    [ "path" .= dependencyPath
-    , "componentName" .= dependencyComponentName
-    , "hasDependencies" .= hasDependencies
-    ]
+  toJSON DepsDependency{..} =
+    object
+      [ "path" .= dependencyPath
+      , "componentName" .= dependencyComponentName
+      , "hasDependencies" .= hasDependencies
+      ]
 
 data NinjaGraphOpts = NinjaGraphOpts
   { ninjaFossaOpts :: ApiOpts

--- a/src/App/OptionExtensions.hs
+++ b/src/App/OptionExtensions.hs
@@ -1,10 +1,10 @@
 module App.OptionExtensions (uriOption, jsonOption) where
 
-import qualified Data.Text as T
-import Options.Applicative
-import Text.URI (URI, mkURI)
 import Data.Aeson
 import Data.String
+import Data.Text qualified as T
+import Options.Applicative
+import Text.URI (URI, mkURI)
 
 uriOption :: Mod OptionFields URI -> Parser URI
 uriOption = option parseUri

--- a/src/App/Pathfinder/Main.hs
+++ b/src/App/Pathfinder/Main.hs
@@ -1,6 +1,6 @@
-module App.Pathfinder.Main
-  ( appMain
-  ) where
+module App.Pathfinder.Main (
+  appMain,
+) where
 
 import App.Pathfinder.Scan (scanMain)
 import App.Types (BaseDir (..))
@@ -24,21 +24,25 @@ appMain = do
           scanMain (unBaseDir resolved) debug
 
 data CommandOpts = LicenseScan (Maybe FilePath) Bool
-  deriving Show
+  deriving (Show)
 
 opts :: ParserInfo CommandOpts
-opts = info (commands <**> helper)
-  ( fullDesc <> header "pathfinder - finds declared licenses in manifest files")
+opts =
+  info
+    (commands <**> helper)
+    (fullDesc <> header "pathfinder - finds declared licenses in manifest files")
 
 commands :: Parser CommandOpts
-commands = hsubparser
-  ( command "scan" scanCmd
-  -- <> command "other" -- etc
-  )
+commands =
+  hsubparser
+    ( command "scan" scanCmd
+    -- <> command "other" -- etc
+    )
 
 scanCmd :: ParserInfo CommandOpts
-scanCmd = info
-  (LicenseScan <$> optional (strOption $ long "basedir" <> short 'd' <> metavar "DIR" <> help "Base directory for scanning")
-           <*> (fromMaybe False <$> optional (switch $ long "debug" <> help "Enable debug logging"))
-  )
-  (progDesc "Scan for licenses")
+scanCmd =
+  info
+    ( LicenseScan <$> optional (strOption $ long "basedir" <> short 'd' <> metavar "DIR" <> help "Base directory for scanning")
+        <*> (fromMaybe False <$> optional (switch $ long "debug" <> help "Enable debug logging"))
+    )
+    (progDesc "Scan for licenses")

--- a/src/App/Pathfinder/Scan.hs
+++ b/src/App/Pathfinder/Scan.hs
@@ -1,9 +1,9 @@
 {-# LANGUAGE PartialTypeSignatures #-}
 {-# LANGUAGE RecordWildCards #-}
 
-module App.Pathfinder.Scan
-  ( scanMain
-  ) where
+module App.Pathfinder.Scan (
+  scanMain,
+) where
 
 import Control.Carrier.AtomicCounter (runAtomicCounter)
 import Control.Carrier.Diagnostics qualified as Diag
@@ -56,8 +56,9 @@ scan ::
   ( Has (Lift IO) sig m
   , Has Logger sig m
   , MonadIO m
-  )
-  => Path Abs Dir -> m ()
+  ) =>
+  Path Abs Dir ->
+  m ()
 scan basedir = runFinally $ do
   sendIO $ PIO.setCurrentDir basedir
   capabilities <- sendIO getNumCapabilities
@@ -73,16 +74,15 @@ scan basedir = runFinally $ do
 
   sendIO (BL.putStr (encode projectResults))
 
-
 discoverFuncs ::
-  ( Has Diag.Diagnostics sig m,
-    Has (Lift IO) sig m,
-    MonadIO m,
-    Has ReadFS sig m,
-    Has ReadFS rsig run,
-    Has Exec rsig run,
-    Has Diag.Diagnostics rsig run,
-    Has (Lift IO) rsig run
+  ( Has Diag.Diagnostics sig m
+  , Has (Lift IO) sig m
+  , MonadIO m
+  , Has ReadFS sig m
+  , Has ReadFS rsig run
+  , Has Exec rsig run
+  , Has Diag.Diagnostics rsig run
+  , Has (Lift IO) rsig run
   ) =>
   -- | Discover functions
   [Path Abs Dir -> m [DiscoveredProject run]]
@@ -91,37 +91,41 @@ discoverFuncs = [Maven.discover, Nuspec.discover]
 data ProjectLicenseScan = ProjectLicenseScan
   { licenseStrategyType :: Text
   , licenseStrategyName :: Text
-  , discoveredLicenses  :: [LicenseResult]
-  } deriving (Eq, Ord, Show)
+  , discoveredLicenses :: [LicenseResult]
+  }
+  deriving (Eq, Ord, Show)
 
 instance ToJSON ProjectLicenseScan where
-  toJSON ProjectLicenseScan{..} = object
-    [ "type"    .= licenseStrategyType
-    , "name"    .= licenseStrategyName
-    , "files"   .= discoveredLicenses
-    ]
+  toJSON ProjectLicenseScan{..} =
+    object
+      [ "type" .= licenseStrategyType
+      , "name" .= licenseStrategyName
+      , "files" .= discoveredLicenses
+      ]
 
 data CompletedLicenseScan = CompletedLicenseScan
-  { completedLicenseName     :: Text
-  , completedLicenses        :: [LicenseResult]
-  } deriving (Eq, Ord, Show)
+  { completedLicenseName :: Text
+  , completedLicenses :: [LicenseResult]
+  }
+  deriving (Eq, Ord, Show)
 
 instance ToJSON CompletedLicenseScan where
-    toJSON CompletedLicenseScan{..} = object
-      [ "name"            .=  completedLicenseName
-      , "licenseResults"  .=  completedLicenses
+  toJSON CompletedLicenseScan{..} =
+    object
+      [ "name" .= completedLicenseName
+      , "licenseResults" .= completedLicenses
       ]
 
 mkLicenseScan :: DiscoveredProject n -> [LicenseResult] -> ProjectLicenseScan
 mkLicenseScan project licenses =
   ProjectLicenseScan
-    { licenseStrategyType = projectType project,
-      licenseStrategyName = projectType project,
-      discoveredLicenses = licenses
+    { licenseStrategyType = projectType project
+    , licenseStrategyName = projectType project
+    , discoveredLicenses = licenses
     }
 
 updateProgress :: Has StickyLogger sig m => Progress -> m ()
-updateProgress Progress {..} =
+updateProgress Progress{..} =
   logSticky'
     ( "[ "
         <> annotate (color Cyan) (pretty pQueued)

--- a/src/App/Types.hs
+++ b/src/App/Types.hs
@@ -1,11 +1,10 @@
-module App.Types
-  ( BaseDir (..),
-    NinjaGraphCLIOptions (..),
-    OverrideProject (..),
-    ProjectMetadata (..),
-    ProjectRevision (..),
-  )
-where
+module App.Types (
+  BaseDir (..),
+  NinjaGraphCLIOptions (..),
+  OverrideProject (..),
+  ProjectMetadata (..),
+  ProjectRevision (..),
+) where
 
 import Data.Text (Text)
 import Path
@@ -13,9 +12,9 @@ import Path
 newtype BaseDir = BaseDir {unBaseDir :: Path Abs Dir} deriving (Eq, Ord, Show)
 
 data OverrideProject = OverrideProject
-  { overrideName :: Maybe Text,
-    overrideRevision :: Maybe Text,
-    overrideBranch :: Maybe Text
+  { overrideName :: Maybe Text
+  , overrideRevision :: Maybe Text
+  , overrideBranch :: Maybe Text
   }
 
 data ProjectMetadata = ProjectMetadata
@@ -25,18 +24,20 @@ data ProjectMetadata = ProjectMetadata
   , projectLink :: Maybe Text
   , projectTeam :: Maybe Text
   , projectPolicy :: Maybe Text
-  } deriving (Eq, Ord, Show)
+  }
+  deriving (Eq, Ord, Show)
 
 data ProjectRevision = ProjectRevision
   { projectName :: Text
   , projectRevision :: Text
   , projectBranch :: Maybe Text
-  } deriving (Eq, Ord, Show)
+  }
+  deriving (Eq, Ord, Show)
 
 data NinjaGraphCLIOptions = NinjaGraphCLIOptions
-  { ninjaBaseDir :: FilePath,
-    ninjaDepsFile :: Maybe FilePath,
-    ninjaLunchTarget :: Maybe Text,
-    ninjaScanId :: Text,
-    ninjaBuildName :: Text
+  { ninjaBaseDir :: FilePath
+  , ninjaDepsFile :: Maybe FilePath
+  , ninjaLunchTarget :: Maybe Text
+  , ninjaScanId :: Text
+  , ninjaBuildName :: Text
   }

--- a/src/App/Util.hs
+++ b/src/App/Util.hs
@@ -1,16 +1,15 @@
 {-# LANGUAGE DataKinds #-}
 
-module App.Util
-  ( validateDir
-  , validateFile
-  )
-where
+module App.Util (
+  validateDir,
+  validateFile,
+) where
 
 import App.Types
 import Control.Monad (unless)
-import qualified Path.IO as P
+import Path (Abs, File, Path)
+import Path.IO qualified as P
 import System.Exit (die)
-import Path ( Path, Abs, File )
 
 -- | Validate that a filepath points to a directory and the directory exists
 validateDir :: FilePath -> IO BaseDir

--- a/src/App/Version.hs
+++ b/src/App/Version.hs
@@ -1,15 +1,14 @@
 {-# LANGUAGE TemplateHaskell #-}
 
-module App.Version
-  ( versionNumber,
-    fullVersionDescription,
-    isDirty,
-  )
-where
+module App.Version (
+  versionNumber,
+  fullVersionDescription,
+  isDirty,
+) where
 
 import App.Version.TH (getCurrentTag)
 import Data.Text (Text)
-import qualified Data.Text as T
+import Data.Text qualified as T
 import Data.Version (showVersion)
 import GitHash (GitInfo, giBranch, giDirty, giHash, tGitInfoCwd)
 import System.Info (compilerName, compilerVersion)
@@ -50,12 +49,12 @@ fullVersionDescription = T.concat items
     dirty = if isDirty then " (dirty)" else ""
     items :: [Text]
     items =
-      [ "spectrometer: ",
-        version,
-        " (revision ",
-        shortCommit,
-        dirty,
-        " compiled with ",
-        compilerId,
-        ")"
+      [ "spectrometer: "
+      , version
+      , " (revision "
+      , shortCommit
+      , dirty
+      , " compiled with "
+      , compilerId
+      , ")"
       ]

--- a/src/App/Version/TH.hs
+++ b/src/App/Version/TH.hs
@@ -1,26 +1,25 @@
 {-# LANGUAGE TemplateHaskell #-}
 
-module App.Version.TH
-  ( getCurrentTag,
-  )
-where
+module App.Version.TH (
+  getCurrentTag,
+) where
 
 import Control.Carrier.Diagnostics (runDiagnostics)
 import Control.Effect.Diagnostics (Diagnostics, fromEitherShow)
-import qualified Data.ByteString.Lazy as BSL
+import Data.ByteString.Lazy qualified as BSL
 import Data.Maybe (fromMaybe)
-import Data.Text (Text)
-import qualified Data.Text as T
 import Data.String.Conversion (decodeUtf8)
+import Data.Text (Text)
+import Data.Text qualified as T
 import Data.Versions (errorBundlePretty, semver)
-import Effect.Exec
-  ( AllowErr (Always),
-    Command (..),
-    Exec,
-    Has,
-    exec,
-    runExecIO,
-  )
+import Effect.Exec (
+  AllowErr (Always),
+  Command (..),
+  Exec,
+  Has,
+  exec,
+  runExecIO,
+ )
 import GitHash (giHash, tGitInfoCwd)
 import Instances.TH.Lift ()
 import Language.Haskell.TH (TExpQ)
@@ -30,9 +29,9 @@ import Path (Dir, Rel, mkRelDir)
 gitTagPointCommand :: Text -> Command
 gitTagPointCommand commit =
   Command
-    { cmdName = "git",
-      cmdArgs = ["tag", "--points-at", commit],
-      cmdAllowErr = Always
+    { cmdName = "git"
+    , cmdArgs = ["tag", "--points-at", commit]
+    , cmdAllowErr = Always
     }
 
 getCurrentTag :: TExpQ (Maybe Text)

--- a/src/Console/Sticky.hs
+++ b/src/Console/Sticky.hs
@@ -1,10 +1,9 @@
-module Console.Sticky
-  ( withStickyRegion,
-    StickyRegion, -- constructors intentionally not exported
-    setSticky,
-    setSticky',
-  )
-where
+module Console.Sticky (
+  withStickyRegion,
+  StickyRegion, -- constructors intentionally not exported
+  setSticky,
+  setSticky',
+) where
 
 import Control.Effect.ConsoleRegion qualified as R
 import Control.Effect.Lift

--- a/src/Control/Carrier/AtomicState.hs
+++ b/src/Control/Carrier/AtomicState.hs
@@ -3,12 +3,11 @@
 
 -- | A carrier for the AtomicState effect that utilizes an 'IORef' for atomic
 -- state updates
-module Control.Carrier.AtomicState
-  ( AtomicStateC (AtomicStateC),
-    runAtomicState,
-    module X,
-  )
-where
+module Control.Carrier.AtomicState (
+  AtomicStateC (AtomicStateC),
+  runAtomicState,
+  module X,
+) where
 
 import Control.Algebra
 import Control.Carrier.Lift

--- a/src/Control/Carrier/Diagnostics.hs
+++ b/src/Control/Carrier/Diagnostics.hs
@@ -3,22 +3,21 @@
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE UndecidableInstances #-}
 
-module Control.Carrier.Diagnostics
-  ( -- * Diagnostic carrier
-    DiagnosticsC (..),
-    runDiagnostics,
+module Control.Carrier.Diagnostics (
+  -- * Diagnostic carrier
+  DiagnosticsC (..),
+  runDiagnostics,
 
-    -- * Helpers
-    logDiagnostic,
-    logErrorBundle,
-    logWithExit_,
-    runDiagnosticsIO,
-    withResult,
+  -- * Helpers
+  logDiagnostic,
+  logErrorBundle,
+  logWithExit_,
+  runDiagnosticsIO,
+  withResult,
 
-    -- * Re-exports
-    module X,
-  )
-where
+  -- * Re-exports
+  module X,
+) where
 
 import Control.Carrier.Error.Either
 import Control.Carrier.Reader

--- a/src/Control/Carrier/Diagnostics/StickyContext.hs
+++ b/src/Control/Carrier/Diagnostics/StickyContext.hs
@@ -8,6 +8,7 @@ module Control.Carrier.Diagnostics.StickyContext (
 import Console.Sticky qualified as Sticky
 import Control.Carrier.Diagnostics qualified as Diag
 import Control.Carrier.Reader
+import Control.Effect.AtomicCounter
 import Control.Effect.Lift
 import Control.Effect.Sum (Member (inj))
 import Control.Monad.IO.Class (MonadIO)
@@ -15,7 +16,6 @@ import Control.Monad.Trans.Class (MonadTrans (..))
 import Data.List (intersperse)
 import Data.Text qualified as T
 import Effect.Logger
-import Control.Effect.AtomicCounter
 
 stickyDiag :: (Has AtomicCounter sig m, Has (Lift IO) sig m) => StickyDiagC m a -> m a
 stickyDiag act = do
@@ -36,7 +36,7 @@ newtype StickyDiagC m a = StickyDiagC {runStickyDiagC :: ReaderC StickyCtx m a}
 
 instance (Algebra sig m, Member Diag.Diagnostics sig, Member (Lift IO) sig, Member Logger sig) => Algebra (Diag.Diagnostics :+: sig) (StickyDiagC m) where
   alg hdl sig ctx = StickyDiagC $ case sig of
-    L thing@(Diag.Context txt _) -> local (\stickyCtx -> stickyCtx { ctxBacktrace = txt : ctxBacktrace stickyCtx }) $ do
+    L thing@(Diag.Context txt _) -> local (\stickyCtx -> stickyCtx{ctxBacktrace = txt : ctxBacktrace stickyCtx}) $ do
       TaskId taskId <- asks ctxTaskId
       region <- asks ctxRegion
       context <- asks ctxBacktrace

--- a/src/Control/Carrier/Finally.hs
+++ b/src/Control/Carrier/Finally.hs
@@ -2,15 +2,14 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE UndecidableInstances #-}
 
-module Control.Carrier.Finally
-  ( -- * Finally carrier
-    FinallyC (..),
-    runFinally,
+module Control.Carrier.Finally (
+  -- * Finally carrier
+  FinallyC (..),
+  runFinally,
 
-    -- * Re-exports
-    module X,
-  )
-where
+  -- * Re-exports
+  module X,
+) where
 
 import Control.Carrier.Reader
 import Control.Effect.Exception (finally)

--- a/src/Control/Carrier/Output/IO.hs
+++ b/src/Control/Carrier/Output/IO.hs
@@ -2,12 +2,11 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE UndecidableInstances #-}
 
-module Control.Carrier.Output.IO
-  ( OutputC (..),
-    runOutput,
-    module X,
-  )
-where
+module Control.Carrier.Output.IO (
+  OutputC (..),
+  runOutput,
+  module X,
+) where
 
 import Control.Applicative (Alternative)
 import Control.Carrier.Reader

--- a/src/Control/Carrier/TaskPool.hs
+++ b/src/Control/Carrier/TaskPool.hs
@@ -2,59 +2,61 @@
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE UndecidableInstances #-}
 
-module Control.Carrier.TaskPool
-  ( withTaskPool
-  , TaskPoolC
+module Control.Carrier.TaskPool (
+  withTaskPool,
+  TaskPoolC,
+  Progress (..),
+  module X,
+) where
 
-  , Progress(..)
-
-  , module X
-  ) where
-
-import Control.Monad (replicateM, join)
-import Control.Effect.Exception
-import Control.Effect.TaskPool as X
 import Control.Carrier.Reader
 import Control.Carrier.Threaded
 import Control.Concurrent.STM
+import Control.Effect.Exception
 import Control.Effect.Lift (sendIO)
+import Control.Effect.TaskPool as X
+import Control.Monad (join, replicateM)
 import Control.Monad.IO.Class (MonadIO)
-import Control.Monad.Trans (MonadTrans(..))
+import Control.Monad.Trans (MonadTrans (..))
 import Data.Foldable (traverse_)
 import Data.Functor (void)
 
-withTaskPool :: Has (Lift IO) sig m
-  => Int -- number of workers
-  -> (Progress -> m ()) -- get progress updates
-  -> TaskPoolC m a
-  -> m ()
+withTaskPool ::
+  Has (Lift IO) sig m =>
+  Int -> -- number of workers
+  (Progress -> m ()) -> -- get progress updates
+  TaskPoolC m a ->
+  m ()
 withTaskPool numWorkers reportProgress act = do
-  state <- sendIO $
-    State <$> newTVarIO []
-          <*> newTVarIO 0
-          <*> newTVarIO 0
-          <*> newEmptyTMVarIO
+  state <-
+    sendIO $
+      State <$> newTVarIO []
+        <*> newTVarIO 0
+        <*> newTVarIO 0
+        <*> newEmptyTMVarIO
 
-  let enqueue action = sendIO $ atomically $ modifyTVar (stQueued state) (action:)
+  let enqueue action = sendIO $ atomically $ modifyTVar (stQueued state) (action :)
   sendIO (enqueue (void (runTaskPool (stQueued state) act)))
 
   let mkThreads = do
         workerHandles <- replicateM numWorkers (fork (worker state))
         progressHandle <- fork (updateProgress reportProgress state)
-        pure (progressHandle:workerHandles)
+        pure (progressHandle : workerHandles)
 
   let cleanup handles = traverse_ kill handles
 
-  let waitForCompletion _ = join $ sendIO $ atomically $ do
-        maybeErr <- tryReadTMVar $ stError state
-        case maybeErr of
-          Just err -> pure $ throwIO err
-          Nothing -> do
-            queued  <- readTVar (stQueued state)
-            check (null queued)
-            running <- readTVar (stRunning state)
-            check (running == 0)
-            pure $ pure ()
+  let waitForCompletion _ = join $
+        sendIO $
+          atomically $ do
+            maybeErr <- tryReadTMVar $ stError state
+            case maybeErr of
+              Just err -> pure $ throwIO err
+              Nothing -> do
+                queued <- readTVar (stQueued state)
+                check (null queued)
+                running <- readTVar (stRunning state)
+                check (running == 0)
+                pure $ pure ()
 
   bracket mkThreads cleanup waitForCompletion
 
@@ -62,16 +64,19 @@ updateProgress :: Has (Lift IO) sig m => (Progress -> m ()) -> State any -> m ()
 updateProgress f st@State{..} = do
   loop (Progress 0 0 0)
   where
-  loop prev = join $ sendIO $ atomically $ stopWhenDone st $ do
-    running <- readTVar stRunning
-    queued <- length <$> readTVar stQueued
-    completed <- readTVar stCompleted
+    loop prev = join $
+      sendIO $
+        atomically $
+          stopWhenDone st $ do
+            running <- readTVar stRunning
+            queued <- length <$> readTVar stQueued
+            completed <- readTVar stCompleted
 
-    let new = Progress running queued completed
+            let new = Progress running queued completed
 
-    check (prev /= new)
+            check (prev /= new)
 
-    pure $ f new *> loop new
+            pure $ f new *> loop new
 
 stopWhenDone :: Applicative m => State any -> STM (m ()) -> STM (m ())
 stopWhenDone State{..} act = do
@@ -87,39 +92,42 @@ stopWhenDone State{..} act = do
 worker :: (Has (Lift IO) sig m) => State m -> m ()
 worker st@State{..} = loop
   where
+    loop = join $
+      sendIO $
+        atomically $
+          stopWhenDone st $ do
+            queued <- readTVar stQueued
+            case queued of
+              [] -> retry
+              (x : xs) -> do
+                writeTVar stQueued xs
+                addRunning
+                pure $
+                  mask $ \restore -> do
+                    res <- try $ restore x
+                    case res of
+                      Left err -> do
+                        _ <- sendIO $ atomically $ tryPutTMVar stError err
+                        pure ()
+                      Right () -> complete *> loop
 
-  loop = join $ sendIO $ atomically $ stopWhenDone st $ do
-    queued <- readTVar stQueued
-    case queued of
-      [] -> retry
-      (x:xs) -> do
-        writeTVar stQueued xs
-        addRunning
-        pure $
-          mask $ \restore -> do
-            res <- try $ restore x
-            case res of
-              Left err -> do
-                _ <- sendIO $ atomically $ tryPutTMVar stError err
-                pure ()
-              Right () -> complete *> loop
+    addRunning :: STM ()
+    addRunning = modifyTVar stRunning (+ 1)
 
-  addRunning :: STM ()
-  addRunning = modifyTVar stRunning (+1)
-
-  complete :: Has (Lift IO) sig m => m ()
-  complete = sendIO $ atomically $ modifyTVar stRunning (subtract 1) *> modifyTVar stCompleted (+1)
+    complete :: Has (Lift IO) sig m => m ()
+    complete = sendIO $ atomically $ modifyTVar stRunning (subtract 1) *> modifyTVar stCompleted (+ 1)
 
 runTaskPool :: TVar [m ()] -> TaskPoolC m a -> m a
 runTaskPool var = runReader var . runTaskPoolC
 
 data Progress = Progress
-  { pRunning   :: Int
-  , pQueued    :: Int
+  { pRunning :: Int
+  , pQueued :: Int
   , pCompleted :: Int
-  } deriving (Eq, Ord, Show)
+  }
+  deriving (Eq, Ord, Show)
 
-newtype TaskPoolC m a = TaskPoolC { runTaskPoolC :: ReaderC (TVar [m ()]) m a }
+newtype TaskPoolC m a = TaskPoolC {runTaskPoolC :: ReaderC (TVar [m ()]) m a}
   deriving (Functor, Applicative, Monad, MonadIO, MonadFail)
 
 instance MonadTrans TaskPoolC where
@@ -129,13 +137,13 @@ instance (Has (Lift IO) sig m, Algebra sig m) => Algebra (TaskPool :+: sig) (Tas
   alg hdl sig ctx = TaskPoolC $ case sig of
     L (ForkTask m) -> do
       var <- ask @(TVar [m ()])
-      sendIO $ atomically $ modifyTVar' var (runReader var (runTaskPoolC (void (hdl (m <$ ctx)))):)
+      sendIO $ atomically $ modifyTVar' var (runReader var (runTaskPoolC (void (hdl (m <$ ctx)))) :)
       pure ctx
     R other -> alg (runTaskPoolC . hdl) (R other) ctx
 
 data State m = State
-  { stQueued    :: TVar [m ()]
-  , stRunning   :: TVar Int
+  { stQueued :: TVar [m ()]
+  , stRunning :: TVar Int
   , stCompleted :: TVar Int
-  , stError     :: TMVar SomeException
+  , stError :: TMVar SomeException
   }

--- a/src/Control/Carrier/Threaded.hs
+++ b/src/Control/Carrier/Threaded.hs
@@ -1,14 +1,13 @@
-module Control.Carrier.Threaded
-  ( fork,
-    kill,
-    wait,
-    Handle (..),
-  )
-where
+module Control.Carrier.Threaded (
+  fork,
+  kill,
+  wait,
+  Handle (..),
+) where
 
 import Control.Carrier.Lift
-import qualified Control.Concurrent as Conc
-import qualified Control.Concurrent.Async as Async
+import Control.Concurrent qualified as Conc
+import Control.Concurrent.Async qualified as Async
 import Control.Concurrent.STM
 import Control.Effect.Exception
 import Control.Monad.IO.Class
@@ -16,8 +15,8 @@ import Data.Functor (void)
 import Prelude
 
 data Handle = Handle
-  { handleTid :: Conc.ThreadId,
-    handleWait :: STM (Either SomeException ())
+  { handleTid :: Conc.ThreadId
+  , handleWait :: STM (Either SomeException ())
   }
 
 fork :: Has (Lift IO) sig m => m a -> m Handle

--- a/src/Control/Effect/AtomicState.hs
+++ b/src/Control/Effect/AtomicState.hs
@@ -3,14 +3,13 @@
 
 -- | An effect that provides an atomically-modifiable state value. Similar to
 -- @Control.Effect.State@
-module Control.Effect.AtomicState
-  ( AtomicState (..),
-    getSet,
-    modify,
-    get,
-    put
-  )
-where
+module Control.Effect.AtomicState (
+  AtomicState (..),
+  getSet,
+  modify,
+  get,
+  put,
+) where
 
 import Control.Algebra
 import Data.Kind
@@ -18,14 +17,14 @@ import Data.Kind
 data AtomicState s (m :: Type -> Type) a where
   Modify :: (s -> (s, a)) -> AtomicState s m a
 
-getSet :: Has (AtomicState s) sig m => (s -> (s,a)) -> m a
+getSet :: Has (AtomicState s) sig m => (s -> (s, a)) -> m a
 getSet = send . Modify
 
 modify :: Has (AtomicState s) sig m => (s -> s) -> m ()
 modify f = send (Modify (\s -> (f s, ())))
 
 get :: Has (AtomicState s) sig m => m s
-get = send (Modify (\s -> (s,s)))
+get = send (Modify (\s -> (s, s)))
 
 put :: Has (AtomicState s) sig m => s -> m ()
-put s = send (Modify (const (s,())))
+put s = send (Modify (const (s, ())))

--- a/src/Control/Effect/ConsoleRegion.hs
+++ b/src/Control/Effect/ConsoleRegion.hs
@@ -1,15 +1,14 @@
 -- | Fused-effects style @Lift IO@ wrappers around 'System.Console.Concurrent'/'System.Console.Regions'
-module Control.Effect.ConsoleRegion
-  ( displayConsoleRegions,
-    withConsoleRegion,
-    setConsoleRegion,
-    appendConsoleRegion,
-    closeConsoleRegion,
-    finishConsoleRegion,
-    getConsoleRegion,
-    module X,
-  )
-where
+module Control.Effect.ConsoleRegion (
+  displayConsoleRegions,
+  withConsoleRegion,
+  setConsoleRegion,
+  appendConsoleRegion,
+  closeConsoleRegion,
+  finishConsoleRegion,
+  getConsoleRegion,
+  module X,
+) where
 
 import Control.Effect.Lift
 import Data.Text (Text)

--- a/src/Control/Effect/Diagnostics.hs
+++ b/src/Control/Effect/Diagnostics.hs
@@ -6,45 +6,44 @@
 -- - "stack trace"-like behavior, closely resembling the golang pattern of errors.Wrap (see: 'context')
 --
 -- - recovery from failures, recording them as "warnings" (see: 'recover' or '<||>')
-module Control.Effect.Diagnostics
-  ( -- * Diagnostics effect and operations
-    Diagnostics (..),
-    fatal,
-    context,
-    recover,
-    recover',
-    errorBoundary,
+module Control.Effect.Diagnostics (
+  -- * Diagnostics effect and operations
+  Diagnostics (..),
+  fatal,
+  context,
+  recover,
+  recover',
+  errorBoundary,
 
-    -- * Diagnostic result types
-    FailureBundle (..),
-    renderFailureBundle,
-    renderSomeDiagnostic,
+  -- * Diagnostic result types
+  FailureBundle (..),
+  renderFailureBundle,
+  renderSomeDiagnostic,
 
-    -- * Diagnostic helpers
-    fatalText,
-    fromEither,
-    fromEitherShow,
-    fromMaybe,
-    fromMaybeText,
-    tagError,
-    (<||>),
-    combineSuccessful,
+  -- * Diagnostic helpers
+  fatalText,
+  fromEither,
+  fromEitherShow,
+  fromMaybe,
+  fromMaybeText,
+  tagError,
+  (<||>),
+  combineSuccessful,
 
-    -- * ToDiagnostic typeclass
-    ToDiagnostic (..),
-    SomeDiagnostic (..),
-    module X,
-  )
-where
+  -- * ToDiagnostic typeclass
+  ToDiagnostic (..),
+  SomeDiagnostic (..),
+  module X,
+) where
 
 import Control.Algebra as X
 import Control.Exception (SomeException (..))
 import Data.List (intersperse)
-import qualified Data.List.NonEmpty as NE
+import Data.List.NonEmpty qualified as NE
 import Data.Maybe (catMaybes)
 import Data.Semigroup (sconcat)
 import Data.Text (Text)
-import qualified Data.Text as T
+import Data.Text qualified as T
 import Data.Text.Prettyprint.Doc
 import Data.Text.Prettyprint.Doc.Render.Terminal
 import Prelude
@@ -150,8 +149,8 @@ combineSuccessful msg actions = do
     Just xs -> pure (sconcat xs)
 
 data FailureBundle = FailureBundle
-  { failureWarnings :: [SomeDiagnostic],
-    failureCause :: SomeDiagnostic
+  { failureWarnings :: [SomeDiagnostic]
+  , failureCause :: SomeDiagnostic
   }
 
 instance Show FailureBundle where
@@ -166,15 +165,15 @@ renderFailureBundle FailureBundle{..} =
     , indent 4 (renderSomeDiagnostic failureCause)
     , ""
     ]
-    ++ if null failureWarnings
-      then []
-      else
-        [ ">>>"
-        , ""
-        , indent 2 (annotate (color Yellow) "Relevant warnings include:")
-        , ""
-        , indent 4 (renderWarnings failureWarnings)
-        ]
+      ++ if null failureWarnings
+        then []
+        else
+          [ ">>>"
+          , ""
+          , indent 2 (annotate (color Yellow) "Relevant warnings include:")
+          , ""
+          , indent 4 (renderWarnings failureWarnings)
+          ]
 
 renderSomeDiagnostic :: SomeDiagnostic -> Doc AnsiStyle
 renderSomeDiagnostic (SomeDiagnostic stack cause) =

--- a/src/Control/Effect/Finally.hs
+++ b/src/Control/Effect/Finally.hs
@@ -1,14 +1,13 @@
 {-# LANGUAGE GADTs #-}
 
-module Control.Effect.Finally
-  ( -- * Finally effect
-    Finally (..),
-    onExit,
+module Control.Effect.Finally (
+  -- * Finally effect
+  Finally (..),
+  onExit,
 
-    -- * Re-exports
-    module X,
-  )
-where
+  -- * Re-exports
+  module X,
+) where
 
 import Control.Algebra as X
 import Prelude

--- a/src/Control/Effect/Output.hs
+++ b/src/Control/Effect/Output.hs
@@ -1,10 +1,10 @@
 {-# LANGUAGE GADTs #-}
 
-module Control.Effect.Output
-  ( Output(..)
-  , output
-  , module X
-  ) where
+module Control.Effect.Output (
+  Output (..),
+  output,
+  module X,
+) where
 
 import Control.Algebra as X
 import Data.Kind (Type)

--- a/src/Control/Effect/Path.hs
+++ b/src/Control/Effect/Path.hs
@@ -1,12 +1,11 @@
 -- | Fused-effects wrapped functions from Path.IO
-module Control.Effect.Path
-  ( withSystemTempDir,
-  )
-where
+module Control.Effect.Path (
+  withSystemTempDir,
+) where
 
 import Control.Effect.Lift
 import Path
-import qualified Path.IO as PIO
+import Path.IO qualified as PIO
 import Prelude
 
 withSystemTempDir ::

--- a/src/Control/Effect/Record.hs
+++ b/src/Control/Effect/Record.hs
@@ -3,14 +3,13 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE UndecidableInstances #-}
 
-module Control.Effect.Record
-  ( Recordable (..),
-    RecordableValue (..),
-    RecordC (..),
-    runRecord,
-    Journal (..),
-  )
-where
+module Control.Effect.Record (
+  Recordable (..),
+  RecordableValue (..),
+  RecordC (..),
+  runRecord,
+  Journal (..),
+) where
 
 import Control.Algebra
 import Control.Carrier.AtomicState
@@ -18,14 +17,14 @@ import Control.Effect.Lift
 import Control.Effect.Sum
 import Control.Monad.Trans
 import Data.Aeson
-import qualified Data.ByteString as BS
-import qualified Data.ByteString.Lazy as BL
+import Data.ByteString qualified as BS
+import Data.ByteString.Lazy qualified as BL
 import Data.Kind
 import Data.Map.Strict (Map)
-import qualified Data.Map.Strict as M
+import Data.Map.Strict qualified as M
 import Data.String.Conversion (decodeUtf8)
-import qualified Data.Text as Text
-import qualified Data.Text.Lazy as LText
+import Data.Text qualified as Text
+import Data.Text.Lazy qualified as LText
 import Path
 import System.Exit
 import Unsafe.Coerce

--- a/src/Control/Effect/Record/TH.hs
+++ b/src/Control/Effect/Record/TH.hs
@@ -1,9 +1,8 @@
 {-# LANGUAGE TemplateHaskell #-}
 
-module Control.Effect.Record.TH
-  ( deriveRecordable,
-  )
-where
+module Control.Effect.Record.TH (
+  deriveRecordable,
+) where
 
 import Control.Effect.Record
 import Control.Monad (replicateM)
@@ -20,8 +19,8 @@ deriveRecordable tyName = do
         (appT [t|Recordable|] (appT (conT tyName) (varT (mkName "m"))))
         -- recordKey :: ...
         [ recordKeyMethod tyCons
-        -- recordValue :: ...
-        , recordValueMethod tyCons
+        , -- recordValue :: ...
+          recordValueMethod tyCons
         ]
     ]
 
@@ -67,7 +66,7 @@ conNm (RecGadtC nms _ _) = head nms
 mkArgs :: Con -> Q [Name]
 mkArgs (NormalC _ tys) = replicateM (length tys) (newName "a")
 mkArgs (RecC _ tys) = replicateM (length tys) (newName "a")
-mkArgs InfixC {} = replicateM 2 (newName "a")
+mkArgs InfixC{} = replicateM 2 (newName "a")
 mkArgs (ForallC _ _ con) = mkArgs con
 mkArgs (GadtC _ tys _) = replicateM (length tys) (newName "a")
 mkArgs (RecGadtC _ tys _) = replicateM (length tys) (newName "a")

--- a/src/Control/Effect/Replay/TH.hs
+++ b/src/Control/Effect/Replay/TH.hs
@@ -1,15 +1,14 @@
 {-# LANGUAGE TemplateHaskell #-}
 
-module Control.Effect.Replay.TH
-  ( deriveReplayable,
-  )
-where
+module Control.Effect.Replay.TH (
+  deriveReplayable,
+) where
 
 import Control.Effect.Replay
-import Language.Haskell.TH
 import Control.Monad (replicateM)
 import Data.Aeson
 import Data.Aeson.Types (parse)
+import Language.Haskell.TH
 
 deriveReplayable :: Name -> Q [Dec]
 deriveReplayable tyName = do
@@ -52,7 +51,7 @@ conNm (RecGadtC nms _ _) = head nms
 mkArgs :: Con -> Q [Name]
 mkArgs (NormalC _ tys) = replicateM (length tys) (newName "a")
 mkArgs (RecC _ tys) = replicateM (length tys) (newName "a")
-mkArgs InfixC {} = replicateM 2 (newName "a")
+mkArgs InfixC{} = replicateM 2 (newName "a")
 mkArgs (ForallC _ _ con) = mkArgs con
 mkArgs (GadtC _ tys _) = replicateM (length tys) (newName "a")
 mkArgs (RecGadtC _ tys _) = replicateM (length tys) (newName "a")

--- a/src/Control/Effect/StickyLogger.hs
+++ b/src/Control/Effect/StickyLogger.hs
@@ -6,8 +6,8 @@ module Control.Effect.StickyLogger (
   module X,
 ) where
 
-import Data.Text (Text)
 import Control.Algebra as X
+import Data.Text (Text)
 import Prettyprinter (Doc, pretty)
 import Prettyprinter.Render.Terminal (AnsiStyle)
 

--- a/src/Control/Effect/TaskPool.hs
+++ b/src/Control/Effect/TaskPool.hs
@@ -1,10 +1,10 @@
 {-# LANGUAGE GADTs #-}
 
-module Control.Effect.TaskPool
-  ( TaskPool(..)
-  , forkTask
-  , module X
-  ) where
+module Control.Effect.TaskPool (
+  TaskPool (..),
+  forkTask,
+  module X,
+) where
 
 import Control.Algebra as X
 

--- a/src/Control/Exception/Extra.hs
+++ b/src/Control/Exception/Extra.hs
@@ -1,10 +1,8 @@
-module Control.Exception.Extra
-  ( isSyncException,
-    safeCatch,
-  )
-where
+module Control.Exception.Extra (
+  isSyncException,
+  safeCatch,
+) where
 
-import Control.Effect.Lift
 import Control.Effect.Exception
 
 safeCatch :: (Exception e, Has (Lift IO) sig m) => m a -> (e -> m a) -> m a

--- a/src/Data/Aeson/Extra.hs
+++ b/src/Data/Aeson/Extra.hs
@@ -1,10 +1,10 @@
 module Data.Aeson.Extra (
-  forbidMembers, 
+  forbidMembers,
   TextLike (..),
 ) where
 
 import Control.Applicative ((<|>))
-import Data.Aeson.Types ( FromJSON(parseJSON), Object, Parser )
+import Data.Aeson.Types (FromJSON (parseJSON), Object, Parser)
 import Data.Foldable (traverse_)
 import Data.HashMap.Strict (member)
 import Data.String.Conversion (toString)
@@ -44,6 +44,7 @@ instance FromJSON TextLike where
 forbidMembers :: Text -> [Text] -> Object -> Parser ()
 forbidMembers typename names obj = traverse_ (badMember obj) names
   where
-    badMember hashmap name = if member name hashmap
-      then fail . toString $ "Invalid field name for " <> typename <> ": " <> name
-      else pure ()
+    badMember hashmap name =
+      if member name hashmap
+        then fail . toString $ "Invalid field name for " <> typename <> ": " <> name
+        else pure ()

--- a/src/Data/FileEmbed/Extra.hs
+++ b/src/Data/FileEmbed/Extra.hs
@@ -1,7 +1,6 @@
-module Data.FileEmbed.Extra
-  ( embedFileIfExists,
-  )
-where
+module Data.FileEmbed.Extra (
+  embedFileIfExists,
+) where
 
 import Data.FileEmbed (embedFile)
 import Language.Haskell.TH

--- a/src/Data/Flag.hs
+++ b/src/Data/Flag.hs
@@ -1,11 +1,10 @@
 -- http://oleg.fi/gists/posts/2019-03-21-flag.html
-module Data.Flag
-  ( Flag,
-    fromFlag,
-    toFlag,
-    flagOpt,
-  )
-where
+module Data.Flag (
+  Flag,
+  fromFlag,
+  toFlag,
+  flagOpt,
+) where
 
 import Options.Applicative (FlagFields, Mod, Parser, switch)
 

--- a/src/Data/Text/Extra.hs
+++ b/src/Data/Text/Extra.hs
@@ -1,18 +1,17 @@
-module Data.Text.Extra
-  ( splitOnceOn,
-    splitOnceOnEnd,
-    breakOnAndRemove,
-    underBS,
-    showT,
-    dropPrefix,
-  )
-where
+module Data.Text.Extra (
+  splitOnceOn,
+  splitOnceOnEnd,
+  breakOnAndRemove,
+  underBS,
+  showT,
+  dropPrefix,
+) where
 
 import Data.ByteString (ByteString)
-import Data.Text (Text)
-import qualified Data.Text as T
-import Data.String.Conversion (decodeUtf8, encodeUtf8)
 import Data.Maybe (fromMaybe)
+import Data.String.Conversion (decodeUtf8, encodeUtf8)
+import Data.Text (Text)
+import Data.Text qualified as T
 
 splitOnceOn :: Text -> Text -> (Text, Text)
 splitOnceOn needle haystack = (first, strippedRemaining)
@@ -39,8 +38,9 @@ splitOnceOnEnd needle haystack = (strippedInitial, end)
 -- Nothing
 breakOnAndRemove :: Text -> Text -> Maybe (Text, Text)
 breakOnAndRemove needle haystack
-  | (before,after) <- T.breakOn needle haystack
-  , T.isPrefixOf needle after = Just (before, T.drop (T.length needle) after)
+  | (before, after) <- T.breakOn needle haystack
+    , T.isPrefixOf needle after =
+    Just (before, T.drop (T.length needle) after)
   | otherwise = Nothing
 
 underBS :: (ByteString -> ByteString) -> Text -> Text

--- a/src/DepTypes.hs
+++ b/src/DepTypes.hs
@@ -1,116 +1,148 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE RecordWildCards #-}
 
-module DepTypes
-  ( Dependency(..)
-  , insertEnvironment
-  , insertTag
-  , insertLocation
-  , DepEnvironment(..)
-  , DepType(..)
-  , VerConstraint(..)
-  ) where
+module DepTypes (
+  Dependency (..),
+  insertEnvironment,
+  insertTag,
+  insertLocation,
+  DepEnvironment (..),
+  DepType (..),
+  VerConstraint (..),
+) where
 
 import Data.Aeson
 import Data.Map.Strict (Map)
+import Data.Map.Strict qualified as M
 import Data.Text (Text)
-import qualified Data.Map.Strict as M
 import GHC.Generics (Generic)
 
 -- FIXME: this needs a smart constructor with empty tags/environments/etc.
 -- We've historically relied on the compile error for making sure we fill all
 -- of these fields. Tests should be used to ensure this instead.
 data Dependency = Dependency
-  { dependencyType         :: DepType
-  , dependencyName         :: Text
-  , dependencyVersion      :: Maybe VerConstraint
-  , dependencyLocations    :: [Text]
+  { dependencyType :: DepType
+  , dependencyName :: Text
+  , dependencyVersion :: Maybe VerConstraint
+  , dependencyLocations :: [Text]
   , dependencyEnvironments :: [DepEnvironment] -- FIXME: this should be a Set
-  , dependencyTags         :: Map Text [Text]
-  } deriving (Eq, Ord, Show)
+  , dependencyTags :: Map Text [Text]
+  }
+  deriving (Eq, Ord, Show)
 
 insertEnvironment :: DepEnvironment -> Dependency -> Dependency
-insertEnvironment env dep = dep { dependencyEnvironments = env : dependencyEnvironments dep }
+insertEnvironment env dep = dep{dependencyEnvironments = env : dependencyEnvironments dep}
 
 insertTag :: Text -> Text -> Dependency -> Dependency
-insertTag key value dep = dep { dependencyTags = M.insertWith (++) key [value] (dependencyTags dep) }
+insertTag key value dep = dep{dependencyTags = M.insertWith (++) key [value] (dependencyTags dep)}
 
 insertLocation :: Text -> Dependency -> Dependency
-insertLocation loc dep = dep { dependencyLocations = loc : dependencyLocations dep }
+insertLocation loc dep = dep{dependencyLocations = loc : dependencyLocations dep}
 
-data DepEnvironment =
-    EnvProduction
+data DepEnvironment
+  = EnvProduction
   | EnvDevelopment
   | EnvTesting
-  | EnvOther Text -- ^ Other environments -- specifically for things like gradle configurations
+  | -- | Other environments -- specifically for things like gradle configurations
+    EnvOther Text
   deriving (Eq, Ord, Show)
 
 -- | A Dependency type. This corresponds to a "fetcher" on the backend
-data DepType =
-    SubprojectType -- ^ A first-party subproject
-  | ComposerType -- ^ Dependency found from the composer fetcher.  
-  | CondaType -- ^ Conda dependency
-  | GitType -- ^ Repository in Github
-  | GemType    -- ^ Gem registry
-  | GooglesourceType  -- ^ android.googlesource.com
-  | HexType    -- ^ Hex registry
-  | MavenType -- ^ Maven registry
-  | NodeJSType -- ^ NPM registry (or similar)
-  | NuGetType -- ^ Nuget registry
-  | PipType    -- ^ Pip registry
-  | PodType    -- ^ Cocoapods registry
-  | GoType -- ^ Go dependency
-  | CargoType -- ^ Rust Cargo Dependency
-  | RPMType -- ^ RPM dependency
-  | URLType -- ^ URL dependency
-  | UserType -- ^ No registry or fetch work needed
-  | HackageType -- ^ Hackage Registry
-  -- TODO: does this break the "location" abstraction?
-  | CarthageType -- ^ A Carthage dependency -- effectively a "git" dependency. Name is repo path and version is tag/branch/hash
+data DepType
+  = -- | A first-party subproject
+    SubprojectType
+  | -- | Dependency found from the composer fetcher.
+    ComposerType
+  | -- | Conda dependency
+    CondaType
+  | -- | Repository in Github
+    GitType
+  | -- | Gem registry
+    GemType
+  | -- | android.googlesource.com
+    GooglesourceType
+  | -- | Hex registry
+    HexType
+  | -- | Maven registry
+    MavenType
+  | -- | NPM registry (or similar)
+    NodeJSType
+  | -- | Nuget registry
+    NuGetType
+  | -- | Pip registry
+    PipType
+  | -- | Cocoapods registry
+    PodType
+  | -- | Go dependency
+    GoType
+  | -- | Rust Cargo Dependency
+    CargoType
+  | -- | RPM dependency
+    RPMType
+  | -- | URL dependency
+    URLType
+  | -- | No registry or fetch work needed
+    UserType
+  | -- | Hackage Registry
+    -- TODO: does this break the "location" abstraction?
+    HackageType
+  | -- | A Carthage dependency -- effectively a "git" dependency. Name is repo path and version is tag/branch/hash
+    CarthageType
   deriving (Eq, Ord, Show, Generic)
 
-data VerConstraint =
-    CEq Text -- ^ equal to, e.g., @CEq "2.0.0"@
-  | CURI Text -- ^ An exact version, at some URI
-  | CCompatible Text -- ^ compatible range. e.g., "~=" in python, "^>=" in haskell
-  | CAnd VerConstraint VerConstraint -- ^ Both constraints need to be satisfied, e.g., @CAnd (CGreaterOrEq "1.0.0") (CLessThan "2.0.0")@
-  | COr  VerConstraint VerConstraint -- ^ At least one constraint needs to be satisfied
-  | CLess Text -- ^ less than
-  | CLessOrEq Text -- ^ less than or equal to
-  | CGreater Text -- ^ greater than
-  | CGreaterOrEq Text -- ^ greater than or equal to
-  | CNot Text -- ^ not this version
+data VerConstraint
+  = -- | equal to, e.g., @CEq "2.0.0"@
+    CEq Text
+  | -- | An exact version, at some URI
+    CURI Text
+  | -- | compatible range. e.g., "~=" in python, "^>=" in haskell
+    CCompatible Text
+  | -- | Both constraints need to be satisfied, e.g., @CAnd (CGreaterOrEq "1.0.0") (CLessThan "2.0.0")@
+    CAnd VerConstraint VerConstraint
+  | -- | At least one constraint needs to be satisfied
+    COr VerConstraint VerConstraint
+  | -- | less than
+    CLess Text
+  | -- | less than or equal to
+    CLessOrEq Text
+  | -- | greater than
+    CGreater Text
+  | -- | greater than or equal to
+    CGreaterOrEq Text
+  | -- | not this version
+    CNot Text
   deriving (Eq, Ord, Show)
 
 instance FromJSON DepType -- use the generic instance
 instance ToJSON DepType -- use the generic instance
 
 instance ToJSON Dependency where
-  toJSON Dependency{..} = object
-    [ "type"      .= dependencyType
-    , "name"      .= dependencyName
-    , "version"   .= dependencyVersion
-    , "locations" .= dependencyLocations
-    , "tags"      .= dependencyTags
-    ]
+  toJSON Dependency{..} =
+    object
+      [ "type" .= dependencyType
+      , "name" .= dependencyName
+      , "version" .= dependencyVersion
+      , "locations" .= dependencyLocations
+      , "tags" .= dependencyTags
+      ]
 
 instance ToJSON VerConstraint where
-  toJSON constraint = let (name, value) = toValue constraint
-                       in object [ "type"  .= name
-                                 , "value" .= value
-                                 ]
-
+  toJSON constraint =
+    let (name, value) = toValue constraint
+     in object
+          [ "type" .= name
+          , "value" .= value
+          ]
     where
-
-    toValue :: VerConstraint -> (Text, Value)
-    toValue = \case
-      CEq text -> ("EQUAL", toJSON text)
-      CURI text -> ("URI", toJSON text)
-      CCompatible text -> ("COMPATIBLE", toJSON text)
-      CAnd a b -> ("AND", toJSON [toJSON a, toJSON b])
-      COr a b -> ("OR", toJSON [toJSON a, toJSON b])
-      CLess text -> ("LESSTHAN", toJSON text)
-      CLessOrEq text -> ("LESSOREQUAL", toJSON text)
-      CGreater text -> ("GREATERTHAN", toJSON text)
-      CGreaterOrEq text -> ("GREATEROREQUAL", toJSON text)
-      CNot text -> ("NOT", toJSON text)
+      toValue :: VerConstraint -> (Text, Value)
+      toValue = \case
+        CEq text -> ("EQUAL", toJSON text)
+        CURI text -> ("URI", toJSON text)
+        CCompatible text -> ("COMPATIBLE", toJSON text)
+        CAnd a b -> ("AND", toJSON [toJSON a, toJSON b])
+        COr a b -> ("OR", toJSON [toJSON a, toJSON b])
+        CLess text -> ("LESSTHAN", toJSON text)
+        CLessOrEq text -> ("LESSOREQUAL", toJSON text)
+        CGreater text -> ("GREATERTHAN", toJSON text)
+        CGreaterOrEq text -> ("GREATEROREQUAL", toJSON text)
+        CNot text -> ("NOT", toJSON text)

--- a/src/Discovery/Archive.hs
+++ b/src/Discovery/Archive.hs
@@ -1,24 +1,23 @@
-module Discovery.Archive
-  ( discover,
-  )
-where
+module Discovery.Archive (
+  discover,
+) where
 
-import qualified Codec.Archive.Tar as Tar
-import qualified Codec.Archive.Zip as Zip
-import qualified Codec.Compression.GZip as GZip
+import Codec.Archive.Tar qualified as Tar
+import Codec.Archive.Zip qualified as Zip
+import Codec.Compression.GZip qualified as GZip
+import Control.Carrier.Diagnostics
 import Control.Effect.Finally
 import Control.Effect.Lift
 import Control.Effect.TaskPool (TaskPool, forkTask)
-import qualified Data.ByteString.Lazy as BL
+import Data.ByteString.Lazy qualified as BL
 import Data.Foldable (traverse_)
 import Data.List (isSuffixOf)
 import Discovery.Archive.RPM (extractRpm)
 import Discovery.Walk
-import Path
-import qualified Path.IO as PIO
-import Prelude hiding (zip)
-import Control.Carrier.Diagnostics
 import Effect.ReadFS (ReadFS)
+import Path
+import Path.IO qualified as PIO
+import Prelude hiding (zip)
 
 -- Given a function to run over unarchived contents, unpack archives
 discover :: (Has (Lift IO) sig m, Has ReadFS sig m, Has Diagnostics sig m, Has Finally sig m, Has TaskPool sig m) => (Path Abs Dir -> m ()) -> Path Abs Dir -> m ()

--- a/src/Discovery/Archive/RPM.hs
+++ b/src/Discovery/Archive/RPM.hs
@@ -1,24 +1,23 @@
-module Discovery.Archive.RPM
-  ( extractRpm,
-  )
-where
+module Discovery.Archive.RPM (
+  extractRpm,
+) where
 
-import qualified Codec.RPM.Conduit as RPM
-import qualified Codec.RPM.Tags as Tags
-import qualified Codec.RPM.Types as RPMTypes
+import Codec.RPM.Conduit qualified as RPM
+import Codec.RPM.Tags qualified as Tags
+import Codec.RPM.Types qualified as RPMTypes
 import Conduit
 import Control.Effect.Lift
 import Control.Exception (throwIO)
 import Control.Monad.Except
-import qualified Data.ByteString as BS
-import qualified Data.ByteString.Char8 as BS8
-import qualified Data.ByteString.Lazy as BL
-import qualified Data.CPIO as CPIO
-import qualified Data.Conduit.Lzma as Lzma
-import qualified Data.Conduit.Zlib as Zlib
+import Data.ByteString qualified as BS
+import Data.ByteString.Char8 qualified as BS8
+import Data.ByteString.Lazy qualified as BL
+import Data.CPIO qualified as CPIO
+import Data.Conduit.Lzma qualified as Lzma
+import Data.Conduit.Zlib qualified as Zlib
 import Data.Foldable (asum)
 import Path
-import qualified Path.IO as PIO
+import Path.IO qualified as PIO
 import Prelude
 
 extractRpm :: Has (Lift IO) sig m => Path Abs Dir -> Path Abs File -> m ()

--- a/src/Discovery/Filters.hs
+++ b/src/Discovery/Filters.hs
@@ -1,18 +1,17 @@
-module Discovery.Filters
-  ( BuildTargetFilter (..),
-    filterParser,
-    applyFilter,
-    applyFilters,
-  )
-where
+module Discovery.Filters (
+  BuildTargetFilter (..),
+  filterParser,
+  applyFilter,
+  applyFilters,
+) where
 
-import qualified Data.List.NonEmpty as NE
+import Data.List.NonEmpty qualified as NE
 import Data.Maybe (mapMaybe)
 import Data.Semigroup (sconcat)
 import Data.Set (Set)
-import qualified Data.Set as S
+import Data.Set qualified as S
 import Data.Text (Text)
-import qualified Data.Text as T
+import Data.Text qualified as T
 import Data.Void (Void)
 import Path
 import Text.Megaparsec
@@ -47,14 +46,14 @@ applyFilters filters tool dir targets = do
 -- 2. The BuildTargets that should be scanned (@Set BuildTarget@)
 applyFilter :: BuildTargetFilter -> Text -> Path Rel Dir -> Set BuildTarget -> Maybe (Set BuildTarget)
 applyFilter (ProjectFilter tool dir) tool' dir' targets
-  | tool == tool',
-    dir == dir' =
+  | tool == tool'
+    , dir == dir' =
     Just targets
   | otherwise = Nothing
 applyFilter (TargetFilter tool dir target) tool' dir' targets
-  | tool == tool',
-    dir == dir',
-    S.member target targets =
+  | tool == tool'
+    , dir == dir'
+    , S.member target targets =
     Just $ S.singleton target
   | otherwise = Nothing
 

--- a/src/Discovery/Walk.hs
+++ b/src/Discovery/Walk.hs
@@ -1,14 +1,13 @@
-module Discovery.Walk
-  ( -- * Walking the filetree
-    walk,
-    walk',
-    WalkStep (..),
+module Discovery.Walk (
+  -- * Walking the filetree
+  walk,
+  walk',
+  WalkStep (..),
 
-    -- * Helpers
-    fileName,
-    findFileNamed,
-  )
-where
+  -- * Helpers
+  fileName,
+  findFileNamed,
+) where
 
 import Control.Carrier.Writer.Church
 import Control.Effect.Diagnostics
@@ -18,9 +17,9 @@ import Data.Foldable (find)
 import Data.Functor (void)
 import Data.List ((\\))
 import Data.Maybe (mapMaybe)
-import qualified Data.Set as S
+import Data.Set qualified as S
 import Data.Text (Text)
-import qualified Data.Text as T
+import Data.Text qualified as T
 import Effect.ReadFS
 import Path
 
@@ -91,10 +90,11 @@ walkDir ::
   -- | Directory where traversal begins
   Path Abs Dir ->
   m ()
-walkDir handler topdir = context "Walking the filetree" $
-  void $
-    --makeAbsolute topdir >>= walkAvoidLoop S.empty
-    walkAvoidLoop S.empty topdir
+walkDir handler topdir =
+  context "Walking the filetree" $
+    void $
+      --makeAbsolute topdir >>= walkAvoidLoop S.empty
+      walkAvoidLoop S.empty topdir
   where
     walkAvoidLoop traversed curdir = do
       mRes <- checkLoop traversed curdir

--- a/src/Effect/Grapher.hs
+++ b/src/Effect/Grapher.hs
@@ -6,45 +6,44 @@
 --
 -- It defines @direct@ and @edge@ combinators analagous to 'G.direct' and
 -- 'G.edge' from 'G.Graphing'
-module Effect.Grapher
-  ( Grapher (..),
-    direct,
-    edge,
-    evalGrapher,
-    runGrapher,
+module Effect.Grapher (
+  Grapher (..),
+  direct,
+  edge,
+  evalGrapher,
+  runGrapher,
 
-    -- * Labeling
-    LabeledGrapher,
-    LabeledGrapherC,
-    label,
-    withLabeling,
+  -- * Labeling
+  LabeledGrapher,
+  LabeledGrapherC,
+  label,
+  withLabeling,
 
-    -- * Mapping
-    MappedGrapher,
-    MappedGrapherC,
-    mapping,
-    withMapping,
-    MappingError(..),
+  -- * Mapping
+  MappedGrapher,
+  MappedGrapherC,
+  mapping,
+  withMapping,
+  MappingError (..),
 
-    -- * Re-exports
-    module X,
-  )
-where
+  -- * Re-exports
+  module X,
+) where
 
 import Control.Algebra as X
-import Control.Carrier.Diagnostics (ToDiagnostic(..))
+import Control.Carrier.Diagnostics (ToDiagnostic (..))
 import Control.Carrier.State.Strict
 import Control.Monad.IO.Class (MonadIO)
 import Data.Kind (Type)
 import Data.Map.Strict (Map)
-import qualified Data.Map.Strict as M
+import Data.Map.Strict qualified as M
 import Data.Maybe (fromMaybe)
 import Data.Set (Set)
-import qualified Data.Set as S
+import Data.Set qualified as S
 import Data.Text (Text)
-import qualified Data.Text as T
+import Data.Text qualified as T
+import Graphing qualified as G
 import Prettyprinter (pretty)
-import qualified Graphing as G
 
 data Grapher ty (m :: Type -> Type) k where
   Direct :: ty -> Grapher ty m ()
@@ -167,7 +166,6 @@ unlabel f labels = G.gmap (\ty -> f ty (findLabels ty))
 -- third primitive, 'mapping'.
 --
 -- > mapping :: Has CabalGrapher sig m => UnitId -> CabalPackage -> m ()
-
 type MappedGrapher ty val = State (Map ty val) :+: Grapher ty
 
 type MappedGrapherC ty val m a = StateC (Map ty val) (GrapherC ty m) a
@@ -191,7 +189,9 @@ withMapping f act = do
   pure result
 
 -- | Errors that may occur when using 'withMapping'
-newtype MappingError = MissingKey Text -- ^ A key did not have an associated value
+newtype MappingError
+  = -- | A key did not have an associated value
+    MissingKey Text
   deriving (Eq, Ord, Show)
 
 instance ToDiagnostic MappingError where

--- a/src/Effect/ReadFS.hs
+++ b/src/Effect/ReadFS.hs
@@ -8,39 +8,38 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 
-module Effect.ReadFS
-  ( -- * ReadFS Effect
-    ReadFS (..),
-    ReadFSErr (..),
-    ReadFSIOC (..),
+module Effect.ReadFS (
+  -- * ReadFS Effect
+  ReadFS (..),
+  ReadFSErr (..),
+  ReadFSIOC (..),
 
-    -- * Reading raw file contents
-    readContentsBS,
-    readContentsText,
+  -- * Reading raw file contents
+  readContentsBS,
+  readContentsText,
 
-    -- * Resolving relative filepaths
-    resolveFile,
-    resolveFile',
-    resolveDir,
-    resolveDir',
+  -- * Resolving relative filepaths
+  resolveFile,
+  resolveFile',
+  resolveDir,
+  resolveDir',
 
-    -- * Checking whether files exist
-    doesFileExist,
-    doesDirExist,
+  -- * Checking whether files exist
+  doesFileExist,
+  doesDirExist,
 
-    -- * Listing a directory
-    listDir,
-    listDir',
+  -- * Listing a directory
+  listDir,
+  listDir',
 
-    -- * Parsing file contents
-    readContentsParser,
-    readContentsJson,
-    readContentsToml,
-    readContentsYaml,
-    readContentsXML,
-    module X,
-  )
-where
+  -- * Parsing file contents
+  readContentsParser,
+  readContentsJson,
+  readContentsToml,
+  readContentsYaml,
+  readContentsXML,
+  module X,
+) where
 
 import Control.Algebra as X
 import Control.Applicative (Alternative)
@@ -50,26 +49,26 @@ import Control.Effect.Record
 import Control.Effect.Record.TH (deriveRecordable)
 import Control.Effect.Replay
 import Control.Effect.Replay.TH (deriveReplayable)
-import qualified Control.Exception as E
+import Control.Exception qualified as E
 import Control.Monad ((<=<))
 import Control.Monad.IO.Class
 import Data.Aeson
 import Data.ByteString (ByteString)
-import qualified Data.ByteString as BS
+import Data.ByteString qualified as BS
 import Data.Kind (Type)
 import Data.String.Conversion (decodeUtf8)
 import Data.Text (Text)
-import qualified Data.Text as T
-import Data.Text.Prettyprint.Doc (pretty, line, indent, vsep)
+import Data.Text qualified as T
+import Data.Text.Prettyprint.Doc (indent, line, pretty, vsep)
 import Data.Void (Void)
 import Data.Yaml (decodeEither', prettyPrintParseException)
 import GHC.Generics (Generic)
 import Parse.XML (FromXML, parseXML, xmlErrorPretty)
 import Path
-import qualified Path.IO as PIO
+import Path.IO qualified as PIO
 import Text.Megaparsec (Parsec, runParser)
 import Text.Megaparsec.Error (errorBundlePretty)
-import qualified Toml
+import Toml qualified
 
 data ReadFS (m :: Type -> Type) k where
   ReadContentsBS' :: Path x File -> ReadFS m (Either ReadFSErr ByteString)

--- a/src/Fossa/API/Types.hs
+++ b/src/Fossa/API/Types.hs
@@ -3,46 +3,45 @@
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE RecordWildCards #-}
 
-module Fossa.API.Types
-  ( ApiKey (..),
-    ApiOpts (..),
-    useApiOpts,
-    Issues (..),
-    IssueRule (..),
-    IssueType (..),
-    Issue (..),
-  )
-where
+module Fossa.API.Types (
+  ApiKey (..),
+  ApiOpts (..),
+  useApiOpts,
+  Issues (..),
+  IssueRule (..),
+  IssueType (..),
+  Issue (..),
+) where
 
 import Control.Effect.Diagnostics hiding (fromMaybe)
 import Data.Aeson
 import Data.Coerce (coerce)
 import Data.List.Extra ((!?))
 import Data.Map.Strict (Map)
-import qualified Data.Map.Strict as M
+import Data.Map.Strict qualified as M
 import Data.Maybe (fromMaybe)
 import Data.String.Conversion (encodeUtf8)
 import Data.Text (Text)
-import qualified Data.Text as T
+import Data.Text qualified as T
 import Data.Text.Prettyprint.Doc
 import Network.HTTP.Req
 import Text.URI (URI, render)
 import Text.URI.QQ (uri)
-import qualified Unsafe.Coerce as Unsafe
+import Unsafe.Coerce qualified as Unsafe
 
 newtype ApiKey = ApiKey {unApiKey :: Text}
   deriving (Eq, Ord, Show)
 
 data ApiOpts = ApiOpts
-  { apiOptsUri :: Maybe URI,
-    apiOptsApiKey :: ApiKey
+  { apiOptsUri :: Maybe URI
+  , apiOptsApiKey :: ApiKey
   }
   deriving (Eq, Ord, Show)
 
 data Issues = Issues
-  { issuesCount :: Int,
-    issuesIssues :: [Issue],
-    issuesStatus :: Text
+  { issuesCount :: Int
+  , issuesIssues :: [Issue]
+  , issuesStatus :: Text
   }
   deriving (Eq, Ord, Show)
 
@@ -65,12 +64,12 @@ renderIssueType = \case
   IssueOther other -> other
 
 data Issue = Issue
-  { issueId :: Int,
-    issuePriorityString :: Maybe Text, -- we only use this field for `fossa test --json`
-    issueResolved :: Bool,
-    issueRevisionId :: Text,
-    issueType :: IssueType,
-    issueRule :: Maybe IssueRule
+  { issueId :: Int
+  , issuePriorityString :: Maybe Text -- we only use this field for `fossa test --json`
+  , issueResolved :: Bool
+  , issueRevisionId :: Text
+  , issueType :: IssueType
+  , issueRule :: Maybe IssueRule
   }
   deriving (Eq, Ord, Show)
 
@@ -86,11 +85,11 @@ instance FromJSON Issues where
       <*> obj .: "status"
 
 instance ToJSON Issues where
-  toJSON Issues {..} =
+  toJSON Issues{..} =
     object
-      [ "count" .= issuesCount,
-        "issues" .= issuesIssues,
-        "status" .= issuesStatus
+      [ "count" .= issuesCount
+      , "issues" .= issuesIssues
+      , "status" .= issuesStatus
       ]
 
 instance FromJSON Issue where
@@ -104,14 +103,14 @@ instance FromJSON Issue where
       <*> obj .:? "rule"
 
 instance ToJSON Issue where
-  toJSON Issue {..} =
+  toJSON Issue{..} =
     object
-      [ "id" .= issueId,
-        "priorityString" .= issuePriorityString,
-        "resolved" .= issueResolved,
-        "revisionId" .= issueRevisionId,
-        "type" .= issueType,
-        "rule" .= issueRule
+      [ "id" .= issueId
+      , "priorityString" .= issuePriorityString
+      , "resolved" .= issueResolved
+      , "revisionId" .= issueRevisionId
+      , "type" .= issueType
+      , "rule" .= issueRule
       ]
 
 instance FromJSON IssueType where
@@ -138,7 +137,7 @@ instance FromJSON IssueRule where
     IssueRule <$> obj .:? "licenseId"
 
 instance ToJSON IssueRule where
-  toJSON IssueRule {..} = object ["licenseId" .= ruleLicenseId]
+  toJSON IssueRule{..} = object ["licenseId" .= ruleLicenseId]
 
 instance Pretty Issues where
   pretty = renderedIssues
@@ -172,15 +171,15 @@ renderedIssues issues = rendered
     renderHeader :: IssueType -> Doc ann
     renderHeader ty =
       vsep
-        [ "========================================================================",
-          pretty $ renderIssueType ty,
-          "========================================================================",
-          hsep $
+        [ "========================================================================"
+        , pretty $ renderIssueType ty
+        , "========================================================================"
+        , hsep $
             map (fill padding) $ case ty of
               IssuePolicyConflict -> ["Dependency", "Revision", "License"]
               IssuePolicyFlag -> ["Dependency", "Revision", "License"]
-              _ -> ["Dependency", "Revision"],
-          ""
+              _ -> ["Dependency", "Revision"]
+        , ""
         ]
 
     renderIssue :: Issue -> Doc ann

--- a/src/Graphing.hs
+++ b/src/Graphing.hs
@@ -7,35 +7,35 @@
 -- For simple (non-cyclic) graphs, try 'unfold'. For graphs with only direct dependencies, try 'fromList'
 --
 -- For describing complex graphs, see the 'Effect.Grapher' effect.
-module Graphing
-  ( -- * Graphing type
-    Graphing(..)
-  , empty
-  , size
-  , direct
-  , edge
+module Graphing (
+  -- * Graphing type
+  Graphing (..),
+  empty,
+  size,
+  direct,
+  edge,
 
   -- * Manipulating a Graphing
-  , gmap
-  , gtraverse
-  , induceJust
-  , filter
-  , pruneUnreachable
-  , stripRoot
+  gmap,
+  gtraverse,
+  induceJust,
+  filter,
+  pruneUnreachable,
+  stripRoot,
 
   -- * Building simple Graphings
-  , fromAdjacencyMap
-  , fromList
-  , unfold
-  ) where
+  fromAdjacencyMap,
+  fromList,
+  unfold,
+) where
 
 import Algebra.Graph.AdjacencyMap (AdjacencyMap)
-import qualified Algebra.Graph.AdjacencyMap as AM
-import qualified Algebra.Graph.AdjacencyMap.Extra as AME
-import qualified Algebra.Graph.AdjacencyMap.Algorithm as AMA
+import Algebra.Graph.AdjacencyMap qualified as AM
+import Algebra.Graph.AdjacencyMap.Algorithm qualified as AMA
+import Algebra.Graph.AdjacencyMap.Extra qualified as AME
 import Data.Maybe (catMaybes)
 import Data.Set (Set)
-import qualified Data.Set as S
+import Data.Set qualified as S
 import Prelude hiding (filter)
 
 -- | A @Graphing ty@ is a graph of nodes with type @ty@.
@@ -46,9 +46,10 @@ import Prelude hiding (filter)
 -- Typically, when consuming a Graphing, we only care about nodes in the graph
 -- reachable from 'graphingDirect'
 data Graphing ty = Graphing
-  { graphingDirect   :: Set ty
+  { graphingDirect :: Set ty
   , graphingAdjacent :: AdjacencyMap ty
-  } deriving (Eq, Ord, Show)
+  }
+  deriving (Eq, Ord, Show)
 
 instance Ord ty => Semigroup (Graphing ty) where
   graphing <> graphing' =
@@ -63,10 +64,10 @@ instance Ord ty => Monoid (Graphing ty) where
 --
 -- Graphing isn't a lawful 'Functor', so we don't provide an instance.
 gmap :: (Ord ty, Ord ty') => (ty -> ty') -> Graphing ty -> Graphing ty'
-gmap f gr = gr { graphingDirect = direct', graphingAdjacent = adjacent' }
+gmap f gr = gr{graphingDirect = direct', graphingAdjacent = adjacent'}
   where
-  direct' = S.map f (graphingDirect gr)
-  adjacent' = AM.gmap f (graphingAdjacent gr)
+    direct' = S.map f (graphingDirect gr)
+    adjacent' = AM.gmap f (graphingAdjacent gr)
 
 -- | Map each element of the Graphing to an action, evaluate the actions, and
 -- collect the results.
@@ -83,14 +84,14 @@ gtraverse f Graphing{..} = Graphing <$> newSet <*> newAdjacent
 
 -- | Like 'AM.induceJust', but for Graphings
 induceJust :: Ord a => Graphing (Maybe a) -> Graphing a
-induceJust gr = gr { graphingDirect = direct', graphingAdjacent = adjacent' }
+induceJust gr = gr{graphingDirect = direct', graphingAdjacent = adjacent'}
   where
     direct' = S.fromList . catMaybes . S.toList $ graphingDirect gr
     adjacent' = AM.induceJust (graphingAdjacent gr)
 
 -- | Filter Graphing elements
 filter :: (ty -> Bool) -> Graphing ty -> Graphing ty
-filter f gr = gr { graphingDirect = direct', graphingAdjacent = adjacent' }
+filter f gr = gr{graphingDirect = direct', graphingAdjacent = adjacent'}
   where
     direct' = S.filter f (graphingDirect gr)
     adjacent' = AM.induce f (graphingAdjacent gr)
@@ -105,24 +106,24 @@ size = AM.vertexCount . graphingAdjacent
 
 -- | Strip all items from the direct set, promote their immediate children to direct items
 stripRoot :: Ord ty => Graphing ty -> Graphing ty
-stripRoot gr = gr { graphingDirect = direct' }
+stripRoot gr = gr{graphingDirect = direct'}
   where
-  roots = S.toList $ graphingDirect gr
-  edgeSet root = AM.postSet root $ graphingAdjacent gr
-  direct' = S.unions $ map edgeSet roots
+    roots = S.toList $ graphingDirect gr
+    edgeSet root = AM.postSet root $ graphingAdjacent gr
+    direct' = S.unions $ map edgeSet roots
 
 -- | Add a direct dependency to this Graphing
 direct :: Ord ty => ty -> Graphing ty -> Graphing ty
-direct dep gr = gr { graphingDirect = direct', graphingAdjacent = adjacent' }
+direct dep gr = gr{graphingDirect = direct', graphingAdjacent = adjacent'}
   where
-  direct' = S.insert dep (graphingDirect gr)
-  adjacent' = AM.overlay (AM.vertex dep) (graphingAdjacent gr)
+    direct' = S.insert dep (graphingDirect gr)
+    adjacent' = AM.overlay (AM.vertex dep) (graphingAdjacent gr)
 
 -- | Add an edge between two nodes in this Graphing
 edge :: Ord ty => ty -> ty -> Graphing ty -> Graphing ty
-edge parent child gr = gr { graphingAdjacent = adjacent' }
+edge parent child gr = gr{graphingAdjacent = adjacent'}
   where
-  adjacent' = AM.overlay (AM.edge parent child) (graphingAdjacent gr)
+    adjacent' = AM.overlay (AM.edge parent child) (graphingAdjacent gr)
 
 -- | @unfold direct getDeps toDependency@ unfolds a graph, given:
 --
@@ -134,12 +135,13 @@ edge parent child gr = gr { graphingAdjacent = adjacent' }
 --
 -- __Unfold does not work for recursive inputs__
 unfold :: forall dep res. Ord res => [dep] -> (dep -> [dep]) -> (dep -> res) -> Graphing res
-unfold seed getDeps toDependency = Graphing
-  { graphingDirect = S.fromList (map toDependency seed)
-  , graphingAdjacent = AM.vertices (map toDependency seed) `AM.overlay` AM.edges [(toDependency parentDep, toDependency childDep) | (parentDep,childDep) <- edgesFrom seed]
-  }
+unfold seed getDeps toDependency =
+  Graphing
+    { graphingDirect = S.fromList (map toDependency seed)
+    , graphingAdjacent = AM.vertices (map toDependency seed) `AM.overlay` AM.edges [(toDependency parentDep, toDependency childDep) | (parentDep, childDep) <- edgesFrom seed]
+    }
   where
-    edgesFrom :: [dep] -> [(dep,dep)]
+    edgesFrom :: [dep] -> [(dep, dep)]
     edgesFrom nodes = do
       node <- nodes
       let children = getDeps node
@@ -158,6 +160,6 @@ fromAdjacencyMap = Graphing S.empty
 --
 -- A vertex is reachable if there's a path from the "direct" vertices to that vertex
 pruneUnreachable :: Ord ty => Graphing ty -> Graphing ty
-pruneUnreachable gr = gr { graphingAdjacent = AM.induce (`S.member` reachable) (graphingAdjacent gr) }
+pruneUnreachable gr = gr{graphingAdjacent = AM.induce (`S.member` reachable) (graphingAdjacent gr)}
   where
     reachable = S.fromList $ AMA.dfs (S.toList (graphingDirect gr)) (graphingAdjacent gr)

--- a/src/Srclib/Converter.hs
+++ b/src/Srclib/Converter.hs
@@ -1,39 +1,40 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE RecordWildCards #-}
 
-module Srclib.Converter
-  ( toSourceUnit,
-    depTypeToFetcher
-  ) where
+module Srclib.Converter (
+  toSourceUnit,
+  depTypeToFetcher,
+) where
 
 import Prelude
 
-import qualified Algebra.Graph.AdjacencyMap as AM
+import Algebra.Graph.AdjacencyMap qualified as AM
 import App.Fossa.Analyze.Project
 import Control.Applicative ((<|>))
+import Data.Set qualified as Set
 import Data.Text (Text)
-import qualified Data.Text as Text
-import qualified Data.Set as Set
+import Data.Text qualified as Text
 import DepTypes
 import Graphing (Graphing)
-import qualified Graphing
+import Graphing qualified
 import Path (toFilePath)
 import Srclib.Types
 
 toSourceUnit :: ProjectResult -> SourceUnit
 toSourceUnit ProjectResult{..} =
   SourceUnit
-    { sourceUnitName = renderedPath,
-      sourceUnitType = projectResultType,
-      sourceUnitManifest = renderedPath,
-      sourceUnitBuild = Just $
-        SourceUnitBuild
-          { buildArtifact = "default",
-            buildSucceeded = True,
-            buildImports = imports,
-            buildDependencies = deps
-          },
-      additionalData = Nothing
+    { sourceUnitName = renderedPath
+    , sourceUnitType = projectResultType
+    , sourceUnitManifest = renderedPath
+    , sourceUnitBuild =
+        Just $
+          SourceUnitBuild
+            { buildArtifact = "default"
+            , buildSucceeded = True
+            , buildImports = imports
+            , buildDependencies = deps
+            }
+    , additionalData = Nothing
     }
   where
     renderedPath = Text.pack (toFilePath projectResultPath)
@@ -54,10 +55,11 @@ toSourceUnit ProjectResult{..} =
     imports = Set.toList $ Graphing.graphingDirect locatorGraph
 
 mkSourceUnitDependency :: AM.AdjacencyMap Locator -> Locator -> SourceUnitDependency
-mkSourceUnitDependency gr locator = SourceUnitDependency
-  { sourceDepLocator = locator
-  , sourceDepImports = Set.toList $ AM.postSet locator gr
-  }
+mkSourceUnitDependency gr locator =
+  SourceUnitDependency
+    { sourceDepLocator = locator
+    , sourceDepImports = Set.toList $ AM.postSet locator gr
+    }
 
 shouldPublishDep :: Dependency -> Bool
 shouldPublishDep Dependency{dependencyEnvironments} =
@@ -72,11 +74,12 @@ isSupportedType :: Dependency -> Bool
 isSupportedType Dependency{dependencyType} = dependencyType /= SubprojectType && dependencyType /= GooglesourceType
 
 toLocator :: Dependency -> Locator
-toLocator dep = Locator
-  { locatorFetcher = depTypeToFetcher (dependencyType dep)
-  , locatorProject = dependencyName dep
-  , locatorRevision = verConstraintToRevision =<< dependencyVersion dep
-  }
+toLocator dep =
+  Locator
+    { locatorFetcher = depTypeToFetcher (dependencyType dep)
+    , locatorProject = dependencyName dep
+    , locatorRevision = verConstraintToRevision =<< dependencyVersion dep
+    }
 
 verConstraintToRevision :: VerConstraint -> Maybe Text
 verConstraintToRevision = \case

--- a/src/Srclib/Types.hs
+++ b/src/Srclib/Types.hs
@@ -1,59 +1,67 @@
 {-# LANGUAGE RecordWildCards #-}
 
-module Srclib.Types
-  ( SourceUnit(..)
-  , SourceUnitBuild(..)
-  , SourceUnitDependency(..)
-  , AdditionalDepData(..)
-  , SourceUserDefDep(..)
-  , Locator(..)
-  , renderLocator
-  , parseLocator
-  ) where
+module Srclib.Types (
+  SourceUnit (..),
+  SourceUnitBuild (..),
+  SourceUnitDependency (..),
+  AdditionalDepData (..),
+  SourceUserDefDep (..),
+  Locator (..),
+  renderLocator,
+  parseLocator,
+) where
 
 import Data.Aeson
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
-import qualified Data.Text as T
+import Data.Text qualified as T
 
 data SourceUnit = SourceUnit
   { sourceUnitName :: Text
   , sourceUnitType :: Text
-  , sourceUnitManifest :: Text -- ^ path to manifest file
+  , -- | path to manifest file
+    sourceUnitManifest :: Text
   , sourceUnitBuild :: Maybe SourceUnitBuild
   , additionalData :: Maybe AdditionalDepData
-  } deriving (Eq, Ord, Show)
+  }
+  deriving (Eq, Ord, Show)
 
 data SourceUnitBuild = SourceUnitBuild
-  { buildArtifact :: Text -- ^ always "default"
-  , buildSucceeded :: Bool -- ^ always true
+  { -- | always "default"
+    buildArtifact :: Text
+  , -- | always true
+    buildSucceeded :: Bool
   , buildImports :: [Locator]
   , buildDependencies :: [SourceUnitDependency]
-  } deriving (Eq, Ord, Show)
+  }
+  deriving (Eq, Ord, Show)
 
 data SourceUnitDependency = SourceUnitDependency
   { sourceDepLocator :: Locator
   , sourceDepImports :: [Locator] -- omitempty
   -- , sourceDepData :: Aeson.Value
-  } deriving (Eq, Ord, Show)
+  }
+  deriving (Eq, Ord, Show)
 
 newtype AdditionalDepData = AdditionalDepData
-  { userDefinedDeps :: [SourceUserDefDep] }
+  {userDefinedDeps :: [SourceUserDefDep]}
   deriving (Eq, Ord, Show)
 
 data SourceUserDefDep = SourceUserDefDep
-  { srcUserDepName :: Text,
-    srcUserDepVersion :: Text,
-    srcUserDepLicense :: Text,
-    srcUserDepDescription :: Maybe Text,
-    srcUserDepUrl :: Maybe Text
-  } deriving (Eq, Ord, Show)
+  { srcUserDepName :: Text
+  , srcUserDepVersion :: Text
+  , srcUserDepLicense :: Text
+  , srcUserDepDescription :: Maybe Text
+  , srcUserDepUrl :: Maybe Text
+  }
+  deriving (Eq, Ord, Show)
 
 data Locator = Locator
   { locatorFetcher :: Text
   , locatorProject :: Text
   , locatorRevision :: Maybe Text
-  } deriving (Eq, Ord, Show)
+  }
+  deriving (Eq, Ord, Show)
 
 renderLocator :: Locator -> Text
 renderLocator Locator{..} =
@@ -62,45 +70,50 @@ renderLocator Locator{..} =
 parseLocator :: Text -> Locator
 parseLocator raw = Locator fetcher project (if T.null revision then Nothing else Just revision)
   where
-    (fetcher,xs) = T.breakOn "+" raw
-    (project,xs') = T.breakOn "$" (T.drop 1 xs)
+    (fetcher, xs) = T.breakOn "+" raw
+    (project, xs') = T.breakOn "$" (T.drop 1 xs)
     revision = T.drop 1 xs'
 
 instance ToJSON SourceUnit where
-  toJSON SourceUnit{..} = object
-    [ "Name" .= sourceUnitName
-    , "Type" .= sourceUnitType
-    , "Manifest" .= sourceUnitManifest
-    , "Build" .= sourceUnitBuild
-    , "AdditionalDependencyData" .= additionalData
-    ]
+  toJSON SourceUnit{..} =
+    object
+      [ "Name" .= sourceUnitName
+      , "Type" .= sourceUnitType
+      , "Manifest" .= sourceUnitManifest
+      , "Build" .= sourceUnitBuild
+      , "AdditionalDependencyData" .= additionalData
+      ]
 
 instance ToJSON SourceUnitBuild where
-  toJSON SourceUnitBuild{..} = object
-    [ "Artifact" .= buildArtifact
-    , "Succeeded" .= buildSucceeded
-    , "Imports" .= buildImports
-    , "Dependencies" .= buildDependencies
-    ]
+  toJSON SourceUnitBuild{..} =
+    object
+      [ "Artifact" .= buildArtifact
+      , "Succeeded" .= buildSucceeded
+      , "Imports" .= buildImports
+      , "Dependencies" .= buildDependencies
+      ]
 
 instance ToJSON SourceUnitDependency where
-  toJSON SourceUnitDependency{..} = object
-    [ "locator" .= sourceDepLocator
-    , "imports" .= sourceDepImports
-    ]
+  toJSON SourceUnitDependency{..} =
+    object
+      [ "locator" .= sourceDepLocator
+      , "imports" .= sourceDepImports
+      ]
 
 instance ToJSON AdditionalDepData where
-  toJSON (AdditionalDepData userdeps) = object
-    [ "UserDefinedDependencies" .= userdeps ]
+  toJSON (AdditionalDepData userdeps) =
+    object
+      ["UserDefinedDependencies" .= userdeps]
 
 instance ToJSON SourceUserDefDep where
-  toJSON SourceUserDefDep{..} = object
-    [ "Name" .= srcUserDepName
-    , "Version" .= srcUserDepVersion
-    , "License" .= srcUserDepLicense
-    , "Description" .= srcUserDepDescription
-    , "Url" .= srcUserDepUrl
-    ]
+  toJSON SourceUserDefDep{..} =
+    object
+      [ "Name" .= srcUserDepName
+      , "Version" .= srcUserDepVersion
+      , "License" .= srcUserDepLicense
+      , "Description" .= srcUserDepDescription
+      , "Url" .= srcUserDepUrl
+      ]
 
 instance ToJSON Locator where
   -- render as text

--- a/src/Strategy/Bundler.hs
+++ b/src/Strategy/Bundler.hs
@@ -1,20 +1,19 @@
-module Strategy.Bundler
-  ( discover,
-    findProjects,
-    mkProject,
-    getDeps,
-  )
-where
+module Strategy.Bundler (
+  discover,
+  findProjects,
+  mkProject,
+  getDeps,
+) where
 
-import Control.Effect.Diagnostics (Diagnostics, (<||>), context)
-import qualified Control.Effect.Diagnostics as Diag
+import Control.Effect.Diagnostics (Diagnostics, context, (<||>))
+import Control.Effect.Diagnostics qualified as Diag
 import Discovery.Walk
 import Effect.Exec
 import Effect.ReadFS
 import Graphing
 import Path
-import qualified Strategy.Ruby.BundleShow as BundleShow
-import qualified Strategy.Ruby.GemfileLock as GemfileLock
+import Strategy.Ruby.BundleShow qualified as BundleShow
+import Strategy.Ruby.GemfileLock qualified as GemfileLock
 import Types
 
 discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has ReadFS rsig run, Has Exec rsig run, Has Diagnostics rsig run) => Path Abs Dir -> m [DiscoveredProject run]
@@ -32,28 +31,28 @@ findProjects = walk' $ \dir _ files -> do
     Just gemfile -> do
       let project =
             BundlerProject
-              { bundlerGemfile = gemfile,
-                bundlerGemfileLock = gemfileLock,
-                bundlerDir = dir
+              { bundlerGemfile = gemfile
+              , bundlerGemfileLock = gemfileLock
+              , bundlerDir = dir
               }
 
       pure ([project], WalkContinue)
 
 data BundlerProject = BundlerProject
-  { bundlerGemfile :: Path Abs File,
-    bundlerGemfileLock :: Maybe (Path Abs File),
-    bundlerDir :: Path Abs Dir
+  { bundlerGemfile :: Path Abs File
+  , bundlerGemfileLock :: Maybe (Path Abs File)
+  , bundlerDir :: Path Abs Dir
   }
   deriving (Eq, Ord, Show)
 
 mkProject :: (Has ReadFS sig n, Has Exec sig n, Has Diagnostics sig n) => BundlerProject -> DiscoveredProject n
 mkProject project =
   DiscoveredProject
-    { projectType = "bundler",
-      projectBuildTargets = mempty,
-      projectDependencyGraph = const $ getDeps project,
-      projectPath = bundlerDir project,
-      projectLicenses = pure []
+    { projectType = "bundler"
+    , projectBuildTargets = mempty
+    , projectDependencyGraph = const $ getDeps project
+    , projectPath = bundlerDir project
+    , projectLicenses = pure []
     }
 
 getDeps :: (Has Exec sig m, Has ReadFS sig m, Has Diagnostics sig m) => BundlerProject -> m (Graphing Dependency)

--- a/src/Strategy/Cargo.hs
+++ b/src/Strategy/Cargo.hs
@@ -1,47 +1,48 @@
-module Strategy.Cargo
-  ( discover
-  , CargoMetadata(..)
-  , NodeDependency(..)
-  , NodeDepKind(..)
-  , PackageId(..)
-  , Resolve(..)
-  , ResolveNode(..)
-  , buildGraph
-  , getDeps
-  , mkProject
-  , findProjects
-  )
-  where
+module Strategy.Cargo (
+  discover,
+  CargoMetadata (..),
+  NodeDependency (..),
+  NodeDepKind (..),
+  PackageId (..),
+  Resolve (..),
+  ResolveNode (..),
+  buildGraph,
+  getDeps,
+  mkProject,
+  findProjects,
+) where
 
 import Control.Effect.Diagnostics
 import Data.Aeson.Types
 import Data.Foldable (for_, traverse_)
-import qualified Data.Map.Strict as M
+import Data.Map.Strict qualified as M
 import Data.Set (Set)
-import qualified Data.Text as T
+import Data.Text qualified as T
 import Discovery.Walk
 import Effect.Exec
 import Effect.Grapher
+import Effect.ReadFS (ReadFS)
 import Graphing (Graphing, stripRoot)
 import Path
 import Types
-import Effect.ReadFS (ReadFS)
 
-newtype CargoLabel =
-  CargoDepKind DepEnvironment
+newtype CargoLabel
+  = CargoDepKind DepEnvironment
   deriving (Eq, Ord, Show)
 
 data PackageId = PackageId
   { pkgIdName :: T.Text
   , pkgIdVersion :: T.Text
   , pkgIdSource :: T.Text
-  } deriving (Eq, Ord, Show)
+  }
+  deriving (Eq, Ord, Show)
 
 data PackageDependency = PackageDependency
   { pkgDepName :: T.Text
   , pkgDepReq :: T.Text
   , pkgDepKind :: Maybe T.Text
-  } deriving (Eq, Ord, Show)
+  }
+  deriving (Eq, Ord, Show)
 
 data Package = Package
   { pkgName :: T.Text
@@ -50,62 +51,68 @@ data Package = Package
   , pkgLicense :: Maybe T.Text
   , pkgLicenseFile :: Maybe T.Text
   , pkgDependencies :: [PackageDependency]
-  } deriving (Eq, Ord, Show)
+  }
+  deriving (Eq, Ord, Show)
 
 data NodeDepKind = NodeDepKind
   { nodeDepKind :: Maybe T.Text
   , nodeDepTarget :: Maybe T.Text
-  } deriving (Eq, Ord, Show)
+  }
+  deriving (Eq, Ord, Show)
 
 data NodeDependency = NodeDependency
   { nodePkg :: PackageId
   , nodeDepKinds :: [NodeDepKind]
-  } deriving (Eq, Ord, Show)
+  }
+  deriving (Eq, Ord, Show)
 
 data ResolveNode = ResolveNode
   { resolveNodeId :: PackageId
   , resolveNodeDeps :: [NodeDependency]
-  } deriving (Eq, Ord, Show)
+  }
+  deriving (Eq, Ord, Show)
 
 newtype Resolve = Resolve
   { resolvedNodes :: [ResolveNode]
-  } deriving (Eq, Ord, Show)
+  }
+  deriving (Eq, Ord, Show)
 
 data CargoMetadata = CargoMetadata
   { metadataPackages :: [Package]
   , metadataWorkspaceMembers :: [PackageId]
   , metadataResolve :: Resolve
-  } deriving (Eq, Ord, Show)
+  }
+  deriving (Eq, Ord, Show)
 
 instance FromJSON PackageDependency where
   parseJSON = withObject "PackageDependency" $ \obj ->
     PackageDependency <$> obj .: "name"
-                      <*> obj .: "req"
-                      <*> obj .:? "kind"
+      <*> obj .: "req"
+      <*> obj .:? "kind"
 
 instance FromJSON Package where
   parseJSON = withObject "Package" $ \obj ->
     Package <$> obj .: "name"
-            <*> obj .: "version"
-            <*> (obj .: "id" >>= parsePkgId)
-            <*> obj .:? "license"
-            <*> obj .:? "license_file"
-            <*> obj .: "dependencies"
+      <*> obj .: "version"
+      <*> (obj .: "id" >>= parsePkgId)
+      <*> obj .:? "license"
+      <*> obj .:? "license_file"
+      <*> obj .: "dependencies"
 
 instance FromJSON NodeDepKind where
   parseJSON = withObject "NodeDepKind" $ \obj ->
     NodeDepKind <$> obj .:? "kind"
-                <*> obj .:? "target"
+      <*> obj .:? "target"
 
 instance FromJSON NodeDependency where
   parseJSON = withObject "NodeDependency" $ \obj ->
     NodeDependency <$> (obj .: "pkg" >>= parsePkgId)
-                   <*> obj .: "dep_kinds"
+      <*> obj .: "dep_kinds"
 
 instance FromJSON ResolveNode where
   parseJSON = withObject "ResolveNode" $ \obj ->
     ResolveNode <$> (obj .: "id" >>= parsePkgId)
-                <*> obj .: "deps"
+      <*> obj .: "deps"
 
 instance FromJSON Resolve where
   parseJSON = withObject "Resolve" $ \obj ->
@@ -114,8 +121,8 @@ instance FromJSON Resolve where
 instance FromJSON CargoMetadata where
   parseJSON = withObject "CargoMetadata" $ \obj ->
     CargoMetadata <$> obj .: "packages"
-                  <*> (obj .: "workspace_members" >>= traverse parsePkgId)
-                  <*> obj .: "resolve"
+      <*> (obj .: "workspace_members" >>= traverse parsePkgId)
+      <*> obj .: "resolve"
 
 discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has Exec rsig run, Has Diagnostics rsig run) => Path Abs Dir -> m [DiscoveredProject run]
 discover dir = context "Cargo" $ do
@@ -129,46 +136,51 @@ findProjects = walk' $ \dir _ files -> do
     Just toml -> do
       let project =
             CargoProject
-              { cargoToml = toml,
-                cargoDir = dir
+              { cargoToml = toml
+              , cargoDir = dir
               }
 
       pure ([project], WalkSkipAll)
 
 data CargoProject = CargoProject
-  { cargoDir :: Path Abs Dir,
-    cargoToml :: Path Abs File
-  } deriving (Eq, Ord, Show)
+  { cargoDir :: Path Abs Dir
+  , cargoToml :: Path Abs File
+  }
+  deriving (Eq, Ord, Show)
 
 mkProject :: (Has Exec sig n, Has Diagnostics sig n) => CargoProject -> DiscoveredProject n
 mkProject project =
   DiscoveredProject
-    { projectType = "cargo",
-      projectBuildTargets = mempty,
-      projectDependencyGraph = const $ getDeps project,
-      projectPath = cargoDir project,
-      projectLicenses = pure []
+    { projectType = "cargo"
+    , projectBuildTargets = mempty
+    , projectDependencyGraph = const $ getDeps project
+    , projectPath = cargoDir project
+    , projectLicenses = pure []
     }
 
 getDeps :: (Has Exec sig m, Has Diagnostics sig m) => CargoProject -> m (Graphing Dependency)
 getDeps = context "Cargo" . context "Dynamic analysis" . analyze . cargoDir
 
 cargoGenLockfileCmd :: Command
-cargoGenLockfileCmd = Command
-  { cmdName = "cargo"
-  , cmdArgs = ["generate-lockfile"]
-  , cmdAllowErr = Never
-  }
+cargoGenLockfileCmd =
+  Command
+    { cmdName = "cargo"
+    , cmdArgs = ["generate-lockfile"]
+    , cmdAllowErr = Never
+    }
 
 cargoMetadataCmd :: Command
-cargoMetadataCmd = Command
-  { cmdName = "cargo"
-  , cmdArgs = ["metadata"]
-  , cmdAllowErr = Never
-  }
+cargoMetadataCmd =
+  Command
+    { cmdName = "cargo"
+    , cmdArgs = ["metadata"]
+    , cmdAllowErr = Never
+    }
 
-analyze :: (Has Exec sig m, Has Diagnostics sig m)
-  => Path Abs Dir -> m (Graphing Dependency)
+analyze ::
+  (Has Exec sig m, Has Diagnostics sig m) =>
+  Path Abs Dir ->
+  m (Graphing Dependency)
 analyze manifestDir = do
   _ <- context "Generating lockfile" $ execThrow manifestDir cargoGenLockfileCmd
   meta <- execJson @CargoMetadata manifestDir cargoMetadataCmd
@@ -176,17 +188,20 @@ analyze manifestDir = do
   context "Building dependency graph" $ pure (buildGraph meta)
 
 toDependency :: PackageId -> Set CargoLabel -> Dependency
-toDependency pkg = foldr applyLabel Dependency
-  { dependencyType = CargoType
-  , dependencyName = pkgIdName pkg
-  , dependencyVersion = Just $ CEq $ pkgIdVersion pkg
-  , dependencyLocations = []
-  , dependencyEnvironments = []
-  , dependencyTags = M.empty
-  }
+toDependency pkg =
+  foldr
+    applyLabel
+    Dependency
+      { dependencyType = CargoType
+      , dependencyName = pkgIdName pkg
+      , dependencyVersion = Just $ CEq $ pkgIdVersion pkg
+      , dependencyLocations = []
+      , dependencyEnvironments = []
+      , dependencyTags = M.empty
+      }
   where
     applyLabel :: CargoLabel -> Dependency -> Dependency
-    applyLabel (CargoDepKind env) dep = dep { dependencyEnvironments = env : dependencyEnvironments dep }
+    applyLabel (CargoDepKind env) dep = dep{dependencyEnvironments = env : dependencyEnvironments dep}
 
 -- Possible values here are "build", "dev", and null.
 -- Null refers to productions, while dev and build refer to development-time dependencies
@@ -194,7 +209,7 @@ toDependency pkg = foldr applyLabel Dependency
 -- so we just simplify it to Development.
 kindToLabel :: Maybe T.Text -> CargoLabel
 kindToLabel (Just _) = CargoDepKind EnvDevelopment
-kindToLabel Nothing  = CargoDepKind EnvProduction
+kindToLabel Nothing = CargoDepKind EnvProduction
 
 addLabel :: Has (LabeledGrapher PackageId CargoLabel) sig m => NodeDependency -> m ()
 addLabel dep = do
@@ -209,12 +224,13 @@ addEdge node = do
     edge parentId $ nodePkg dep
 
 buildGraph :: CargoMetadata -> Graphing Dependency
-buildGraph meta = stripRoot $ run . withLabeling toDependency $ do
-  traverse_ direct $ metadataWorkspaceMembers meta
-  traverse_ addEdge $ resolvedNodes $ metadataResolve meta
+buildGraph meta = stripRoot $
+  run . withLabeling toDependency $ do
+    traverse_ direct $ metadataWorkspaceMembers meta
+    traverse_ addEdge $ resolvedNodes $ metadataResolve meta
 
 parsePkgId :: T.Text -> Parser PackageId
 parsePkgId t =
   case T.splitOn " " t of
-    [a,b,c] -> pure $ PackageId a b c
+    [a, b, c] -> pure $ PackageId a b c
     _ -> fail "malformed Package ID"

--- a/src/Strategy/Carthage.hs
+++ b/src/Strategy/Carthage.hs
@@ -1,33 +1,33 @@
 {-# LANGUAGE TemplateHaskell #-}
 
-module Strategy.Carthage
-  ( discover
-  , findProjects
-  , getDeps
-  , mkProject
-  , analyze
-  , ResolvedEntry(..)
-  , EntryType(..)
-  ) where
+module Strategy.Carthage (
+  discover,
+  findProjects,
+  getDeps,
+  mkProject,
+  analyze,
+  ResolvedEntry (..),
+  EntryType (..),
+) where
 
 import Control.Effect.Diagnostics
 import Data.Char (isSpace)
 import Data.Foldable (for_, traverse_)
 import Data.Functor (void)
-import qualified Data.Map.Strict as M
+import Data.Map.Strict qualified as M
 import Data.Text (Text)
-import qualified Data.Text as T
+import Data.Text qualified as T
 import Data.Void (Void)
 import DepTypes
 import Discovery.Walk
 import Effect.Grapher
 import Effect.ReadFS
 import Graphing (Graphing)
-import qualified Graphing as G
+import Graphing qualified as G
 import Path
 import Text.Megaparsec
 import Text.Megaparsec.Char
-import qualified Text.Megaparsec.Char.Lexer as L
+import Text.Megaparsec.Char.Lexer qualified as L
 import Types
 
 discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has ReadFS rsig run, Has Diagnostics rsig run) => Path Abs Dir -> m [DiscoveredProject run]
@@ -40,11 +40,10 @@ findProjects = walk' $ \dir _ files -> do
   case findFileNamed "Cartfile.resolved" files of
     Nothing -> pure ([], WalkContinue)
     Just cartfile -> do
-
       let project =
             CarthageProject
-              { carthageLock = cartfile,
-                carthageDir = dir
+              { carthageLock = cartfile
+              , carthageDir = dir
               }
 
       pure ([project], WalkSkipAll)
@@ -52,16 +51,17 @@ findProjects = walk' $ \dir _ files -> do
 data CarthageProject = CarthageProject
   { carthageDir :: Path Abs Dir
   , carthageLock :: Path Abs File
-  } deriving (Eq, Ord, Show)
+  }
+  deriving (Eq, Ord, Show)
 
 mkProject :: (Has ReadFS sig n, Has Diagnostics sig n) => CarthageProject -> DiscoveredProject n
 mkProject project =
   DiscoveredProject
-    { projectType = "carthage",
-      projectBuildTargets = mempty,
-      projectDependencyGraph = const $ getDeps project,
-      projectPath = carthageDir project,
-      projectLicenses = pure []
+    { projectType = "carthage"
+    , projectBuildTargets = mempty
+    , projectDependencyGraph = const $ getDeps project
+    , projectPath = carthageDir project
+    , projectLicenses = pure []
     }
 
 getDeps :: (Has ReadFS sig m, Has Diagnostics sig m) => CarthageProject -> m (Graphing Dependency)
@@ -73,8 +73,9 @@ relCheckoutsDir file = parent file </> $(mkRelDir "Carthage/Checkouts")
 analyze ::
   ( Has ReadFS sig m
   , Has Diagnostics sig m
-  )
-  => Path Abs File -> m (G.Graphing ResolvedEntry)
+  ) =>
+  Path Abs File ->
+  m (G.Graphing ResolvedEntry)
 analyze topPath = evalGrapher $ do
   -- We only care about top-level resolved cartfile errors, so we don't
   -- 'recover' here, but we do below in 'descend'
@@ -83,37 +84,38 @@ analyze topPath = evalGrapher $ do
   for_ topEntries $ \entry -> do
     direct entry
     descend (relCheckoutsDir topPath) entry
-
   where
+    analyzeSingle ::
+      ( Has ReadFS sig m
+      , Has Diagnostics sig m
+      , Has (Grapher ResolvedEntry) sig m
+      ) =>
+      Path Abs File ->
+      m [ResolvedEntry]
+    analyzeSingle path = do
+      entries <- readContentsParser @[ResolvedEntry] resolvedCartfileParser path
+      traverse_ (descend (relCheckoutsDir path)) entries
+      pure entries
 
-  analyzeSingle ::
-    ( Has ReadFS sig m
-    , Has Diagnostics sig m
-    , Has (Grapher ResolvedEntry) sig m
-    )
-    => Path Abs File -> m [ResolvedEntry]
-  analyzeSingle path = do
-    entries <- readContentsParser @[ResolvedEntry] resolvedCartfileParser path
-    traverse_ (descend (relCheckoutsDir path)) entries
-    pure entries
+    descend ::
+      ( Has ReadFS sig m
+      , Has Diagnostics sig m
+      , Has (Grapher ResolvedEntry) sig m
+      ) =>
+      Path Abs Dir {- checkouts directory -} ->
+      ResolvedEntry ->
+      m ()
+    descend checkoutsDir entry = do
+      let checkoutName = T.unpack $ entryToCheckoutName entry
 
-  descend ::
-    ( Has ReadFS sig m
-    , Has Diagnostics sig m
-    , Has (Grapher ResolvedEntry) sig m
-    )
-    => Path Abs Dir {- checkouts directory -} -> ResolvedEntry -> m ()
-  descend checkoutsDir entry = do
-    let checkoutName = T.unpack $ entryToCheckoutName entry
+      case parseRelDir checkoutName of
+        Nothing -> pure ()
+        Just path -> do
+          let checkoutPath :: Path Abs Dir
+              checkoutPath = checkoutsDir </> path
 
-    case parseRelDir checkoutName of
-      Nothing -> pure ()
-      Just path -> do
-        let checkoutPath :: Path Abs Dir
-            checkoutPath = checkoutsDir </> path
-
-        deeper <- recover $ analyzeSingle (checkoutPath </> $(mkRelFile "Cartfile.resolved"))
-        traverse_ (traverse_ (edge entry)) deeper
+          deeper <- recover $ analyzeSingle (checkoutPath </> $(mkRelFile "Cartfile.resolved"))
+          traverse_ (traverse_ (edge entry)) deeper
 
 entryToCheckoutName :: ResolvedEntry -> Text
 entryToCheckoutName entry =
@@ -131,14 +133,15 @@ entryToDepName entry =
     BinaryType -> resolvedName entry
 
 toDependency :: ResolvedEntry -> Dependency
-toDependency entry = Dependency
-  { dependencyType = CarthageType
-  , dependencyName = entryToDepName entry
-  , dependencyVersion = Just (CEq (resolvedVersion entry))
-  , dependencyTags = M.empty
-  , dependencyEnvironments = []
-  , dependencyLocations = [] -- TODO: git location?
-  }
+toDependency entry =
+  Dependency
+    { dependencyType = CarthageType
+    , dependencyName = entryToDepName entry
+    , dependencyVersion = Just (CEq (resolvedVersion entry))
+    , dependencyTags = M.empty
+    , dependencyEnvironments = []
+    , dependencyLocations = [] -- TODO: git location?
+    }
 
 -- Exemplary Cartfile.resolved:
 -- https://github.com/Carthage/Carthage/blob/8b34a90f607c5da85c75fee1f0cf20ae742bdeb2/Tests/CarthageKitTests/Resources/TestResolvedCartfile.resolved
@@ -150,29 +153,33 @@ resolvedCartfileParser = many parseSingleEntry <* eof
 
 parseSingleEntry :: Parser ResolvedEntry
 parseSingleEntry = L.nonIndented scn $ do
-  entryType <- lexeme $ choice
-    [ GithubType <$ chunk "github"
-    , GitEntry    <$ chunk "git"
-    , BinaryType <$ chunk "binary"
-    ]
+  entryType <-
+    lexeme $
+      choice
+        [ GithubType <$ chunk "github"
+        , GitEntry <$ chunk "git"
+        , BinaryType <$ chunk "binary"
+        ]
 
-  entryName    <- word
+  entryName <- word
   entryVersion <- word
   _ <- scn
 
   pure (ResolvedEntry entryType entryName entryVersion)
 
 word :: Parser Text
-word = T.pack <$> choice
-  [ lexeme (char '\"' *> someTill (satisfy (not . isSpace)) (char '\"'))
-  , lexeme (some (satisfy (not . isSpace)))
-  ]
+word =
+  T.pack
+    <$> choice
+      [ lexeme (char '\"' *> someTill (satisfy (not . isSpace)) (char '\"'))
+      , lexeme (some (satisfy (not . isSpace)))
+      ]
 
 scn :: Parser ()
-scn =  L.space space1 empty empty
+scn = L.space space1 empty empty
 
 sc :: Parser ()
-sc =  L.space (void $ some (char ' ')) empty empty
+sc = L.space (void $ some (char ' ')) empty empty
 
 lexeme :: Parser a -> Parser a
 lexeme = L.lexeme sc
@@ -180,10 +187,11 @@ lexeme = L.lexeme sc
 type Parser = Parsec Void Text
 
 data ResolvedEntry = ResolvedEntry
-  { resolvedType    :: EntryType
-  , resolvedName    :: Text
+  { resolvedType :: EntryType
+  , resolvedName :: Text
   , resolvedVersion :: Text
-  } deriving (Eq, Ord, Show)
+  }
+  deriving (Eq, Ord, Show)
 
 data EntryType = GithubType | GitEntry | BinaryType
   deriving (Eq, Ord, Show)

--- a/src/Strategy/Cocoapods.hs
+++ b/src/Strategy/Cocoapods.hs
@@ -1,20 +1,19 @@
-module Strategy.Cocoapods
-  ( discover,
-    findProjects,
-    getDeps,
-    mkProject,
-  )
-where
+module Strategy.Cocoapods (
+  discover,
+  findProjects,
+  getDeps,
+  mkProject,
+) where
 
 import Control.Applicative ((<|>))
-import Control.Effect.Diagnostics (Diagnostics, (<||>), context)
-import qualified Control.Effect.Diagnostics as Diag
+import Control.Effect.Diagnostics (Diagnostics, context, (<||>))
+import Control.Effect.Diagnostics qualified as Diag
 import Discovery.Walk
 import Effect.ReadFS
 import Graphing
 import Path
-import qualified Strategy.Cocoapods.Podfile as Podfile
-import qualified Strategy.Cocoapods.PodfileLock as PodfileLock
+import Strategy.Cocoapods.Podfile qualified as Podfile
+import Strategy.Cocoapods.PodfileLock qualified as PodfileLock
 import Types
 
 discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has ReadFS rsig run, Has Diagnostics rsig run) => Path Abs Dir -> m [DiscoveredProject run]
@@ -29,9 +28,9 @@ findProjects = walk' $ \dir _ files -> do
 
   let project =
         CocoapodsProject
-          { cocoapodsPodfile = podfile,
-            cocoapodsPodfileLock = podfileLock,
-            cocoapodsDir = dir
+          { cocoapodsPodfile = podfile
+          , cocoapodsPodfileLock = podfileLock
+          , cocoapodsDir = dir
           }
 
   case podfile <|> podfileLock of
@@ -39,20 +38,20 @@ findProjects = walk' $ \dir _ files -> do
     Just _ -> pure ([project], WalkContinue)
 
 data CocoapodsProject = CocoapodsProject
-  { cocoapodsPodfile :: Maybe (Path Abs File),
-    cocoapodsPodfileLock :: Maybe (Path Abs File),
-    cocoapodsDir :: Path Abs Dir
+  { cocoapodsPodfile :: Maybe (Path Abs File)
+  , cocoapodsPodfileLock :: Maybe (Path Abs File)
+  , cocoapodsDir :: Path Abs Dir
   }
   deriving (Eq, Ord, Show)
 
 mkProject :: (Has ReadFS sig n, Has Diagnostics sig n) => CocoapodsProject -> DiscoveredProject n
 mkProject project =
   DiscoveredProject
-    { projectType = "cocoapods",
-      projectBuildTargets = mempty,
-      projectDependencyGraph = const $ getDeps project,
-      projectPath = cocoapodsDir project,
-      projectLicenses = pure []
+    { projectType = "cocoapods"
+    , projectBuildTargets = mempty
+    , projectDependencyGraph = const $ getDeps project
+    , projectPath = cocoapodsDir project
+    , projectLicenses = pure []
     }
 
 getDeps :: (Has ReadFS sig m, Has Diagnostics sig m) => CocoapodsProject -> m (Graphing Dependency)

--- a/src/Strategy/Cocoapods/Podfile.hs
+++ b/src/Strategy/Cocoapods/Podfile.hs
@@ -1,30 +1,29 @@
 {-# LANGUAGE RecordWildCards #-}
 
-module Strategy.Cocoapods.Podfile
-  ( analyze'
-  , buildGraph
-  , parsePodfile
-
-  , Pod (..)
-  , Podfile (..)
-  , PropertyType (..)
-  ) where
+module Strategy.Cocoapods.Podfile (
+  analyze',
+  buildGraph,
+  parsePodfile,
+  Pod (..),
+  Podfile (..),
+  PropertyType (..),
+) where
 
 import Control.Effect.Diagnostics
 import Data.Functor (void)
 import Data.Map.Strict (Map)
-import qualified Data.Map.Strict as M
+import Data.Map.Strict qualified as M
 import Data.Text (Text)
-import qualified Data.Text as T
+import Data.Text qualified as T
 import Data.Void (Void)
 import DepTypes
 import Effect.ReadFS
 import Graphing (Graphing)
-import qualified Graphing
+import Graphing qualified
 import Path
 import Text.Megaparsec hiding (label)
 import Text.Megaparsec.Char
-import qualified Text.Megaparsec.Char.Lexer as L
+import Text.Megaparsec.Char.Lexer qualified as L
 
 analyze' :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs File -> m (Graphing Dependency)
 analyze' file = do
@@ -33,59 +32,62 @@ analyze' file = do
 
 buildGraph :: Podfile -> Graphing Dependency
 buildGraph podfile = Graphing.fromList (map toDependency direct)
-    where
+  where
     direct = pods podfile
     toDependency Pod{..} =
-      Dependency { dependencyType = PodType
-                 , dependencyName = name
-                 , dependencyVersion = CEq <$> version
-                 , dependencyLocations = case M.lookup SourceProperty properties of
-                                            Just repo -> [repo]
-                                            _ -> [source podfile]
-                 , dependencyEnvironments = []
-                 , dependencyTags = M.empty
-                 }
+      Dependency
+        { dependencyType = PodType
+        , dependencyName = name
+        , dependencyVersion = CEq <$> version
+        , dependencyLocations = case M.lookup SourceProperty properties of
+            Just repo -> [repo]
+            _ -> [source podfile]
+        , dependencyEnvironments = []
+        , dependencyTags = M.empty
+        }
 
 type Parser = Parsec Void Text
 
 data Pod = Pod
-     { name      :: Text
-     , version   :: Maybe Text
-     , properties :: Map PropertyType Text
-     } deriving (Eq, Ord, Show)
+  { name :: Text
+  , version :: Maybe Text
+  , properties :: Map PropertyType Text
+  }
+  deriving (Eq, Ord, Show)
 
 data PropertyType = GitProperty | CommitProperty | SourceProperty | PathProperty
   deriving (Eq, Ord, Show)
 
 data Podfile = Podfile
-      { pods :: [Pod]
-      , source :: Text
-      } deriving (Eq, Ord, Show)
+  { pods :: [Pod]
+  , source :: Text
+  }
+  deriving (Eq, Ord, Show)
 
-data Line =
-      PodLine Pod
-      | SourceLine Text
-      deriving (Eq, Ord, Show)
+data Line
+  = PodLine Pod
+  | SourceLine Text
+  deriving (Eq, Ord, Show)
 
 parsePodfile :: Parser Podfile
 parsePodfile = linesToPodfile (Podfile [] "") . concat <$> ((try podParser <|> findSource <|> ignoredLine) `sepBy` eol) <* eof
 
 linesToPodfile :: Podfile -> [Line] -> Podfile
-linesToPodfile file (PodLine pod : xs) = linesToPodfile (file { pods = pod : pods file }) xs
-linesToPodfile file (SourceLine sourceLine : xs) = linesToPodfile (file { source = sourceLine }) xs
+linesToPodfile file (PodLine pod : xs) = linesToPodfile (file{pods = pod : pods file}) xs
+linesToPodfile file (SourceLine sourceLine : xs) = linesToPodfile (file{source = sourceLine}) xs
 linesToPodfile file [] = file
 
 findSource :: Parser [Line]
 findSource = do
-          _ <- chunk "source \'"
-          source <- takeWhileP (Just "source parser") (/= '\'')
-          _ <- char '\''
-          pure [SourceLine source]
+  _ <- chunk "source \'"
+  source <- takeWhileP (Just "source parser") (/= '\'')
+  _ <- char '\''
+  pure [SourceLine source]
 
 podParser :: Parser [Line]
 podParser = do
   sc
-  _   <- symbol "pod"
+  _ <- symbol "pod"
   name <- stringLiteral
   version <- optional (try (comma *> stringLiteral))
   properties <- many property
@@ -98,12 +100,13 @@ comma = () <$ symbol ","
 property :: Parser (PropertyType, Text)
 property = do
   comma
-  propertyType <- choice
-    [ GitProperty    <$ symbol ":git"
-    , CommitProperty <$ symbol ":commit"
-    , SourceProperty <$ symbol ":source"
-    , PathProperty   <$ symbol ":path"
-    ]
+  propertyType <-
+    choice
+      [ GitProperty <$ symbol ":git"
+      , CommitProperty <$ symbol ":commit"
+      , SourceProperty <$ symbol ":source"
+      , PathProperty <$ symbol ":path"
+      ]
   _ <- symbol "=>"
   value <- stringLiteral
   pure (propertyType, value)
@@ -117,11 +120,12 @@ lexeme = L.lexeme sc
 stringLiteral :: Parser Text
 stringLiteral = T.pack <$> go
   where
-  go = (char '"'  *> manyTill L.charLiteral (char '"'))
-   <|> (char '\'' *> manyTill L.charLiteral (char '\''))
+    go =
+      (char '"' *> manyTill L.charLiteral (char '"'))
+        <|> (char '\'' *> manyTill L.charLiteral (char '\''))
 
 sc :: Parser ()
-sc =  L.space (void $ some (char ' ')) (L.skipLineComment "#") empty
+sc = L.space (void $ some (char ' ')) (L.skipLineComment "#") empty
 
 restOfLine :: Parser Text
 restOfLine = takeWhileP (Just "ignored") (not . isEndLine)
@@ -129,7 +133,7 @@ restOfLine = takeWhileP (Just "ignored") (not . isEndLine)
 isEndLine :: Char -> Bool
 isEndLine '\n' = True
 isEndLine '\r' = True
-isEndLine _    = False
+isEndLine _ = False
 
 ignoredLine :: Parser [Line]
 ignoredLine = do

--- a/src/Strategy/Cocoapods/PodfileLock.hs
+++ b/src/Strategy/Cocoapods/PodfileLock.hs
@@ -1,22 +1,21 @@
-module Strategy.Cocoapods.PodfileLock
-  ( analyze'
-  , buildGraph
-  , findSections
-
-  , Dep (..)
-  , Pod (..)
-  , Section (..)
-  ) where
+module Strategy.Cocoapods.PodfileLock (
+  analyze',
+  buildGraph,
+  findSections,
+  Dep (..),
+  Pod (..),
+  Section (..),
+) where
 
 import Control.Effect.Diagnostics
-import qualified Data.Char as C
+import Data.Char qualified as C
 import Data.Foldable (traverse_)
 import Data.Functor (void)
 import Data.Map.Strict (Map)
-import qualified Data.Map.Strict as M
+import Data.Map.Strict qualified as M
 import Data.Set (Set)
 import Data.Text (Text)
-import qualified Data.Text as T
+import Data.Text qualified as T
 import Data.Void (Void)
 import DepTypes
 import Effect.Grapher
@@ -25,86 +24,91 @@ import Graphing (Graphing)
 import Path
 import Text.Megaparsec hiding (label)
 import Text.Megaparsec.Char
-import qualified Text.Megaparsec.Char.Lexer as L
+import Text.Megaparsec.Char.Lexer qualified as L
 
 analyze' :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs File -> m (Graphing Dependency)
 analyze' file = do
   podfileLock <- readContentsParser findSections file
   context "Building dependency graph" $ pure (buildGraph podfileLock)
 
-newtype PodfilePkg = PodfilePkg { pkgName :: Text }
+newtype PodfilePkg = PodfilePkg {pkgName :: Text}
   deriving (Eq, Ord, Show)
 
 type PodfileGrapher = LabeledGrapher PodfilePkg PodfileLabel
 
-newtype PodfileLabel =
-    PodfileVersion Text
+newtype PodfileLabel
+  = PodfileVersion Text
   deriving (Eq, Ord, Show)
 
 toDependency :: PodfilePkg -> Set PodfileLabel -> Dependency
 toDependency pkg = foldr applyLabel start
   where
+    start :: Dependency
+    start =
+      Dependency
+        { dependencyType = PodType
+        , dependencyName = pkgName pkg
+        , dependencyVersion = Nothing
+        , dependencyLocations = []
+        , dependencyEnvironments = []
+        , dependencyTags = M.empty
+        }
 
-  start :: Dependency
-  start = Dependency
-    { dependencyType = PodType
-    , dependencyName = pkgName pkg
-    , dependencyVersion = Nothing
-    , dependencyLocations = []
-    , dependencyEnvironments = []
-    , dependencyTags = M.empty
-    }
-
-  applyLabel :: PodfileLabel -> Dependency -> Dependency
-  applyLabel (PodfileVersion ver) dep = dep { dependencyVersion = Just (CEq ver) }
+    applyLabel :: PodfileLabel -> Dependency -> Dependency
+    applyLabel (PodfileVersion ver) dep = dep{dependencyVersion = Just (CEq ver)}
 
 buildGraph :: [Section] -> Graphing Dependency
-buildGraph sections = run . withLabeling toDependency $
-  traverse_ addSection sections
+buildGraph sections =
+  run . withLabeling toDependency $
+    traverse_ addSection sections
   where
-  addSection :: Has PodfileGrapher sig m => Section -> m ()
-  addSection (DependencySection deps) = traverse_ (direct . PodfilePkg . depName) deps
-  addSection (PodSection pods) = traverse_ addSpec pods
-  addSection _ = pure ()
+    addSection :: Has PodfileGrapher sig m => Section -> m ()
+    addSection (DependencySection deps) = traverse_ (direct . PodfilePkg . depName) deps
+    addSection (PodSection pods) = traverse_ addSpec pods
+    addSection _ = pure ()
 
-  addSpec :: Has PodfileGrapher sig m => Pod -> m ()
-  addSpec pod = do
-    let pkg = PodfilePkg (podName pod)
-    -- add edges between spec and specdeps
-    traverse_ (edge pkg . PodfilePkg . depName) (podSpecs pod)
-    -- add a label for version
-    label pkg (PodfileVersion (podVersion pod))
+    addSpec :: Has PodfileGrapher sig m => Pod -> m ()
+    addSpec pod = do
+      let pkg = PodfilePkg (podName pod)
+      -- add edges between spec and specdeps
+      traverse_ (edge pkg . PodfilePkg . depName) (podSpecs pod)
+      -- add a label for version
+      label pkg (PodfileVersion (podVersion pod))
 
 type Parser = Parsec Void Text
 
-data Section =
-      PodSection [Pod]
-      | DependencySection [Dep]
-      | SpecRepos [Remote]
-      | ExternalSources [SourceDep]
-      | CheckoutOptions [SourceDep]
-      | UnknownSection Text
-      deriving (Eq, Ord, Show)
+data Section
+  = PodSection [Pod]
+  | DependencySection [Dep]
+  | SpecRepos [Remote]
+  | ExternalSources [SourceDep]
+  | CheckoutOptions [SourceDep]
+  | UnknownSection Text
+  deriving (Eq, Ord, Show)
 
 newtype Dep = Dep
-      { depName :: Text
-      } deriving (Eq, Ord, Show)
+  { depName :: Text
+  }
+  deriving (Eq, Ord, Show)
 
 data SourceDep = SourceDep
-      { sDepName :: Text
-      , tags     :: Map Text Text
-      } deriving (Eq, Ord, Show)
+  { sDepName :: Text
+  , tags :: Map Text Text
+  }
+  deriving (Eq, Ord, Show)
 
 data Pod = Pod
-     { podName    :: Text
-     , podVersion :: Text
-     , podSpecs   :: [Dep]
-     } deriving (Eq, Ord, Show)
+  { podName :: Text
+  , podVersion :: Text
+  , podSpecs :: [Dep]
+  }
+  deriving (Eq, Ord, Show)
 
 data Remote = Remote
-     { remoteLocation :: Text
-     , remoteDeps     :: [Dep]
-     } deriving (Eq, Ord, Show)
+  { remoteLocation :: Text
+  , remoteDeps :: [Dep]
+  }
+  deriving (Eq, Ord, Show)
 
 findSections :: Parser [Section]
 findSections = manyTill (try podSectionParser <|> try dependenciesSectionParser <|> try specRepoParser <|> try externalSourcesParser <|> try checkoutOptionsParser <|> unknownSection) eof
@@ -131,9 +135,10 @@ checkoutOptionsParser :: Parser Section
 checkoutOptionsParser = sectionParser "CHECKOUT OPTIONS:" CheckoutOptions externalDepsParser
 
 sectionParser :: Text -> ([a] -> Section) -> Parser a -> Parser Section
-sectionParser sectionName lambda parser = nonIndented $ indentBlock $ do
-  _ <- chunk sectionName
-  return (L.IndentMany Nothing (pure . lambda) parser)
+sectionParser sectionName lambda parser = nonIndented $
+  indentBlock $ do
+    _ <- chunk sectionName
+    return (L.IndentMany Nothing (pure . lambda) parser)
 
 externalDepsParser :: Parser SourceDep
 externalDepsParser = indentBlock $ do
@@ -152,7 +157,7 @@ tagParser = do
 remoteParser :: Parser Remote
 remoteParser = indentBlock $ do
   location <- restOfLine
-  pure (L.IndentMany Nothing (\deps -> pure $ Remote (T.dropWhileEnd (==':') location) deps) depParser)
+  pure (L.IndentMany Nothing (\deps -> pure $ Remote (T.dropWhileEnd (== ':') location) deps) depParser)
 
 podParser :: Parser Pod
 podParser = indentBlock $ do
@@ -181,7 +186,7 @@ restOfLine = takeWhileP (Just "ignored") (not . isEndLine)
 isEndLine :: Char -> Bool
 isEndLine '\n' = True
 isEndLine '\r' = True
-isEndLine _    = False
+isEndLine _ = False
 
 nonIndented :: Parser a -> Parser a
 nonIndented = L.nonIndented scn
@@ -190,10 +195,10 @@ indentBlock :: Parser (L.IndentOpt Parser a b) -> Parser a
 indentBlock = L.indentBlock scn
 
 scn :: Parser ()
-scn =  L.space space1 empty empty
+scn = L.space space1 empty empty
 
 lexeme :: Parser a -> Parser a
 lexeme = L.lexeme sc
 
 sc :: Parser ()
-sc =  L.space (void $ some (char ' ')) empty empty
+sc = L.space (void $ some (char ' ')) empty empty

--- a/src/Strategy/Conda.hs
+++ b/src/Strategy/Conda.hs
@@ -1,7 +1,6 @@
-module Strategy.Conda
-  ( discover,
-  )
-where
+module Strategy.Conda (
+  discover,
+) where
 
 import Control.Carrier.Diagnostics hiding (fromMaybe)
 import Discovery.Walk
@@ -9,8 +8,8 @@ import Effect.Exec
 import Effect.ReadFS
 import Graphing (Graphing)
 import Path
-import qualified Strategy.Conda.CondaList as CondaList
-import qualified Strategy.Conda.EnvironmentYml as EnvironmentYml
+import Strategy.Conda.CondaList qualified as CondaList
+import Strategy.Conda.EnvironmentYml qualified as EnvironmentYml
 import Types
 
 discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has ReadFS rsig run, Has Exec rsig run, Has Diagnostics rsig run) => Path Abs Dir -> m [DiscoveredProject run]
@@ -23,25 +22,25 @@ findProjects = walk' $ \dir _ files -> do
     Just envYml -> do
       let project =
             CondaProject
-              { condaDir = dir,
-                condaEnvironmentYml = envYml
+              { condaDir = dir
+              , condaEnvironmentYml = envYml
               }
       pure ([project], WalkSkipAll) -- Once we find an environment.yml file, skip the rest of the walk
 
 data CondaProject = CondaProject
-  { condaDir :: Path Abs Dir,
-    condaEnvironmentYml :: Path Abs File
+  { condaDir :: Path Abs Dir
+  , condaEnvironmentYml :: Path Abs File
   }
   deriving (Eq, Ord, Show)
 
 mkProject :: (Has ReadFS sig m, Has Exec sig m, Has Diagnostics sig m) => CondaProject -> DiscoveredProject m
 mkProject project =
   DiscoveredProject
-    { projectType = "conda",
-      projectBuildTargets = mempty,
-      projectDependencyGraph = const $ getDeps project,
-      projectPath = condaDir project,
-      projectLicenses = pure []
+    { projectType = "conda"
+    , projectBuildTargets = mempty
+    , projectDependencyGraph = const $ getDeps project
+    , projectPath = condaDir project
+    , projectLicenses = pure []
     }
 
 -- Prefer analyzeCondaList over analyzeEnvironmentYml, results shoudln't be combined, it's either/or.

--- a/src/Strategy/Conda/CondaList.hs
+++ b/src/Strategy/Conda/CondaList.hs
@@ -1,16 +1,15 @@
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TypeApplications #-}
 
-module Strategy.Conda.CondaList
-  ( analyze,
-    buildGraph,
-    CondaListDep (..),
-  )
-where
+module Strategy.Conda.CondaList (
+  analyze,
+  buildGraph,
+  CondaListDep (..),
+) where
 
 import Control.Carrier.Diagnostics hiding (fromMaybe)
 import Data.Aeson
-import qualified Data.Map.Strict as M
+import Data.Map.Strict qualified as M
 import Data.Text (Text)
 import Effect.Exec
 import Graphing (Graphing, fromList)
@@ -21,28 +20,28 @@ import Types
 condaListCmd :: Command
 condaListCmd =
   Command
-    { cmdName = "conda",
-      cmdArgs = ["list", "--json"],
-      cmdAllowErr = Never
+    { cmdName = "conda"
+    , cmdArgs = ["list", "--json"]
+    , cmdAllowErr = Never
     }
 
 buildGraph :: [CondaListDep] -> Graphing Dependency
 buildGraph deps = Graphing.fromList (map toDependency deps)
   where
     toDependency :: CondaListDep -> Dependency
-    toDependency CondaListDep {..} =
+    toDependency CondaListDep{..} =
       Dependency
-        { dependencyType = CondaType,
-          dependencyName = listName,
-          dependencyVersion = CEq <$> listVersion,
-          dependencyLocations = [],
-          dependencyEnvironments = [],
-          dependencyTags = M.empty
+        { dependencyType = CondaType
+        , dependencyName = listName
+        , dependencyVersion = CEq <$> listVersion
+        , dependencyLocations = []
+        , dependencyEnvironments = []
+        , dependencyTags = M.empty
         }
 
 analyze ::
-  ( Has Exec sig m,
-    Has Diagnostics sig m
+  ( Has Exec sig m
+  , Has Diagnostics sig m
   ) =>
   Path Abs Dir ->
   m (Graphing Dependency)
@@ -50,9 +49,9 @@ analyze dir = do
   buildGraph <$> execJson @[CondaListDep] dir condaListCmd
 
 data CondaListDep = CondaListDep
-  { listName :: Text,
-    listVersion :: Maybe Text,
-    listBuild :: Maybe Text
+  { listName :: Text
+  , listVersion :: Maybe Text
+  , listBuild :: Maybe Text
   }
   deriving (Eq, Ord, Show)
 

--- a/src/Strategy/Conda/EnvironmentYml.hs
+++ b/src/Strategy/Conda/EnvironmentYml.hs
@@ -1,20 +1,19 @@
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TypeApplications #-}
 
-module Strategy.Conda.EnvironmentYml
-  ( analyze,
-    buildGraph,
-    EnvironmentYmlFile (..),
-  )
-where
+module Strategy.Conda.EnvironmentYml (
+  analyze,
+  buildGraph,
+  EnvironmentYmlFile (..),
+) where
 
 import Control.Carrier.Diagnostics hiding (fromMaybe)
 import Data.Aeson
 import Data.List.Extra ((!?))
-import qualified Data.Map.Strict as M
+import Data.Map.Strict qualified as M
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
-import qualified Data.Text as T
+import Data.Text qualified as T
 import Effect.ReadFS
 import Graphing (Graphing, fromList)
 import Path
@@ -25,19 +24,19 @@ buildGraph envYmlFile = Graphing.fromList (map toDependency allDeps)
   where
     allDeps = map getCondaDepFromText (dependencies envYmlFile)
     toDependency :: CondaDep -> Dependency
-    toDependency CondaDep {..} =
+    toDependency CondaDep{..} =
       Dependency
-        { dependencyType = CondaType,
-          dependencyName = depName,
-          dependencyVersion = CEq <$> depVersion, -- todo - properly handle version constraints
-          dependencyLocations = [],
-          dependencyEnvironments = [],
-          dependencyTags = M.empty
+        { dependencyType = CondaType
+        , dependencyName = depName
+        , dependencyVersion = CEq <$> depVersion -- todo - properly handle version constraints
+        , dependencyLocations = []
+        , dependencyEnvironments = []
+        , dependencyTags = M.empty
         }
 
 analyze ::
-  ( Has ReadFS sig m,
-    Has Diagnostics sig m
+  ( Has ReadFS sig m
+  , Has Diagnostics sig m
   ) =>
   Path Abs File ->
   m (Graphing Dependency)
@@ -49,11 +48,11 @@ analyze envYml = buildGraph <$> readContentsYaml @EnvironmentYmlFile envYml
 getCondaDepFromText :: Text -> CondaDep
 getCondaDepFromText rcd =
   CondaDep
-    { depName = name,
-      depVersion = version,
-      -- Note these aren't currently being used
-      depBuild = build,
-      depFullVersion = fullVersion
+    { depName = name
+    , depVersion = version
+    , -- Note these aren't currently being used
+      depBuild = build
+    , depFullVersion = fullVersion
     }
   where
     depSplit = T.split (== '=') rcd
@@ -75,8 +74,8 @@ getCondaDepFromText rcd =
       pure (aVal <> bVal)
 
 data EnvironmentYmlFile = EnvironmentYmlFile
-  { name :: Text,
-    dependencies :: [Text]
+  { name :: Text
+  , dependencies :: [Text]
   }
   deriving (Eq, Ord, Show)
 
@@ -86,9 +85,9 @@ instance FromJSON EnvironmentYmlFile where
       <*> obj .: "dependencies"
 
 data CondaDep = CondaDep
-  { depName :: Text,
-    depVersion :: Maybe Text,
-    depBuild :: Maybe Text,
-    depFullVersion :: Maybe Text
+  { depName :: Text
+  , depVersion :: Maybe Text
+  , depBuild :: Maybe Text
+  , depFullVersion :: Maybe Text
   }
   deriving (Eq, Ord, Show)

--- a/src/Strategy/Erlang/ConfigParser.hs
+++ b/src/Strategy/Erlang/ConfigParser.hs
@@ -1,36 +1,35 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
-module Strategy.Erlang.ConfigParser
-  ( parseConfig,
-    parseErlValue,
-    parseAtom,
-    parseNumber,
-    parseRadixLiteral,
-    parseErlString,
-    parseTuple,
-    parseErlArray,
-    parseCharNum,
-    parseIntLiteral,
-    parseFloatLiteral,
-    atom,
-    AtomText (..),
-    ErlValue (..),
-    ConfigValues (..),
-    intLiteralInBase,
-    alphaNumToInt,
-  )
-where
+module Strategy.Erlang.ConfigParser (
+  parseConfig,
+  parseErlValue,
+  parseAtom,
+  parseNumber,
+  parseRadixLiteral,
+  parseErlString,
+  parseTuple,
+  parseErlArray,
+  parseCharNum,
+  parseIntLiteral,
+  parseFloatLiteral,
+  atom,
+  AtomText (..),
+  ErlValue (..),
+  ConfigValues (..),
+  intLiteralInBase,
+  alphaNumToInt,
+) where
 
 import Data.Aeson.Types (ToJSON (toJSON))
-import qualified Data.Char as C
-import Data.Functor ( ($>) )
+import Data.Char qualified as C
+import Data.Functor (($>))
 import Data.Text (Text)
-import qualified Data.Text as T
+import Data.Text qualified as T
 import Data.Void
 import GHC.Generics (Generic)
 import Text.Megaparsec
 import Text.Megaparsec.Char
-import qualified Text.Megaparsec.Char.Lexer as L
+import Text.Megaparsec.Char.Lexer qualified as L
 
 type Parser = Parsec Void Text
 
@@ -54,7 +53,6 @@ instance ToJSON ErlValue where
     ErlFloat a -> toJSON a
     ErlArray a -> toJSON a
     ErlTuple a -> toJSON a
-
 
 alphaNumSeq :: [Char]
 alphaNumSeq = ['0' .. '9'] <> ['A' .. 'Z']
@@ -106,8 +104,7 @@ alphaNumToInt :: Char -> Int
 alphaNumToInt c =
   if C.isDigit c
     then C.digitToInt c
-    else
-      -- Get ascii code offset from 'A' (65), but start at 10 (A is 10 in hex)
+    else -- Get ascii code offset from 'A' (65), but start at 10 (A is 10 in hex)
       C.ord (C.toUpper c) - C.ord 'A' + 10
 
 {-  Erlang-specific: $char

--- a/src/Strategy/Erlang/Rebar3Tree.hs
+++ b/src/Strategy/Erlang/Rebar3Tree.hs
@@ -1,36 +1,35 @@
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TemplateHaskell #-}
 
-module Strategy.Erlang.Rebar3Tree
-  ( analyze'
-
-  , buildGraph
-  , rebar3TreeParser
-  , Rebar3Dep(..)
-  )
-  where
+module Strategy.Erlang.Rebar3Tree (
+  analyze',
+  buildGraph,
+  rebar3TreeParser,
+  Rebar3Dep (..),
+) where
 
 import Control.Effect.Diagnostics
-import qualified Data.Map.Strict as M
+import Data.Map.Strict qualified as M
 import Data.Maybe (mapMaybe)
 import Data.Text (Text)
-import qualified Data.Text as T
+import Data.Text qualified as T
 import Data.Void (Void)
 import DepTypes
 import Effect.Exec
 import Effect.ReadFS
 import Graphing (Graphing, unfold)
 import Path
-import Strategy.Erlang.ConfigParser (parseConfig, ErlValue (..), ConfigValues (..), AtomText (..))
+import Strategy.Erlang.ConfigParser (AtomText (..), ConfigValues (..), ErlValue (..), parseConfig)
 import Text.Megaparsec
 import Text.Megaparsec.Char
 
 rebar3TreeCmd :: Command
-rebar3TreeCmd = Command
-  { cmdName = "rebar3"
-  , cmdArgs = ["tree", "-v"]
-  , cmdAllowErr = Never
-  }
+rebar3TreeCmd =
+  Command
+    { cmdName = "rebar3"
+    , cmdArgs = ["tree", "-v"]
+    , cmdAllowErr = Never
+    }
 
 analyze' :: (Has Exec sig m, Has ReadFS sig m, Has Diagnostics sig m) => Path Abs Dir -> m (Graphing Dependency)
 analyze' dir = do
@@ -58,7 +57,6 @@ extractAliasLookup (ConfigValues erls) = foldr extract M.empty erls
           ErlTuple [ErlAtom (AtomText realname), ErlTuple [ErlAtom (AtomText "pkg"), ErlAtom (AtomText alias)]] -> Just (realname, alias)
           _ -> Nothing
 
-
 unaliasDeps :: M.Map Text Text -> [Rebar3Dep] -> [Rebar3Dep]
 unaliasDeps aliasMap = map unalias
   where
@@ -67,74 +65,76 @@ unaliasDeps aliasMap = map unalias
     lookupName :: M.Map Text Text -> Text -> Text
     lookupName map' name = M.findWithDefault name name map'
     changeName :: Rebar3Dep -> Text -> Rebar3Dep
-    changeName dep name = dep { depName = name }
+    changeName dep name = dep{depName = name}
 
 buildGraph :: [Rebar3Dep] -> Graphing Dependency
 buildGraph deps = unfold deps subDeps toDependency
   where
-  toDependency Rebar3Dep{..} =
-    Dependency { dependencyType = if T.isInfixOf "github.com" depLocation then GitType else HexType
-                 , dependencyName = if T.isInfixOf "github.com" depLocation then depLocation else depName
-                 , dependencyVersion = Just (CEq depVersion)
-                 , dependencyLocations = []
-                 , dependencyEnvironments = []
-                 , dependencyTags = M.empty
-                 }
+    toDependency Rebar3Dep{..} =
+      Dependency
+        { dependencyType = if T.isInfixOf "github.com" depLocation then GitType else HexType
+        , dependencyName = if T.isInfixOf "github.com" depLocation then depLocation else depName
+        , dependencyVersion = Just (CEq depVersion)
+        , dependencyLocations = []
+        , dependencyEnvironments = []
+        , dependencyTags = M.empty
+        }
 
 data Rebar3Dep = Rebar3Dep
-  { depName     :: Text
-  , depVersion  :: Text
+  { depName :: Text
+  , depVersion :: Text
   , depLocation :: Text
-  , subDeps     :: [Rebar3Dep]
-  } deriving (Eq, Ord, Show)
+  , subDeps :: [Rebar3Dep]
+  }
+  deriving (Eq, Ord, Show)
 
 type Parser = Parsec Void Text
 
 rebar3TreeParser :: Parser [Rebar3Dep]
 rebar3TreeParser = concat <$> ((try (rebarDep 0) <|> ignoredLine) `sepBy` eol) <* eof
   where
-  isEndLine :: Char -> Bool
-  isEndLine '\n' = True
-  isEndLine '\r' = True
-  isEndLine _    = False
+    isEndLine :: Char -> Bool
+    isEndLine '\n' = True
+    isEndLine '\r' = True
+    isEndLine _ = False
 
-  -- ignore content until the end of the line
-  ignored :: Parser ()
-  ignored = () <$ takeWhileP (Just "ignored") (not . isEndLine)
+    -- ignore content until the end of the line
+    ignored :: Parser ()
+    ignored = () <$ takeWhileP (Just "ignored") (not . isEndLine)
 
-  ignoredLine :: Parser [Rebar3Dep]
-  ignoredLine = do
-    ignored
-    pure []
+    ignoredLine :: Parser [Rebar3Dep]
+    ignoredLine = do
+      ignored
+      pure []
 
-  findName :: Parser Text
-  findName = takeWhileP (Just "dep") (/= '─')
+    findName :: Parser Text
+    findName = takeWhileP (Just "dep") (/= '─')
 
-  findVersion :: Parser Text
-  findVersion = takeWhileP (Just "version") (/= ' ')
+    findVersion :: Parser Text
+    findVersion = takeWhileP (Just "version") (/= ' ')
 
-  findLocation :: Parser Text
-  findLocation = takeWhileP (Just "location") (/= ')')
+    findLocation :: Parser Text
+    findLocation = takeWhileP (Just "location") (/= ')')
 
-  rebarDep :: Int -> Parser [Rebar3Dep]
-  rebarDep depth = do
-    _ <- chunk " "
-    slashCount <- many "  │"
-    _ <- satisfy (\_ -> length slashCount == depth)
+    rebarDep :: Int -> Parser [Rebar3Dep]
+    rebarDep depth = do
+      _ <- chunk " "
+      slashCount <- many "  │"
+      _ <- satisfy (\_ -> length slashCount == depth)
 
-    _ <- chunk "  & " <|> chunk "  ├─ " <|> chunk " ├─ " <|> chunk " └─ "
-    dep <- findName
-    _ <- chunk "─"
-    version <- findVersion
-    _ <- chunk " ("
-    location <- findLocation
-    _ <- chunk ")"
+      _ <- chunk "  & " <|> chunk "  ├─ " <|> chunk " ├─ " <|> chunk " └─ "
+      dep <- findName
+      _ <- chunk "─"
+      version <- findVersion
+      _ <- chunk " ("
+      location <- findLocation
+      _ <- chunk ")"
 
-    deps <- many $ try $ rebarRecurse $ depth + 1
+      deps <- many $ try $ rebarRecurse $ depth + 1
 
-    pure [Rebar3Dep dep version location (concat deps)]
+      pure [Rebar3Dep dep version location (concat deps)]
 
-  rebarRecurse :: Int -> Parser [Rebar3Dep]
-  rebarRecurse depth = do
-    _ <- chunk "\n"
-    rebarDep depth
+    rebarRecurse :: Int -> Parser [Rebar3Dep]
+    rebarRecurse depth = do
+      _ <- chunk "\n"
+      rebarDep depth

--- a/src/Strategy/Glide.hs
+++ b/src/Strategy/Glide.hs
@@ -1,14 +1,13 @@
-module Strategy.Glide
-  ( discover,
-  )
-where
+module Strategy.Glide (
+  discover,
+) where
 
 import Control.Effect.Diagnostics (Diagnostics, context)
 import Discovery.Walk
 import Effect.ReadFS
 import Graphing
 import Path
-import qualified Strategy.Go.GlideLock as GlideLock
+import Strategy.Go.GlideLock qualified as GlideLock
 import Types
 
 discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has ReadFS rsig run, Has Diagnostics rsig run) => Path Abs Dir -> m [DiscoveredProject run]
@@ -23,18 +22,18 @@ findProjects = walk' $ \dir _ files -> do
     Just lockfile -> pure ([GlideProject lockfile dir], WalkSkipAll)
 
 data GlideProject = GlideProject
-  { glideLock :: Path Abs File,
-    glideDir :: Path Abs Dir
+  { glideLock :: Path Abs File
+  , glideDir :: Path Abs Dir
   }
 
 mkProject :: (Has ReadFS sig n, Has Diagnostics sig n) => GlideProject -> DiscoveredProject n
 mkProject project =
   DiscoveredProject
-    { projectType = "glide",
-      projectBuildTargets = mempty,
-      projectDependencyGraph = const $ getDeps project,
-      projectPath = glideDir project,
-      projectLicenses = pure []
+    { projectType = "glide"
+    , projectBuildTargets = mempty
+    , projectDependencyGraph = const $ getDeps project
+    , projectPath = glideDir project
+    , projectLicenses = pure []
     }
 
 getDeps :: (Has ReadFS sig m, Has Diagnostics sig m) => GlideProject -> m (Graphing Dependency)

--- a/src/Strategy/Go/GlideLock.hs
+++ b/src/Strategy/Go/GlideLock.hs
@@ -1,28 +1,25 @@
 {-# LANGUAGE RecordWildCards #-}
 
-module Strategy.Go.GlideLock
-  ( analyze'
-
-  , GlideLockfile(..)
-  , GlideDep(..)
-
-  , buildGraph
-  )
-  where
+module Strategy.Go.GlideLock (
+  analyze',
+  GlideLockfile (..),
+  GlideDep (..),
+  buildGraph,
+) where
 
 import Control.Applicative ((<|>))
 import Control.Effect.Diagnostics
 import Data.Aeson
-import qualified Data.Map.Strict as M
+import Data.Map.Strict qualified as M
 import Data.Text (Text)
-import qualified Data.Text as T
+import Data.Text qualified as T
 import DepTypes
 import Effect.ReadFS
 import Graphing (Graphing)
-import qualified Graphing
+import Graphing qualified
 import Path
 
-analyze' :: (Has ReadFS sig m , Has Diagnostics sig m) => Path Abs File -> m (Graphing Dependency)
+analyze' :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs File -> m (Graphing Dependency)
 analyze' file = do
   lockfile <- readContentsYaml @GlideLockfile file
   context "Building dependency graph" $ pure (buildGraph lockfile)
@@ -30,40 +27,43 @@ analyze' file = do
 buildGraph :: GlideLockfile -> Graphing Dependency
 buildGraph lockfile = Graphing.fromList (map toDependency direct)
   where
-  direct = imports lockfile
-  toDependency GlideDep{..} =
-    Dependency { dependencyType = GoType
-               , dependencyName = depName
-               , dependencyVersion = Just (CEq depVersion)
-               , dependencyLocations = []
-               , dependencyEnvironments = []
-               , dependencyTags = M.empty
-               }
+    direct = imports lockfile
+    toDependency GlideDep{..} =
+      Dependency
+        { dependencyType = GoType
+        , dependencyName = depName
+        , dependencyVersion = Just (CEq depVersion)
+        , dependencyLocations = []
+        , dependencyEnvironments = []
+        , dependencyTags = M.empty
+        }
 
 data GlideLockfile = GlideLockfile
-  { hash    :: Text
+  { hash :: Text
   , updated :: Text
   , imports :: [GlideDep]
-  } deriving (Eq, Ord, Show)
+  }
+  deriving (Eq, Ord, Show)
 
 data GlideDep = GlideDep
-  { depName    :: Text
+  { depName :: Text
   , depVersion :: Text
-  , depRepo    :: Maybe Text
-  } deriving (Eq, Ord, Show)
+  , depRepo :: Maybe Text
+  }
+  deriving (Eq, Ord, Show)
 
 instance FromJSON GlideLockfile where
   parseJSON = withObject "GlideLockfile" $ \obj ->
     GlideLockfile <$> obj .: "hash"
-                  <*> obj .: "updated"
-                  <*> obj .: "imports"
+      <*> obj .: "updated"
+      <*> obj .: "imports"
 
 instance FromJSON GlideDep where
   parseJSON = withObject "GlideDep" $ \obj ->
-    GlideDep <$> obj .:  "name"
-               -- version field can be text or an int (hexadecimal hash)
-               <*> (obj .: "version" <|> (intToText <$> obj .: "version"))
-               <*> obj .:? "repo"
+    GlideDep <$> obj .: "name"
+      -- version field can be text or an int (hexadecimal hash)
+      <*> (obj .: "version" <|> (intToText <$> obj .: "version"))
+      <*> obj .:? "repo"
 
 intToText :: Int -> Text
 intToText = T.pack . show

--- a/src/Strategy/Go/GoList.hs
+++ b/src/Strategy/Go/GoList.hs
@@ -1,19 +1,17 @@
 {-# LANGUAGE RecordWildCards #-}
 
-module Strategy.Go.GoList
-  ( analyze'
-
-  , Require(..)
-  )
-  where
+module Strategy.Go.GoList (
+  analyze',
+  Require (..),
+) where
 
 import Control.Effect.Diagnostics
-import qualified Data.ByteString.Lazy as BL
+import Data.ByteString.Lazy qualified as BL
 import Data.Foldable (traverse_)
 import Data.Maybe (mapMaybe)
 import Data.String.Conversion (decodeUtf8)
 import Data.Text (Text)
-import qualified Data.Text as T
+import Data.Text qualified as T
 import DepTypes
 import Effect.Exec
 import Effect.Grapher
@@ -25,20 +23,23 @@ import Strategy.Go.Types
 data Require = Require
   { reqPackage :: Text
   , reqVersion :: Text
-  } deriving (Eq, Ord, Show)
+  }
+  deriving (Eq, Ord, Show)
 
 golistCmd :: Command
-golistCmd = Command
-  { cmdName = "go"
-  , cmdArgs = ["list", "-m", "all"]
-  , cmdAllowErr = Never
-  }
+golistCmd =
+  Command
+    { cmdName = "go"
+    , cmdArgs = ["list", "-m", "all"]
+    , cmdAllowErr = Never
+    }
 
 analyze' ::
   ( Has Exec sig m
   , Has Diagnostics sig m
-  )
-  => Path Abs Dir -> m (Graphing Dependency)
+  ) =>
+  Path Abs Dir ->
+  m (Graphing Dependency)
 analyze' dir = graphingGolang $ do
   stdout <- context "Getting direct dependencies" $ execThrow dir golistCmd
 
@@ -59,9 +60,8 @@ analyze' dir = graphingGolang $ do
 buildGraph :: Has GolangGrapher sig m => [Require] -> m ()
 buildGraph = traverse_ go
   where
-
-  go :: Has GolangGrapher sig m => Require -> m ()
-  go Require{..} = do
-    let pkg = mkGolangPackage reqPackage
-    direct pkg
-    label pkg (mkGolangVersion reqVersion)
+    go :: Has GolangGrapher sig m => Require -> m ()
+    go Require{..} = do
+      let pkg = mkGolangPackage reqPackage
+      direct pkg
+      label pkg (mkGolangVersion reqVersion)

--- a/src/Strategy/Go/GopkgLock.hs
+++ b/src/Strategy/Go/GopkgLock.hs
@@ -1,15 +1,12 @@
 {-# LANGUAGE RecordWildCards #-}
 
-module Strategy.Go.GopkgLock
-  ( analyze'
-
-  , GoLock(..)
-  , Project(..)
-
-  , buildGraph
-  , golockCodec
-  )
-  where
+module Strategy.Go.GopkgLock (
+  analyze',
+  GoLock (..),
+  Project (..),
+  buildGraph,
+  golockCodec,
+) where
 
 import Control.Effect.Diagnostics
 import Data.Foldable (traverse_)
@@ -24,34 +21,39 @@ import Path
 import Strategy.Go.Transitive (fillInTransitive)
 import Strategy.Go.Types
 import Toml (TomlCodec, (.=))
-import qualified Toml
+import Toml qualified
 
 golockCodec :: TomlCodec GoLock
-golockCodec = GoLock
-  <$> Toml.list projectCodec "projects" .= lockProjects
+golockCodec =
+  GoLock
+    <$> Toml.list projectCodec "projects" .= lockProjects
 
 projectCodec :: TomlCodec Project
-projectCodec = Project
-  <$> Toml.text "name" .= projectName
-  <*> Toml.dioptional (Toml.text "source") .= projectSource
-  <*> Toml.text "revision" .= projectRevision
+projectCodec =
+  Project
+    <$> Toml.text "name" .= projectName
+    <*> Toml.dioptional (Toml.text "source") .= projectSource
+    <*> Toml.text "revision" .= projectRevision
 
 newtype GoLock = GoLock
   { lockProjects :: [Project]
-  } deriving (Eq, Ord, Show)
+  }
+  deriving (Eq, Ord, Show)
 
 data Project = Project
-  { projectName     :: Text
-  , projectSource   :: Maybe Text
+  { projectName :: Text
+  , projectSource :: Maybe Text
   , projectRevision :: Text
-  } deriving (Eq, Ord, Show)
+  }
+  deriving (Eq, Ord, Show)
 
 analyze' ::
   ( Has ReadFS sig m
   , Has Exec sig m
   , Has Diagnostics sig m
-  )
-  => Path Abs File -> m (Graphing Dependency)
+  ) =>
+  Path Abs File ->
+  m (Graphing Dependency)
 analyze' file = graphingGolang $ do
   golock <- readContentsToml golockCodec file
   context "Building dependency graph" $ buildGraph (lockProjects golock)
@@ -61,12 +63,12 @@ analyze' file = graphingGolang $ do
 buildGraph :: Has GolangGrapher sig m => [Project] -> m ()
 buildGraph = void . traverse_ go
   where
-  go :: Has GolangGrapher sig m => Project -> m ()
-  go Project{..} = do
-    let pkg = mkGolangPackage projectName
+    go :: Has GolangGrapher sig m => Project -> m ()
+    go Project{..} = do
+      let pkg = mkGolangPackage projectName
 
-    direct pkg
-    label pkg (mkGolangVersion projectRevision)
+      direct pkg
+      label pkg (mkGolangVersion projectRevision)
 
-    -- label location when it exists
-    traverse_ (label pkg . GolangLabelLocation) projectSource
+      -- label location when it exists
+      traverse_ (label pkg . GolangLabelLocation) projectSource

--- a/src/Strategy/Godep.hs
+++ b/src/Strategy/Godep.hs
@@ -1,18 +1,17 @@
-module Strategy.Godep
-  ( discover,
-  )
-where
+module Strategy.Godep (
+  discover,
+) where
 
 import Control.Applicative ((<|>))
-import Control.Effect.Diagnostics (Diagnostics, (<||>), context)
-import qualified Control.Effect.Diagnostics as Diag
+import Control.Effect.Diagnostics (Diagnostics, context, (<||>))
+import Control.Effect.Diagnostics qualified as Diag
 import Discovery.Walk
 import Effect.Exec
 import Effect.ReadFS
 import Graphing
 import Path
-import qualified Strategy.Go.GopkgLock as GopkgLock
-import qualified Strategy.Go.GopkgToml as GopkgToml
+import Strategy.Go.GopkgLock qualified as GopkgLock
+import Strategy.Go.GopkgToml qualified as GopkgToml
 import Types
 
 discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has ReadFS rsig run, Has Exec rsig run, Has Diagnostics rsig run) => Path Abs Dir -> m [DiscoveredProject run]
@@ -25,9 +24,9 @@ findProjects = walk' $ \dir _ files -> do
 
   let project =
         GodepProject
-          { godepToml = gopkgToml,
-            godepLock = gopkgLock,
-            godepDir = dir
+          { godepToml = gopkgToml
+          , godepLock = gopkgLock
+          , godepDir = dir
           }
 
   case gopkgToml <|> gopkgLock of
@@ -35,19 +34,19 @@ findProjects = walk' $ \dir _ files -> do
     Just _ -> pure ([project], WalkSkipSome ["vendor"])
 
 data GodepProject = GodepProject
-  { godepDir :: Path Abs Dir,
-    godepToml :: Maybe (Path Abs File),
-    godepLock :: Maybe (Path Abs File)
+  { godepDir :: Path Abs Dir
+  , godepToml :: Maybe (Path Abs File)
+  , godepLock :: Maybe (Path Abs File)
   }
 
 mkProject :: (Has ReadFS sig n, Has Exec sig n, Has Diagnostics sig n) => GodepProject -> DiscoveredProject n
 mkProject project =
   DiscoveredProject
-    { projectType = "godep",
-      projectBuildTargets = mempty,
-      projectDependencyGraph = const $ getDeps project,
-      projectPath = godepDir project,
-      projectLicenses = pure []
+    { projectType = "godep"
+    , projectBuildTargets = mempty
+    , projectDependencyGraph = const $ getDeps project
+    , projectPath = godepDir project
+    , projectLicenses = pure []
     }
 
 getDeps :: (Has ReadFS sig m, Has Exec sig m, Has Diagnostics sig m) => GodepProject -> m (Graphing Dependency)

--- a/src/Strategy/Gomodules.hs
+++ b/src/Strategy/Gomodules.hs
@@ -1,19 +1,18 @@
-module Strategy.Gomodules
-  ( discover,
-    findProjects,
-    getDeps,
-    mkProject,
-  )
-where
+module Strategy.Gomodules (
+  discover,
+  findProjects,
+  getDeps,
+  mkProject,
+) where
 
-import Control.Effect.Diagnostics (Diagnostics, (<||>), context)
+import Control.Effect.Diagnostics (Diagnostics, context, (<||>))
 import Discovery.Walk
 import Effect.Exec
 import Effect.ReadFS
 import Graphing
 import Path
-import qualified Strategy.Go.GoList as GoList
-import qualified Strategy.Go.Gomod as Gomod
+import Strategy.Go.GoList qualified as GoList
+import Strategy.Go.Gomod qualified as Gomod
 import Types
 
 discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has ReadFS rsig run, Has Exec rsig run, Has Diagnostics rsig run) => Path Abs Dir -> m [DiscoveredProject run]
@@ -28,18 +27,18 @@ findProjects = walk' $ \dir _ files -> do
     Just gomod -> pure ([GomodulesProject gomod dir], WalkSkipSome ["vendor"])
 
 data GomodulesProject = GomodulesProject
-  { gomodulesGomod :: Path Abs File,
-    gomodulesDir :: Path Abs Dir
+  { gomodulesGomod :: Path Abs File
+  , gomodulesDir :: Path Abs Dir
   }
 
 mkProject :: (Has Exec sig n, Has ReadFS sig n, Has Diagnostics sig n) => GomodulesProject -> DiscoveredProject n
 mkProject project =
   DiscoveredProject
-    { projectType = "gomod",
-      projectBuildTargets = mempty,
-      projectDependencyGraph = const $ getDeps project,
-      projectPath = gomodulesDir project,
-      projectLicenses = pure []
+    { projectType = "gomod"
+    , projectBuildTargets = mempty
+    , projectDependencyGraph = const $ getDeps project
+    , projectPath = gomodulesDir project
+    , projectLicenses = pure []
     }
 
 getDeps :: (Has Exec sig m, Has ReadFS sig m, Has Diagnostics sig m) => GomodulesProject -> m (Graphing Dependency)

--- a/src/Strategy/Maven.hs
+++ b/src/Strategy/Maven.hs
@@ -1,9 +1,8 @@
-module Strategy.Maven
-  ( discover,
-    mkProject,
-    getDeps,
-  )
-where
+module Strategy.Maven (
+  discover,
+  mkProject,
+  getDeps,
+) where
 
 import Control.Effect.Diagnostics
 import Control.Effect.Lift
@@ -12,20 +11,20 @@ import Effect.Exec
 import Effect.ReadFS
 import Graphing (Graphing)
 import Path
-import qualified Strategy.Maven.PluginStrategy as Plugin
-import qualified Strategy.Maven.Pom as Pom
-import qualified Strategy.Maven.Pom.Closure as PomClosure
+import Strategy.Maven.PluginStrategy qualified as Plugin
+import Strategy.Maven.Pom qualified as Pom
+import Strategy.Maven.Pom.Closure qualified as PomClosure
 import Types
 
 discover ::
-  ( MonadIO m,
-    Has (Lift IO) sig m,
-    Has Diagnostics sig m,
-    Has ReadFS sig m,
-    Has Exec rsig run,
-    Has ReadFS rsig run,
-    Has Diagnostics rsig run,
-    Has (Lift IO) rsig run
+  ( MonadIO m
+  , Has (Lift IO) sig m
+  , Has Diagnostics sig m
+  , Has ReadFS sig m
+  , Has Exec rsig run
+  , Has ReadFS rsig run
+  , Has Diagnostics rsig run
+  , Has (Lift IO) rsig run
   ) =>
   Path Abs Dir ->
   m [DiscoveredProject run]
@@ -36,14 +35,16 @@ discover dir = context "Maven" $ do
 mkProject ::
   (Has ReadFS sig n, Has Exec sig n, Has (Lift IO) sig n, Has Diagnostics sig n) =>
   -- | basedir; required for licenses
-  Path Abs Dir -> PomClosure.MavenProjectClosure -> DiscoveredProject n
+  Path Abs Dir ->
+  PomClosure.MavenProjectClosure ->
+  DiscoveredProject n
 mkProject basedir closure =
   DiscoveredProject
-    { projectType = "maven",
-      projectPath = parent $ PomClosure.closurePath closure,
-      projectBuildTargets = mempty,
-      projectDependencyGraph = const $ getDeps closure,
-      projectLicenses = pure $ Pom.getLicenses basedir closure
+    { projectType = "maven"
+    , projectPath = parent $ PomClosure.closurePath closure
+    , projectBuildTargets = mempty
+    , projectDependencyGraph = const $ getDeps closure
+    , projectLicenses = pure $ Pom.getLicenses basedir closure
     }
 
 getDeps ::

--- a/src/Strategy/Maven/Plugin.hs
+++ b/src/Strategy/Maven/Plugin.hs
@@ -1,15 +1,14 @@
-{-# language TemplateHaskell #-}
+{-# LANGUAGE TemplateHaskell #-}
 
-module Strategy.Maven.Plugin
-  ( withUnpackedPlugin
-  , installPlugin
-  , execPlugin
-  , parsePluginOutput
-
-  , PluginOutput(..)
-  , Artifact(..)
-  , Edge(..)
-  ) where
+module Strategy.Maven.Plugin (
+  withUnpackedPlugin,
+  installPlugin,
+  execPlugin,
+  parsePluginOutput,
+  PluginOutput (..),
+  Artifact (..),
+  Edge (..),
+) where
 
 import Control.Algebra
 import Control.Effect.Diagnostics
@@ -17,16 +16,16 @@ import Control.Effect.Exception
 import Control.Effect.Lift (sendIO)
 import Data.Aeson
 import Data.ByteString (ByteString)
-import qualified Data.ByteString as BS
+import Data.ByteString qualified as BS
 import Data.FileEmbed (embedFile)
 import Data.Functor (void)
 import Data.Text (Text)
-import qualified Data.Text as T
+import Data.Text qualified as T
 import Effect.Exec
 import Effect.ReadFS
 import Path
 import Path.IO (createTempDir, getTempDir, removeDirRecur)
-import qualified System.FilePath as FP
+import System.FilePath qualified as FP
 
 pluginGroup :: Text
 pluginGroup = "com.github.ferstl"
@@ -42,20 +41,20 @@ pluginJar = $(embedFile "scripts/depgraph-maven-plugin-3.3.0.jar")
 
 withUnpackedPlugin ::
   ( Has (Lift IO) sig m
-  )
-  => (FP.FilePath -> m a) -> m a
+  ) =>
+  (FP.FilePath -> m a) ->
+  m a
 withUnpackedPlugin act =
-  bracket (sendIO (getTempDir >>= \tmp -> createTempDir tmp "fossa-maven"))
-          (sendIO . removeDirRecur)
-          go
-
+  bracket
+    (sendIO (getTempDir >>= \tmp -> createTempDir tmp "fossa-maven"))
+    (sendIO . removeDirRecur)
+    go
   where
+    go tmpDir = do
+      let pluginJarFilepath = fromAbsDir tmpDir FP.</> "plugin.jar"
+      sendIO (BS.writeFile pluginJarFilepath pluginJar)
 
-  go tmpDir = do
-    let pluginJarFilepath = fromAbsDir tmpDir FP.</> "plugin.jar"
-    sendIO (BS.writeFile pluginJarFilepath pluginJar)
-
-    act pluginJarFilepath
+      act pluginJarFilepath
 
 installPlugin :: (Has Exec sig m, Has Diagnostics sig m) => Path Abs Dir -> FP.FilePath -> m ()
 installPlugin dir path = void $ execThrow dir (mavenInstallPluginCmd path)
@@ -70,70 +69,74 @@ parsePluginOutput :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs Dir -
 parsePluginOutput dir = readContentsJson (dir </> outputFile)
 
 mavenInstallPluginCmd :: FP.FilePath -> Command
-mavenInstallPluginCmd pluginFilePath = Command
-  { cmdName = "mvn"
-  , cmdArgs =
-    [ "install:install-file"
-    , "-DgroupId=" <> pluginGroup
-    , "-DartifactId=" <> pluginArtifact
-    , "-Dversion=" <> pluginVersion
-    , "-Dpackaging=jar"
-    , "-Dfile=" <> T.pack pluginFilePath
-    ]
-  , cmdAllowErr = Never
-  }
+mavenInstallPluginCmd pluginFilePath =
+  Command
+    { cmdName = "mvn"
+    , cmdArgs =
+        [ "install:install-file"
+        , "-DgroupId=" <> pluginGroup
+        , "-DartifactId=" <> pluginArtifact
+        , "-Dversion=" <> pluginVersion
+        , "-Dpackaging=jar"
+        , "-Dfile=" <> T.pack pluginFilePath
+        ]
+    , cmdAllowErr = Never
+    }
 
 mavenPluginDependenciesCmd :: Command
-mavenPluginDependenciesCmd = Command
-  { cmdName = "mvn"
-  , cmdArgs =
-    [ pluginGroup <> ":" <> pluginArtifact <> ":" <> pluginVersion <> ":aggregate"
-    , "-DgraphFormat=json"
-    , "-DmergeScopes"
-    , "-DreduceEdges=false"
-    ]
-  , cmdAllowErr = Never
-  }
+mavenPluginDependenciesCmd =
+  Command
+    { cmdName = "mvn"
+    , cmdArgs =
+        [ pluginGroup <> ":" <> pluginArtifact <> ":" <> pluginVersion <> ":aggregate"
+        , "-DgraphFormat=json"
+        , "-DmergeScopes"
+        , "-DreduceEdges=false"
+        ]
+    , cmdAllowErr = Never
+    }
 
 data PluginOutput = PluginOutput
   { outArtifacts :: [Artifact]
-  , outEdges     :: [Edge]
-  } deriving (Eq, Ord, Show)
+  , outEdges :: [Edge]
+  }
+  deriving (Eq, Ord, Show)
 
 -- NOTE: artifact numeric IDs are 1-indexed, whereas edge numeric references are 0-indexed.
 -- the json parser for artifacts converts them to be 0-indexed.
 data Artifact = Artifact
-  { artifactNumericId  :: Int
-  , artifactGroupId    :: Text
+  { artifactNumericId :: Int
+  , artifactGroupId :: Text
   , artifactArtifactId :: Text
-  , artifactVersion    :: Text
-  , artifactOptional   :: Bool
-  , artifactScopes     :: [Text]
-  } deriving (Eq, Ord, Show)
+  , artifactVersion :: Text
+  , artifactOptional :: Bool
+  , artifactScopes :: [Text]
+  }
+  deriving (Eq, Ord, Show)
 
 data Edge = Edge
   { edgeFrom :: Int
-  , edgeTo   :: Int
-  } deriving (Eq, Ord, Show)
+  , edgeTo :: Int
+  }
+  deriving (Eq, Ord, Show)
 
 instance FromJSON PluginOutput where
   parseJSON = withObject "PluginOutput" $ \obj ->
-    PluginOutput <$> obj .:? "artifacts"    .!= []
-                 <*> obj .:? "dependencies" .!= []
+    PluginOutput <$> obj .:? "artifacts" .!= []
+      <*> obj .:? "dependencies" .!= []
 
 instance FromJSON Artifact where
   parseJSON = withObject "Artifact" $ \obj ->
     Artifact <$> (offset <$> obj .: "numericId")
-             <*> obj .: "groupId"
-             <*> obj .: "artifactId"
-             <*> obj .: "version"
-             <*> obj .: "optional"
-             <*> obj .: "scopes"
+      <*> obj .: "groupId"
+      <*> obj .: "artifactId"
+      <*> obj .: "version"
+      <*> obj .: "optional"
+      <*> obj .: "scopes"
     where
-
-    offset = subtract 1
+      offset = subtract 1
 
 instance FromJSON Edge where
   parseJSON = withObject "Edge" $ \obj ->
     Edge <$> obj .: "numericFrom"
-         <*> obj .: "numericTo"
+      <*> obj .: "numericTo"

--- a/src/Strategy/Maven/PluginStrategy.hs
+++ b/src/Strategy/Maven/PluginStrategy.hs
@@ -1,15 +1,15 @@
 {-# LANGUAGE RecordWildCards #-}
 
-module Strategy.Maven.PluginStrategy
-  ( analyze'
-  , buildGraph
-  ) where
+module Strategy.Maven.PluginStrategy (
+  analyze',
+  buildGraph,
+) where
 
 import Control.Effect.Diagnostics
 import Control.Effect.Lift
 import Data.Foldable (traverse_)
 import Data.Map.Strict (Map)
-import qualified Data.Map.Strict as M
+import Data.Map.Strict qualified as M
 import DepTypes
 import Effect.Exec
 import Effect.Grapher hiding (Edge)
@@ -23,8 +23,9 @@ analyze' ::
   , Has ReadFS sig m
   , Has Exec sig m
   , Has Diagnostics sig m
-  )
-  => Path Abs Dir -> m (Graphing Dependency)
+  ) =>
+  Path Abs Dir ->
+  m (Graphing Dependency)
 analyze' dir = withUnpackedPlugin $ \filepath -> do
   context "Installing plugin" $ installPlugin dir filepath
   context "Running plugin" $ execPlugin dir
@@ -32,37 +33,38 @@ analyze' dir = withUnpackedPlugin $ \filepath -> do
   context "Building dependency graph" $ pure (buildGraph pluginOutput)
 
 buildGraph :: PluginOutput -> Graphing Dependency
-buildGraph PluginOutput{..} = run $ evalGrapher $ do
-  let byNumeric :: Map Int Artifact
-      byNumeric = indexBy artifactNumericId outArtifacts
+buildGraph PluginOutput{..} = run $
+  evalGrapher $ do
+    let byNumeric :: Map Int Artifact
+        byNumeric = indexBy artifactNumericId outArtifacts
 
-  let depsByNumeric :: Map Int Dependency
-      depsByNumeric = M.map toDependency byNumeric
+    let depsByNumeric :: Map Int Dependency
+        depsByNumeric = M.map toDependency byNumeric
 
-  traverse_ (visitEdge depsByNumeric) outEdges
-
+    traverse_ (visitEdge depsByNumeric) outEdges
   where
+    toDependency :: Artifact -> Dependency
+    toDependency Artifact{..} =
+      Dependency
+        { dependencyType = MavenType
+        , dependencyName = artifactGroupId <> ":" <> artifactArtifactId
+        , dependencyVersion = Just (CEq artifactVersion)
+        , dependencyLocations = []
+        , dependencyEnvironments = if "test" `elem` artifactScopes then [EnvTesting] else []
+        , dependencyTags =
+            M.fromList $
+              ("scopes", artifactScopes) :
+                [("optional", ["true"]) | artifactOptional]
+        }
 
-  toDependency :: Artifact -> Dependency
-  toDependency Artifact{..} = Dependency
-    { dependencyType = MavenType
-    , dependencyName = artifactGroupId <> ":" <> artifactArtifactId
-    , dependencyVersion = Just (CEq artifactVersion)
-    , dependencyLocations = []
-    , dependencyEnvironments = if "test" `elem` artifactScopes then [EnvTesting] else []
-    , dependencyTags = M.fromList $
-      ("scopes", artifactScopes) :
-      [("optional", ["true"]) | artifactOptional]
-    }
+    visitEdge :: Has (Grapher Dependency) sig m => Map Int Dependency -> Edge -> m ()
+    visitEdge refsByNumeric Edge{..} = do
+      let refs = do
+            parentRef <- M.lookup edgeFrom refsByNumeric
+            childRef <- M.lookup edgeTo refsByNumeric
+            Just (parentRef, childRef)
 
-  visitEdge :: Has (Grapher Dependency) sig m => Map Int Dependency -> Edge -> m ()
-  visitEdge refsByNumeric Edge{..} = do
-    let refs = do
-          parentRef <- M.lookup edgeFrom refsByNumeric
-          childRef <- M.lookup edgeTo refsByNumeric
-          Just (parentRef, childRef)
+      traverse_ (uncurry edge) refs
 
-    traverse_ (uncurry edge) refs
-
-  indexBy :: Ord k => (v -> k) -> [v] -> Map k v
-  indexBy f = M.fromList . map (\v -> (f v, v))
+    indexBy :: Ord k => (v -> k) -> [v] -> Map k v
+    indexBy f = M.fromList . map (\v -> (f v, v))

--- a/src/Strategy/Maven/Pom/Closure.hs
+++ b/src/Strategy/Maven/Pom/Closure.hs
@@ -1,25 +1,25 @@
-module Strategy.Maven.Pom.Closure
-  ( findProjects
-  , MavenProjectClosure(..)
-  , buildProjectClosures
-  ) where
+module Strategy.Maven.Pom.Closure (
+  findProjects,
+  MavenProjectClosure (..),
+  buildProjectClosures,
+) where
 
-import qualified Algebra.Graph.AdjacencyMap as AM
-import qualified Algebra.Graph.AdjacencyMap.Algorithm as AM
+import Algebra.Graph.AdjacencyMap qualified as AM
+import Algebra.Graph.AdjacencyMap.Algorithm qualified as AM
 import Control.Algebra
 import Control.Carrier.State.Strict
 import Control.Effect.Diagnostics
 import Data.Foldable (traverse_)
 import Data.List (isSuffixOf)
 import Data.Map.Strict (Map)
-import qualified Data.Map.Strict as M
+import Data.Map.Strict qualified as M
 import Data.Maybe (mapMaybe)
 import Data.Set (Set)
-import qualified Data.Set as S
+import Data.Set qualified as S
 import Discovery.Walk
 import Effect.ReadFS
 import Path
-import qualified Path.IO as PIO
+import Path.IO qualified as PIO
 import Strategy.Maven.Pom.PomFile
 import Strategy.Maven.Pom.Resolver
 
@@ -40,20 +40,20 @@ findPomFiles dir = execState @[Path Abs File] [] $
 buildProjectClosures :: Path Abs Dir -> GlobalClosure -> [MavenProjectClosure]
 buildProjectClosures basedir global = closures
   where
-  closures = map (\(path, (coord, pom)) -> toClosure path coord pom) (M.toList projectRoots)
+    closures = map (\(path, (coord, pom)) -> toClosure path coord pom) (M.toList projectRoots)
 
-  toClosure :: Path Abs File -> MavenCoordinate -> Pom -> MavenProjectClosure
-  toClosure path coord pom = MavenProjectClosure path coord pom reachableGraph reachablePomMap
-    where
-      reachableGraph = AM.induce (`S.member` reachablePoms) $ globalGraph global
-      reachablePomMap = M.filterWithKey (\k _ -> S.member k reachablePoms) $ globalPoms global
-      reachablePoms = bidirectionalReachable coord (globalGraph global)
+    toClosure :: Path Abs File -> MavenCoordinate -> Pom -> MavenProjectClosure
+    toClosure path coord pom = MavenProjectClosure path coord pom reachableGraph reachablePomMap
+      where
+        reachableGraph = AM.induce (`S.member` reachablePoms) $ globalGraph global
+        reachablePomMap = M.filterWithKey (\k _ -> S.member k reachablePoms) $ globalPoms global
+        reachablePoms = bidirectionalReachable coord (globalGraph global)
 
-  projectRoots :: Map (Path Abs File) (MavenCoordinate, Pom)
-  projectRoots = determineProjectRoots basedir global graphRoots
+    projectRoots :: Map (Path Abs File) (MavenCoordinate, Pom)
+    projectRoots = determineProjectRoots basedir global graphRoots
 
-  graphRoots :: [MavenCoordinate]
-  graphRoots = sourceVertices (globalGraph global)
+    graphRoots :: [MavenCoordinate]
+    graphRoots = sourceVertices (globalGraph global)
 
 -- Find reachable nodes both below (children, grandchildren, ...) and above (parents, grandparents) the node
 bidirectionalReachable :: Ord a => a -> AM.AdjacencyMap a -> S.Set a
@@ -65,36 +65,40 @@ sourceVertices graph = [v | v <- AM.vertexList graph, S.null (AM.preSet v graph)
 determineProjectRoots :: Path Abs Dir -> GlobalClosure -> [MavenCoordinate] -> Map (Path Abs File) (MavenCoordinate, Pom)
 determineProjectRoots rootDir closure = go . S.fromList
   where
-  go :: Set MavenCoordinate -> Map (Path Abs File) (MavenCoordinate, Pom)
-  go coordRoots
-    | S.null coordRoots = M.empty
-    | otherwise = M.union projects (go frontier)
-    where
-    inRoot :: Set (MavenCoordinate, Path Abs File, Pom)
-    inRoot = S.fromList $
-      mapMaybe (\coord -> do
-                   (abspath, pom) <- M.lookup coord (globalPoms closure)
-                   -- This ensures that the absolute path is relative to the root directory
-                   _ <- PIO.makeRelative rootDir abspath
-                   Just (coord, abspath, pom)) (S.toList coordRoots)
+    go :: Set MavenCoordinate -> Map (Path Abs File) (MavenCoordinate, Pom)
+    go coordRoots
+      | S.null coordRoots = M.empty
+      | otherwise = M.union projects (go frontier)
+      where
+        inRoot :: Set (MavenCoordinate, Path Abs File, Pom)
+        inRoot =
+          S.fromList $
+            mapMaybe
+              ( \coord -> do
+                  (abspath, pom) <- M.lookup coord (globalPoms closure)
+                  -- This ensures that the absolute path is relative to the root directory
+                  _ <- PIO.makeRelative rootDir abspath
+                  Just (coord, abspath, pom)
+              )
+              (S.toList coordRoots)
 
-    inRootCoords :: Set MavenCoordinate
-    inRootCoords = S.map (\(c,_,_) -> c) inRoot
+        inRootCoords :: Set MavenCoordinate
+        inRootCoords = S.map (\(c, _, _) -> c) inRoot
 
-    remainingCoords :: Set MavenCoordinate
-    remainingCoords = coordRoots S.\\ inRootCoords
+        remainingCoords :: Set MavenCoordinate
+        remainingCoords = coordRoots S.\\ inRootCoords
 
-    projects :: Map (Path Abs File) (MavenCoordinate, Pom)
-    projects = M.fromList $ S.toList $ S.map (\(coord,path,pom) -> (path, (coord, pom))) inRoot
+        projects :: Map (Path Abs File) (MavenCoordinate, Pom)
+        projects = M.fromList $ S.toList $ S.map (\(coord, path, pom) -> (path, (coord, pom))) inRoot
 
-    frontier :: Set MavenCoordinate
-    frontier = S.unions $ S.map (\coord -> AM.postSet coord (globalGraph closure)) remainingCoords
-
+        frontier :: Set MavenCoordinate
+        frontier = S.unions $ S.map (\coord -> AM.postSet coord (globalGraph closure)) remainingCoords
 
 data MavenProjectClosure = MavenProjectClosure
-  { closurePath      :: Path Abs File
+  { closurePath :: Path Abs File
   , closureRootCoord :: MavenCoordinate
-  , closureRootPom   :: Pom
-  , closureGraph     :: AM.AdjacencyMap MavenCoordinate
-  , closurePoms      :: Map MavenCoordinate (Path Abs File, Pom)
-  } deriving (Eq, Ord, Show)
+  , closureRootPom :: Pom
+  , closureGraph :: AM.AdjacencyMap MavenCoordinate
+  , closurePoms :: Map MavenCoordinate (Path Abs File, Pom)
+  }
+  deriving (Eq, Ord, Show)

--- a/src/Strategy/Maven/Pom/PomFile.hs
+++ b/src/Strategy/Maven/Pom/PomFile.hs
@@ -1,25 +1,24 @@
 {-# LANGUAGE RecordWildCards #-}
 
 module Strategy.Maven.Pom.PomFile
-  -- TODO: sort
-  ( Pom(..)
-  , RawDependency(..)
-  , RawParent(..)
-  , RawPom(..)
-  , MavenCoordinate(..)
-  , MvnDepBody(..)
-  , PomLicense(..)
+-- TODO: sort
+  (
+  Pom (..),
+  RawDependency (..),
+  RawParent (..),
+  RawPom (..),
+  MavenCoordinate (..),
+  MvnDepBody (..),
+  PomLicense (..),
+  Group,
+  Artifact,
+  validatePom,
+) where
 
-  , Group
-  , Artifact
-
-  , validatePom
-  ) where
-
-import Control.Applicative ((<|>), optional)
-import Data.Text (Text)
+import Control.Applicative (optional, (<|>))
 import Data.Map.Strict (Map)
-import qualified Data.Map.Strict as M
+import Data.Map.Strict qualified as M
+import Data.Text (Text)
 import Parse.XML
 
 ----- Validating POM files
@@ -39,16 +38,17 @@ validatePom raw = do
 rawDepsToDeps :: [RawDependency] -> Map (Group, Artifact) MvnDepBody
 rawDepsToDeps = M.fromList . map (\dep -> (depToKey dep, depToBody dep))
   where
-  depToKey :: RawDependency -> (Group, Artifact)
-  depToKey raw = (rawDependencyGroup raw, rawDependencyArtifact raw)
+    depToKey :: RawDependency -> (Group, Artifact)
+    depToKey raw = (rawDependencyGroup raw, rawDependencyArtifact raw)
 
-  depToBody :: RawDependency -> MvnDepBody
-  depToBody RawDependency{..} = MvnDepBody
-    { depVersion = rawDependencyVersion
-    , depClassifier = rawDependencyClassifier
-    , depScope = rawDependencyScope
-    , depOptional = rawDependencyOptional
-    }
+    depToBody :: RawDependency -> MvnDepBody
+    depToBody RawDependency{..} =
+      MvnDepBody
+        { depVersion = rawDependencyVersion
+        , depClassifier = rawDependencyClassifier
+        , depScope = rawDependencyScope
+        , depOptional = rawDependencyOptional
+        }
 
 -- Build a full coordinate from a pom, falling back to the group/version from
 -- the parent
@@ -59,42 +59,46 @@ rawDepsToDeps = M.fromList . map (\dep -> (depToKey dep, depToBody dep))
 validateCoordinate :: RawPom -> Maybe MavenCoordinate
 validateCoordinate RawPom{..} = MavenCoordinate <$> group <*> artifact <*> version
   where
-  group, artifact, version :: Maybe Text
-  group = rawPomGroup <|> (rawParentGroup <$> rawPomParent)
-  artifact = pure rawPomArtifact
-  version = rawPomVersion <|> (rawParentVersion <$> rawPomParent)
+    group, artifact, version :: Maybe Text
+    group = rawPomGroup <|> (rawParentGroup <$> rawPomParent)
+    artifact = pure rawPomArtifact
+    version = rawPomVersion <|> (rawParentVersion <$> rawPomParent)
 
 parentToCoordinate :: RawParent -> MavenCoordinate
-parentToCoordinate RawParent{..} = MavenCoordinate
-  { coordGroup    = rawParentGroup
-  , coordArtifact = rawParentArtifact
-  , coordVersion  = rawParentVersion
-  }
+parentToCoordinate RawParent{..} =
+  MavenCoordinate
+    { coordGroup = rawParentGroup
+    , coordArtifact = rawParentArtifact
+    , coordVersion = rawParentVersion
+    }
 
 -- TODO: newtypes?
 type Group = Text
 type Artifact = Text
 data Pom = Pom
-  { pomCoord                :: MavenCoordinate
-  , pomParentCoord          :: Maybe MavenCoordinate
-  , pomProperties           :: Map Text Text
+  { pomCoord :: MavenCoordinate
+  , pomParentCoord :: Maybe MavenCoordinate
+  , pomProperties :: Map Text Text
   , pomDependencyManagement :: Map (Group, Artifact) MvnDepBody
-  , pomDependencies         :: Map (Group, Artifact) MvnDepBody
-  , pomLicenses             :: [PomLicense]
-  } deriving (Eq, Ord, Show)
+  , pomDependencies :: Map (Group, Artifact) MvnDepBody
+  , pomLicenses :: [PomLicense]
+  }
+  deriving (Eq, Ord, Show)
 
 data MavenCoordinate = MavenCoordinate
-  { coordGroup    :: Text
+  { coordGroup :: Text
   , coordArtifact :: Text
-  , coordVersion  :: Text
-  } deriving (Eq, Ord, Show)
+  , coordVersion :: Text
+  }
+  deriving (Eq, Ord, Show)
 
 data MvnDepBody = MvnDepBody
-  { depVersion    :: Maybe Text
+  { depVersion :: Maybe Text
   , depClassifier :: Maybe Text
-  , depScope      :: Maybe Text
-  , depOptional   :: Maybe Text
-  } deriving (Eq, Ord, Show)
+  , depScope :: Maybe Text
+  , depOptional :: Maybe Text
+  }
+  deriving (Eq, Ord, Show)
 
 instance Semigroup Pom where
   -- left-biased, similar to M.union
@@ -104,72 +108,77 @@ instance Semigroup Pom where
   --
   -- we overlay dependencyManagement and dependencies with MvnDepBody's
   -- Semigroup instance
-  childPom <> parentPom = Pom
-    { pomCoord = pomCoord childPom
-    , pomParentCoord = pomParentCoord childPom
-    , pomProperties = M.union (pomProperties childPom) (pomProperties parentPom)
-    , pomDependencyManagement = M.unionWith (<>) (pomDependencyManagement childPom) (pomDependencyManagement parentPom)
-    , pomDependencies = M.unionWith (<>) (pomDependencies childPom) (pomDependencies parentPom)
-    , pomLicenses = pomLicenses childPom
-    }
-
+  childPom <> parentPom =
+    Pom
+      { pomCoord = pomCoord childPom
+      , pomParentCoord = pomParentCoord childPom
+      , pomProperties = M.union (pomProperties childPom) (pomProperties parentPom)
+      , pomDependencyManagement = M.unionWith (<>) (pomDependencyManagement childPom) (pomDependencyManagement parentPom)
+      , pomDependencies = M.unionWith (<>) (pomDependencies childPom) (pomDependencies parentPom)
+      , pomLicenses = pomLicenses childPom
+      }
 
 instance Semigroup MvnDepBody where
   -- left-biased, similar to M.union
-  left <> right = MvnDepBody
-    { depVersion = depVersion left <|> depVersion right
-    , depClassifier = depClassifier left <|> depClassifier right
-    , depScope = depScope left <|> depScope right
-    , depOptional = depOptional left <|> depOptional right
-    }
+  left <> right =
+    MvnDepBody
+      { depVersion = depVersion left <|> depVersion right
+      , depClassifier = depClassifier left <|> depClassifier right
+      , depScope = depScope left <|> depScope right
+      , depOptional = depOptional left <|> depOptional right
+      }
 
 ----- Raw POM files + deserialization
 
 -- a POM file as found in the filesystem
 data RawPom = RawPom
-  { rawPomParent               :: Maybe RawParent
-  , rawPomGroup                :: Maybe Text
-  , rawPomArtifact             :: Text
-  , rawPomVersion              :: Maybe Text
-  , rawPomProperties           :: Map Text Text
-  , rawPomModules              :: [Text]
+  { rawPomParent :: Maybe RawParent
+  , rawPomGroup :: Maybe Text
+  , rawPomArtifact :: Text
+  , rawPomVersion :: Maybe Text
+  , rawPomProperties :: Map Text Text
+  , rawPomModules :: [Text]
   , rawPomDependencyManagement :: [RawDependency]
-  , rawPomDependencies         :: [RawDependency]
-  , rawPomLicenses             :: [PomLicense]
-  } deriving (Eq, Ord, Show)
+  , rawPomDependencies :: [RawDependency]
+  , rawPomLicenses :: [PomLicense]
+  }
+  deriving (Eq, Ord, Show)
 
 data RawParent = RawParent
-  { rawParentGroup        :: Text
-  , rawParentArtifact     :: Text
-  , rawParentVersion      :: Text
+  { rawParentGroup :: Text
+  , rawParentArtifact :: Text
+  , rawParentVersion :: Text
   , rawParentRelativePath :: Maybe Text
-  } deriving (Eq, Ord, Show)
+  }
+  deriving (Eq, Ord, Show)
 
 data RawDependency = RawDependency
-  { rawDependencyGroup      :: Text
-  , rawDependencyArtifact   :: Text
-  , rawDependencyVersion    :: Maybe Text
+  { rawDependencyGroup :: Text
+  , rawDependencyArtifact :: Text
+  , rawDependencyVersion :: Maybe Text
   , rawDependencyClassifier :: Maybe Text
-  , rawDependencyScope      :: Maybe Text
-  , rawDependencyOptional   :: Maybe Text
-  } deriving (Eq, Ord, Show)
+  , rawDependencyScope :: Maybe Text
+  , rawDependencyOptional :: Maybe Text
+  }
+  deriving (Eq, Ord, Show)
 
 data PomLicense = PomLicense
   { pomLicenseName :: Maybe Text
   , pomLicenseUrl :: Maybe Text
-  } deriving (Eq, Ord, Show)
+  }
+  deriving (Eq, Ord, Show)
 
 instance FromXML RawPom where
   parseElement el =
     RawPom <$> optional (child "parent" el)
-           <*> optional (child "groupId" el)
-           <*> child "artifactId" el
-           <*> optional (child "version" el)
-           <*> optional (child "properties" el) `defaultsTo` M.empty
-           <*> optional (child "modules" el >>= children "module") `defaultsTo` []
-           <*> optional (child "dependencyManagement" el >>= children "dependency") `defaultsTo` []
-           <*> optional (child "dependencies" el >>= children "dependency") `defaultsTo` []
-           <*> optional (child "licenses" el >>= children "license") `defaultsTo` []
+      <*> optional (child "groupId" el)
+      <*> child "artifactId" el
+      <*> optional (child "version" el)
+      <*> optional (child "properties" el) `defaultsTo` M.empty
+      <*> optional (child "modules" el >>= children "module") `defaultsTo` []
+      <*> optional (child "dependencyManagement" el >>= children "dependency") `defaultsTo` []
+      <*> optional (child "dependencies" el >>= children "dependency") `defaultsTo` []
+      <*> optional (child "licenses" el >>= children "license") `defaultsTo` []
 
 instance FromXML RawParent where
   -- TODO: move this documentation
@@ -178,20 +187,20 @@ instance FromXML RawParent where
   -- https://maven.apache.org/pom.html#Inheritance
   parseElement el =
     RawParent <$> child "groupId" el
-              <*> child "artifactId" el
-              <*> child "version" el
-              <*> optional (child "relativePath" el)
+      <*> child "artifactId" el
+      <*> child "version" el
+      <*> optional (child "relativePath" el)
 
 instance FromXML RawDependency where
   parseElement el =
     RawDependency <$> child "groupId" el
-                  <*> child "artifactId" el
-                  <*> optional (child "version" el)
-                  <*> optional (child "classifier" el)
-                  <*> optional (child "scope" el)
-                  <*> optional (child "optional" el)
+      <*> child "artifactId" el
+      <*> optional (child "version" el)
+      <*> optional (child "classifier" el)
+      <*> optional (child "scope" el)
+      <*> optional (child "optional" el)
 
 instance FromXML PomLicense where
   parseElement el =
     PomLicense <$> optional (child "name" el)
-               <*> optional (child "url" el)
+      <*> optional (child "url" el)

--- a/src/Strategy/Node/NpmLock.hs
+++ b/src/Strategy/Node/NpmLock.hs
@@ -1,20 +1,18 @@
 {-# LANGUAGE RecordWildCards #-}
 
-module Strategy.Node.NpmLock
-  ( analyze'
-  , buildGraph
-
-  , NpmPackageJson(..)
-  , NpmDep(..)
-  )
-  where
+module Strategy.Node.NpmLock (
+  analyze',
+  buildGraph,
+  NpmPackageJson (..),
+  NpmDep (..),
+) where
 
 import Control.Effect.Diagnostics
 import Data.Aeson
 import Data.Foldable (traverse_)
 import Data.Functor (void)
 import Data.Map.Strict (Map)
-import qualified Data.Map.Strict as M
+import Data.Map.Strict qualified as M
 import Data.Set (Set)
 import Data.Text (Text)
 import DepTypes
@@ -24,32 +22,35 @@ import Graphing (Graphing)
 import Path
 
 data NpmPackageJson = NpmPackageJson
-  { packageName         :: Text
-  , packageVersion      :: Text
+  { packageName :: Text
+  , packageVersion :: Text
   , packageDependencies :: Map Text NpmDep
-  } deriving (Eq, Ord, Show)
+  }
+  deriving (Eq, Ord, Show)
 
 data NpmDep = NpmDep
-  { depVersion      :: Text
-  , depDev          :: Maybe Bool
-  , depResolved     :: Maybe Text
-  , depRequires     :: Maybe (Map Text Text) -- ^ name to version spec
+  { depVersion :: Text
+  , depDev :: Maybe Bool
+  , depResolved :: Maybe Text
+  , -- | name to version spec
+    depRequires :: Maybe (Map Text Text)
   , depDependencies :: Maybe (Map Text NpmDep)
-  } deriving (Eq, Ord, Show)
+  }
+  deriving (Eq, Ord, Show)
 
 instance FromJSON NpmPackageJson where
   parseJSON = withObject "NpmPackageJson" $ \obj ->
     NpmPackageJson <$> obj .: "name"
-                   <*> obj .: "version"
-                   <*> obj .: "dependencies"
+      <*> obj .: "version"
+      <*> obj .: "dependencies"
 
 instance FromJSON NpmDep where
   parseJSON = withObject "NpmDep" $ \obj ->
-    NpmDep <$> obj .:  "version"
-           <*> obj .:? "dev"
-           <*> obj .:? "resolved"
-           <*> obj .:? "requires"
-           <*> obj .:? "dependencies"
+    NpmDep <$> obj .: "version"
+      <*> obj .:? "dev"
+      <*> obj .:? "resolved"
+      <*> obj .:? "requires"
+      <*> obj .:? "dependencies"
 
 analyze' :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs File -> m (Graphing Dependency)
 analyze' file = do
@@ -57,9 +58,10 @@ analyze' file = do
   context "Building dependency graph" $ pure (buildGraph packageJson)
 
 data NpmPackage = NpmPackage
-  { pkgName    :: Text
+  { pkgName :: Text
   , pkgVersion :: Text
-  } deriving (Eq, Ord, Show)
+  }
+  deriving (Eq, Ord, Show)
 
 type NpmGrapher = LabeledGrapher NpmPackage NpmPackageLabel
 
@@ -71,46 +73,46 @@ buildGraph packageJson = run . withLabeling toDependency $ do
   _ <- M.traverseWithKey addDirect (packageDependencies packageJson)
   _ <- M.traverseWithKey addDep (packageDependencies packageJson)
   pure ()
-
   where
-  addDirect :: Has NpmGrapher sig m => Text -> NpmDep -> m ()
-  addDirect name NpmDep{depVersion} = direct (NpmPackage name depVersion)
+    addDirect :: Has NpmGrapher sig m => Text -> NpmDep -> m ()
+    addDirect name NpmDep{depVersion} = direct (NpmPackage name depVersion)
 
-  addDep :: Has NpmGrapher sig m => Text -> NpmDep -> m ()
-  addDep name NpmDep{..} = do
-    let pkg = NpmPackage name depVersion
+    addDep :: Has NpmGrapher sig m => Text -> NpmDep -> m ()
+    addDep name NpmDep{..} = do
+      let pkg = NpmPackage name depVersion
 
-    case depDev of
-      Just True -> label pkg (NpmPackageEnv EnvDevelopment)
-      _         -> label pkg (NpmPackageEnv EnvProduction)
+      case depDev of
+        Just True -> label pkg (NpmPackageEnv EnvDevelopment)
+        _ -> label pkg (NpmPackageEnv EnvProduction)
 
-    traverse_ (label pkg . NpmPackageLocation) depResolved
+      traverse_ (label pkg . NpmPackageLocation) depResolved
 
-    -- add edges to required packages
-    case depRequires of
-      Nothing -> pure ()
-      Just required ->
-        void $ M.traverseWithKey (\reqName reqVer -> edge pkg (NpmPackage reqName reqVer)) required
+      -- add edges to required packages
+      case depRequires of
+        Nothing -> pure ()
+        Just required ->
+          void $ M.traverseWithKey (\reqName reqVer -> edge pkg (NpmPackage reqName reqVer)) required
 
-    -- add dependency nodes
-    case depDependencies of
-      Nothing -> pure ()
-      Just deps ->
-        void $ M.traverseWithKey addDep deps
+      -- add dependency nodes
+      case depDependencies of
+        Nothing -> pure ()
+        Just deps ->
+          void $ M.traverseWithKey addDep deps
 
-  toDependency :: NpmPackage -> Set NpmPackageLabel -> Dependency
-  toDependency pkg = foldr addLabel (start pkg)
+    toDependency :: NpmPackage -> Set NpmPackageLabel -> Dependency
+    toDependency pkg = foldr addLabel (start pkg)
 
-  addLabel :: NpmPackageLabel -> Dependency -> Dependency
-  addLabel (NpmPackageEnv env) dep = dep { dependencyEnvironments = env : dependencyEnvironments dep }
-  addLabel (NpmPackageLocation loc) dep = dep { dependencyLocations = loc : dependencyLocations dep }
+    addLabel :: NpmPackageLabel -> Dependency -> Dependency
+    addLabel (NpmPackageEnv env) dep = dep{dependencyEnvironments = env : dependencyEnvironments dep}
+    addLabel (NpmPackageLocation loc) dep = dep{dependencyLocations = loc : dependencyLocations dep}
 
-  start :: NpmPackage -> Dependency
-  start NpmPackage{..} = Dependency
-    { dependencyType = NodeJSType
-    , dependencyName = pkgName
-    , dependencyVersion = Just $ CEq pkgVersion
-    , dependencyLocations = []
-    , dependencyEnvironments = []
-    , dependencyTags = M.empty
-    }
+    start :: NpmPackage -> Dependency
+    start NpmPackage{..} =
+      Dependency
+        { dependencyType = NodeJSType
+        , dependencyName = pkgName
+        , dependencyVersion = Just $ CEq pkgVersion
+        , dependencyLocations = []
+        , dependencyEnvironments = []
+        , dependencyTags = M.empty
+        }

--- a/src/Strategy/Node/PackageJson.hs
+++ b/src/Strategy/Node/PackageJson.hs
@@ -1,16 +1,15 @@
 {-# LANGUAGE RecordWildCards #-}
 
-module Strategy.Node.PackageJson
-  ( buildGraph
-  , analyze'
-
-  , PackageJson(..)
-  ) where
+module Strategy.Node.PackageJson (
+  buildGraph,
+  analyze',
+  PackageJson (..),
+) where
 
 import Control.Effect.Diagnostics
 import Data.Aeson
 import Data.Map.Strict (Map)
-import qualified Data.Map.Strict as M
+import Data.Map.Strict qualified as M
 import Data.Set (Set)
 import Data.Text (Text)
 import DepTypes
@@ -20,14 +19,15 @@ import Graphing (Graphing)
 import Path
 
 data PackageJson = PackageJson
-  { packageDeps    :: Map Text Text
+  { packageDeps :: Map Text Text
   , packageDevDeps :: Map Text Text
-  } deriving (Eq, Ord, Show)
+  }
+  deriving (Eq, Ord, Show)
 
 instance FromJSON PackageJson where
   parseJSON = withObject "PackageJson" $ \obj ->
-    PackageJson <$> obj .:? "dependencies"    .!= M.empty
-                <*> obj .:? "devDependencies" .!= M.empty
+    PackageJson <$> obj .:? "dependencies" .!= M.empty
+      <*> obj .:? "devDependencies" .!= M.empty
 
 analyze' :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs File -> m (Graphing Dependency)
 analyze' file = do
@@ -36,9 +36,10 @@ analyze' file = do
 
 -- TODO: decode version constraints
 data NodePackage = NodePackage
-  { pkgName       :: Text
+  { pkgName :: Text
   , pkgConstraint :: Text
-  } deriving (Eq, Ord, Show)
+  }
+  deriving (Eq, Ord, Show)
 
 type NodeGrapher = LabeledGrapher NodePackage NodePackageLabel
 
@@ -50,28 +51,27 @@ buildGraph PackageJson{..} = run . withLabeling toDependency $ do
   _ <- M.traverseWithKey (addDep EnvProduction) packageDeps
   _ <- M.traverseWithKey (addDep EnvDevelopment) packageDevDeps
   pure ()
-
   where
+    addDep :: Has NodeGrapher sig m => DepEnvironment -> Text -> Text -> m ()
+    addDep env name constraint = do
+      let pkg = NodePackage name constraint
+      direct pkg
+      label pkg (NodePackageEnv env)
 
-  addDep :: Has NodeGrapher sig m => DepEnvironment -> Text -> Text -> m ()
-  addDep env name constraint = do
-    let pkg = NodePackage name constraint
-    direct pkg
-    label pkg (NodePackageEnv env)
+    toDependency :: NodePackage -> Set NodePackageLabel -> Dependency
+    toDependency dep = foldr addLabel (start dep)
 
-  toDependency :: NodePackage -> Set NodePackageLabel -> Dependency
-  toDependency dep = foldr addLabel (start dep)
+    addLabel :: NodePackageLabel -> Dependency -> Dependency
+    addLabel (NodePackageEnv env) dep =
+      dep{dependencyEnvironments = env : dependencyEnvironments dep}
 
-  addLabel :: NodePackageLabel -> Dependency -> Dependency
-  addLabel (NodePackageEnv env) dep =
-    dep { dependencyEnvironments = env : dependencyEnvironments dep }
-
-  start :: NodePackage -> Dependency
-  start NodePackage{..} = Dependency
-    { dependencyType = NodeJSType
-    , dependencyName = pkgName
-    , dependencyVersion = Just (CCompatible pkgConstraint)
-    , dependencyLocations = []
-    , dependencyEnvironments = []
-    , dependencyTags = M.empty
-    }
+    start :: NodePackage -> Dependency
+    start NodePackage{..} =
+      Dependency
+        { dependencyType = NodeJSType
+        , dependencyName = pkgName
+        , dependencyVersion = Just (CCompatible pkgConstraint)
+        , dependencyLocations = []
+        , dependencyEnvironments = []
+        , dependencyTags = M.empty
+        }

--- a/src/Strategy/Npm.hs
+++ b/src/Strategy/Npm.hs
@@ -1,18 +1,17 @@
-module Strategy.Npm
-  ( discover
-  )
-where
+module Strategy.Npm (
+  discover,
+) where
 
-import Control.Effect.Diagnostics ((<||>), Diagnostics, context)
-import qualified Control.Effect.Diagnostics as Diag
+import Control.Effect.Diagnostics (Diagnostics, context, (<||>))
+import Control.Effect.Diagnostics qualified as Diag
 import Discovery.Walk
 import Effect.Exec
 import Effect.ReadFS
 import Graphing
 import Path
-import qualified Strategy.Node.NpmList as NpmList
-import qualified Strategy.Node.NpmLock as NpmLock
-import qualified Strategy.Node.PackageJson as PackageJson
+import Strategy.Node.NpmList qualified as NpmList
+import Strategy.Node.NpmLock qualified as NpmLock
+import Strategy.Node.PackageJson qualified as PackageJson
 import Types
 
 discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has ReadFS rsig run, Has Exec rsig run, Has Diagnostics rsig run) => Path Abs Dir -> m [DiscoveredProject run]
@@ -34,28 +33,28 @@ findProjects = walk' $ \dir _ files -> do
 
           let project =
                 NpmProject
-                  { npmDir = dir,
-                    npmPackageJson = packageJson,
-                    npmPackageLock = packageLock
+                  { npmDir = dir
+                  , npmPackageJson = packageJson
+                  , npmPackageLock = packageLock
                   }
 
           pure ([project], WalkSkipSome ["node_modules"])
 
 data NpmProject = NpmProject
-  { npmDir :: Path Abs Dir,
-    npmPackageJson :: Path Abs File,
-    npmPackageLock :: Maybe (Path Abs File)
+  { npmDir :: Path Abs Dir
+  , npmPackageJson :: Path Abs File
+  , npmPackageLock :: Maybe (Path Abs File)
   }
   deriving (Eq, Ord, Show)
 
 mkProject :: (Has ReadFS sig n, Has Exec sig n, Has Diagnostics sig n) => NpmProject -> DiscoveredProject n
 mkProject project =
   DiscoveredProject
-    { projectType = "npm",
-      projectBuildTargets = mempty,
-      projectDependencyGraph = const $ getDeps project,
-      projectPath = npmDir project,
-      projectLicenses = pure []
+    { projectType = "npm"
+    , projectBuildTargets = mempty
+    , projectDependencyGraph = const $ getDeps project
+    , projectPath = npmDir project
+    , projectLicenses = pure []
     }
 
 getDeps :: (Has Exec sig m, Has ReadFS sig m, Has Diagnostics sig m) => NpmProject -> m (Graphing Dependency)
@@ -65,8 +64,9 @@ analyzeNpmList :: (Has Exec sig m, Has Diagnostics sig m) => NpmProject -> m (Gr
 analyzeNpmList = context "npm-list analysis" . NpmList.analyze' . npmDir
 
 analyzeNpmLock :: (Has ReadFS sig m, Has Diagnostics sig m) => NpmProject -> m (Graphing Dependency)
-analyzeNpmLock project = context "package-lock.json analysis" $
-  Diag.fromMaybeText "No package-lock.json present in the project" (npmPackageLock project) >>= NpmLock.analyze'
+analyzeNpmLock project =
+  context "package-lock.json analysis" $
+    Diag.fromMaybeText "No package-lock.json present in the project" (npmPackageLock project) >>= NpmLock.analyze'
 
 analyzeNpmJson :: (Has ReadFS sig m, Has Diagnostics sig m) => NpmProject -> m (Graphing Dependency)
 analyzeNpmJson = context "package.json analysis" . PackageJson.analyze' . npmPackageJson

--- a/src/Strategy/NuGet/Nuspec.hs
+++ b/src/Strategy/NuGet/Nuspec.hs
@@ -1,30 +1,29 @@
 {-# LANGUAGE RecordWildCards #-}
 
-module Strategy.NuGet.Nuspec
-  ( discover,
-    findProjects,
-    getDeps,
-    mkProject,
-    buildGraph,
-
-    Nuspec(..),
-    Group(..),
-    NuGetDependency(..),
-    NuspecLicense(..),
-  ) where
+module Strategy.NuGet.Nuspec (
+  discover,
+  findProjects,
+  getDeps,
+  mkProject,
+  buildGraph,
+  Nuspec (..),
+  Group (..),
+  NuGetDependency (..),
+  NuspecLicense (..),
+) where
 
 import Control.Applicative (optional)
 import Control.Effect.Diagnostics
 import Data.Foldable (find)
-import qualified Data.List as L
-import qualified Data.Map.Strict as M
+import Data.List qualified as L
+import Data.Map.Strict qualified as M
 import Data.Text (Text)
-import qualified Data.Text as T
+import Data.Text qualified as T
 import DepTypes
 import Discovery.Walk
 import Effect.ReadFS
 import Graphing (Graphing)
-import qualified Graphing
+import Graphing qualified
 import Parse.XML
 import Path
 import Types
@@ -48,11 +47,11 @@ newtype NuspecProject = NuspecProject
 mkProject :: (Has ReadFS sig n, Has Diagnostics sig n) => NuspecProject -> DiscoveredProject n
 mkProject project =
   DiscoveredProject
-    { projectType = "nuspec",
-      projectBuildTargets = mempty,
-      projectDependencyGraph = const $ getDeps project,
-      projectPath = parent $ nuspecFile project,
-      projectLicenses = analyzeLicenses (nuspecFile project)
+    { projectType = "nuspec"
+    , projectBuildTargets = mempty
+    , projectDependencyGraph = const $ getDeps project
+    , projectPath = parent $ nuspecFile project
+    , projectLicenses = analyzeLicenses (nuspecFile project)
     }
 
 getDeps :: (Has ReadFS sig m, Has Diagnostics sig m) => NuspecProject -> m (Graphing Dependency)
@@ -70,49 +69,53 @@ analyzeLicenses file = do
 
 nuspecLicenses :: Nuspec -> [License]
 nuspecLicenses nuspec = url ++ licenseField
-          where
-            url = case licenseUrl nuspec of
-              Just location -> [License LicenseURL location]
-              Nothing -> []
-            licenseField = foldr (\a b -> b ++ [License (parseLicenseType $ nuspecLicenseType a) (nuspecLicenseValue a)]) [] (license nuspec)
+  where
+    url = case licenseUrl nuspec of
+      Just location -> [License LicenseURL location]
+      Nothing -> []
+    licenseField = foldr (\a b -> b ++ [License (parseLicenseType $ nuspecLicenseType a) (nuspecLicenseValue a)]) [] (license nuspec)
 
 parseLicenseType :: Text -> LicenseType
 parseLicenseType rawType = case T.unpack rawType of
-                            "expression" -> LicenseSPDX
-                            "file" -> LicenseFile
-                            _ -> UnknownType
+  "expression" -> LicenseSPDX
+  "file" -> LicenseFile
+  _ -> UnknownType
 
 data Nuspec = Nuspec
-  { groups        :: [Group]
-  , license       :: [NuspecLicense]
-  , licenseUrl    :: Maybe Text
-  } deriving (Eq, Ord, Show)
+  { groups :: [Group]
+  , license :: [NuspecLicense]
+  , licenseUrl :: Maybe Text
+  }
+  deriving (Eq, Ord, Show)
 
 data NuspecLicense = NuspecLicense
-  { nuspecLicenseType  :: Text
+  { nuspecLicenseType :: Text
   , nuspecLicenseValue :: Text
-  } deriving (Eq, Ord, Show)
+  }
+  deriving (Eq, Ord, Show)
 
 newtype Group = Group
-  { dependencies  :: [NuGetDependency]
-  } deriving (Eq, Ord, Show)
+  { dependencies :: [NuGetDependency]
+  }
+  deriving (Eq, Ord, Show)
 
 data NuGetDependency = NuGetDependency
-  { depID      :: Text
+  { depID :: Text
   , depVersion :: Text
-  } deriving (Eq, Ord, Show)
+  }
+  deriving (Eq, Ord, Show)
 
 instance FromXML Nuspec where
   parseElement el = do
-    metadata     <- child "metadata" el
+    metadata <- child "metadata" el
     Nuspec <$> optional (child "dependencies" metadata >>= children "group") `defaultsTo` []
-           <*> children "license" metadata
-           <*> optional (child "licenseUrl" metadata)
+      <*> children "license" metadata
+      <*> optional (child "licenseUrl" metadata)
 
 instance FromXML NuspecLicense where
   parseElement el =
     NuspecLicense <$> optional (attr "type" el) `defaultsTo` ""
-                  <*> content el
+      <*> content el
 
 instance FromXML Group where
   parseElement el = Group <$> children "dependency" el
@@ -120,17 +123,18 @@ instance FromXML Group where
 instance FromXML NuGetDependency where
   parseElement el =
     NuGetDependency <$> attr "id" el
-                    <*> attr "version" el
+      <*> attr "version" el
 
 buildGraph :: Nuspec -> Graphing Dependency
 buildGraph project = Graphing.fromList (map toDependency direct)
-    where
+  where
     direct = concatMap dependencies (groups project)
     toDependency NuGetDependency{..} =
-      Dependency { dependencyType = NuGetType
-                 , dependencyName = depID
-                 , dependencyVersion = Just (CEq depVersion)
-                 , dependencyLocations = []
-                 , dependencyEnvironments = []
-                 , dependencyTags = M.empty
-                 }
+      Dependency
+        { dependencyType = NuGetType
+        , dependencyName = depID
+        , dependencyVersion = Just (CEq depVersion)
+        , dependencyLocations = []
+        , dependencyEnvironments = []
+        , dependencyTags = M.empty
+        }

--- a/src/Strategy/NuGet/Paket.hs
+++ b/src/Strategy/NuGet/Paket.hs
@@ -1,25 +1,24 @@
-module Strategy.NuGet.Paket
-  ( discover
-  , findProjects
-  , getDeps
-  , mkProject
-  , findSections
-  , buildGraph
-
-  , PaketDep(..)
-  , Section(..)
-  , Remote(..)
-  ) where
+module Strategy.NuGet.Paket (
+  discover,
+  findProjects,
+  getDeps,
+  mkProject,
+  findSections,
+  buildGraph,
+  PaketDep (..),
+  Section (..),
+  Remote (..),
+) where
 
 import Control.Effect.Diagnostics
 import Control.Monad (guard)
-import qualified Data.Char as C
+import Data.Char qualified as C
 import Data.Foldable (traverse_)
 import Data.Functor (void)
-import qualified Data.Map.Strict as M
+import Data.Map.Strict qualified as M
 import Data.Set (Set)
 import Data.Text (Text)
-import qualified Data.Text as T
+import Data.Text qualified as T
 import Data.Void (Void)
 import DepTypes
 import Discovery.Walk
@@ -29,7 +28,7 @@ import Graphing (Graphing)
 import Path
 import Text.Megaparsec hiding (label)
 import Text.Megaparsec.Char
-import qualified Text.Megaparsec.Char.Lexer as L
+import Text.Megaparsec.Char.Lexer qualified as L
 import Types
 
 type Parser = Parsec Void Text
@@ -53,11 +52,11 @@ newtype PaketProject = PaketProject
 mkProject :: (Has ReadFS sig n, Has Diagnostics sig n) => PaketProject -> DiscoveredProject n
 mkProject project =
   DiscoveredProject
-    { projectType = "paket",
-      projectBuildTargets = mempty,
-      projectDependencyGraph = const $ getDeps project,
-      projectPath = parent $ paketLock project,
-      projectLicenses = pure []
+    { projectType = "paket"
+    , projectBuildTargets = mempty
+    , projectDependencyGraph = const $ getDeps project
+    , projectPath = parent $ paketLock project
+    , projectLicenses = pure []
     }
 
 getDeps :: (Has ReadFS sig m, Has Diagnostics sig m) => PaketProject -> m (Graphing Dependency)
@@ -68,13 +67,13 @@ analyze' file = do
   sections <- readContentsParser findSections file
   context "Building dependency graph" $ pure (buildGraph sections)
 
-newtype PaketPkg = PaketPkg { pkgName :: Text }
+newtype PaketPkg = PaketPkg {pkgName :: Text}
   deriving (Eq, Ord, Show)
 
 type PaketGrapher = LabeledGrapher PaketPkg PaketLabel
 
-data PaketLabel =
-    PaketVersion Text
+data PaketLabel
+  = PaketVersion Text
   | PaketRemote Text
   | GroupName Text
   | DepLocation Text
@@ -83,106 +82,110 @@ data PaketLabel =
 toDependency :: PaketPkg -> Set PaketLabel -> Dependency
 toDependency pkg = foldr applyLabel start
   where
+    start :: Dependency
+    start =
+      Dependency
+        { dependencyType = NuGetType
+        , dependencyName = pkgName pkg
+        , dependencyVersion = Nothing
+        , dependencyLocations = []
+        , dependencyEnvironments = []
+        , dependencyTags = M.empty
+        }
 
-  start :: Dependency
-  start = Dependency
-    { dependencyType = NuGetType
-    , dependencyName = pkgName pkg
-    , dependencyVersion = Nothing
-    , dependencyLocations = []
-    , dependencyEnvironments = []
-    , dependencyTags = M.empty
-    }
-
-  applyLabel :: PaketLabel -> Dependency -> Dependency
-  applyLabel (PaketVersion ver) dep = dep { dependencyVersion = Just (CEq ver) }
-  applyLabel (GroupName name) dep = dep { dependencyTags = M.insertWith (++) "group" [name] (dependencyTags dep) }
-  applyLabel (DepLocation loc) dep = dep { dependencyTags = M.insertWith (++) "location" [loc] (dependencyTags dep) }
-  applyLabel (PaketRemote repo) dep = dep { dependencyLocations = repo : dependencyLocations dep }
+    applyLabel :: PaketLabel -> Dependency -> Dependency
+    applyLabel (PaketVersion ver) dep = dep{dependencyVersion = Just (CEq ver)}
+    applyLabel (GroupName name) dep = dep{dependencyTags = M.insertWith (++) "group" [name] (dependencyTags dep)}
+    applyLabel (DepLocation loc) dep = dep{dependencyTags = M.insertWith (++) "location" [loc] (dependencyTags dep)}
+    applyLabel (PaketRemote repo) dep = dep{dependencyLocations = repo : dependencyLocations dep}
 
 buildGraph :: [Section] -> Graphing Dependency
-buildGraph sections = run . withLabeling toDependency $
-      traverse_ (addSection "MAIN") sections
-      where
-            addSection :: Has PaketGrapher sig m => Text -> Section -> m ()
-            addSection group (StandardSection location remotes) = traverse_ (addRemote group location) remotes
-            addSection _ (GroupSection group gSections) = traverse_ (addSection group) gSections
-            addSection _ (UnknownSection _) = pure ()
+buildGraph sections =
+  run . withLabeling toDependency $
+    traverse_ (addSection "MAIN") sections
+  where
+    addSection :: Has PaketGrapher sig m => Text -> Section -> m ()
+    addSection group (StandardSection location remotes) = traverse_ (addRemote group location) remotes
+    addSection _ (GroupSection group gSections) = traverse_ (addSection group) gSections
+    addSection _ (UnknownSection _) = pure ()
 
-            addRemote :: Has PaketGrapher sig m => Text -> Text -> Remote -> m ()
-            addRemote group loc remote = traverse_ (addSpec (DepLocation loc) (PaketRemote $ remoteLocation remote) (GroupName group)) (remoteDependencies remote)
+    addRemote :: Has PaketGrapher sig m => Text -> Text -> Remote -> m ()
+    addRemote group loc remote = traverse_ (addSpec (DepLocation loc) (PaketRemote $ remoteLocation remote) (GroupName group)) (remoteDependencies remote)
 
-            addSpec :: Has PaketGrapher sig m => PaketLabel -> PaketLabel -> PaketLabel -> PaketDep -> m ()
-            addSpec loc remote group dep = do
-              -- add edges, labels, and direct deps
-              let pkg = PaketPkg (depName dep)
-              traverse_ (edge pkg . PaketPkg) (transitive dep)
-              label pkg (PaketVersion (depVersion dep))
-              label pkg remote
-              label pkg group
-              label pkg loc
-              direct pkg
+    addSpec :: Has PaketGrapher sig m => PaketLabel -> PaketLabel -> PaketLabel -> PaketDep -> m ()
+    addSpec loc remote group dep = do
+      -- add edges, labels, and direct deps
+      let pkg = PaketPkg (depName dep)
+      traverse_ (edge pkg . PaketPkg) (transitive dep)
+      label pkg (PaketVersion (depVersion dep))
+      label pkg remote
+      label pkg group
+      label pkg loc
+      direct pkg
 
 type Name = Text
 type Location = Text
 
-data Section =
-       StandardSection Location [Remote]
-      | UnknownSection Text
-      | GroupSection Name [Section]
-      deriving (Eq, Ord, Show)
+data Section
+  = StandardSection Location [Remote]
+  | UnknownSection Text
+  | GroupSection Name [Section]
+  deriving (Eq, Ord, Show)
 
 data Remote = Remote
-     { remoteLocation :: Text
-     , remoteDependencies  :: [PaketDep]
-     } deriving (Eq, Ord, Show)
+  { remoteLocation :: Text
+  , remoteDependencies :: [PaketDep]
+  }
+  deriving (Eq, Ord, Show)
 
 data PaketDep = PaketDep
-     { depName    :: Text
-     , depVersion    :: Text
-     , transitive :: [Text]
-     } deriving (Eq, Ord, Show)
+  { depName :: Text
+  , depVersion :: Text
+  , transitive :: [Text]
+  }
+  deriving (Eq, Ord, Show)
 
 data Group = Group
-     { groupName    :: Text
-     , groupSections :: [Section]
-     } deriving (Eq, Ord, Show)
-
+  { groupName :: Text
+  , groupSections :: [Section]
+  }
+  deriving (Eq, Ord, Show)
 
 findSections :: Parser [Section]
 findSections = many (try standardSectionParser <|> try groupSection <|> try unknownSection) <* eof
 
 groupSection :: Parser Section
 groupSection = do
-          _ <- chunk "GROUP"
-          name <- textValue
-          sections <- many (try standardSectionParser <|>  try unknownSection)
-          pure $ GroupSection name sections
+  _ <- chunk "GROUP"
+  name <- textValue
+  sections <- many (try standardSectionParser <|> try unknownSection)
+  pure $ GroupSection name sections
 
 unknownSection :: Parser Section
 unknownSection = do
-      emptyLine <- restOfLine
-      guard $ not $ "GROUP" `T.isPrefixOf` emptyLine
-      _ <- eol
-      pure $ UnknownSection emptyLine
+  emptyLine <- restOfLine
+  guard $ not $ "GROUP" `T.isPrefixOf` emptyLine
+  _ <- eol
+  pure $ UnknownSection emptyLine
 
 standardSectionParser :: Parser Section
-standardSectionParser = L.nonIndented scn $ L.indentBlock scn $ do
-          location <- chunk "HTTP" <|> "GITHUB" <|> "NUGET"
-          return $ L.IndentMany Nothing (pure . StandardSection location) remoteParser
+standardSectionParser = L.nonIndented scn $
+  L.indentBlock scn $ do
+    location <- chunk "HTTP" <|> "GITHUB" <|> "NUGET"
+    return $ L.IndentMany Nothing (pure . StandardSection location) remoteParser
 
 remoteParser :: Parser Remote
 remoteParser = L.indentBlock scn $ do
-      _ <- chunk "remote:"
-      value <- textValue
-      pure $ L.IndentMany Nothing (pure . Remote value) specParser
+  _ <- chunk "remote:"
+  value <- textValue
+  pure $ L.IndentMany Nothing (pure . Remote value) specParser
 
 specParser :: Parser PaketDep
 specParser = L.indentBlock scn $ do
-        name <- findDep
-        version <- findVersion
-        _ <- restOfLine
-        pure $ L.IndentMany Nothing (pure . PaketDep name version) specsParser
+  name <- findDep
+  version <- findVersion
+  _ <- restOfLine
+  pure $ L.IndentMany Nothing (pure . PaketDep name version) specsParser
 
 specsParser :: Parser Text
 specsParser = findDep <* restOfLine
@@ -202,13 +205,13 @@ restOfLine = takeWhileP (Just "ignored") (not . isEndLine)
 isEndLine :: Char -> Bool
 isEndLine '\n' = True
 isEndLine '\r' = True
-isEndLine _    = False
+isEndLine _ = False
 
 scn :: Parser ()
-scn =  L.space space1 empty empty
+scn = L.space space1 empty empty
 
 lexeme :: Parser a -> Parser a
 lexeme = L.lexeme sc
 
 sc :: Parser ()
-sc =  L.space (void $ some (char ' ')) empty empty
+sc = L.space (void $ some (char ' ')) empty empty

--- a/src/Strategy/Python/Pipenv.hs
+++ b/src/Strategy/Python/Pipenv.hs
@@ -1,28 +1,26 @@
 {-# LANGUAGE RecordWildCards #-}
 
-module Strategy.Python.Pipenv
-  ( discover
-  , findProjects
-  , getDeps
-  , mkProject
-
-  , PipenvGraphDep(..)
-  , PipfileLock(..)
-  , PipfileMeta(..)
-  , PipfileSource(..)
-  , PipfileDep(..)
-  , buildGraph
-  )
-  where
+module Strategy.Python.Pipenv (
+  discover,
+  findProjects,
+  getDeps,
+  mkProject,
+  PipenvGraphDep (..),
+  PipfileLock (..),
+  PipfileMeta (..),
+  PipfileSource (..),
+  PipfileDep (..),
+  buildGraph,
+) where
 
 import Control.Effect.Diagnostics
 import Data.Aeson
 import Data.Foldable (for_, traverse_)
 import Data.Map.Strict (Map)
-import qualified Data.Map.Strict as M
+import Data.Map.Strict qualified as M
 import Data.Set (Set)
 import Data.Text (Text)
-import qualified Data.Text as T
+import Data.Text qualified as T
 import DepTypes
 import Discovery.Walk
 import Effect.Exec
@@ -47,8 +45,9 @@ getDeps ::
   ( Has ReadFS sig m
   , Has Exec sig m
   , Has Diagnostics sig m
-  )
-  => PipenvProject -> m (Graphing Dependency)
+  ) =>
+  PipenvProject ->
+  m (Graphing Dependency)
 getDeps project = context "Pipenv" $ do
   lock <- context "Getting direct dependencies" $ readContentsJson (pipenvLockfile project)
   maybeDeps <- context "Getting deep dependencies" $ recover $ execJson (parent (pipenvLockfile project)) pipenvGraphCmd
@@ -56,13 +55,14 @@ getDeps project = context "Pipenv" $ do
   context "Building dependency graph" $ pure (buildGraph lock maybeDeps)
 
 mkProject :: (Has ReadFS sig n, Has Exec sig n, Has Diagnostics sig n) => PipenvProject -> DiscoveredProject n
-mkProject project = DiscoveredProject
-  { projectType = "pipenv"
-  , projectBuildTargets = mempty
-  , projectDependencyGraph = const $ getDeps project
-  , projectPath = parent $ pipenvLockfile project
-  , projectLicenses = pure []
-  }
+mkProject project =
+  DiscoveredProject
+    { projectType = "pipenv"
+    , projectBuildTargets = mempty
+    , projectDependencyGraph = const $ getDeps project
+    , projectPath = parent $ pipenvLockfile project
+    , projectLicenses = pure []
+    }
 
 newtype PipenvProject = PipenvProject
   { pipenvLockfile :: Path Abs File
@@ -70,11 +70,12 @@ newtype PipenvProject = PipenvProject
   deriving (Eq, Ord, Show)
 
 pipenvGraphCmd :: Command
-pipenvGraphCmd = Command
-  { cmdName = "pipenv"
-  , cmdArgs = ["graph", "--json-tree"]
-  , cmdAllowErr = Never
-  }
+pipenvGraphCmd =
+  Command
+    { cmdName = "pipenv"
+    , cmdArgs = ["graph", "--json-tree"]
+    , cmdAllowErr = Never
+    }
 
 buildGraph :: PipfileLock -> Maybe [PipenvGraphDep] -> Graphing Dependency
 buildGraph lock maybeDeps = run . withLabeling toDependency $ do
@@ -82,33 +83,34 @@ buildGraph lock maybeDeps = run . withLabeling toDependency $ do
   case maybeDeps of
     Just deps -> buildEdges deps
     Nothing -> pure ()
-
   where
-  toDependency :: PipPkg -> Set PipLabel -> Dependency
-  toDependency pkg = foldr applyLabel start
-    where
-    applyLabel :: PipLabel -> Dependency -> Dependency
-    applyLabel (PipSource loc) dep = dep { dependencyLocations = loc : dependencyLocations dep }
-    applyLabel (PipEnvironment env) dep = dep { dependencyEnvironments = env : dependencyEnvironments dep }
+    toDependency :: PipPkg -> Set PipLabel -> Dependency
+    toDependency pkg = foldr applyLabel start
+      where
+        applyLabel :: PipLabel -> Dependency -> Dependency
+        applyLabel (PipSource loc) dep = dep{dependencyLocations = loc : dependencyLocations dep}
+        applyLabel (PipEnvironment env) dep = dep{dependencyEnvironments = env : dependencyEnvironments dep}
 
-    start = Dependency
-      { dependencyType = PipType
-      , dependencyName = pipPkgName pkg
-      , dependencyVersion = CEq <$> pipPkgVersion pkg
-      , dependencyLocations = []
-      , dependencyEnvironments = []
-      , dependencyTags = M.empty
-      }
+        start =
+          Dependency
+            { dependencyType = PipType
+            , dependencyName = pipPkgName pkg
+            , dependencyVersion = CEq <$> pipPkgVersion pkg
+            , dependencyLocations = []
+            , dependencyEnvironments = []
+            , dependencyTags = M.empty
+            }
 
 data PipPkg = PipPkg
-  { pipPkgName    :: Text
+  { pipPkgName :: Text
   , pipPkgVersion :: Maybe Text
-  } deriving (Eq, Ord, Show)
+  }
+  deriving (Eq, Ord, Show)
 
 type PipGrapher = LabeledGrapher PipPkg PipLabel
 
-data PipLabel =
-    PipSource Text -- location
+data PipLabel
+  = PipSource Text -- location
   | PipEnvironment DepEnvironment
   deriving (Eq, Ord, Show)
 
@@ -122,74 +124,75 @@ buildNodes PipfileLock{..} = do
   _ <- M.traverseWithKey (addWithEnv EnvDevelopment sourcesMap) fileDevelop
   _ <- M.traverseWithKey (addWithEnv EnvProduction sourcesMap) fileDefault
   pure ()
-
   where
+    addWithEnv ::
+      DepEnvironment ->
+      Map Text PipfileSource ->
+      Text -> -- dep name
+      PipfileDep ->
+      m ()
+    addWithEnv env sourcesMap depName dep = do
+      let pkg = PipPkg depName (T.drop 2 <$> fileDepVersion dep)
+      -- TODO: reachable instead of direct
+      direct pkg
+      label pkg (PipEnvironment env)
 
-  addWithEnv :: DepEnvironment
-               -> Map Text PipfileSource
-               -> Text -- dep name
-               -> PipfileDep
-               -> m ()
-  addWithEnv env sourcesMap depName dep = do
-    let pkg = PipPkg depName (T.drop 2 <$> fileDepVersion dep)
-    -- TODO: reachable instead of direct
-    direct pkg
-    label pkg (PipEnvironment env)
-
-    -- add label for source when it exists
-    for_ (fileDepIndex dep) $ \index ->
-      case M.lookup index sourcesMap of
-        Just source -> label pkg (PipSource (sourceUrl source))
-        Nothing -> pure ()
+      -- add label for source when it exists
+      for_ (fileDepIndex dep) $ \index ->
+        case M.lookup index sourcesMap of
+          Just source -> label pkg (PipSource (sourceUrl source))
+          Nothing -> pure ()
 
 buildEdges :: Has PipGrapher sig m => [PipenvGraphDep] -> m ()
 buildEdges pipenvDeps = do
   traverse_ (direct . mkPkg) pipenvDeps
   traverse_ mkEdges pipenvDeps
-
   where
+    mkPkg :: PipenvGraphDep -> PipPkg
+    mkPkg dep = PipPkg (depName dep) $ Just (depInstalled dep)
 
-  mkPkg :: PipenvGraphDep -> PipPkg
-  mkPkg dep = PipPkg (depName dep) $ Just (depInstalled dep)
-
-  mkEdges :: Has PipGrapher sig m => PipenvGraphDep -> m ()
-  mkEdges parentDep =
-    for_ (depDependencies parentDep) $ \childDep -> do
-      edge (mkPkg parentDep) (mkPkg childDep)
-      mkEdges childDep
+    mkEdges :: Has PipGrapher sig m => PipenvGraphDep -> m ()
+    mkEdges parentDep =
+      for_ (depDependencies parentDep) $ \childDep -> do
+        edge (mkPkg parentDep) (mkPkg childDep)
+        mkEdges childDep
 
 ---------- Pipfile.lock
 
 data PipfileLock = PipfileLock
-  { fileMeta    :: PipfileMeta
+  { fileMeta :: PipfileMeta
   , fileDefault :: Map Text PipfileDep
   , fileDevelop :: Map Text PipfileDep
-  } deriving (Eq, Ord, Show)
+  }
+  deriving (Eq, Ord, Show)
 
 newtype PipfileMeta = PipfileMeta
   { fileSources :: [PipfileSource]
-  } deriving (Eq, Ord, Show)
+  }
+  deriving (Eq, Ord, Show)
 
 data PipfileSource = PipfileSource
   { sourceName :: Text
-  , sourceUrl  :: Text
-  } deriving (Eq, Ord, Show)
+  , sourceUrl :: Text
+  }
+  deriving (Eq, Ord, Show)
 
 data PipfileDep = PipfileDep
   { fileDepVersion :: Maybe Text
-  , fileDepIndex   :: Maybe Text
-  } deriving (Eq, Ord, Show)
+  , fileDepIndex :: Maybe Text
+  }
+  deriving (Eq, Ord, Show)
 
 instance FromJSON PipfileLock where
   parseJSON = withObject "PipfileLock" $ \obj ->
     PipfileLock <$> obj .: "_meta"
-                <*> obj .: "default"
-                <*> obj .: "develop"
+      <*> obj .: "default"
+      <*> obj .: "develop"
 
 instance FromJSON PipfileDep where
   parseJSON = withObject "PipfileDep" $ \obj ->
     PipfileDep <$> obj .:? "version"
-               <*> obj .:? "index"
+      <*> obj .:? "index"
 
 instance FromJSON PipfileMeta where
   parseJSON = withObject "PipfileMeta" $ \obj ->
@@ -198,20 +201,21 @@ instance FromJSON PipfileMeta where
 instance FromJSON PipfileSource where
   parseJSON = withObject "PipfileSource" $ \obj ->
     PipfileSource <$> obj .: "name"
-                  <*> obj .: "url"
+      <*> obj .: "url"
 
 ---------- pipenv graph
 
 data PipenvGraphDep = PipenvGraphDep
-  { depName         :: Text
-  , depInstalled    :: Text
-  , depRequired     :: Text
+  { depName :: Text
+  , depInstalled :: Text
+  , depRequired :: Text
   , depDependencies :: [PipenvGraphDep]
-  } deriving (Eq, Ord, Show)
+  }
+  deriving (Eq, Ord, Show)
 
 instance FromJSON PipenvGraphDep where
   parseJSON = withObject "PipenvGraphDep" $ \obj ->
     PipenvGraphDep <$> obj .: "package_name"
-                   <*> obj .: "installed_version"
-                   <*> obj .: "required_version"
-                   <*> obj .: "dependencies"
+      <*> obj .: "installed_version"
+      <*> obj .: "required_version"
+      <*> obj .: "dependencies"

--- a/src/Strategy/Python/ReqTxt.hs
+++ b/src/Strategy/Python/ReqTxt.hs
@@ -1,8 +1,7 @@
-module Strategy.Python.ReqTxt
-  ( analyze'
-  , requirementsTxtParser
-  )
-  where
+module Strategy.Python.ReqTxt (
+  analyze',
+  requirementsTxtParser,
+) where
 
 import Control.Effect.Diagnostics
 import Data.Foldable (asum)
@@ -25,28 +24,28 @@ type Parser = Parsec Void Text
 
 -- https://pip.pypa.io/en/stable/reference/pip_install/#requirements-file-format
 requirementsTxtParser :: Parser [Req]
-requirementsTxtParser =  concat <$> manyTill reqParser eof
+requirementsTxtParser = concat <$> manyTill reqParser eof
 
 reqParser :: Parser [Req]
-reqParser = [] <$ char '-' <* ignored -- pip options
-     <|> [] <$ char '.' <* ignored -- relative path
-     <|> [] <$ char '/' <* ignored -- absolute path
-     <|> [] <$ oneOfS ["http:", "https:", "git+", "hg+", "svn+", "bzr+"] <* ignored -- URLs
-     <|> [] <$ comment
-     <|> (pure <$> try requirementParser <* ignored)
-     <|> [] <$ ignored -- something else we're not able to parse
-
+reqParser =
+  [] <$ char '-' <* ignored -- pip options
+    <|> [] <$ char '.' <* ignored -- relative path
+    <|> [] <$ char '/' <* ignored -- absolute path
+    <|> [] <$ oneOfS ["http:", "https:", "git+", "hg+", "svn+", "bzr+"] <* ignored -- URLs
+    <|> [] <$ comment
+    <|> (pure <$> try requirementParser <* ignored)
+    <|> [] <$ ignored -- something else we're not able to parse
   where
-  isEndLine :: Char -> Bool
-  isEndLine '\n' = True
-  isEndLine '\r' = True
-  isEndLine _    = False
+    isEndLine :: Char -> Bool
+    isEndLine '\n' = True
+    isEndLine '\r' = True
+    isEndLine _ = False
 
-  -- ignore content until the end of the line
-  ignored :: Parser ()
-  ignored = () <$ takeWhileP (Just "ignored") (not . isEndLine) <* takeWhileP (Just "end of line") isEndLine
+    -- ignore content until the end of the line
+    ignored :: Parser ()
+    ignored = () <$ takeWhileP (Just "ignored") (not . isEndLine) <* takeWhileP (Just "end of line") isEndLine
 
-  comment :: Parser ()
-  comment = char '#' *> ignored
+    comment :: Parser ()
+    comment = char '#' *> ignored
 
-  oneOfS = asum . map string
+    oneOfS = asum . map string

--- a/src/Strategy/Python/SetupPy.hs
+++ b/src/Strategy/Python/SetupPy.hs
@@ -1,7 +1,6 @@
-module Strategy.Python.SetupPy
-  ( analyze'
-  )
-  where
+module Strategy.Python.SetupPy (
+  analyze',
+) where
 
 import Control.Effect.Diagnostics
 import Data.Text (Text)
@@ -12,7 +11,7 @@ import Path
 import Strategy.Python.Util
 import Text.Megaparsec
 import Text.Megaparsec.Char
-import qualified Text.Megaparsec.Char.Lexer as L
+import Text.Megaparsec.Char.Lexer qualified as L
 import Types
 
 analyze' :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs File -> m (Graphing Dependency)
@@ -25,13 +24,13 @@ type Parser = Parsec Void Text
 installRequiresParser :: Parser [Req]
 installRequiresParser = prefix *> entries <* end
   where
-  prefix  = skipManyTill anySingle (symbol "install_requires") *> symbol "=" *> symbol "["
-  entries = (requireSurroundedBy "\"" <|> requireSurroundedBy "\'") `sepEndBy` symbol ","
+    prefix = skipManyTill anySingle (symbol "install_requires") *> symbol "=" *> symbol "["
+    entries = (requireSurroundedBy "\"" <|> requireSurroundedBy "\'") `sepEndBy` symbol ","
 
-  requireSurroundedBy :: Text -> Parser Req
-  requireSurroundedBy quote = between (symbol quote) (symbol quote) requirementParser
+    requireSurroundedBy :: Text -> Parser Req
+    requireSurroundedBy quote = between (symbol quote) (symbol quote) requirementParser
 
-  end     = symbol "]"
+    end = symbol "]"
 
-  symbol :: Text -> Parser Text
-  symbol = L.symbol space
+    symbol :: Text -> Parser Text
+    symbol = L.symbol space

--- a/src/Strategy/Rebar3.hs
+++ b/src/Strategy/Rebar3.hs
@@ -1,10 +1,9 @@
-module Strategy.Rebar3
-  ( discover,
-    findProjects,
-    getDeps,
-    mkProject,
-  )
-where
+module Strategy.Rebar3 (
+  discover,
+  findProjects,
+  getDeps,
+  mkProject,
+) where
 
 import Control.Effect.Diagnostics (Diagnostics, context)
 import Discovery.Walk
@@ -12,7 +11,7 @@ import Effect.Exec
 import Effect.ReadFS
 import Graphing
 import Path
-import qualified Strategy.Erlang.Rebar3Tree as Rebar3Tree
+import Strategy.Erlang.Rebar3Tree qualified as Rebar3Tree
 import Types
 
 discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has ReadFS rsig run, Has Exec rsig run, Has Diagnostics rsig run) => Path Abs Dir -> m [DiscoveredProject run]
@@ -34,11 +33,11 @@ newtype RebarProject = RebarProject
 mkProject :: (Has Exec sig n, Has ReadFS sig n, Has Diagnostics sig n) => RebarProject -> DiscoveredProject n
 mkProject project =
   DiscoveredProject
-    { projectType = "rebar3",
-      projectBuildTargets = mempty,
-      projectDependencyGraph = const $ getDeps project,
-      projectPath = rebarDir project,
-      projectLicenses = pure []
+    { projectType = "rebar3"
+    , projectBuildTargets = mempty
+    , projectDependencyGraph = const $ getDeps project
+    , projectPath = rebarDir project
+    , projectLicenses = pure []
     }
 
 getDeps :: (Has Exec sig m, Has ReadFS sig m, Has Diagnostics sig m) => RebarProject -> m (Graphing Dependency)

--- a/src/Strategy/Ruby/BundleShow.hs
+++ b/src/Strategy/Ruby/BundleShow.hs
@@ -1,32 +1,31 @@
 {-# LANGUAGE RecordWildCards #-}
 
-module Strategy.Ruby.BundleShow
-  ( analyze'
-
-  , BundleShowDep(..)
-  , buildGraph
-  , bundleShowParser
-  )
-  where
+module Strategy.Ruby.BundleShow (
+  analyze',
+  BundleShowDep (..),
+  buildGraph,
+  bundleShowParser,
+) where
 
 import Control.Effect.Diagnostics
-import qualified Data.Map.Strict as M
+import Data.Map.Strict qualified as M
 import Data.Text (Text)
 import Data.Void (Void)
 import DepTypes
 import Effect.Exec
 import Graphing (Graphing)
-import qualified Graphing
+import Graphing qualified
 import Path
 import Text.Megaparsec
 import Text.Megaparsec.Char
 
 bundleShowCmd :: Command
-bundleShowCmd = Command
-  { cmdName = "bundle"
-  , cmdArgs = ["show"]
-  , cmdAllowErr = Never
-  }
+bundleShowCmd =
+  Command
+    { cmdName = "bundle"
+    , cmdArgs = ["show"]
+    , cmdAllowErr = Never
+    }
 
 analyze' :: (Has Exec sig m, Has Diagnostics sig m) => Path Abs Dir -> m (Graphing Dependency)
 analyze' dir = do
@@ -36,50 +35,52 @@ analyze' dir = do
 buildGraph :: [BundleShowDep] -> Graphing Dependency
 buildGraph = Graphing.fromList . map toDependency
   where
-  toDependency BundleShowDep{..} =
-    Dependency { dependencyType = GemType
-               , dependencyName = depName
-               , dependencyVersion = Just (CEq depVersion)
-               , dependencyLocations = []
-               , dependencyEnvironments = []
-               , dependencyTags = M.empty
-               }
+    toDependency BundleShowDep{..} =
+      Dependency
+        { dependencyType = GemType
+        , dependencyName = depName
+        , dependencyVersion = Just (CEq depVersion)
+        , dependencyLocations = []
+        , dependencyEnvironments = []
+        , dependencyTags = M.empty
+        }
 
 data BundleShowDep = BundleShowDep
-  { depName    :: Text
+  { depName :: Text
   , depVersion :: Text
-  } deriving (Eq, Ord, Show)
+  }
+  deriving (Eq, Ord, Show)
 
 type Parser = Parsec Void Text
 
 bundleShowParser :: Parser [BundleShowDep]
 bundleShowParser = concat <$> ((line <|> ignoredLine) `sepBy` eol) <* eof
   where
-  isEndLine :: Char -> Bool
-  isEndLine '\n' = True
-  isEndLine '\r' = True
-  isEndLine _    = False
+    isEndLine :: Char -> Bool
+    isEndLine '\n' = True
+    isEndLine '\r' = True
+    isEndLine _ = False
 
-  -- ignore content until the end of the line
-  ignored :: Parser ()
-  ignored = () <$ takeWhileP (Just "ignored") (not . isEndLine)
+    -- ignore content until the end of the line
+    ignored :: Parser ()
+    ignored = () <$ takeWhileP (Just "ignored") (not . isEndLine)
 
-  ignoredLine :: Parser [BundleShowDep]
-  ignoredLine = do
-    ignored
-    pure []
+    ignoredLine :: Parser [BundleShowDep]
+    ignoredLine = do
+      ignored
+      pure []
 
-  findDep :: Parser Text
-  findDep = takeWhileP (Just "dep") (/= ' ')
+    findDep :: Parser Text
+    findDep = takeWhileP (Just "dep") (/= ' ')
 
-  findVersion :: Parser Text
-  findVersion = takeWhileP (Just "version") (/= ')')
+    findVersion :: Parser Text
+    findVersion = takeWhileP (Just "version") (/= ')')
 
-  line :: Parser [BundleShowDep]
-  line = do
-    _ <- chunk "  * "
-    dep <- findDep
-    _ <- chunk " ("
-    version <- findVersion
-    _ <- char ')'
-    pure [BundleShowDep dep version]
+    line :: Parser [BundleShowDep]
+    line = do
+      _ <- chunk "  * "
+      dep <- findDep
+      _ <- chunk " ("
+      version <- findVersion
+      _ <- char ')'
+      pure [BundleShowDep dep version]

--- a/src/Strategy/Scala.hs
+++ b/src/Strategy/Scala.hs
@@ -6,35 +6,34 @@
 -- The only non-trivial logic that exists in this strategy is adding edges
 -- between poms in the maven "global closure", before building the individual
 -- multi-project closures.
-module Strategy.Scala
-  ( discover,
-    findProjects,
-  )
-where
+module Strategy.Scala (
+  discover,
+  findProjects,
+) where
 
 import Control.Carrier.Diagnostics
 import Data.Maybe (mapMaybe)
 import Data.String.Conversion (decodeUtf8)
 import Data.Text (Text)
-import qualified Data.Text as T
-import qualified Data.Text.Lazy as TL
+import Data.Text qualified as T
+import Data.Text.Lazy qualified as TL
 import Discovery.Walk
 import Effect.Exec
 import Effect.Logger hiding (group)
 import Effect.ReadFS
 import Path
-import qualified Strategy.Maven.Pom as Pom
+import Strategy.Maven.Pom qualified as Pom
 import Strategy.Maven.Pom.Closure (MavenProjectClosure, buildProjectClosures)
-import qualified Strategy.Maven.Pom.Closure as PomClosure
+import Strategy.Maven.Pom.Closure qualified as PomClosure
 import Strategy.Maven.Pom.Resolver (buildGlobalClosure)
 import Types
 
 discover ::
-  ( Has Exec sig m,
-    Has ReadFS sig m,
-    Has Logger sig m,
-    Has Diagnostics sig m,
-    Applicative run
+  ( Has Exec sig m
+  , Has ReadFS sig m
+  , Has Logger sig m
+  , Has Diagnostics sig m
+  , Applicative run
   ) =>
   Path Abs Dir ->
   m [DiscoveredProject run]
@@ -50,12 +49,12 @@ mkProject ::
   DiscoveredProject n
 mkProject basedir closure =
   DiscoveredProject
-    { projectType = "scala",
-      projectPath = parent $ PomClosure.closurePath closure,
-      projectBuildTargets = mempty,
-      -- only do static analysis of generated pom files
-      projectDependencyGraph = \_ -> pure (Pom.analyze' closure),
-      projectLicenses = pure $ Pom.getLicenses basedir closure
+    { projectType = "scala"
+    , projectPath = parent $ PomClosure.closurePath closure
+    , projectBuildTargets = mempty
+    , -- only do static analysis of generated pom files
+      projectDependencyGraph = \_ -> pure (Pom.analyze' closure)
+    , projectLicenses = pure $ Pom.getLicenses basedir closure
     }
 
 pathToText :: Path ar fd -> Text
@@ -80,11 +79,11 @@ findProjects = walk' $ \dir _ files -> do
 makePomCmd :: Command
 makePomCmd =
   Command
-    { cmdName = "sbt",
-      -- --no-colors to disable ANSI escape codes
+    { cmdName = "sbt"
+    , -- --no-colors to disable ANSI escape codes
       -- --batch to disable interactivity. normally, if an `sbt` command fails, it'll drop into repl mode: --batch will disable the repl.
-      cmdArgs = ["--no-colors", "--batch", "makePom"],
-      cmdAllowErr = Never
+      cmdArgs = ["--no-colors", "--batch", "makePom"]
+    , cmdAllowErr = Never
     }
 
 genPoms :: (Has Exec sig m, Has ReadFS sig m, Has Diagnostics sig m) => Path Abs Dir -> m [MavenProjectClosure]

--- a/src/Strategy/VSI.hs
+++ b/src/Strategy/VSI.hs
@@ -1,7 +1,6 @@
-module Strategy.VSI
-  ( discover,
-  )
-where
+module Strategy.VSI (
+  discover,
+) where
 
 import App.Fossa.EmbeddedBinary
 import App.Fossa.VPS.Scan.RunWiggins
@@ -30,9 +29,9 @@ newtype VSILocator = VSILocator
   deriving (Eq, Ord, Show, Generic, FromJSON)
 
 data ValidVSILocator = ValidVSILocator
-  { validType :: DepType,
-    validName :: T.Text,
-    validRevision :: Maybe T.Text
+  { validType :: DepType
+  , validName :: T.Text
+  , validRevision :: Maybe T.Text
   }
 
 data VSIError = UnsupportedLocatorType Locator T.Text
@@ -52,11 +51,11 @@ discover apiOpts dir = context "VSI" $ do
 mkProject :: (Has (Lift IO) sig n, MonadIO n, Has Exec sig n, Has Diagnostics sig n) => WigginsOpts -> VSIProject -> DiscoveredProject n
 mkProject wigginsOpts project =
   DiscoveredProject
-    { projectType = "vsi",
-      projectBuildTargets = mempty,
-      projectDependencyGraph = const $ analyze wigginsOpts,
-      projectPath = vsiDir project,
-      projectLicenses = pure []
+    { projectType = "vsi"
+    , projectBuildTargets = mempty
+    , projectDependencyGraph = const $ analyze wigginsOpts
+    , projectPath = vsiDir project
+    , projectLicenses = pure []
     }
 
 buildGraph :: [VSILocator] -> Either VSIError (Graphing Dependency)

--- a/src/Strategy/Yarn/V1/YarnLock.hs
+++ b/src/Strategy/Yarn/V1/YarnLock.hs
@@ -1,21 +1,21 @@
-module Strategy.Yarn.V1.YarnLock
-  ( analyze
-  , buildGraph
-  ) where
+module Strategy.Yarn.V1.YarnLock (
+  analyze,
+  buildGraph,
+) where
 
 import Control.Effect.Diagnostics
 import Data.Bifunctor (first)
 import Data.Foldable (for_)
-import qualified Data.List.NonEmpty as NE
-import qualified Data.Map.Strict as M
-import qualified Data.MultiKeyedMap as MKM
+import Data.List.NonEmpty qualified as NE
+import Data.Map.Strict qualified as M
+import Data.MultiKeyedMap qualified as MKM
 import DepTypes
 import Effect.Grapher
 import Effect.ReadFS
 import Graphing (Graphing)
 import Path
-import qualified Yarn.Lock as YL
-import qualified Yarn.Lock.Types as YL
+import Yarn.Lock qualified as YL
+import Yarn.Lock.Types qualified as YL
 
 analyze :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs File -> m (Graphing Dependency)
 analyze lockfile = context "Lockfile V1 analysis" $ do
@@ -27,29 +27,31 @@ analyze lockfile = context "Lockfile V1 analysis" $ do
     Right parsed -> context "Building dependency graph" $ pure (buildGraph parsed)
 
 buildGraph :: YL.Lockfile -> Graphing Dependency
-buildGraph lockfile = run . evalGrapher $
-  traverse (add . first NE.head) (MKM.toList lockfile)
+buildGraph lockfile =
+  run . evalGrapher $
+    traverse (add . first NE.head) (MKM.toList lockfile)
   where
-  add :: Has (Grapher Dependency) sig m => (YL.PackageKey, YL.Package) -> m ()
-  add parentPkg@(_, package) =
-    for_ (YL.dependencies package) $ \childKey -> do
-      let childPkg = (childKey, MKM.at lockfile childKey)
-      edge (toDependency parentPkg) (toDependency childPkg)
+    add :: Has (Grapher Dependency) sig m => (YL.PackageKey, YL.Package) -> m ()
+    add parentPkg@(_, package) =
+      for_ (YL.dependencies package) $ \childKey -> do
+        let childPkg = (childKey, MKM.at lockfile childKey)
+        edge (toDependency parentPkg) (toDependency childPkg)
 
-  toDependency (key,package) =
-    Dependency { dependencyType = NodeJSType
-               , dependencyName =
-                   case YL.name key of
-                     YL.SimplePackageKey name -> name
-                     YL.ScopedPackageKey scope name -> "@" <> scope <> "/" <> name
-               , dependencyVersion = Just (CEq (YL.version package))
-               , dependencyLocations =
-                   case YL.remote package of
-                     YL.FileLocal _ _ -> [] -- FUTURE: upload this for analysis?
-                     YL.FileLocalNoIntegrity _ -> [] -- FUTURE: upload this for analysis?
-                     YL.FileRemote url _ -> [url]
-                     YL.FileRemoteNoIntegrity url -> [url]
-                     YL.GitRemote url rev -> [url <> "@" <> rev]
-               , dependencyEnvironments = []
-               , dependencyTags = M.empty
-               }
+    toDependency (key, package) =
+      Dependency
+        { dependencyType = NodeJSType
+        , dependencyName =
+            case YL.name key of
+              YL.SimplePackageKey name -> name
+              YL.ScopedPackageKey scope name -> "@" <> scope <> "/" <> name
+        , dependencyVersion = Just (CEq (YL.version package))
+        , dependencyLocations =
+            case YL.remote package of
+              YL.FileLocal _ _ -> [] -- FUTURE: upload this for analysis?
+              YL.FileLocalNoIntegrity _ -> [] -- FUTURE: upload this for analysis?
+              YL.FileRemote url _ -> [url]
+              YL.FileRemoteNoIntegrity url -> [url]
+              YL.GitRemote url rev -> [url <> "@" <> rev]
+        , dependencyEnvironments = []
+        , dependencyTags = M.empty
+        }

--- a/src/Text/URI/Builder.hs
+++ b/src/Text/URI/Builder.hs
@@ -2,15 +2,14 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE LambdaCase #-}
 
-module Text.URI.Builder
-  ( Query (..),
-    PathComponent (..),
-    TrailingSlash (..),
-    renderPath,
-    setPath,
-    setQuery,
-  )
-where
+module Text.URI.Builder (
+  Query (..),
+  PathComponent (..),
+  TrailingSlash (..),
+  renderPath,
+  setPath,
+  setQuery,
+) where
 
 import Control.Effect.Diagnostics
 import Data.List.NonEmpty (NonEmpty (..))
@@ -26,7 +25,7 @@ type URIPath = Maybe (Bool, NonEmpty (RText 'PathPiece))
 setPath :: Has Diagnostics sig m => [PathComponent] -> TrailingSlash -> URI -> m URI
 setPath pcomlist slash uri = do
   newpath <- convertPaths pcomlist slash
-  pure $ uri {uriPath = newpath}
+  pure $ uri{uriPath = newpath}
 
 convertPaths :: Has Diagnostics sig m => [PathComponent] -> TrailingSlash -> m URIPath
 convertPaths [] _ = pure Nothing
@@ -37,7 +36,7 @@ convertPaths (path : paths) (TrailingSlash slash) = do
 renderPath :: Has Diagnostics sig m => [PathComponent] -> TrailingSlash -> m Text
 renderPath paths slash = render <$> setPath paths slash uri
   where
-    uri = emptyURI {uriAuthority = Left True}
+    uri = emptyURI{uriAuthority = Left True}
 
 data Query
   = Flag Text
@@ -53,4 +52,4 @@ setQuery qlist uri = do
           Pair k v -> QueryParam <$> mkQueryKey k <*> mkQueryValue v
 
   qplist <- traverse xform qlist
-  pure $ uri {uriQuery = qplist}
+  pure $ uri{uriQuery = qplist}

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -1,16 +1,14 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE RecordWildCards #-}
 
-module Types
-  ( DiscoveredProject(..)
-  , BuildTarget(..)
-
-  , LicenseResult(..)
-  , License(..)
-  , LicenseType(..)
-
-  , module DepTypes
-  ) where
+module Types (
+  DiscoveredProject (..),
+  BuildTarget (..),
+  LicenseResult (..),
+  License (..),
+  LicenseType (..),
+  module DepTypes,
+) where
 
 import Data.Aeson
 import Data.Set (Set)
@@ -20,52 +18,56 @@ import Graphing
 import Path
 
 -- TODO: results should be within a graph of build targets && eliminate SubprojectType
+
 -- | A project found during project discovery, parameterized by the monad
 -- used to perform dependency analysis
 data DiscoveredProject m = DiscoveredProject
-  { projectType :: Text,
-    projectPath :: Path Abs Dir,
-    projectBuildTargets :: Set BuildTarget,
-    projectDependencyGraph :: Set BuildTarget -> m (Graphing Dependency),
-    projectLicenses :: m [LicenseResult]
+  { projectType :: Text
+  , projectPath :: Path Abs Dir
+  , projectBuildTargets :: Set BuildTarget
+  , projectDependencyGraph :: Set BuildTarget -> m (Graphing Dependency)
+  , projectLicenses :: m [LicenseResult]
   }
 
-newtype BuildTarget = BuildTarget { unBuildTarget :: Text }
+newtype BuildTarget = BuildTarget {unBuildTarget :: Text}
   deriving (Eq, Ord, Show)
 
 data LicenseResult = LicenseResult
-  { licenseFile   :: FilePath
+  { licenseFile :: FilePath
   , licensesFound :: [License]
-  } deriving (Eq, Ord, Show)
+  }
+  deriving (Eq, Ord, Show)
 
 data License = License
-  { licenseType  :: LicenseType
+  { licenseType :: LicenseType
   , licenseValue :: Text
-  } deriving (Eq, Ord, Show)
+  }
+  deriving (Eq, Ord, Show)
 
-data LicenseType =
-          LicenseURL
-        | LicenseFile
-        | LicenseSPDX
-        | UnknownType
-          deriving (Eq, Ord, Show)
+data LicenseType
+  = LicenseURL
+  | LicenseFile
+  | LicenseSPDX
+  | UnknownType
+  deriving (Eq, Ord, Show)
 
 instance ToJSON License where
-    toJSON License{..} = object
-      [ "type"   .=  textType licenseType
-      , "value"  .=  licenseValue
+  toJSON License{..} =
+    object
+      [ "type" .= textType licenseType
+      , "value" .= licenseValue
       ]
-
-      where
-        textType :: LicenseType -> Text
-        textType = \case
-          LicenseURL  -> "url"
-          LicenseFile -> "file"
-          LicenseSPDX -> "spdx"
-          UnknownType -> "unknown"
+    where
+      textType :: LicenseType -> Text
+      textType = \case
+        LicenseURL -> "url"
+        LicenseFile -> "file"
+        LicenseSPDX -> "spdx"
+        UnknownType -> "unknown"
 
 instance ToJSON LicenseResult where
-    toJSON LicenseResult{..} = object
-      [ "filepath"  .=  licenseFile
-      , "licenses"  .=  licensesFound
+  toJSON LicenseResult{..} =
+    object
+      [ "filepath" .= licenseFile
+      , "licenses" .= licensesFound
       ]

--- a/src/VCS/Git.hs
+++ b/src/VCS/Git.hs
@@ -1,17 +1,16 @@
-module VCS.Git
-  ( gitLogCmd,
-    fetchGitContributors,
-  )
-where
+module VCS.Git (
+  gitLogCmd,
+  fetchGitContributors,
+) where
 
 import App.Fossa.FossaAPIV1 (Contributors (..))
-import qualified Control.Carrier.Diagnostics as Diag
+import Control.Carrier.Diagnostics qualified as Diag
 import Control.Effect.Lift (Lift, sendIO)
-import qualified Data.Map as M
+import Data.Map qualified as M
 import Data.Maybe (mapMaybe)
 import Data.String.Conversion (decodeUtf8)
 import Data.Text (Text)
-import qualified Data.Text as T
+import Data.Text qualified as T
 import Data.Text.Extra (splitOnceOn)
 import Data.Time
 import Data.Time.Format.ISO8601 (iso8601Show)
@@ -21,9 +20,9 @@ import Path
 gitLogCmd :: UTCTime -> Command
 gitLogCmd now =
   Command
-    { cmdName = "git",
-      cmdArgs = ["log", "--since", sinceArg, "--date=short", "--format=%ae|%cd"],
-      cmdAllowErr = Never
+    { cmdName = "git"
+    , cmdArgs = ["log", "--since", sinceArg, "--date=short", "--format=%ae|%cd"]
+    , cmdAllowErr = Never
     }
   where
     sinceArg = T.pack . iso8601Show $ utctDay wayBack
@@ -31,9 +30,9 @@ gitLogCmd now =
     wayBack = addUTCTime delta now
 
 fetchGitContributors ::
-  ( Has Diag.Diagnostics sig m,
-    Has Exec sig m,
-    Has (Lift IO) sig m
+  ( Has Diag.Diagnostics sig m
+  , Has Exec sig m
+  , Has (Lift IO) sig m
   ) =>
   Path x Dir ->
   m Contributors

--- a/test/App/Fossa/Configuration/ConfigurationSpec.hs
+++ b/test/App/Fossa/Configuration/ConfigurationSpec.hs
@@ -1,44 +1,43 @@
 {-# LANGUAGE BlockArguments #-}
 {-# LANGUAGE TemplateHaskell #-}
 
-module App.Fossa.Configuration.ConfigurationSpec
-  ( spec,
-  )
-where
+module App.Fossa.Configuration.ConfigurationSpec (
+  spec,
+) where
 
 import App.Fossa.Configuration
-import qualified Control.Carrier.Diagnostics as Diag
+import Control.Carrier.Diagnostics qualified as Diag
 import Effect.ReadFS
 import Path
-import qualified Test.Hspec as T
+import Test.Hspec qualified as T
 
 expectedConfigFile :: ConfigFile
 expectedConfigFile =
   ConfigFile
-    { configVersion = 3,
-      configServer = Just "https://app.fossa.com",
-      configApiKey = Just "123",
-      configProject = Just expectedConfigProject,
-      configRevision = Just expectedConfigRevision
+    { configVersion = 3
+    , configServer = Just "https://app.fossa.com"
+    , configApiKey = Just "123"
+    , configProject = Just expectedConfigProject
+    , configRevision = Just expectedConfigRevision
     }
 
 expectedConfigProject :: ConfigProject
 expectedConfigProject =
   ConfigProject
-    { configProjID = Just "github.com/fossa-cli",
-      configName = Just "fossa-cli",
-      configLink = Just "fossa.com",
-      configTeam = Just "fossa-team",
-      configJiraKey = Just "key",
-      configUrl = Just "fossa.com",
-      configPolicy = Just "license-policy"
+    { configProjID = Just "github.com/fossa-cli"
+    , configName = Just "fossa-cli"
+    , configLink = Just "fossa.com"
+    , configTeam = Just "fossa-team"
+    , configJiraKey = Just "key"
+    , configUrl = Just "fossa.com"
+    , configPolicy = Just "license-policy"
     }
 
 expectedConfigRevision :: ConfigRevision
 expectedConfigRevision =
   ConfigRevision
-    { configCommit = Just "12345",
-      configBranch = Just "master"
+    { configCommit = Just "12345"
+    , configBranch = Just "master"
     }
 
 testFile :: Path Rel File

--- a/test/App/Fossa/Report/AttributionSpec.hs
+++ b/test/App/Fossa/Report/AttributionSpec.hs
@@ -1,15 +1,14 @@
-module App.Fossa.Report.AttributionSpec
-  ( spec,
-  )
-where
+module App.Fossa.Report.AttributionSpec (
+  spec,
+) where
 
 import App.Fossa.Report.Attribution
 import Control.Applicative (liftA2)
 import Data.Aeson
 import Data.Map.Strict (Map)
 import Data.Text (Text)
-import qualified Hedgehog.Gen as Gen
-import qualified Hedgehog.Range as Range
+import Hedgehog.Gen qualified as Gen
+import Hedgehog.Range qualified as Range
 import Test.Hspec
 import Test.Hspec.Hedgehog
 
@@ -65,13 +64,13 @@ arbitraryText = Gen.text (Range.linear 3 25) Gen.unicodeAll
 
 spec :: Spec
 spec =
-  describe "Attribution ToJSON/FromJSON instances"
-    $ modifyMaxSuccess (const 20)
-    $ it "are roundtrippable"
-    $ hedgehog
-    $ do
-      attr <- forAll genAttribution
-      roundtripJson attr
+  describe "Attribution ToJSON/FromJSON instances" $
+    modifyMaxSuccess (const 20) $
+      it "are roundtrippable" $
+        hedgehog $
+          do
+            attr <- forAll genAttribution
+            roundtripJson attr
 
 roundtripJson :: (MonadTest m, Show a, Eq a, ToJSON a, FromJSON a) => a -> m ()
 roundtripJson a = tripping a toJSON fromJSON

--- a/test/App/Fossa/VPS/NinjaGraphSpec.hs
+++ b/test/App/Fossa/VPS/NinjaGraphSpec.hs
@@ -1,16 +1,15 @@
-module App.Fossa.VPS.NinjaGraphSpec
-  ( spec
-  ) where
+module App.Fossa.VPS.NinjaGraphSpec (
+  spec,
+) where
 
-import qualified Data.Text.IO as TIO
-import qualified Data.Text as T
-import qualified Data.List as List
 import App.Fossa.VPS.NinjaGraph
 import App.Fossa.VPS.Types
-import Data.Text.Encoding
-import Test.Hspec
 import Control.Carrier.Diagnostics
-
+import Data.List qualified as List
+import Data.Text qualified as T
+import Data.Text.Encoding
+import Data.Text.IO qualified as TIO
+import Test.Hspec
 
 -- out/target/product/coral/obj/STATIC_LIBRARIES/libgptutils_intermediates/gpt-utils.o: #deps 2, deps mtime 1583962189 (VALID)
 --     device/google/coral/gpt-utils/gpt-utils.cpp
@@ -18,107 +17,138 @@ import Control.Carrier.Diagnostics
 --     external/libcxx/include/__config
 
 inputOne :: DepsDependency
-inputOne = DepsDependency { dependencyPath = "device/google/coral/gpt-utils/gpt-utils.cpp"
-                          , dependencyComponentName = Nothing
-                          , hasDependencies = False
-                          }
+inputOne =
+  DepsDependency
+    { dependencyPath = "device/google/coral/gpt-utils/gpt-utils.cpp"
+    , dependencyComponentName = Nothing
+    , hasDependencies = False
+    }
 
 dependencyOneA :: DepsDependency
-dependencyOneA = DepsDependency { dependencyPath = "external/libcxx/include/stdio.h"
-                                , dependencyComponentName = Nothing
-                                , hasDependencies = False
-                                }
+dependencyOneA =
+  DepsDependency
+    { dependencyPath = "external/libcxx/include/stdio.h"
+    , dependencyComponentName = Nothing
+    , hasDependencies = False
+    }
 
 dependencyOneB :: DepsDependency
-dependencyOneB = DepsDependency { dependencyPath = "external/libcxx/include/__config"
-                                , dependencyComponentName = Nothing
-                                , hasDependencies = False
-                                }
+dependencyOneB =
+  DepsDependency
+    { dependencyPath = "external/libcxx/include/__config"
+    , dependencyComponentName = Nothing
+    , hasDependencies = False
+    }
 
 targetOne :: DepsTarget
-targetOne = DepsTarget { targetPath = "out/target/product/coral/obj/STATIC_LIBRARIES/libgptutils_intermediates/gpt-utils.o"
-                       , targetDependencies = [dependencyOneA, dependencyOneB]
-                       , targetInputs = [inputOne]
-                       , targetComponentName = Nothing
-                       }
+targetOne =
+  DepsTarget
+    { targetPath = "out/target/product/coral/obj/STATIC_LIBRARIES/libgptutils_intermediates/gpt-utils.o"
+    , targetDependencies = [dependencyOneA, dependencyOneB]
+    , targetInputs = [inputOne]
+    , targetComponentName = Nothing
+    }
 
 -- out/target/product/coral/obj/APPS/Settings_intermediates/package.apk: #deps 0, deps mtime 1583991062 (VALID)
 targetTwo :: DepsTarget
-targetTwo = DepsTarget { targetPath = "out/target/product/coral/obj/APPS/Settings_intermediates/package.apk"
-                       , targetDependencies = []
-                       , targetInputs = []
-                       , targetComponentName = Nothing
-                       }
+targetTwo =
+  DepsTarget
+    { targetPath = "out/target/product/coral/obj/APPS/Settings_intermediates/package.apk"
+    , targetDependencies = []
+    , targetInputs = []
+    , targetComponentName = Nothing
+    }
+
 -- out/target/product/coral/obj/JAVA_LIBRARIES/wifi-service_intermediates/dexpreopt.zip: #deps 2, deps mtime 1583991124 (VALID)
 --     out/soong/host/linux-x86/bin/dex2oatd
 --     out/soong/host/linux-x86/bin/profman
 --     out/soong/host/linux-x86/bin/soong_zip
 
 inputThree :: DepsDependency
-inputThree = DepsDependency { dependencyPath = "out/soong/host/linux-x86/bin/dex2oatd"
-                          , dependencyComponentName = Nothing
-                          , hasDependencies = True
-                          }
+inputThree =
+  DepsDependency
+    { dependencyPath = "out/soong/host/linux-x86/bin/dex2oatd"
+    , dependencyComponentName = Nothing
+    , hasDependencies = True
+    }
 
 dependencyThreeA :: DepsDependency
-dependencyThreeA = DepsDependency { dependencyPath = "out/soong/host/linux-x86/bin/profman"
-                                , dependencyComponentName = Nothing
-                                , hasDependencies = True
-                                }
+dependencyThreeA =
+  DepsDependency
+    { dependencyPath = "out/soong/host/linux-x86/bin/profman"
+    , dependencyComponentName = Nothing
+    , hasDependencies = True
+    }
 
 dependencyThreeB :: DepsDependency
-dependencyThreeB = DepsDependency { dependencyPath = "out/soong/host/linux-x86/bin/soong_zip"
-                                , dependencyComponentName = Nothing
-                                , hasDependencies = True
-                                }
+dependencyThreeB =
+  DepsDependency
+    { dependencyPath = "out/soong/host/linux-x86/bin/soong_zip"
+    , dependencyComponentName = Nothing
+    , hasDependencies = True
+    }
 
 targetThree :: DepsTarget
-targetThree = DepsTarget { targetPath = "out/target/product/coral/obj/JAVA_LIBRARIES/wifi-service_intermediates/dexpreopt.zip"
-                       , targetDependencies = [dependencyThreeA, dependencyThreeB]
-                       , targetInputs = [inputThree]
-                       , targetComponentName = Nothing
-                       }
+targetThree =
+  DepsTarget
+    { targetPath = "out/target/product/coral/obj/JAVA_LIBRARIES/wifi-service_intermediates/dexpreopt.zip"
+    , targetDependencies = [dependencyThreeA, dependencyThreeB]
+    , targetInputs = [inputThree]
+    , targetComponentName = Nothing
+    }
 
 smallNinjaDepsTargets :: [DepsTarget]
-smallNinjaDepsTargets =  [targetOne, targetTwo, targetThree]
+smallNinjaDepsTargets = [targetOne, targetTwo, targetThree]
 
 cfiBlacklistDep :: DepsDependency
-cfiBlacklistDep = DepsDependency { dependencyPath = "external/compiler-rt/lib/cfi/cfi_blacklist.txt"
-                                 , dependencyComponentName = Nothing
-                                 , hasDependencies = False
-                                 }
+cfiBlacklistDep =
+  DepsDependency
+    { dependencyPath = "external/compiler-rt/lib/cfi/cfi_blacklist.txt"
+    , dependencyComponentName = Nothing
+    , hasDependencies = False
+    }
 
 integerOverflowBlacklistDep :: DepsDependency
-integerOverflowBlacklistDep = DepsDependency { dependencyPath = "build/soong/cc/config/integer_overflow_blacklist.txt"
-                                             , dependencyComponentName = Nothing
-                                             , hasDependencies = False
-                                             }
+integerOverflowBlacklistDep =
+  DepsDependency
+    { dependencyPath = "build/soong/cc/config/integer_overflow_blacklist.txt"
+    , dependencyComponentName = Nothing
+    , hasDependencies = False
+    }
 
 inetDep :: DepsDependency
-inetDep = DepsDependency { dependencyPath = "bionic/libc/include/arpa/inet.h"
-                         , dependencyComponentName = Nothing
-                         , hasDependencies = False
-                         }
+inetDep =
+  DepsDependency
+    { dependencyPath = "bionic/libc/include/arpa/inet.h"
+    , dependencyComponentName = Nothing
+    , hasDependencies = False
+    }
 
 bpfLoaderDep :: DepsDependency
-bpfLoaderDep = DepsDependency { dependencyPath = "system/bpf/bpfloader/BpfLoader.cpp"
-                              , dependencyComponentName = Nothing
-                              , hasDependencies = False
-                              }
+bpfLoaderDep =
+  DepsDependency
+    { dependencyPath = "system/bpf/bpfloader/BpfLoader.cpp"
+    , dependencyComponentName = Nothing
+    , hasDependencies = False
+    }
 
 targetWithFirstLevelWeirdnessFix :: DepsTarget
-targetWithFirstLevelWeirdnessFix = DepsTarget { targetPath = "out/soong/.intermediates/system/bpf/bpfloader/bpfloader/android_arm64_armv8-a_core/obj/system/bpf/bpfloader/BpfLoader.o"
-                                              , targetDependencies = [integerOverflowBlacklistDep, inetDep]
-                                              , targetInputs = [bpfLoaderDep]
-                                              , targetComponentName = Nothing
-                                              }
+targetWithFirstLevelWeirdnessFix =
+  DepsTarget
+    { targetPath = "out/soong/.intermediates/system/bpf/bpfloader/bpfloader/android_arm64_armv8-a_core/obj/system/bpf/bpfloader/BpfLoader.o"
+    , targetDependencies = [integerOverflowBlacklistDep, inetDep]
+    , targetInputs = [bpfLoaderDep]
+    , targetComponentName = Nothing
+    }
 
 targetWithSecondLevelWeirdnessFix :: DepsTarget
-targetWithSecondLevelWeirdnessFix = DepsTarget { targetPath = "out/soong/.intermediates/system/bpf/bpfloader/bpfloader/android_arm64_armv8-a_core/obj/system/bpf/bpfloader/BpfLoader.o"
-                                               , targetDependencies = [cfiBlacklistDep, integerOverflowBlacklistDep, inetDep]
-                                               , targetInputs = [bpfLoaderDep]
-                                               , targetComponentName = Nothing
-                                               }
+targetWithSecondLevelWeirdnessFix =
+  DepsTarget
+    { targetPath = "out/soong/.intermediates/system/bpf/bpfloader/bpfloader/android_arm64_armv8-a_core/obj/system/bpf/bpfloader/BpfLoader.o"
+    , targetDependencies = [cfiBlacklistDep, integerOverflowBlacklistDep, inetDep]
+    , targetInputs = [bpfLoaderDep]
+    , targetComponentName = Nothing
+    }
 spec :: Spec
 spec = do
   smallNinjaDeps <- runIO (TIO.readFile "test/App/Fossa/VPS/testdata/small-ninja-deps")

--- a/test/App/Fossa/YamlDepsSpec.hs
+++ b/test/App/Fossa/YamlDepsSpec.hs
@@ -1,18 +1,17 @@
-module App.Fossa.YamlDepsSpec
-  ( spec,
-  )
-where
+module App.Fossa.YamlDepsSpec (
+  spec,
+) where
 
-import App.Fossa.YamlDeps
-  ( CustomDependency (CustomDependency),
-    ReferencedDependency (ReferencedDependency),
-    YamlDependencies (YamlDependencies),
-  )
+import App.Fossa.YamlDeps (
+  CustomDependency (CustomDependency),
+  ReferencedDependency (ReferencedDependency),
+  YamlDependencies (YamlDependencies),
+ )
 import Control.Effect.Exception (displayException)
 import Data.ByteString qualified as BS
 import Data.Yaml (decodeEither')
 import DepTypes (DepType (..))
-import Test.Hspec (Spec, describe, expectationFailure, it, runIO, shouldBe, Expectation, shouldContain)
+import Test.Hspec (Expectation, Spec, describe, expectationFailure, it, runIO, shouldBe, shouldContain)
 import Test.Hspec.Core.Spec (SpecM)
 
 getTestDataFile :: String -> SpecM a BS.ByteString
@@ -22,20 +21,19 @@ theWorks :: YamlDependencies
 theWorks = YamlDependencies references customs
   where
     references =
-        [ ReferencedDependency "one" GemType Nothing,
-          ReferencedDependency "two" URLType $ Just "1.0.0"
-        ]
+      [ ReferencedDependency "one" GemType Nothing
+      , ReferencedDependency "two" URLType $ Just "1.0.0"
+      ]
     customs =
-        [ CustomDependency "hello" "1.2.3" "MIT" Nothing Nothing,
-          CustomDependency "full" "3.2.1" "GPL-3.0" (Just "description for full") (Just "we don't validate url's")
-        ]
+      [ CustomDependency "hello" "1.2.3" "MIT" Nothing Nothing
+      , CustomDependency "full" "3.2.1" "GPL-3.0" (Just "description for full") (Just "we don't validate url's")
+      ]
 
 exceptionContains :: BS.ByteString -> String -> Expectation
 exceptionContains yamlBytes partial = case decodeEither' @YamlDependencies yamlBytes of
   -- Ethics issue: right is wrong
   Right _ -> expectationFailure $ "Expected to fail with message containing: " <> partial
   Left exc -> displayException exc `shouldContain` partial
-
 
 spec :: Spec
 spec =

--- a/test/Cargo/MetadataSpec.hs
+++ b/test/Cargo/MetadataSpec.hs
@@ -1,17 +1,17 @@
-module Cargo.MetadataSpec
-  ( spec
-  ) where
+module Cargo.MetadataSpec (
+  spec,
+) where
 
 import Data.Aeson
-import qualified Data.ByteString.Lazy as BL
-import qualified Data.Map.Strict as M
+import Data.ByteString.Lazy qualified as BL
+import Data.Map.Strict qualified as M
 import Data.Text (Text)
-import qualified Data.Text as T
+import Data.Text qualified as T
 import DepTypes
 import GraphUtil
 import Graphing
 import Strategy.Cargo
-import qualified Test.Hspec as Test
+import Test.Hspec qualified as Test
 
 expectedMetadata :: CargoMetadata
 expectedMetadata = CargoMetadata [] [jfmtId] $ Resolve expectedResolveNodes

--- a/test/Carthage/CarthageSpec.hs
+++ b/test/Carthage/CarthageSpec.hs
@@ -1,14 +1,14 @@
 {-# LANGUAGE TemplateHaskell #-}
 
-module Carthage.CarthageSpec
-  ( spec
-  ) where
+module Carthage.CarthageSpec (
+  spec,
+) where
 
 import Control.Carrier.Diagnostics
 import Data.Function ((&))
 import Effect.ReadFS
 import GraphUtil
-import qualified Graphing as G
+import Graphing qualified as G
 import Path
 import Path.IO (makeAbsolute)
 import Strategy.Carthage
@@ -22,9 +22,10 @@ testProjectComplex = $(mkRelFile "test/Carthage/testdata/testproject/Cartfile.re
 
 spec :: Spec
 spec = do
-  let runIt f = analyze f
-        & runReadFSIO
-        & runDiagnostics
+  let runIt f =
+        analyze f
+          & runReadFSIO
+          & runDiagnostics
 
   emptyResult <- runIO $ runIt =<< makeAbsolute testProjectEmpty
   complexResult <- runIO $ runIt =<< makeAbsolute testProjectComplex
@@ -40,19 +41,23 @@ spec = do
         Left err -> expectationFailure ("analyze failed: " <> show (renderFailureBundle err))
         Right graph -> do
           expectDirect [nimble713, swinject, ocmock] graph
-          expectDeps [ nimble713
-                     , nimble703
-                     , swinject
-                     , ocmock
-                     , quick
-                     , cwlPreconditionTesting
-                     , cwlCatchException
-                     ] graph
-          expectEdges [ (nimble713, cwlPreconditionTesting)
-                      , (nimble713, cwlCatchException)
-                      , (swinject, nimble703)
-                      , (swinject, quick)
-                      ] graph
+          expectDeps
+            [ nimble713
+            , nimble703
+            , swinject
+            , ocmock
+            , quick
+            , cwlPreconditionTesting
+            , cwlCatchException
+            ]
+            graph
+          expectEdges
+            [ (nimble713, cwlPreconditionTesting)
+            , (nimble713, cwlCatchException)
+            , (swinject, nimble703)
+            , (swinject, quick)
+            ]
+            graph
 
 nimble713 :: ResolvedEntry
 nimble713 = ResolvedEntry GithubType "Quick/Nimble" "v7.1.3"

--- a/test/Clojure/ClojureSpec.hs
+++ b/test/Clojure/ClojureSpec.hs
@@ -1,11 +1,10 @@
-module Clojure.ClojureSpec
-  ( spec,
-  )
-where
+module Clojure.ClojureSpec (
+  spec,
+) where
 
-import qualified Data.EDN as EDN
-import qualified Data.Map.Strict as M
-import qualified Data.Text.IO as TIO
+import Data.EDN qualified as EDN
+import Data.Map.Strict qualified as M
+import Data.Text.IO qualified as TIO
 import DepTypes
 import GraphUtil
 import Strategy.Leiningen
@@ -28,59 +27,59 @@ spec = do
 clojureComplete :: Dependency
 clojureComplete =
   Dependency
-    { dependencyType = MavenType,
-      dependencyName = "clojure-complete",
-      dependencyVersion = Just (CEq "0.2.5"),
-      dependencyLocations = [],
-      dependencyEnvironments = [],
-      dependencyTags = M.empty
+    { dependencyType = MavenType
+    , dependencyName = "clojure-complete"
+    , dependencyVersion = Just (CEq "0.2.5")
+    , dependencyLocations = []
+    , dependencyEnvironments = []
+    , dependencyTags = M.empty
     }
 
 -- [koan-engine "0.2.5"] {[fresh "1.0.2"] nil},
 koanEngine :: Dependency
 koanEngine =
   Dependency
-    { dependencyType = MavenType,
-      dependencyName = "koan-engine",
-      dependencyVersion = Just (CEq "0.2.5"),
-      dependencyLocations = [],
-      dependencyEnvironments = [],
-      dependencyTags = M.empty
+    { dependencyType = MavenType
+    , dependencyName = "koan-engine"
+    , dependencyVersion = Just (CEq "0.2.5")
+    , dependencyLocations = []
+    , dependencyEnvironments = []
+    , dependencyTags = M.empty
     }
 
 fresh :: Dependency
 fresh =
   Dependency
-    { dependencyType = MavenType,
-      dependencyName = "fresh",
-      dependencyVersion = Just (CEq "1.0.2"),
-      dependencyLocations = [],
-      dependencyEnvironments = [],
-      dependencyTags = M.empty
+    { dependencyType = MavenType
+    , dependencyName = "fresh"
+    , dependencyVersion = Just (CEq "1.0.2")
+    , dependencyLocations = []
+    , dependencyEnvironments = []
+    , dependencyTags = M.empty
     }
 
 -- [lein-koan "0.1.5" :scope "test"] nil,
 leinKoan :: Dependency
 leinKoan =
   Dependency
-    { dependencyType = MavenType,
-      dependencyName = "lein-koan",
-      dependencyVersion = Just (CEq "0.1.5"),
-      dependencyLocations = [],
-      dependencyEnvironments = [EnvTesting],
-      dependencyTags = M.empty
+    { dependencyType = MavenType
+    , dependencyName = "lein-koan"
+    , dependencyVersion = Just (CEq "0.1.5")
+    , dependencyLocations = []
+    , dependencyEnvironments = [EnvTesting]
+    , dependencyTags = M.empty
     }
 
 -- [nrepl "0.6.0" :exclusions [[org.clojure/clojure]]] nil,
 nrepl :: Dependency
 nrepl =
   Dependency
-    { dependencyType = MavenType,
-      dependencyName = "nrepl",
-      dependencyVersion = Just (CEq "0.6.0"),
-      dependencyLocations = [],
-      dependencyEnvironments = [],
-      dependencyTags = M.empty
+    { dependencyType = MavenType
+    , dependencyName = "nrepl"
+    , dependencyVersion = Just (CEq "0.6.0")
+    , dependencyLocations = []
+    , dependencyEnvironments = []
+    , dependencyTags = M.empty
     }
 
 -- [org.clojure/clojure "1.10.0"]
@@ -89,32 +88,32 @@ nrepl =
 clojure :: Dependency
 clojure =
   Dependency
-    { dependencyType = MavenType,
-      dependencyName = "org.clojure:clojure",
-      dependencyVersion = Just (CEq "1.10.0"),
-      dependencyLocations = [],
-      dependencyEnvironments = [],
-      dependencyTags = M.empty
+    { dependencyType = MavenType
+    , dependencyName = "org.clojure:clojure"
+    , dependencyVersion = Just (CEq "1.10.0")
+    , dependencyLocations = []
+    , dependencyEnvironments = []
+    , dependencyTags = M.empty
     }
 
 clojureSpecsAlpha :: Dependency
 clojureSpecsAlpha =
   Dependency
-    { dependencyType = MavenType,
-      dependencyName = "org.clojure:core.specs.alpha",
-      dependencyVersion = Just (CEq "0.2.44"),
-      dependencyLocations = [],
-      dependencyEnvironments = [],
-      dependencyTags = M.empty
+    { dependencyType = MavenType
+    , dependencyName = "org.clojure:core.specs.alpha"
+    , dependencyVersion = Just (CEq "0.2.44")
+    , dependencyLocations = []
+    , dependencyEnvironments = []
+    , dependencyTags = M.empty
     }
 
 clojureSpecAlpha :: Dependency
 clojureSpecAlpha =
   Dependency
-    { dependencyType = MavenType,
-      dependencyName = "org.clojure:spec.alpha",
-      dependencyVersion = Just (CEq "0.2.176"),
-      dependencyLocations = [],
-      dependencyEnvironments = [],
-      dependencyTags = M.empty
+    { dependencyType = MavenType
+    , dependencyName = "org.clojure:spec.alpha"
+    , dependencyVersion = Just (CEq "0.2.176")
+    , dependencyLocations = []
+    , dependencyEnvironments = []
+    , dependencyTags = M.empty
     }

--- a/test/Cocoapods/PodfileLockSpec.hs
+++ b/test/Cocoapods/PodfileLockSpec.hs
@@ -1,50 +1,58 @@
-module Cocoapods.PodfileLockSpec
-  ( spec
-  ) where
+module Cocoapods.PodfileLockSpec (
+  spec,
+) where
 
-import qualified Data.Map.Strict as M
-import qualified Data.Text.IO as TIO
+import Data.Map.Strict qualified as M
+import Data.Text.IO qualified as TIO
 import DepTypes
 import GraphUtil
 import Strategy.Cocoapods.PodfileLock
-import qualified Test.Hspec as T
+import Test.Hspec qualified as T
 import Text.Megaparsec
 
 dependencyOne :: Dependency
-dependencyOne = Dependency { dependencyType = PodType
-                           , dependencyName = "one"
-                           , dependencyVersion = Just (CEq "1.0.0")
-                           , dependencyLocations = []
-                           , dependencyEnvironments = []
-                           , dependencyTags = M.empty
-                           }
+dependencyOne =
+  Dependency
+    { dependencyType = PodType
+    , dependencyName = "one"
+    , dependencyVersion = Just (CEq "1.0.0")
+    , dependencyLocations = []
+    , dependencyEnvironments = []
+    , dependencyTags = M.empty
+    }
 
 dependencyTwo :: Dependency
-dependencyTwo = Dependency { dependencyType = PodType
-                           , dependencyName = "two"
-                           , dependencyVersion = Just (CEq "2.0.0")
-                           , dependencyLocations = []
-                           , dependencyEnvironments = []
-                           , dependencyTags = M.empty
-                           }
+dependencyTwo =
+  Dependency
+    { dependencyType = PodType
+    , dependencyName = "two"
+    , dependencyVersion = Just (CEq "2.0.0")
+    , dependencyLocations = []
+    , dependencyEnvironments = []
+    , dependencyTags = M.empty
+    }
 
 dependencyThree :: Dependency
-dependencyThree = Dependency { dependencyType = PodType
-                             , dependencyName = "three"
-                             , dependencyVersion = Just (CEq "3.0.0")
-                             , dependencyLocations = []
-                             , dependencyEnvironments = []
-                             , dependencyTags = M.empty
-                             }
+dependencyThree =
+  Dependency
+    { dependencyType = PodType
+    , dependencyName = "three"
+    , dependencyVersion = Just (CEq "3.0.0")
+    , dependencyLocations = []
+    , dependencyEnvironments = []
+    , dependencyTags = M.empty
+    }
 
 dependencyFour :: Dependency
-dependencyFour = Dependency { dependencyType = PodType
-                            , dependencyName = "four"
-                            , dependencyVersion = Just (CEq "4.0.0")
-                            , dependencyLocations = []
-                            , dependencyEnvironments = []
-                            , dependencyTags = M.empty
-                            }
+dependencyFour =
+  Dependency
+    { dependencyType = PodType
+    , dependencyName = "four"
+    , dependencyVersion = Just (CEq "4.0.0")
+    , dependencyLocations = []
+    , dependencyEnvironments = []
+    , dependencyTags = M.empty
+    }
 
 podSection :: Section
 podSection = PodSection [Pod "one" "1.0.0" [Dep "two", Dep "three"], Pod "two" "2.0.0" [], Pod "three" "3.0.0" [Dep "four"], Pod "four" "4.0.0" []]
@@ -60,10 +68,12 @@ spec = do
 
       expectDeps [dependencyOne, dependencyTwo, dependencyThree, dependencyFour] graph
       expectDirect [dependencyOne, dependencyThree] graph
-      expectEdges [ (dependencyOne, dependencyTwo)
-                  , (dependencyOne, dependencyThree)
-                  , (dependencyThree, dependencyFour)
-                  ] graph
+      expectEdges
+        [ (dependencyOne, dependencyTwo)
+        , (dependencyOne, dependencyThree)
+        , (dependencyThree, dependencyFour)
+        ]
+        graph
 
   podLockFile <- T.runIO (TIO.readFile "test/Cocoapods/testdata/Podfile.lock")
   T.describe "podfile lock parser" $

--- a/test/Cocoapods/PodfileSpec.hs
+++ b/test/Cocoapods/PodfileSpec.hs
@@ -1,50 +1,58 @@
-module Cocoapods.PodfileSpec
-  ( spec
-  ) where
+module Cocoapods.PodfileSpec (
+  spec,
+) where
 
-import qualified Data.Map.Strict as M
-import qualified Data.Text.IO as TIO
+import Data.Map.Strict qualified as M
+import Data.Text.IO qualified as TIO
 import DepTypes
 import GraphUtil
 import Strategy.Cocoapods.Podfile
-import qualified Test.Hspec as T
+import Test.Hspec qualified as T
 import Text.Megaparsec
 
 dependencyOne :: Dependency
-dependencyOne = Dependency { dependencyType = PodType
-                           , dependencyName = "one"
-                           , dependencyVersion = Just (CEq "1.0.0")
-                           , dependencyLocations = ["test.repo"]
-                           , dependencyEnvironments = []
-                           , dependencyTags = M.empty
-                           }
+dependencyOne =
+  Dependency
+    { dependencyType = PodType
+    , dependencyName = "one"
+    , dependencyVersion = Just (CEq "1.0.0")
+    , dependencyLocations = ["test.repo"]
+    , dependencyEnvironments = []
+    , dependencyTags = M.empty
+    }
 
 dependencyTwo :: Dependency
-dependencyTwo = Dependency { dependencyType = PodType
-                           , dependencyName = "two"
-                           , dependencyVersion = Just (CEq "2.0.0")
-                           , dependencyLocations = ["custom.repo"]
-                           , dependencyEnvironments = []
-                           , dependencyTags = M.empty
-                           }
+dependencyTwo =
+  Dependency
+    { dependencyType = PodType
+    , dependencyName = "two"
+    , dependencyVersion = Just (CEq "2.0.0")
+    , dependencyLocations = ["custom.repo"]
+    , dependencyEnvironments = []
+    , dependencyTags = M.empty
+    }
 
 dependencyThree :: Dependency
-dependencyThree = Dependency { dependencyType = PodType
-                             , dependencyName = "three"
-                             , dependencyVersion = Just (CEq "3.0.0")
-                             , dependencyLocations = ["test.repo"]
-                             , dependencyEnvironments = []
-                             , dependencyTags = M.empty
-                             }
+dependencyThree =
+  Dependency
+    { dependencyType = PodType
+    , dependencyName = "three"
+    , dependencyVersion = Just (CEq "3.0.0")
+    , dependencyLocations = ["test.repo"]
+    , dependencyEnvironments = []
+    , dependencyTags = M.empty
+    }
 
 dependencyFour :: Dependency
-dependencyFour = Dependency { dependencyType = PodType
-                             , dependencyName = "four"
-                             , dependencyVersion = Nothing
-                             , dependencyLocations = ["test.repo"]
-                             , dependencyEnvironments = []
-                             , dependencyTags = M.empty
-                             }
+dependencyFour =
+  Dependency
+    { dependencyType = PodType
+    , dependencyName = "four"
+    , dependencyVersion = Nothing
+    , dependencyLocations = ["test.repo"]
+    , dependencyEnvironments = []
+    , dependencyTags = M.empty
+    }
 
 podOne :: Pod
 podOne = Pod "one" (Just "1.0.0") M.empty
@@ -80,5 +88,5 @@ spec = do
       case runParser parsePodfile "" podLockFile of
         Left _ -> T.expectationFailure "failed to parse"
         Right result -> do
-            pods result `T.shouldMatchList` testPods
-            source result `T.shouldBe` "test.repo"
+          pods result `T.shouldMatchList` testPods
+          source result `T.shouldBe` "test.repo"

--- a/test/Composer/ComposerLockSpec.hs
+++ b/test/Composer/ComposerLockSpec.hs
@@ -1,11 +1,10 @@
-module Composer.ComposerLockSpec
-  ( spec,
-  )
-where
+module Composer.ComposerLockSpec (
+  spec,
+) where
 
-import qualified Data.ByteString as BS
-import qualified Data.Map.Strict as M
 import Data.Aeson
+import Data.ByteString qualified as BS
+import Data.Map.Strict qualified as M
 import DepTypes
 import GraphUtil
 import Strategy.Composer
@@ -14,67 +13,67 @@ import Test.Hspec
 dependencyOne :: Dependency
 dependencyOne =
   Dependency
-    { dependencyType = ComposerType,
-      dependencyName = "one",
-      dependencyVersion = Just (CEq "1.0.0"),
-      dependencyLocations = [],
-      dependencyEnvironments = [EnvProduction],
-      dependencyTags = M.empty
+    { dependencyType = ComposerType
+    , dependencyName = "one"
+    , dependencyVersion = Just (CEq "1.0.0")
+    , dependencyLocations = []
+    , dependencyEnvironments = [EnvProduction]
+    , dependencyTags = M.empty
     }
 
 dependencyTwo :: Dependency
 dependencyTwo =
   Dependency
-    { dependencyType = ComposerType,
-      dependencyName = "two",
-      dependencyVersion = Just (CEq "2.0.0"),
-      dependencyLocations = [],
-      dependencyEnvironments = [EnvProduction],
-      dependencyTags = M.empty
+    { dependencyType = ComposerType
+    , dependencyName = "two"
+    , dependencyVersion = Just (CEq "2.0.0")
+    , dependencyLocations = []
+    , dependencyEnvironments = [EnvProduction]
+    , dependencyTags = M.empty
     }
 
 dependencyThree :: Dependency
 dependencyThree =
   Dependency
-    { dependencyType = ComposerType,
-      dependencyName = "three",
-      dependencyVersion = Just (CEq "3.0.0"),
-      dependencyLocations = [],
-      dependencyEnvironments = [EnvProduction],
-      dependencyTags = M.empty
+    { dependencyType = ComposerType
+    , dependencyName = "three"
+    , dependencyVersion = Just (CEq "3.0.0")
+    , dependencyLocations = []
+    , dependencyEnvironments = [EnvProduction]
+    , dependencyTags = M.empty
     }
 
 dependencyFour :: Dependency
 dependencyFour =
   Dependency
-    { dependencyType = ComposerType,
-      dependencyName = "four",
-      dependencyVersion = Just (CEq "4.0.0"),
-      dependencyLocations = [],
-      dependencyEnvironments = [EnvProduction],
-      dependencyTags = M.empty
+    { dependencyType = ComposerType
+    , dependencyName = "four"
+    , dependencyVersion = Just (CEq "4.0.0")
+    , dependencyLocations = []
+    , dependencyEnvironments = [EnvProduction]
+    , dependencyTags = M.empty
     }
 
 dependencyFive :: Dependency
 dependencyFive =
   Dependency
-    { dependencyType = ComposerType,
-      dependencyName = "five",
-      dependencyVersion = Just (CEq "5.0.0"),
-      dependencyLocations = [],
-      dependencyEnvironments = [EnvDevelopment],
-      dependencyTags = M.empty
+    { dependencyType = ComposerType
+    , dependencyName = "five"
+    , dependencyVersion = Just (CEq "5.0.0")
+    , dependencyLocations = []
+    , dependencyEnvironments = [EnvDevelopment]
+    , dependencyTags = M.empty
     }
 
 dependencySourceless :: Dependency
 dependencySourceless =
   Dependency
-    { dependencyType = ComposerType,
-      dependencyName = "sourceless",
-      dependencyVersion = Just (CEq "5.0.0"),
-      dependencyLocations = [],
-      dependencyEnvironments = [EnvProduction],
-      dependencyTags = M.empty
+    { dependencyType = ComposerType
+    , dependencyName = "sourceless"
+    , dependencyVersion = Just (CEq "5.0.0")
+    , dependencyLocations = []
+    , dependencyEnvironments = [EnvProduction]
+    , dependencyTags = M.empty
     }
 
 spec :: Spec

--- a/test/Conda/CondaListSpec.hs
+++ b/test/Conda/CondaListSpec.hs
@@ -1,12 +1,11 @@
-module Conda.CondaListSpec
-  ( spec,
-  )
-where
+module Conda.CondaListSpec (
+  spec,
+) where
 
 import Control.Carrier.Diagnostics
 import Data.Aeson
-import qualified Data.ByteString as BS
-import qualified Data.Map.Strict as M
+import Data.ByteString qualified as BS
+import Data.Map.Strict qualified as M
 import DepTypes
 import Effect.Grapher
 import Graphing (Graphing)
@@ -18,30 +17,30 @@ expected :: Graphing Dependency
 expected = run . evalGrapher $ do
   direct $
     Dependency
-      { dependencyType = CondaType,
-        dependencyName = "biopython",
-        dependencyVersion = Just (CEq "1.78"),
-        dependencyLocations = [],
-        dependencyEnvironments = [],
-        dependencyTags = M.empty
+      { dependencyType = CondaType
+      , dependencyName = "biopython"
+      , dependencyVersion = Just (CEq "1.78")
+      , dependencyLocations = []
+      , dependencyEnvironments = []
+      , dependencyTags = M.empty
       }
   direct $
     Dependency
-      { dependencyType = CondaType,
-        dependencyName = "blas",
-        dependencyVersion = Just (CEq "1.0"),
-        dependencyLocations = [],
-        dependencyEnvironments = [],
-        dependencyTags = M.empty
+      { dependencyType = CondaType
+      , dependencyName = "blas"
+      , dependencyVersion = Just (CEq "1.0")
+      , dependencyLocations = []
+      , dependencyEnvironments = []
+      , dependencyTags = M.empty
       }
   direct $
     Dependency
-      { dependencyType = CondaType,
-        dependencyName = "ca-certificates",
-        dependencyVersion = Just (CEq "2021.1.19"),
-        dependencyLocations = [],
-        dependencyEnvironments = [],
-        dependencyTags = M.empty
+      { dependencyType = CondaType
+      , dependencyName = "ca-certificates"
+      , dependencyVersion = Just (CEq "2021.1.19")
+      , dependencyLocations = []
+      , dependencyEnvironments = []
+      , dependencyTags = M.empty
       }
 
 spec :: Spec

--- a/test/Conda/EnvironmentYmlSpec.hs
+++ b/test/Conda/EnvironmentYmlSpec.hs
@@ -1,84 +1,83 @@
-module Conda.EnvironmentYmlSpec
-  ( spec,
-  )
-where
+module Conda.EnvironmentYmlSpec (
+  spec,
+) where
 
-import qualified Data.ByteString as BS
-import qualified Data.Map.Strict as M
+import Data.ByteString qualified as BS
+import Data.Map.Strict qualified as M
 import Data.Yaml (decodeEither', prettyPrintParseException)
-import DepTypes
-  ( DepType (CondaType),
-    Dependency (..),
-    VerConstraint (CEq),
-  )
+import DepTypes (
+  DepType (CondaType),
+  Dependency (..),
+  VerConstraint (CEq),
+ )
 import Effect.Grapher
 import GraphUtil (expectDeps)
 import Graphing (Graphing)
 import Strategy.Conda.EnvironmentYml (EnvironmentYmlFile (..), buildGraph)
 import Test.Hspec
-import qualified Test.Hspec as T
+import Test.Hspec qualified as T
 
 dependencyOne :: Dependency
 dependencyOne =
   Dependency
-    { dependencyType = CondaType,
-      dependencyName = "name",
-      dependencyVersion = Just (CEq "version1"),
-      dependencyLocations = [],
-      dependencyEnvironments = [],
-      dependencyTags = M.empty
+    { dependencyType = CondaType
+    , dependencyName = "name"
+    , dependencyVersion = Just (CEq "version1")
+    , dependencyLocations = []
+    , dependencyEnvironments = []
+    , dependencyTags = M.empty
     }
 
 dependencyTwo :: Dependency
 dependencyTwo =
   Dependency
-    { dependencyType = CondaType,
-      dependencyName = "name",
-      dependencyVersion = Just (CEq "version2"),
-      dependencyLocations = [],
-      dependencyEnvironments = [],
-      dependencyTags = M.empty
+    { dependencyType = CondaType
+    , dependencyName = "name"
+    , dependencyVersion = Just (CEq "version2")
+    , dependencyLocations = []
+    , dependencyEnvironments = []
+    , dependencyTags = M.empty
     }
 
 dependencyThree :: Dependency
 dependencyThree =
   Dependency
-    { dependencyType = CondaType,
-      dependencyName = "name",
-      dependencyVersion = Nothing,
-      dependencyLocations = [],
-      dependencyEnvironments = [],
-      dependencyTags = M.empty
+    { dependencyType = CondaType
+    , dependencyName = "name"
+    , dependencyVersion = Nothing
+    , dependencyLocations = []
+    , dependencyEnvironments = []
+    , dependencyTags = M.empty
     }
 
 expectedGraph :: Graphing Dependency
 expectedGraph = run . evalGrapher $ do
   direct $
     Dependency
-      { dependencyType = CondaType,
-        dependencyName = "biopython",
-        dependencyVersion = Just (CEq "1.78"),
-        dependencyLocations = [],
-        dependencyEnvironments = [],
-        dependencyTags = M.empty
+      { dependencyType = CondaType
+      , dependencyName = "biopython"
+      , dependencyVersion = Just (CEq "1.78")
+      , dependencyLocations = []
+      , dependencyEnvironments = []
+      , dependencyTags = M.empty
       }
   direct $
     Dependency
-      { dependencyType = CondaType,
-        dependencyName = "blas",
-        dependencyVersion = Just (CEq "1.0"),
-        dependencyLocations = [],
-        dependencyEnvironments = [],
-        dependencyTags = M.empty
+      { dependencyType = CondaType
+      , dependencyName = "blas"
+      , dependencyVersion = Just (CEq "1.0")
+      , dependencyLocations = []
+      , dependencyEnvironments = []
+      , dependencyTags = M.empty
       }
   direct $
     Dependency
-      { dependencyType = CondaType,
-        dependencyName = "ca-certificates",
-        dependencyVersion = Just (CEq "2021.1.19"),
-        dependencyLocations = [],
-        dependencyEnvironments = [],
-        dependencyTags = M.empty
+      { dependencyType = CondaType
+      , dependencyName = "ca-certificates"
+      , dependencyVersion = Just (CEq "2021.1.19")
+      , dependencyLocations = []
+      , dependencyEnvironments = []
+      , dependencyTags = M.empty
       }
 
 envFile :: EnvironmentYmlFile

--- a/test/Discovery/FiltersSpec.hs
+++ b/test/Discovery/FiltersSpec.hs
@@ -1,11 +1,10 @@
 {-# LANGUAGE TemplateHaskell #-}
 
-module Discovery.FiltersSpec
-  ( spec,
-  )
-where
+module Discovery.FiltersSpec (
+  spec,
+) where
 
-import qualified Data.Set as S
+import Data.Set qualified as S
 import Discovery.Filters
 import Path
 import Test.Hspec

--- a/test/Effect/ExecSpec.hs
+++ b/test/Effect/ExecSpec.hs
@@ -1,7 +1,6 @@
-module Effect.ExecSpec
-  ( spec,
-  )
-where
+module Effect.ExecSpec (
+  spec,
+) where
 
 import Data.Either (isLeft)
 import Effect.Exec

--- a/test/Erlang/ConfigParserSpec.hs
+++ b/test/Erlang/ConfigParserSpec.hs
@@ -1,12 +1,11 @@
-module Erlang.ConfigParserSpec
-  ( spec,
-  )
-where
+module Erlang.ConfigParserSpec (
+  spec,
+) where
 
-import qualified Data.Char as C
-import Data.Text ( Text )
-import qualified Data.Text.IO as TIO
-import Data.Void ( Void )
+import Data.Char qualified as C
+import Data.Text (Text)
+import Data.Text.IO qualified as TIO
+import Data.Void (Void)
 import Strategy.Erlang.ConfigParser
 import Test.Hspec
 import Test.Hspec.Megaparsec
@@ -47,7 +46,6 @@ spec = do
       "\"\\n\"" `shouldParseInto` ErlString "\n"
       "\"\\\"\"" `shouldParseInto` ErlString "\"" -- in source, LHS would appear as -> "\""
       "\"a\" \"b\"" `shouldParseInto` ErlString "ab" -- run-on strings -> "a" "b"
-
     it "should parse an array" $ do
       let shouldParseInto input = parseMatch parseErlArray input
 
@@ -100,21 +98,22 @@ spec = do
       parse parseRadixLiteral "" `shouldFailOn` "-2#10"
 
     it "should parse everything at once" $
-      parse parseConfig "stresstest.config" oneWithEverything `shouldParse`
-        ConfigValues
-          [ErlTuple [
-            atom "rawAtom",
-            atom "quotedAtom",
-            ErlString "Regular String",
-            ErlString "Escaped \" String",
-            ErlInt 1234, -- Literal
-            ErlFloat 3.14159,
-            ErlInt 120, -- '$x'
-            ErlInt 35338, -- 'wes' in base 33
-            ErlArray [atom "arr1"],
-            ErlArray [ErlTuple [atom "key", ErlString "value"]],
-            ErlTuple [atom "number", ErlInt 5678] -- Literal
-          ]]
+      parse parseConfig "stresstest.config" oneWithEverything
+        `shouldParse` ConfigValues
+          [ ErlTuple
+              [ atom "rawAtom"
+              , atom "quotedAtom"
+              , ErlString "Regular String"
+              , ErlString "Escaped \" String"
+              , ErlInt 1234 -- Literal
+              , ErlFloat 3.14159
+              , ErlInt 120 -- '$x'
+              , ErlInt 35338 -- 'wes' in base 33
+              , ErlArray [atom "arr1"]
+              , ErlArray [ErlTuple [atom "key", ErlString "value"]]
+              , ErlTuple [atom "number", ErlInt 5678] -- Literal
+              ]
+          ]
 
   describe "radix parser" $
     it "should parse number strings correctly" $ do
@@ -123,7 +122,6 @@ spec = do
       intLiteralInBase 10 "1234" `shouldBe` 1234
       intLiteralInBase 16 "abcd" `shouldBe` 0xabcd
       intLiteralInBase 36 "1z" `shouldBe` 71 -- (36 * 2 - 1)
-
   describe "alphaNumToInt" $
     it "should provide the correct value for chars" $ do
       alphaNumToInt 'a' `shouldBe` 10

--- a/test/Erlang/Rebar3TreeSpec.hs
+++ b/test/Erlang/Rebar3TreeSpec.hs
@@ -1,101 +1,116 @@
-module Erlang.Rebar3TreeSpec
-  ( spec
-  ) where
+module Erlang.Rebar3TreeSpec (
+  spec,
+) where
 
-import qualified Data.Map.Strict as M
-import qualified Data.Text.IO as TIO
+import Data.Map.Strict qualified as M
+import Data.Text.IO qualified as TIO
 import Text.Megaparsec
 
 import DepTypes
-import Graphing()
-import Strategy.Erlang.Rebar3Tree
 import GraphUtil
+import Graphing ()
+import Strategy.Erlang.Rebar3Tree
 
 import Test.Hspec
 
 dependencyOne :: Dependency
-dependencyOne = Dependency { dependencyType = GitType
-                      , dependencyName = "https://github.com/dep/one"
-                      , dependencyVersion = Just (CEq "1.0.0")
-                      , dependencyLocations = []
-                      , dependencyEnvironments = []
-                      , dependencyTags = M.empty
-                      }
+dependencyOne =
+  Dependency
+    { dependencyType = GitType
+    , dependencyName = "https://github.com/dep/one"
+    , dependencyVersion = Just (CEq "1.0.0")
+    , dependencyLocations = []
+    , dependencyEnvironments = []
+    , dependencyTags = M.empty
+    }
 
 dependencyTwo :: Dependency
-dependencyTwo = Dependency { dependencyType = HexType
-                      , dependencyName = "two"
-                      , dependencyVersion = Just (CEq "2.0.0")
-                      , dependencyLocations = []
-                      , dependencyEnvironments = []
-                      , dependencyTags = M.empty
-                      }
+dependencyTwo =
+  Dependency
+    { dependencyType = HexType
+    , dependencyName = "two"
+    , dependencyVersion = Just (CEq "2.0.0")
+    , dependencyLocations = []
+    , dependencyEnvironments = []
+    , dependencyTags = M.empty
+    }
 dependencyThree :: Dependency
-dependencyThree = Dependency { dependencyType = HexType
-                      , dependencyName = "three"
-                      , dependencyVersion = Just (CEq "3.0.0")
-                      , dependencyLocations = []
-                      , dependencyEnvironments = []
-                      , dependencyTags = M.empty
-                      }
+dependencyThree =
+  Dependency
+    { dependencyType = HexType
+    , dependencyName = "three"
+    , dependencyVersion = Just (CEq "3.0.0")
+    , dependencyLocations = []
+    , dependencyEnvironments = []
+    , dependencyTags = M.empty
+    }
 
 dependencyFour :: Dependency
-dependencyFour = Dependency { dependencyType = GitType
-                      , dependencyName = "https://github.com/dep/four"
-                      , dependencyVersion = Just (CEq "4.0.0")
-                      , dependencyLocations = []
-                      , dependencyEnvironments = []
-                      , dependencyTags = M.empty
-                      }
+dependencyFour =
+  Dependency
+    { dependencyType = GitType
+    , dependencyName = "https://github.com/dep/four"
+    , dependencyVersion = Just (CEq "4.0.0")
+    , dependencyLocations = []
+    , dependencyEnvironments = []
+    , dependencyTags = M.empty
+    }
 
 dependencyFive :: Dependency
-dependencyFive = Dependency { dependencyType = HexType
-                      , dependencyName = "five"
-                      , dependencyVersion = Just (CEq "5.0.0")
-                      , dependencyLocations = []
-                      , dependencyEnvironments = []
-                      , dependencyTags = M.empty
-                      }
+dependencyFive =
+  Dependency
+    { dependencyType = HexType
+    , dependencyName = "five"
+    , dependencyVersion = Just (CEq "5.0.0")
+    , dependencyLocations = []
+    , dependencyEnvironments = []
+    , dependencyTags = M.empty
+    }
 
 depOne :: Rebar3Dep
-depOne = Rebar3Dep
-          { depName = "one"
-          , depVersion = "1.0.0"
-          , depLocation = "https://github.com/dep/one"
-          , subDeps = [depTwo, depFour]
-          }
+depOne =
+  Rebar3Dep
+    { depName = "one"
+    , depVersion = "1.0.0"
+    , depLocation = "https://github.com/dep/one"
+    , subDeps = [depTwo, depFour]
+    }
 
 depTwo :: Rebar3Dep
-depTwo = Rebar3Dep
-          { depName = "two"
-          , depVersion = "2.0.0"
-          , depLocation = "hex package"
-          , subDeps = [depThree]
-          }
+depTwo =
+  Rebar3Dep
+    { depName = "two"
+    , depVersion = "2.0.0"
+    , depLocation = "hex package"
+    , subDeps = [depThree]
+    }
 
 depThree :: Rebar3Dep
-depThree = Rebar3Dep
-          { depName = "three"
-          , depVersion = "3.0.0"
-          , depLocation = "hex package"
-          , subDeps = []
-          }
+depThree =
+  Rebar3Dep
+    { depName = "three"
+    , depVersion = "3.0.0"
+    , depLocation = "hex package"
+    , subDeps = []
+    }
 
 depFour :: Rebar3Dep
-depFour = Rebar3Dep
-          { depName = "four"
-          , depVersion = "4.0.0"
-          , depLocation = "https://github.com/dep/four"
-          , subDeps = []
-          }
+depFour =
+  Rebar3Dep
+    { depName = "four"
+    , depVersion = "4.0.0"
+    , depLocation = "https://github.com/dep/four"
+    , subDeps = []
+    }
 
 depFive :: Rebar3Dep
-depFive = Rebar3Dep
-          { depName = "five"
-          , depVersion = "5.0.0"
-          , depLocation = "hex package"
-          , subDeps = []
-          }
+depFive =
+  Rebar3Dep
+    { depName = "five"
+    , depVersion = "5.0.0"
+    , depLocation = "hex package"
+    , subDeps = []
+    }
 
 spec :: Spec
 spec = do

--- a/test/Extra/TextSpec.hs
+++ b/test/Extra/TextSpec.hs
@@ -1,10 +1,10 @@
 module Extra.TextSpec (
-    spec
+  spec,
 ) where
 
-import qualified Test.Hspec as Test
-import Prelude
 import Data.Text.Extra
+import Test.Hspec qualified as Test
+import Prelude
 
 spec :: Test.Spec
 spec = do

--- a/test/Fossa/API/TypesSpec.hs
+++ b/test/Fossa/API/TypesSpec.hs
@@ -1,10 +1,10 @@
 module Fossa.API.TypesSpec (spec) where
 
-import Fossa.API.Types (Issue (..), IssueRule (..), IssueType (..), Issues (..))
 import Data.Aeson (FromJSON, ToJSON, fromJSON, toJSON)
 import Data.Text (Text)
-import qualified Hedgehog.Gen as Gen
-import qualified Hedgehog.Range as Range
+import Fossa.API.Types (Issue (..), IssueRule (..), IssueType (..), Issues (..))
+import Hedgehog.Gen qualified as Gen
+import Hedgehog.Range qualified as Range
 import Test.Hspec
 import Test.Hspec.Hedgehog
 import Prelude
@@ -12,9 +12,10 @@ import Prelude
 spec :: Spec
 spec = do
   describe "Issues ToJSON/FromJSON instances" $ do
-    it "are roundtrippable" $ hedgehog $ do
-      issues <- forAll genIssues
-      roundtripJson issues
+    it "are roundtrippable" $
+      hedgehog $ do
+        issues <- forAll genIssues
+        roundtripJson issues
 
 genIssues :: Gen Issues
 genIssues =
@@ -36,12 +37,12 @@ genIssue =
 genIssueType :: Gen IssueType
 genIssueType =
   Gen.element
-    [ IssuePolicyConflict,
-      IssuePolicyFlag,
-      IssueVulnerability,
-      IssueUnlicensedDependency,
-      IssueOutdatedDependency,
-      IssueOther "something else"
+    [ IssuePolicyConflict
+    , IssuePolicyFlag
+    , IssueVulnerability
+    , IssueUnlicensedDependency
+    , IssueOutdatedDependency
+    , IssueOther "something else"
     ]
 
 genIssueRule :: Gen IssueRule

--- a/test/Go/GlideLockSpec.hs
+++ b/test/Go/GlideLockSpec.hs
@@ -1,9 +1,9 @@
-module Go.GlideLockSpec
-  ( spec
-  ) where
+module Go.GlideLockSpec (
+  spec,
+) where
 
-import qualified Data.Map.Strict as M
-import qualified Data.ByteString as BS
+import Data.ByteString qualified as BS
+import Data.Map.Strict qualified as M
 import Data.Yaml
 
 import Control.Algebra
@@ -16,40 +16,43 @@ import Test.Hspec
 
 expected :: Graphing Dependency
 expected = run . evalGrapher $ do
-  direct $ Dependency
-               { dependencyType = GoType
-               , dependencyName = "github.com/pkg/one"
-               , dependencyVersion = Just (CEq "1234")
-               , dependencyLocations = []
-               , dependencyEnvironments = []
-               , dependencyTags = M.empty
-               }
-  direct $ Dependency
-               { dependencyType = GoType
-               , dependencyName = "github.com/pkg/three/v3"
-               , dependencyVersion = Just (CEq "4bd8")
-               , dependencyLocations = []
-               , dependencyEnvironments = []
-               , dependencyTags = M.empty
-               }
+  direct $
+    Dependency
+      { dependencyType = GoType
+      , dependencyName = "github.com/pkg/one"
+      , dependencyVersion = Just (CEq "1234")
+      , dependencyLocations = []
+      , dependencyEnvironments = []
+      , dependencyTags = M.empty
+      }
+  direct $
+    Dependency
+      { dependencyType = GoType
+      , dependencyName = "github.com/pkg/three/v3"
+      , dependencyVersion = Just (CEq "4bd8")
+      , dependencyLocations = []
+      , dependencyEnvironments = []
+      , dependencyTags = M.empty
+      }
 
 glideLockfile :: GlideLockfile
 glideLockfile =
-  GlideLockfile { hash = "123"
-  , updated = "now"
-  , imports =
-    [ GlideDep
-        { depName = "github.com/pkg/one"
-        , depVersion = "1234"
-        , depRepo = Just "testRepo"
+  GlideLockfile
+    { hash = "123"
+    , updated = "now"
+    , imports =
+        [ GlideDep
+            { depName = "github.com/pkg/one"
+            , depVersion = "1234"
+            , depRepo = Just "testRepo"
+            }
+        , GlideDep
+            { depName = "github.com/pkg/three/v3"
+            , depVersion = "4bd8"
+            , depRepo = Just "testRepo"
+            }
+        ]
     }
-    , GlideDep
-        { depName = "github.com/pkg/three/v3"
-        , depVersion = "4bd8"
-        , depRepo = Just "testRepo"
-    }
-  ]
-  }
 
 spec :: Spec
 spec = do

--- a/test/Go/GoListSpec.hs
+++ b/test/Go/GoListSpec.hs
@@ -2,16 +2,16 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE UndecidableInstances #-}
 
-module Go.GoListSpec
-  ( spec
-  ) where
+module Go.GoListSpec (
+  spec,
+) where
 
 import Control.Algebra
 import Control.Carrier.Diagnostics
 import Control.Carrier.Reader
-import qualified Data.ByteString.Lazy as BL
+import Data.ByteString.Lazy qualified as BL
 import Data.Function ((&))
-import qualified Data.Map.Strict as M
+import Data.Map.Strict qualified as M
 import DepTypes
 import Effect.Exec
 import Effect.Grapher
@@ -23,7 +23,7 @@ import Test.Hspec
 runConstExec :: BL.ByteString -> ConstExecC m a -> m a
 runConstExec output = runReader output . runConstExecC
 
-newtype ConstExecC m a = ConstExecC { runConstExecC :: ReaderC (BL.ByteString) m a }
+newtype ConstExecC m a = ConstExecC {runConstExecC :: ReaderC (BL.ByteString) m a}
   deriving (Functor, Applicative, Monad)
 
 instance Algebra sig m => Algebra (Exec :+: sig) (ConstExecC m) where
@@ -35,20 +35,24 @@ instance Algebra sig m => Algebra (Exec :+: sig) (ConstExecC m) where
 
 expected :: Graphing Dependency
 expected = run . evalGrapher $ do
-  direct $ Dependency { dependencyType = GoType
-                      , dependencyName = "github.com/pkg/one"
-                      , dependencyVersion = Just (CEq "commithash")
-                      , dependencyLocations = []
-                      , dependencyEnvironments = []
-                      , dependencyTags = M.empty
-                      }
-  direct $ Dependency { dependencyType = GoType
-                      , dependencyName = "github.com/pkg/two"
-                      , dependencyVersion = Just (CEq "v2.0.0")
-                      , dependencyLocations = []
-                      , dependencyEnvironments = []
-                      , dependencyTags = M.empty
-                      }
+  direct $
+    Dependency
+      { dependencyType = GoType
+      , dependencyName = "github.com/pkg/one"
+      , dependencyVersion = Just (CEq "commithash")
+      , dependencyLocations = []
+      , dependencyEnvironments = []
+      , dependencyTags = M.empty
+      }
+  direct $
+    Dependency
+      { dependencyType = GoType
+      , dependencyName = "github.com/pkg/two"
+      , dependencyVersion = Just (CEq "v2.0.0")
+      , dependencyLocations = []
+      , dependencyEnvironments = []
+      , dependencyTags = M.empty
+      }
 
 spec :: Spec
 spec = do
@@ -75,5 +79,5 @@ spec = do
               & run
 
       case result of
-          Left err -> fail $ "failed to build graph" <> show (renderFailureBundle err)
-          Right graph -> length (graphingDirect graph) `shouldBe` 12
+        Left err -> fail $ "failed to build graph" <> show (renderFailureBundle err)
+        Right graph -> length (graphingDirect graph) `shouldBe` 12

--- a/test/Go/GomodSpec.hs
+++ b/test/Go/GomodSpec.hs
@@ -2,11 +2,11 @@ module Go.GomodSpec (spec) where
 
 import Control.Algebra (run)
 import Data.Function ((&))
-import qualified Data.Map.Strict as M
+import Data.Map.Strict qualified as M
 import Data.SemVer (version)
 import Data.SemVer.Internal (Identifier (..))
 import Data.Text (Text)
-import qualified Data.Text.IO as TIO
+import Data.Text.IO qualified as TIO
 import DepTypes (DepType (GoType), Dependency (..), VerConstraint (CEq))
 import Effect.Grapher (direct, evalGrapher)
 import Graphing (Graphing (..))
@@ -24,12 +24,12 @@ semver x y z = Semantic $ version x y z [] []
 dep :: Text -> Text -> Dependency
 dep name revision =
   Dependency
-    { dependencyType = GoType,
-      dependencyName = name,
-      dependencyVersion = Just (CEq revision),
-      dependencyLocations = [],
-      dependencyEnvironments = [],
-      dependencyTags = M.empty
+    { dependencyType = GoType
+    , dependencyName = name
+    , dependencyVersion = Just (CEq revision)
+    , dependencyLocations = []
+    , dependencyEnvironments = []
+    , dependencyTags = M.empty
     }
 
 -- Fixtures for testing.
@@ -37,15 +37,15 @@ dep name revision =
 trivialGomod :: Gomod
 trivialGomod =
   Gomod
-    { modName = "github.com/my/package",
-      modRequires =
-        [ Require "github.com/pkg/one" (semver 1 0 0),
-          Require "github.com/pkg/two/v2" (semver 2 0 0),
-          Require "github.com/pkg/three/v3" (semver 3 0 0)
-        ],
-      modReplaces = M.fromList [("github.com/pkg/two/v2", Require "github.com/pkg/overridden" (NonCanonical "overridden"))],
-      modLocalReplaces = M.empty,
-      modExcludes = []
+    { modName = "github.com/my/package"
+    , modRequires =
+        [ Require "github.com/pkg/one" (semver 1 0 0)
+        , Require "github.com/pkg/two/v2" (semver 2 0 0)
+        , Require "github.com/pkg/three/v3" (semver 3 0 0)
+        ]
+    , modReplaces = M.fromList [("github.com/pkg/two/v2", Require "github.com/pkg/overridden" (NonCanonical "overridden"))]
+    , modLocalReplaces = M.empty
+    , modExcludes = []
     }
 
 trivialGraph :: Graphing Dependency
@@ -54,19 +54,18 @@ trivialGraph = run . evalGrapher $ do
   direct $ dep "github.com/pkg/overridden" "overridden"
   direct $ dep "github.com/pkg/three/v3" "v3.0.0"
 
-
 localReplaceGomod :: Gomod
 localReplaceGomod =
   Gomod
-    { modName = "github.com/my/package",
-      modRequires =
-        [ Require "github.com/pkg/one" (semver 1 0 0),
-          Require "github.com/pkg/two/v2" (semver 2 0 0),
-          Require "github.com/pkg/three/v3" (semver 3 0 0)
-        ],
-      modReplaces = M.empty,
-      modLocalReplaces = M.fromList [("github.com/pkg/two/v2", "./foo")],
-      modExcludes = []
+    { modName = "github.com/my/package"
+    , modRequires =
+        [ Require "github.com/pkg/one" (semver 1 0 0)
+        , Require "github.com/pkg/two/v2" (semver 2 0 0)
+        , Require "github.com/pkg/three/v3" (semver 3 0 0)
+        ]
+    , modReplaces = M.empty
+    , modLocalReplaces = M.fromList [("github.com/pkg/two/v2", "./foo")]
+    , modExcludes = []
     }
 
 localReplaceGraph :: Graphing Dependency
@@ -77,75 +76,75 @@ localReplaceGraph = run . evalGrapher $ do
 edgeCaseGomod :: Gomod
 edgeCaseGomod =
   Gomod
-    { modName = "test/package",
-      modRequires =
-        [ Require "repo/name/A" (semver 1 0 0),
-          Require "repo/B" (Pseudo "000000000002"),
-          Require "repo/C" (semver 1 1 0),
-          Require "repo/name/D" (semver 4 0 0),
-          Require "repo/E" (Semantic $ version 8 0 0 [] [IText "incompatible"]),
-          Require "repo/F_underscore" (semver 1 0 0)
-        ],
-      modReplaces =
+    { modName = "test/package"
+    , modRequires =
+        [ Require "repo/name/A" (semver 1 0 0)
+        , Require "repo/B" (Pseudo "000000000002")
+        , Require "repo/C" (semver 1 1 0)
+        , Require "repo/name/D" (semver 4 0 0)
+        , Require "repo/E" (Semantic $ version 8 0 0 [] [IText "incompatible"])
+        , Require "repo/F_underscore" (semver 1 0 0)
+        ]
+    , modReplaces =
         M.fromList
-          [ ("repo/B", Require "alias/repo/B" $ semver 0 1 0),
-            ("repo/C", Require "alias/repo/C" $ Pseudo "000000000003"),
-            ("repo/E", Require "alias/repo/E" $ Pseudo "000000000005"),
-            ("repo/F_underscore", Require "repo/F_underscore" $ semver 2 0 0)
-          ],
-      modLocalReplaces =
+          [ ("repo/B", Require "alias/repo/B" $ semver 0 1 0)
+          , ("repo/C", Require "alias/repo/C" $ Pseudo "000000000003")
+          , ("repo/E", Require "alias/repo/E" $ Pseudo "000000000005")
+          , ("repo/F_underscore", Require "repo/F_underscore" $ semver 2 0 0)
+          ]
+    , modLocalReplaces =
         M.fromList
-          [ ("foo", "../foo"),
-            ("bar", "/foo/bar/baz")
-          ],
-      modExcludes =
-        [ Require "repo/B" (semver 0 9 0),
-          Require "repo/C" (semver 1 0 0),
-          Require "repo/name/D" (semver 3 0 0)
+          [ ("foo", "../foo")
+          , ("bar", "/foo/bar/baz")
+          ]
+    , modExcludes =
+        [ Require "repo/B" (semver 0 9 0)
+        , Require "repo/C" (semver 1 0 0)
+        , Require "repo/name/D" (semver 3 0 0)
         ]
     }
 
 versionsGomod :: Gomod
 versionsGomod =
   Gomod
-    { modName = "github.com/hashicorp/nomad",
-      modRequires =
+    { modName = "github.com/hashicorp/nomad"
+    , modRequires =
         [ Require
-            { reqPackage = "github.com/containerd/go-cni",
-              reqVersion = Pseudo "d20b7eebc7ee"
-            },
-          Require
-            { reqPackage = "gopkg.in/tomb.v2",
-              reqVersion = Pseudo "14b3d72120e8"
-            },
-          Require
-            { reqPackage = "github.com/docker/docker",
-              reqVersion = Pseudo "7f8b4b621b5d"
-            },
-          Require
-            { reqPackage = "github.com/containernetworking/plugins",
-              reqVersion = Pseudo "2d6d46d308b2"
-            },
-          Require
-            { reqPackage = "github.com/ryanuber/columnize",
-              reqVersion = Pseudo "abc90934186a"
-            },
-          Require
-            { reqPackage = "github.com/opencontainers/runc",
-              reqVersion = Semantic (version 1 0 0 [IText "rc92"] [])
-            },
-          Require
-            { reqPackage = "honnef.co/go/tools",
-              reqVersion = Semantic (version 0 0 1 [INum 2020, INum 1, INum 4] [])
-            },
-          Require
-            { reqPackage = "hub.com/docker/distribution",
-              reqVersion = Semantic (version 2 7 1 [] [IText "incompatible"])
+            { reqPackage = "github.com/containerd/go-cni"
+            , reqVersion = Pseudo "d20b7eebc7ee"
             }
-        ],
-      modReplaces = mempty,
-      modLocalReplaces = mempty,
-      modExcludes = []
+        , Require
+            { reqPackage = "gopkg.in/tomb.v2"
+            , reqVersion = Pseudo "14b3d72120e8"
+            }
+        , Require
+            { reqPackage = "github.com/docker/docker"
+            , reqVersion = Pseudo "7f8b4b621b5d"
+            }
+        , Require
+            { reqPackage = "github.com/containernetworking/plugins"
+            , reqVersion = Pseudo "2d6d46d308b2"
+            }
+        , Require
+            { reqPackage = "github.com/ryanuber/columnize"
+            , reqVersion = Pseudo "abc90934186a"
+            }
+        , Require
+            { reqPackage = "github.com/opencontainers/runc"
+            , reqVersion = Semantic (version 1 0 0 [IText "rc92"] [])
+            }
+        , Require
+            { reqPackage = "honnef.co/go/tools"
+            , reqVersion = Semantic (version 0 0 1 [INum 2020, INum 1, INum 4] [])
+            }
+        , Require
+            { reqPackage = "hub.com/docker/distribution"
+            , reqVersion = Semantic (version 2 7 1 [] [IText "incompatible"])
+            }
+        ]
+    , modReplaces = mempty
+    , modLocalReplaces = mempty
+    , modExcludes = []
     }
 
 versionsGraph :: Graphing Dependency

--- a/test/Go/GopkgLockSpec.hs
+++ b/test/Go/GopkgLockSpec.hs
@@ -1,17 +1,17 @@
-module Go.GopkgLockSpec
-  ( spec
-  ) where
+module Go.GopkgLockSpec (
+  spec,
+) where
 
 import Data.Function ((&))
-import qualified Data.Map.Strict as M
-import qualified Data.Text.IO as TIO
+import Data.Map.Strict qualified as M
+import Data.Text.IO qualified as TIO
 import DepTypes
 import Effect.Grapher
 import Graphing (Graphing)
 import Strategy.Go.GopkgLock
 import Strategy.Go.Types (graphingGolang)
 import Test.Hspec
-import qualified Toml
+import Toml qualified
 
 projects :: [Project]
 projects =
@@ -34,30 +34,33 @@ projects =
 
 expected :: Graphing Dependency
 expected = run . evalGrapher $ do
-  direct $ Dependency
-             { dependencyType = GoType
-             , dependencyName = "repo/name/A"
-             , dependencyVersion = Just (CEq "3012a1dbe2e4bd1391d42b32f0577cb7bbc7f005")
-             , dependencyLocations = []
-             , dependencyEnvironments = []
-             , dependencyTags = M.empty
-             }
-  direct $ Dependency
-             { dependencyType = GoType
-             , dependencyName = "repo/name/B"
-             , dependencyVersion = Just (CEq "12345")
-             , dependencyLocations = []
-             , dependencyEnvironments = []
-             , dependencyTags = M.empty
-             }
-  direct $ Dependency
-             { dependencyType = GoType
-             , dependencyName = "repo/name/C"
-             , dependencyVersion = Just (CEq "12345")
-             , dependencyLocations = ["https://someotherlocation/"]
-             , dependencyEnvironments = []
-             , dependencyTags = M.empty
-             }
+  direct $
+    Dependency
+      { dependencyType = GoType
+      , dependencyName = "repo/name/A"
+      , dependencyVersion = Just (CEq "3012a1dbe2e4bd1391d42b32f0577cb7bbc7f005")
+      , dependencyLocations = []
+      , dependencyEnvironments = []
+      , dependencyTags = M.empty
+      }
+  direct $
+    Dependency
+      { dependencyType = GoType
+      , dependencyName = "repo/name/B"
+      , dependencyVersion = Just (CEq "12345")
+      , dependencyLocations = []
+      , dependencyEnvironments = []
+      , dependencyTags = M.empty
+      }
+  direct $
+    Dependency
+      { dependencyType = GoType
+      , dependencyName = "repo/name/C"
+      , dependencyVersion = Just (CEq "12345")
+      , dependencyLocations = ["https://someotherlocation/"]
+      , dependencyEnvironments = []
+      , dependencyTags = M.empty
+      }
 
 spec :: Spec
 spec = do

--- a/test/Go/GopkgTomlSpec.hs
+++ b/test/Go/GopkgTomlSpec.hs
@@ -1,95 +1,100 @@
-module Go.GopkgTomlSpec
-  ( spec
-  ) where
+module Go.GopkgTomlSpec (
+  spec,
+) where
 
 import Data.Function ((&))
-import qualified Data.Map.Strict as M
-import qualified Data.Text.IO as TIO
+import Data.Map.Strict qualified as M
+import Data.Text.IO qualified as TIO
 import DepTypes
 import Effect.Grapher
 import Graphing (Graphing)
 import Strategy.Go.GopkgToml
 import Strategy.Go.Types (graphingGolang)
 import Test.Hspec
-import qualified Toml
+import Toml qualified
 
 gopkg :: Gopkg
-gopkg = Gopkg
-  { pkgConstraints =
-      [ PkgConstraint
-          { constraintName = "cat/fossa"
-          , constraintSource = Just "https://someotherlocation/"
-          , constraintVersion = Just "v3.0.0"
-          , constraintBranch = Nothing
-          , constraintRevision = Nothing
-          }
-      , PkgConstraint
-          { constraintName = "repo/name/A"
-          , constraintSource = Nothing
-          , constraintVersion = Just "v1.0.0"
-          , constraintBranch = Nothing
-          , constraintRevision = Nothing
-          }
-      , PkgConstraint
-          { constraintName = "repo/name/B"
-          , constraintSource = Nothing
-          , constraintVersion = Nothing
-          , constraintBranch = Nothing
-          , constraintRevision = Just "12345"
-          }
-      , PkgConstraint
-          { constraintName = "repo/name/C"
-          , constraintSource = Nothing
-          , constraintVersion = Nothing
-          , constraintBranch = Just "branchname"
-          , constraintRevision = Nothing
-          }
-      ]
-  , pkgOverrides =
-    [ PkgConstraint
-        { constraintName = "repo/name/B"
-        , constraintSource = Nothing
-        , constraintVersion = Nothing
-        , constraintBranch = Just "overridebranch"
-        , constraintRevision = Nothing
-        }
-    ]
-  }
+gopkg =
+  Gopkg
+    { pkgConstraints =
+        [ PkgConstraint
+            { constraintName = "cat/fossa"
+            , constraintSource = Just "https://someotherlocation/"
+            , constraintVersion = Just "v3.0.0"
+            , constraintBranch = Nothing
+            , constraintRevision = Nothing
+            }
+        , PkgConstraint
+            { constraintName = "repo/name/A"
+            , constraintSource = Nothing
+            , constraintVersion = Just "v1.0.0"
+            , constraintBranch = Nothing
+            , constraintRevision = Nothing
+            }
+        , PkgConstraint
+            { constraintName = "repo/name/B"
+            , constraintSource = Nothing
+            , constraintVersion = Nothing
+            , constraintBranch = Nothing
+            , constraintRevision = Just "12345"
+            }
+        , PkgConstraint
+            { constraintName = "repo/name/C"
+            , constraintSource = Nothing
+            , constraintVersion = Nothing
+            , constraintBranch = Just "branchname"
+            , constraintRevision = Nothing
+            }
+        ]
+    , pkgOverrides =
+        [ PkgConstraint
+            { constraintName = "repo/name/B"
+            , constraintSource = Nothing
+            , constraintVersion = Nothing
+            , constraintBranch = Just "overridebranch"
+            , constraintRevision = Nothing
+            }
+        ]
+    }
 
 expected :: Graphing Dependency
 expected = run . evalGrapher $ do
-  direct $ Dependency
-             { dependencyType = GoType
-             , dependencyName = "cat/fossa"
-             , dependencyVersion = Just (CEq "v3.0.0")
-             , dependencyLocations = ["https://someotherlocation/"]
-             , dependencyEnvironments = []
-             , dependencyTags = M.empty
-             }
-  direct $ Dependency
-             { dependencyType = GoType
-             , dependencyName = "repo/name/A"
-             , dependencyVersion = Just (CEq "v1.0.0")
-             , dependencyLocations = []
-             , dependencyEnvironments = []
-             , dependencyTags = M.empty
-             }
-  direct $ Dependency
-             { dependencyType = GoType
-             , dependencyName = "repo/name/B"
-             , dependencyVersion = Just (CEq "overridebranch")
-             , dependencyLocations = []
-             , dependencyEnvironments = []
-             , dependencyTags = M.empty
-             }
-  direct $ Dependency
-             { dependencyType = GoType
-             , dependencyName = "repo/name/C"
-             , dependencyVersion = Just (CEq "branchname")
-             , dependencyLocations = []
-             , dependencyEnvironments = []
-             , dependencyTags = M.empty
-             }
+  direct $
+    Dependency
+      { dependencyType = GoType
+      , dependencyName = "cat/fossa"
+      , dependencyVersion = Just (CEq "v3.0.0")
+      , dependencyLocations = ["https://someotherlocation/"]
+      , dependencyEnvironments = []
+      , dependencyTags = M.empty
+      }
+  direct $
+    Dependency
+      { dependencyType = GoType
+      , dependencyName = "repo/name/A"
+      , dependencyVersion = Just (CEq "v1.0.0")
+      , dependencyLocations = []
+      , dependencyEnvironments = []
+      , dependencyTags = M.empty
+      }
+  direct $
+    Dependency
+      { dependencyType = GoType
+      , dependencyName = "repo/name/B"
+      , dependencyVersion = Just (CEq "overridebranch")
+      , dependencyLocations = []
+      , dependencyEnvironments = []
+      , dependencyTags = M.empty
+      }
+  direct $
+    Dependency
+      { dependencyType = GoType
+      , dependencyName = "repo/name/C"
+      , dependencyVersion = Just (CEq "branchname")
+      , dependencyLocations = []
+      , dependencyEnvironments = []
+      , dependencyTags = M.empty
+      }
 
 spec :: Spec
 spec = do

--- a/test/Gradle/GradleSpec.hs
+++ b/test/Gradle/GradleSpec.hs
@@ -1,72 +1,78 @@
-module Gradle.GradleSpec
-  ( spec
-  ) where
+module Gradle.GradleSpec (
+  spec,
+) where
 
 import Data.Map.Strict (Map)
-import qualified Data.Map.Strict as M
+import Data.Map.Strict qualified as M
 import Data.Text (Text)
 import DepTypes
 import GraphUtil
 import Graphing (Graphing, empty)
-import Strategy.Gradle (JsonDep (..), buildGraph, PackageName(..), ConfigName(..))
+import Strategy.Gradle (ConfigName (..), JsonDep (..), PackageName (..), buildGraph)
 import Test.Hspec
 
 projectOne :: Dependency
-projectOne = Dependency
-  { dependencyType = SubprojectType
-  , dependencyName = ":projectOne"
-  , dependencyVersion = Nothing
-  , dependencyLocations = []
-  , dependencyEnvironments = [EnvOther "config"]
-  , dependencyTags = M.empty
-  }
+projectOne =
+  Dependency
+    { dependencyType = SubprojectType
+    , dependencyName = ":projectOne"
+    , dependencyVersion = Nothing
+    , dependencyLocations = []
+    , dependencyEnvironments = [EnvOther "config"]
+    , dependencyTags = M.empty
+    }
 
 projectTwo :: Dependency
-projectTwo = Dependency
-  { dependencyType = SubprojectType
-  , dependencyName = ":projectTwo"
-  , dependencyVersion = Nothing
-  , dependencyLocations = []
-  , dependencyEnvironments = [EnvDevelopment, EnvOther "config"]
-  , dependencyTags = M.empty
-  }
+projectTwo =
+  Dependency
+    { dependencyType = SubprojectType
+    , dependencyName = ":projectTwo"
+    , dependencyVersion = Nothing
+    , dependencyLocations = []
+    , dependencyEnvironments = [EnvDevelopment, EnvOther "config"]
+    , dependencyTags = M.empty
+    }
 
 projectThree :: Dependency
-projectThree = Dependency
-  { dependencyType = SubprojectType
-  , dependencyName = ":projectThree"
-  , dependencyVersion = Nothing
-  , dependencyLocations = []
-  , dependencyEnvironments = [EnvDevelopment, EnvTesting]
-  , dependencyTags = M.empty
-  }
+projectThree =
+  Dependency
+    { dependencyType = SubprojectType
+    , dependencyName = ":projectThree"
+    , dependencyVersion = Nothing
+    , dependencyLocations = []
+    , dependencyEnvironments = [EnvDevelopment, EnvTesting]
+    , dependencyTags = M.empty
+    }
 
 packageOne :: Dependency
-packageOne = Dependency
-  { dependencyType = MavenType
-  , dependencyName = "mygroup:packageOne"
-  , dependencyVersion = Just (CEq "1.0.0")
-  , dependencyLocations = []
-  , dependencyEnvironments = [EnvDevelopment]
-  , dependencyTags = M.empty
-  }
+packageOne =
+  Dependency
+    { dependencyType = MavenType
+    , dependencyName = "mygroup:packageOne"
+    , dependencyVersion = Just (CEq "1.0.0")
+    , dependencyLocations = []
+    , dependencyEnvironments = [EnvDevelopment]
+    , dependencyTags = M.empty
+    }
 
 packageTwo :: Dependency
-packageTwo = Dependency
-  { dependencyType = MavenType
-  , dependencyName = "mygroup:packageTwo"
-  , dependencyVersion = Just (CEq "2.0.0")
-  , dependencyLocations = []
-  , dependencyEnvironments = [EnvTesting]
-  , dependencyTags = M.empty
-  }
+packageTwo =
+  Dependency
+    { dependencyType = MavenType
+    , dependencyName = "mygroup:packageTwo"
+    , dependencyVersion = Just (CEq "2.0.0")
+    , dependencyLocations = []
+    , dependencyEnvironments = [EnvTesting]
+    , dependencyTags = M.empty
+    }
 
 gradleOutput :: Map (Text, Text) [JsonDep]
-gradleOutput = M.fromList
-  [ ((":projectOne", "config"), [ProjectDep ":projectTwo"])
-  , ((":projectTwo", "compileOnly"), [ProjectDep ":projectThree", PackageDep "mygroup:packageOne" "1.0.0" []])
-  , ((":projectThree", "testCompileOnly"), [PackageDep "mygroup:packageTwo" "2.0.0" []])
-  ]
+gradleOutput =
+  M.fromList
+    [ ((":projectOne", "config"), [ProjectDep ":projectTwo"])
+    , ((":projectTwo", "compileOnly"), [ProjectDep ":projectThree", PackageDep "mygroup:packageOne" "1.0.0" []])
+    , ((":projectThree", "testCompileOnly"), [PackageDep "mygroup:packageTwo" "2.0.0" []])
+    ]
 
 wrapKeys :: (Text, Text) -> (PackageName, ConfigName)
 wrapKeys (a, b) = (PackageName a, ConfigName b)
@@ -82,8 +88,10 @@ spec = do
       let graph = buildGraph $ M.mapKeys wrapKeys gradleOutput
       expectDeps [projectOne, projectTwo, projectThree, packageOne, packageTwo] graph
       expectDirect [projectOne, projectTwo, projectThree] graph
-      expectEdges [ (projectOne, projectTwo)
-                  , (projectTwo, projectThree)
-                  , (projectTwo, packageOne)
-                  , (projectThree, packageTwo)
-                  ] graph
+      expectEdges
+        [ (projectOne, projectTwo)
+        , (projectTwo, projectThree)
+        , (projectTwo, packageOne)
+        , (projectThree, packageTwo)
+        ]
+        graph

--- a/test/GraphUtil.hs
+++ b/test/GraphUtil.hs
@@ -1,24 +1,26 @@
-module GraphUtil
-  ( expectDeps
-  , expectDirect
-  , expectEdges
-  ) where
+module GraphUtil (
+  expectDeps,
+  expectDirect,
+  expectEdges,
+) where
 
-import qualified Algebra.Graph.AdjacencyMap as AM
+import Algebra.Graph.AdjacencyMap qualified as AM
 import Algebra.Graph.ToGraph (vertexSet)
 import Data.Foldable (toList, traverse_)
 import Graphing
 import Test.Hspec
 
 -- TODO: expectReachable instead?
+
 -- | Expect the given dependencies to be the deps in the graph
 expectDeps :: (Ord a, Show a) => [a] -> Graphing a -> Expectation
 expectDeps deps graph = toList (vertexSet (graphingAdjacent graph)) `shouldMatchList` deps
 
 -- TODO: I expect the shouldSatisfy will produce poor test failure messages
+
 -- | Expect only the given edges between @[(parent,child)]@ dependencies to be present in the graph
-expectEdges :: (Ord a, Show a) => [(a,a)] -> Graphing a -> Expectation
-expectEdges edges graph = (length edges `shouldBe` AM.edgeCount (graphingAdjacent graph)) *> traverse_ (`shouldSatisfy` \(from,to) -> AM.hasEdge from to (graphingAdjacent graph)) edges
+expectEdges :: (Ord a, Show a) => [(a, a)] -> Graphing a -> Expectation
+expectEdges edges graph = (length edges `shouldBe` AM.edgeCount (graphingAdjacent graph)) *> traverse_ (`shouldSatisfy` \(from, to) -> AM.hasEdge from to (graphingAdjacent graph)) edges
 
 -- | Expect the given dependencies to be the direct deps in the graph
 expectDirect :: (Eq a, Show a) => [a] -> Graphing a -> Expectation

--- a/test/GraphingSpec.hs
+++ b/test/GraphingSpec.hs
@@ -1,20 +1,19 @@
-module GraphingSpec
-  ( spec
-  )
-  where
+module GraphingSpec (
+  spec,
+) where
 
+import GraphUtil
+import Graphing
 import Test.Hspec
 import Prelude
-import Graphing
-import GraphUtil
 
 spec :: Spec
 spec = do
   describe "unfold" $ do
     it "should unfold deeply" $ do
       let graph :: Graphing Int
-          graph = unfold [10] (\x -> if x > 0 then [x-2] else []) id
+          graph = unfold [10] (\x -> if x > 0 then [x -2] else []) id
 
       expectDirect [10] graph
       expectDeps [10, 8, 6, 4, 2, 0] graph
-      expectEdges [(10,8), (8,6), (6,4), (4,2), (2,0)] graph
+      expectEdges [(10, 8), (8, 6), (6, 4), (4, 2), (2, 0)] graph

--- a/test/Haskell/CabalSpec.hs
+++ b/test/Haskell/CabalSpec.hs
@@ -1,19 +1,18 @@
 {-# LANGUAGE RecordWildCards #-}
 
-module Haskell.CabalSpec
-  ( spec,
-  )
-where
+module Haskell.CabalSpec (
+  spec,
+) where
 
 import Control.Carrier.Diagnostics
 import Data.Aeson
-import qualified Data.ByteString.Lazy as BL
-import qualified Data.Set as S
+import Data.ByteString.Lazy qualified as BL
+import Data.Set qualified as S
 import DepTypes
 import GraphUtil
 import Graphing
 import Strategy.Haskell.Cabal
-import qualified Test.Hspec as Test
+import Test.Hspec qualified as Test
 
 buildPlan :: [InstallPlan]
 buildPlan = [aesonPlan, basePlan, deepDepPlan, rtsPlan, spectrometerFossaPlan, spectrometerLibPlan, withCompPlan]

--- a/test/Haskell/StackSpec.hs
+++ b/test/Haskell/StackSpec.hs
@@ -1,20 +1,19 @@
 {-# LANGUAGE RecordWildCards #-}
 
-module Haskell.StackSpec
-  ( spec,
-  )
-where
+module Haskell.StackSpec (
+  spec,
+) where
 
-import Data.Aeson
-import qualified Data.ByteString.Lazy as BL
-import Data.Text (Text)
-import qualified Graphing as G
-import qualified Test.Hspec as Test
-import Prelude
-import Strategy.Haskell.Stack
 import Control.Carrier.Diagnostics
-import Types
+import Data.Aeson
+import Data.ByteString.Lazy qualified as BL
+import Data.Text (Text)
 import GraphUtil
+import Graphing qualified as G
+import Strategy.Haskell.Stack
+import Test.Hspec qualified as Test
+import Types
+import Prelude
 
 allDeps :: [StackDep]
 allDeps = [builtinDep, deepDep, localDep, remoteDep]

--- a/test/Maven/PluginStrategySpec.hs
+++ b/test/Maven/PluginStrategySpec.hs
@@ -1,8 +1,8 @@
-module Maven.PluginStrategySpec
-  ( spec
-  ) where
+module Maven.PluginStrategySpec (
+  spec,
+) where
 
-import qualified Data.Map.Strict as M
+import Data.Map.Strict qualified as M
 import DepTypes
 import GraphUtil
 import Strategy.Maven.Plugin
@@ -10,52 +10,55 @@ import Strategy.Maven.PluginStrategy
 import Test.Hspec
 
 packageOne :: Dependency
-packageOne = Dependency
-  { dependencyType = MavenType
-  , dependencyName = "mygroup:packageOne"
-  , dependencyVersion = Just (CEq "1.0.0")
-  , dependencyLocations = []
-  , dependencyEnvironments = [EnvTesting]
-  , dependencyTags = M.fromList [("scopes", ["compile", "test"])]
-  }
+packageOne =
+  Dependency
+    { dependencyType = MavenType
+    , dependencyName = "mygroup:packageOne"
+    , dependencyVersion = Just (CEq "1.0.0")
+    , dependencyLocations = []
+    , dependencyEnvironments = [EnvTesting]
+    , dependencyTags = M.fromList [("scopes", ["compile", "test"])]
+    }
 
 packageTwo :: Dependency
-packageTwo = Dependency
-  { dependencyType = MavenType
-  , dependencyName = "mygroup:packageTwo"
-  , dependencyVersion = Just (CEq "2.0.0")
-  , dependencyLocations = []
-  , dependencyEnvironments = []
-  , dependencyTags = M.fromList [("scopes", ["compile"]), ("optional", ["true"])]
-  }
+packageTwo =
+  Dependency
+    { dependencyType = MavenType
+    , dependencyName = "mygroup:packageTwo"
+    , dependencyVersion = Just (CEq "2.0.0")
+    , dependencyLocations = []
+    , dependencyEnvironments = []
+    , dependencyTags = M.fromList [("scopes", ["compile"]), ("optional", ["true"])]
+    }
 
 mavenOutput :: PluginOutput
-mavenOutput = PluginOutput
-  { outArtifacts =
-    [ Artifact
-        { artifactNumericId = 0
-        , artifactGroupId = "mygroup"
-        , artifactArtifactId = "packageOne"
-        , artifactVersion = "1.0.0"
-        , artifactOptional = False
-        , artifactScopes = ["compile", "test"]
-        }
-    , Artifact
-        { artifactNumericId = 1
-        , artifactGroupId = "mygroup"
-        , artifactArtifactId = "packageTwo"
-        , artifactVersion = "2.0.0"
-        , artifactOptional = True
-        , artifactScopes = ["compile"]
-        }
-    ]
-  , outEdges =
-    [ Edge
-        { edgeFrom = 0
-        , edgeTo = 1
-        }
-    ]
-  }
+mavenOutput =
+  PluginOutput
+    { outArtifacts =
+        [ Artifact
+            { artifactNumericId = 0
+            , artifactGroupId = "mygroup"
+            , artifactArtifactId = "packageOne"
+            , artifactVersion = "1.0.0"
+            , artifactOptional = False
+            , artifactScopes = ["compile", "test"]
+            }
+        , Artifact
+            { artifactNumericId = 1
+            , artifactGroupId = "mygroup"
+            , artifactArtifactId = "packageTwo"
+            , artifactVersion = "2.0.0"
+            , artifactOptional = True
+            , artifactScopes = ["compile"]
+            }
+        ]
+    , outEdges =
+        [ Edge
+            { edgeFrom = 0
+            , edgeTo = 1
+            }
+        ]
+    }
 
 spec :: Spec
 spec = do
@@ -63,6 +66,6 @@ spec = do
     it "should produce expected output" $ do
       let graph = buildGraph mavenOutput
 
-      expectDeps [ packageOne, packageTwo ] graph
+      expectDeps [packageOne, packageTwo] graph
       expectDirect [] graph
       expectEdges [(packageOne, packageTwo)] graph

--- a/test/Maven/PomStrategySpec.hs
+++ b/test/Maven/PomStrategySpec.hs
@@ -1,9 +1,8 @@
-module Maven.PomStrategySpec
-  ( spec,
-  )
-where
+module Maven.PomStrategySpec (
+  spec,
+) where
 
-import qualified Data.Map.Strict as M
+import Data.Map.Strict qualified as M
 import Strategy.Maven.Pom (interpolateProperties)
 import Strategy.Maven.Pom.PomFile
 import Test.Hspec
@@ -18,7 +17,7 @@ spec = do
       interpolateProperties pom "${project.version}" `shouldBe` "MYVERSION"
 
     it "should prefer user-specified properties over computed ones" $ do
-      let pom' = pom { pomProperties = M.singleton "project.groupId" "OTHERGROUP" }
+      let pom' = pom{pomProperties = M.singleton "project.groupId" "OTHERGROUP"}
       interpolateProperties pom' "${project.groupId}" `shouldBe` "OTHERGROUP"
 
     it "should work in the middle of strings" $ do

--- a/test/Node/NpmLockSpec.hs
+++ b/test/Node/NpmLockSpec.hs
@@ -1,72 +1,89 @@
-module Node.NpmLockSpec
-  ( spec
-  ) where
+module Node.NpmLockSpec (
+  spec,
+) where
 
-import qualified Data.Map.Strict as M
+import Data.Map.Strict qualified as M
 import DepTypes
 import GraphUtil
 import Strategy.Node.NpmLock
 import Test.Hspec
 
 mockInput :: NpmPackageJson
-mockInput = NpmPackageJson
-  { packageName = "example"
-  , packageVersion = "1.0.0"
-  , packageDependencies = M.fromList
-    [ ("packageOne", NpmDep
-        { depVersion = "1.0.0"
-        , depDev = Nothing
-        , depResolved = Just "https://example.com/one.tgz"
-        , depRequires = Just (M.fromList [("packageTwo", "2.0.0")])
-        , depDependencies = Just (M.fromList
-            [ ("packageTwo", NpmDep
-                { depVersion = "2.0.0"
+mockInput =
+  NpmPackageJson
+    { packageName = "example"
+    , packageVersion = "1.0.0"
+    , packageDependencies =
+        M.fromList
+          [
+            ( "packageOne"
+            , NpmDep
+                { depVersion = "1.0.0"
+                , depDev = Nothing
+                , depResolved = Just "https://example.com/one.tgz"
+                , depRequires = Just (M.fromList [("packageTwo", "2.0.0")])
+                , depDependencies =
+                    Just
+                      ( M.fromList
+                          [
+                            ( "packageTwo"
+                            , NpmDep
+                                { depVersion = "2.0.0"
+                                , depDev = Just True
+                                , depResolved = Just "https://example.com/two.tgz"
+                                , depRequires = Just (M.fromList [("packageThree", "3.0.0")])
+                                , depDependencies = Nothing
+                                }
+                            )
+                          ]
+                      )
+                }
+            )
+          ,
+            ( "packageThree"
+            , NpmDep
+                { depVersion = "3.0.0"
                 , depDev = Just True
-                , depResolved = Just "https://example.com/two.tgz"
-                , depRequires = Just (M.fromList [("packageThree", "3.0.0")])
+                , depResolved = Nothing
+                , depRequires = Just (M.fromList [("packageOne", "1.0.0")])
                 , depDependencies = Nothing
-                })
-            ])
-        })
-    , ("packageThree", NpmDep
-        { depVersion = "3.0.0"
-        , depDev = Just True
-        , depResolved = Nothing
-        , depRequires = Just (M.fromList [("packageOne", "1.0.0")])
-        , depDependencies = Nothing
-        })
-    ]
-  }
+                }
+            )
+          ]
+    }
 
 packageOne :: Dependency
-packageOne = Dependency
-  { dependencyType = NodeJSType
-  , dependencyName = "packageOne"
-  , dependencyVersion = Just (CEq "1.0.0")
-  , dependencyLocations = ["https://example.com/one.tgz"]
-  , dependencyEnvironments = [EnvProduction]
-  , dependencyTags = M.empty
-  }
+packageOne =
+  Dependency
+    { dependencyType = NodeJSType
+    , dependencyName = "packageOne"
+    , dependencyVersion = Just (CEq "1.0.0")
+    , dependencyLocations = ["https://example.com/one.tgz"]
+    , dependencyEnvironments = [EnvProduction]
+    , dependencyTags = M.empty
+    }
 
 packageTwo :: Dependency
-packageTwo = Dependency
-  { dependencyType = NodeJSType
-  , dependencyName = "packageTwo"
-  , dependencyVersion = Just (CEq "2.0.0")
-  , dependencyLocations = ["https://example.com/two.tgz"]
-  , dependencyEnvironments = [EnvDevelopment]
-  , dependencyTags = M.empty
-  }
+packageTwo =
+  Dependency
+    { dependencyType = NodeJSType
+    , dependencyName = "packageTwo"
+    , dependencyVersion = Just (CEq "2.0.0")
+    , dependencyLocations = ["https://example.com/two.tgz"]
+    , dependencyEnvironments = [EnvDevelopment]
+    , dependencyTags = M.empty
+    }
 
 packageThree :: Dependency
-packageThree = Dependency
-  { dependencyType = NodeJSType
-  , dependencyName = "packageThree"
-  , dependencyVersion = Just (CEq "3.0.0")
-  , dependencyLocations = []
-  , dependencyEnvironments = [EnvDevelopment]
-  , dependencyTags = M.empty
-  }
+packageThree =
+  Dependency
+    { dependencyType = NodeJSType
+    , dependencyName = "packageThree"
+    , dependencyVersion = Just (CEq "3.0.0")
+    , dependencyLocations = []
+    , dependencyEnvironments = [EnvDevelopment]
+    , dependencyTags = M.empty
+    }
 
 spec :: Spec
 spec = do
@@ -75,7 +92,9 @@ spec = do
       let graph = buildGraph mockInput
       expectDeps [packageOne, packageTwo, packageThree] graph
       expectDirect [packageOne, packageThree] graph
-      expectEdges [ (packageOne, packageTwo)
-                  , (packageTwo, packageThree)
-                  , (packageThree, packageOne)
-                  ] graph
+      expectEdges
+        [ (packageOne, packageTwo)
+        , (packageTwo, packageThree)
+        , (packageThree, packageOne)
+        ]
+        graph

--- a/test/Node/PackageJsonSpec.hs
+++ b/test/Node/PackageJsonSpec.hs
@@ -1,38 +1,41 @@
-module Node.PackageJsonSpec
-  ( spec
-  ) where
+module Node.PackageJsonSpec (
+  spec,
+) where
 
-import qualified Data.Map.Strict as M
+import Data.Map.Strict qualified as M
 import DepTypes
 import GraphUtil
 import Strategy.Node.PackageJson
 import Test.Hspec
 
 mockInput :: PackageJson
-mockInput = PackageJson
-  { packageDeps = M.fromList [("packageOne", "^1.0.0")]
-  , packageDevDeps = M.fromList [("packageTwo", "^2.0.0")]
-  }
+mockInput =
+  PackageJson
+    { packageDeps = M.fromList [("packageOne", "^1.0.0")]
+    , packageDevDeps = M.fromList [("packageTwo", "^2.0.0")]
+    }
 
 packageOne :: Dependency
-packageOne = Dependency
-  { dependencyType = NodeJSType
-  , dependencyName = "packageOne"
-  , dependencyVersion = Just (CCompatible "^1.0.0")
-  , dependencyLocations = []
-  , dependencyEnvironments = [EnvProduction]
-  , dependencyTags = M.empty
-  }
+packageOne =
+  Dependency
+    { dependencyType = NodeJSType
+    , dependencyName = "packageOne"
+    , dependencyVersion = Just (CCompatible "^1.0.0")
+    , dependencyLocations = []
+    , dependencyEnvironments = [EnvProduction]
+    , dependencyTags = M.empty
+    }
 
 packageTwo :: Dependency
-packageTwo = Dependency
-  { dependencyType = NodeJSType
-  , dependencyName = "packageTwo"
-  , dependencyVersion = Just (CCompatible "^2.0.0")
-  , dependencyLocations = []
-  , dependencyEnvironments = [EnvDevelopment]
-  , dependencyTags = M.empty
-  }
+packageTwo =
+  Dependency
+    { dependencyType = NodeJSType
+    , dependencyName = "packageTwo"
+    , dependencyVersion = Just (CCompatible "^2.0.0")
+    , dependencyLocations = []
+    , dependencyEnvironments = [EnvDevelopment]
+    , dependencyTags = M.empty
+    }
 
 spec :: Spec
 spec = do

--- a/test/NuGet/NuspecSpec.hs
+++ b/test/NuGet/NuspecSpec.hs
@@ -1,10 +1,10 @@
-module NuGet.NuspecSpec
-  ( spec
-  ) where
+module NuGet.NuspecSpec (
+  spec,
+) where
 
-import qualified Data.Map.Strict as M
-import qualified Data.Text as T
-import qualified Data.Text.IO as TIO
+import Data.Map.Strict qualified as M
+import Data.Text qualified as T
+import Data.Text.IO qualified as TIO
 import DepTypes
 import GraphUtil
 import Parse.XML
@@ -12,31 +12,37 @@ import Strategy.NuGet.Nuspec
 import Test.Hspec
 
 dependencyOne :: Dependency
-dependencyOne = Dependency { dependencyType = NuGetType
-                        , dependencyName = "one"
-                        , dependencyVersion = Just (CEq "1.0.0")
-                        , dependencyLocations = []
-                        , dependencyEnvironments = []
-                        , dependencyTags = M.empty
-                        }
+dependencyOne =
+  Dependency
+    { dependencyType = NuGetType
+    , dependencyName = "one"
+    , dependencyVersion = Just (CEq "1.0.0")
+    , dependencyLocations = []
+    , dependencyEnvironments = []
+    , dependencyTags = M.empty
+    }
 
 dependencyTwo :: Dependency
-dependencyTwo = Dependency { dependencyType = NuGetType
-                        , dependencyName = "two"
-                        , dependencyVersion = Just (CEq "2.0.0")
-                        , dependencyLocations = []
-                        , dependencyEnvironments = []
-                        , dependencyTags = M.empty
-                        }
+dependencyTwo =
+  Dependency
+    { dependencyType = NuGetType
+    , dependencyName = "two"
+    , dependencyVersion = Just (CEq "2.0.0")
+    , dependencyLocations = []
+    , dependencyEnvironments = []
+    , dependencyTags = M.empty
+    }
 
 dependencyThree :: Dependency
-dependencyThree = Dependency { dependencyType = NuGetType
-                        , dependencyName = "three"
-                        , dependencyVersion = Just (CEq "3.0.0")
-                        , dependencyLocations = []
-                        , dependencyEnvironments = []
-                        , dependencyTags = M.empty
-                        }
+dependencyThree =
+  Dependency
+    { dependencyType = NuGetType
+    , dependencyName = "three"
+    , dependencyVersion = Just (CEq "3.0.0")
+    , dependencyLocations = []
+    , dependencyEnvironments = []
+    , dependencyTags = M.empty
+    }
 
 nuspec :: Nuspec
 nuspec = Nuspec groupList licenses (Just "test.com")
@@ -88,7 +94,7 @@ spec = do
         Left err -> expectationFailure (T.unpack ("could not parse nuspec file: " <> xmlErrorPretty err))
 
     it "constructs an accurate graph" $ do
-          let graph = buildGraph nuspec
-          expectDeps [dependencyOne, dependencyTwo, dependencyThree] graph
-          expectDirect [dependencyOne, dependencyTwo, dependencyThree] graph
-          expectEdges [] graph
+      let graph = buildGraph nuspec
+      expectDeps [dependencyOne, dependencyTwo, dependencyThree] graph
+      expectDirect [dependencyOne, dependencyTwo, dependencyThree] graph
+      expectEdges [] graph

--- a/test/NuGet/PackageReferenceSpec.hs
+++ b/test/NuGet/PackageReferenceSpec.hs
@@ -1,10 +1,10 @@
-module NuGet.PackageReferenceSpec
-  ( spec
-  ) where
+module NuGet.PackageReferenceSpec (
+  spec,
+) where
 
-import qualified Data.Map.Strict as M
-import qualified Data.Text as T
-import qualified Data.Text.IO as TIO
+import Data.Map.Strict qualified as M
+import Data.Text qualified as T
+import Data.Text.IO qualified as TIO
 import DepTypes
 import GraphUtil
 import Parse.XML
@@ -12,40 +12,48 @@ import Strategy.NuGet.PackageReference
 import Test.Hspec
 
 dependencyOne :: Dependency
-dependencyOne = Dependency { dependencyType = NuGetType
-                           , dependencyName = "one"
-                           , dependencyVersion = Just (CEq "1.0.0")
-                           , dependencyLocations = []
-                           , dependencyEnvironments = []
-                           , dependencyTags = M.empty
-                           }
+dependencyOne =
+  Dependency
+    { dependencyType = NuGetType
+    , dependencyName = "one"
+    , dependencyVersion = Just (CEq "1.0.0")
+    , dependencyLocations = []
+    , dependencyEnvironments = []
+    , dependencyTags = M.empty
+    }
 
 dependencyTwo :: Dependency
-dependencyTwo = Dependency { dependencyType = NuGetType
-                           , dependencyName = "two"
-                           , dependencyVersion = Just (CEq "2.0.0")
-                           , dependencyLocations = []
-                           , dependencyEnvironments = []
-                           , dependencyTags = M.empty
-                           }
+dependencyTwo =
+  Dependency
+    { dependencyType = NuGetType
+    , dependencyName = "two"
+    , dependencyVersion = Just (CEq "2.0.0")
+    , dependencyLocations = []
+    , dependencyEnvironments = []
+    , dependencyTags = M.empty
+    }
 
 dependencyThree :: Dependency
-dependencyThree = Dependency { dependencyType = NuGetType
-                             , dependencyName = "three"
-                             , dependencyVersion = Just (CEq "3.0.0")
-                             , dependencyLocations = []
-                             , dependencyEnvironments = []
-                             , dependencyTags = M.empty
-                             }
+dependencyThree =
+  Dependency
+    { dependencyType = NuGetType
+    , dependencyName = "three"
+    , dependencyVersion = Just (CEq "3.0.0")
+    , dependencyLocations = []
+    , dependencyEnvironments = []
+    , dependencyTags = M.empty
+    }
 
 dependencyFour :: Dependency
-dependencyFour = Dependency { dependencyType = NuGetType
-                            , dependencyName = "four"
-                            , dependencyVersion = Nothing
-                            , dependencyLocations = []
-                            , dependencyEnvironments = []
-                            , dependencyTags = M.empty
-                            }
+dependencyFour =
+  Dependency
+    { dependencyType = NuGetType
+    , dependencyName = "four"
+    , dependencyVersion = Nothing
+    , dependencyLocations = []
+    , dependencyEnvironments = []
+    , dependencyTags = M.empty
+    }
 
 packageReference :: PackageReference
 packageReference = PackageReference itemGroupList
@@ -76,7 +84,7 @@ spec = do
         Left err -> expectationFailure (T.unpack ("could not parse package reference file" <> xmlErrorPretty err))
 
     it "constructs an accurate graph" $ do
-          let graph = buildGraph packageReference
-          expectDeps [dependencyOne, dependencyTwo, dependencyThree, dependencyFour] graph
-          expectDirect [dependencyOne, dependencyTwo, dependencyThree, dependencyFour] graph
-          expectEdges [] graph
+      let graph = buildGraph packageReference
+      expectDeps [dependencyOne, dependencyTwo, dependencyThree, dependencyFour] graph
+      expectDirect [dependencyOne, dependencyTwo, dependencyThree, dependencyFour] graph
+      expectEdges [] graph

--- a/test/NuGet/PackagesConfigSpec.hs
+++ b/test/NuGet/PackagesConfigSpec.hs
@@ -1,33 +1,37 @@
-module NuGet.PackagesConfigSpec
-  ( spec
-  ) where
+module NuGet.PackagesConfigSpec (
+  spec,
+) where
 
-import qualified Data.Map.Strict as M
-import qualified Data.Text as T
-import qualified Data.Text.IO as TIO
+import Data.Map.Strict qualified as M
+import Data.Text qualified as T
+import Data.Text.IO qualified as TIO
 import DepTypes
 import GraphUtil
-import Strategy.NuGet.PackagesConfig
 import Parse.XML
+import Strategy.NuGet.PackagesConfig
 import Test.Hspec
 
 dependencyOne :: Dependency
-dependencyOne = Dependency { dependencyType = NuGetType
-                        , dependencyName = "one"
-                        , dependencyVersion = Just (CEq "1.0.0")
-                        , dependencyLocations = []
-                        , dependencyEnvironments = []
-                        , dependencyTags = M.empty
-                        }
+dependencyOne =
+  Dependency
+    { dependencyType = NuGetType
+    , dependencyName = "one"
+    , dependencyVersion = Just (CEq "1.0.0")
+    , dependencyLocations = []
+    , dependencyEnvironments = []
+    , dependencyTags = M.empty
+    }
 
 dependencyTwo :: Dependency
-dependencyTwo = Dependency { dependencyType = NuGetType
-                        , dependencyName = "two"
-                        , dependencyVersion = Just (CEq "2.0.0")
-                        , dependencyLocations = []
-                        , dependencyEnvironments = []
-                        , dependencyTags = M.empty
-                        }
+dependencyTwo =
+  Dependency
+    { dependencyType = NuGetType
+    , dependencyName = "two"
+    , dependencyVersion = Just (CEq "2.0.0")
+    , dependencyLocations = []
+    , dependencyEnvironments = []
+    , dependencyTags = M.empty
+    }
 
 packagesConfig :: PackagesConfig
 packagesConfig = PackagesConfig depList
@@ -46,7 +50,7 @@ spec = do
         Left err -> expectationFailure (T.unpack ("could not parse packages.config file" <> xmlErrorPretty err))
 
     it "constructs an accurate graph" $ do
-          let graph = buildGraph packagesConfig
-          expectDeps [dependencyOne, dependencyTwo] graph
-          expectDirect [dependencyOne, dependencyTwo] graph
-          expectEdges [] graph
+      let graph = buildGraph packagesConfig
+      expectDeps [dependencyOne, dependencyTwo] graph
+      expectDirect [dependencyOne, dependencyTwo] graph
+      expectEdges [] graph

--- a/test/NuGet/PaketSpec.hs
+++ b/test/NuGet/PaketSpec.hs
@@ -1,88 +1,109 @@
-module NuGet.PaketSpec
-  ( spec
-  ) where
+module NuGet.PaketSpec (
+  spec,
+) where
 
-import qualified Data.Map.Strict as M
-import qualified Data.Text.IO as TIO
+import Data.Map.Strict qualified as M
+import Data.Text.IO qualified as TIO
 import DepTypes
 import GraphUtil
 import Strategy.NuGet.Paket
-import qualified Test.Hspec as T
+import Test.Hspec qualified as T
 import Text.Megaparsec
 
 dependencyOne :: Dependency
-dependencyOne = Dependency { dependencyType = NuGetType
-                           , dependencyName = "one"
-                           , dependencyVersion = Just (CEq "1.0.0")
-                           , dependencyLocations = ["nuget.com"]
-                           , dependencyEnvironments = []
-                           , dependencyTags = M.fromList [("location", ["NUGET"]), ("group", ["MAIN"])]
-                           }
+dependencyOne =
+  Dependency
+    { dependencyType = NuGetType
+    , dependencyName = "one"
+    , dependencyVersion = Just (CEq "1.0.0")
+    , dependencyLocations = ["nuget.com"]
+    , dependencyEnvironments = []
+    , dependencyTags = M.fromList [("location", ["NUGET"]), ("group", ["MAIN"])]
+    }
 
 dependencyTwo :: Dependency
-dependencyTwo = Dependency { dependencyType = NuGetType
-                           , dependencyName = "two"
-                           , dependencyVersion = Just (CEq "2.0.0")
-                           , dependencyLocations = ["nuget-v2.com", "nuget.com"]
-                           , dependencyEnvironments = []
-                           , dependencyTags = M.fromList [("location", ["NUGET"]), ("group", ["MAIN", "TEST"])]
-                           }
+dependencyTwo =
+  Dependency
+    { dependencyType = NuGetType
+    , dependencyName = "two"
+    , dependencyVersion = Just (CEq "2.0.0")
+    , dependencyLocations = ["nuget-v2.com", "nuget.com"]
+    , dependencyEnvironments = []
+    , dependencyTags = M.fromList [("location", ["NUGET"]), ("group", ["MAIN", "TEST"])]
+    }
 
 dependencyThree :: Dependency
-dependencyThree = Dependency { dependencyType = NuGetType
-                             , dependencyName = "three"
-                             , dependencyVersion = Just (CEq "3.0.0")
-                             , dependencyLocations = ["custom-site.com"]
-                             , dependencyEnvironments = []
-                             , dependencyTags = M.fromList [("location", ["HTTP"]), ("group", ["MAIN"])]
-                             }
+dependencyThree =
+  Dependency
+    { dependencyType = NuGetType
+    , dependencyName = "three"
+    , dependencyVersion = Just (CEq "3.0.0")
+    , dependencyLocations = ["custom-site.com"]
+    , dependencyEnvironments = []
+    , dependencyTags = M.fromList [("location", ["HTTP"]), ("group", ["MAIN"])]
+    }
 
 dependencyFour :: Dependency
-dependencyFour = Dependency { dependencyType = NuGetType
-                            , dependencyName = "four"
-                            , dependencyVersion = Just (CEq "4.0.0")
-                            , dependencyLocations = ["nuget-v2.com"]
-                            , dependencyEnvironments = []
-                            , dependencyTags = M.fromList [("location", ["NUGET"]), ("group", ["TEST"])]
-                            }
+dependencyFour =
+  Dependency
+    { dependencyType = NuGetType
+    , dependencyName = "four"
+    , dependencyVersion = Just (CEq "4.0.0")
+    , dependencyLocations = ["nuget-v2.com"]
+    , dependencyEnvironments = []
+    , dependencyTags = M.fromList [("location", ["NUGET"]), ("group", ["TEST"])]
+    }
 
 dependencyFive :: Dependency
-dependencyFive = Dependency { dependencyType = NuGetType
-                            , dependencyName = "five"
-                            , dependencyVersion = Just (CEq "5.0.0")
-                            , dependencyLocations = ["nuget-v2.com"]
-                            , dependencyEnvironments = []
-                            , dependencyTags = M.fromList [("location", ["NUGET"]), ("group", ["TEST"])]
-                            }
+dependencyFive =
+  Dependency
+    { dependencyType = NuGetType
+    , dependencyName = "five"
+    , dependencyVersion = Just (CEq "5.0.0")
+    , dependencyLocations = ["nuget-v2.com"]
+    , dependencyEnvironments = []
+    , dependencyTags = M.fromList [("location", ["NUGET"]), ("group", ["TEST"])]
+    }
 
 dependencySix :: Dependency
-dependencySix = Dependency { dependencyType = NuGetType
-                           , dependencyName = "six"
-                           , dependencyVersion = Just (CEq "6.0.0")
-                           , dependencyLocations = ["github.com"]
-                           , dependencyEnvironments = []
-                           , dependencyTags = M.fromList [("location", ["GITHUB"]), ("group", ["TEST"])]
-                           }
+dependencySix =
+  Dependency
+    { dependencyType = NuGetType
+    , dependencyName = "six"
+    , dependencyVersion = Just (CEq "6.0.0")
+    , dependencyLocations = ["github.com"]
+    , dependencyEnvironments = []
+    , dependencyTags = M.fromList [("location", ["GITHUB"]), ("group", ["TEST"])]
+    }
 
 nugetSection :: Section
-nugetSection = StandardSection "NUGET" [Remote "nuget.com" [PaketDep "one" "1.0.0" ["two"]
-                                                , PaketDep "two" "2.0.0" []
-                                                ]]
+nugetSection =
+  StandardSection
+    "NUGET"
+    [ Remote
+        "nuget.com"
+        [ PaketDep "one" "1.0.0" ["two"]
+        , PaketDep "two" "2.0.0" []
+        ]
+    ]
 
 httpSection :: Section
 httpSection = StandardSection "HTTP" [Remote "custom-site.com" [PaketDep "three" "3.0.0" []]]
 
 nugetGroupRemote :: Remote
-nugetGroupRemote = Remote "nuget-v2.com" [PaketDep "four" "4.0.0" ["five"]
-                                         , PaketDep "five" "5.0.0" []
-                                         , PaketDep "two" "2.0.0" []
-                                         ]
+nugetGroupRemote =
+  Remote
+    "nuget-v2.com"
+    [ PaketDep "four" "4.0.0" ["five"]
+    , PaketDep "five" "5.0.0" []
+    , PaketDep "two" "2.0.0" []
+    ]
 
 gitGroupRemote :: Remote
 gitGroupRemote = Remote "github.com" [PaketDep "six" "6.0.0" []]
 
 groupSection :: Section
-groupSection = GroupSection "TEST" [ StandardSection "NUGET" [nugetGroupRemote], StandardSection "GITHUB" [gitGroupRemote] ]
+groupSection = GroupSection "TEST" [StandardSection "NUGET" [nugetGroupRemote], StandardSection "GITHUB" [gitGroupRemote]]
 
 paketLockSections :: [Section]
 paketLockSections = [nugetSection, httpSection, groupSection]
@@ -95,9 +116,11 @@ spec = do
 
       expectDeps [dependencyOne, dependencyTwo, dependencyThree, dependencyFour, dependencyFive, dependencySix] graph
       expectDirect [dependencyOne, dependencyTwo, dependencyThree, dependencyFour, dependencyFive, dependencySix] graph
-      expectEdges [ (dependencyOne, dependencyTwo)
-                  , (dependencyFour, dependencyFive)
-                  ] graph
+      expectEdges
+        [ (dependencyOne, dependencyTwo)
+        , (dependencyFour, dependencyFive)
+        ]
+        graph
 
   paketLockFile <- T.runIO (TIO.readFile "test/NuGet/testdata/paket.lock")
   T.describe "paket lock parser" $
@@ -105,6 +128,6 @@ spec = do
       case runParser findSections "" paketLockFile of
         Left _ -> T.expectationFailure "failed to parse"
         Right result -> do
-            result `T.shouldContain` [nugetSection]
-            result `T.shouldContain` [httpSection]
-            result `T.shouldContain` [groupSection]
+          result `T.shouldContain` [nugetSection]
+          result `T.shouldContain` [httpSection]
+          result `T.shouldContain` [groupSection]

--- a/test/NuGet/ProjectAssetsJsonSpec.hs
+++ b/test/NuGet/ProjectAssetsJsonSpec.hs
@@ -1,50 +1,58 @@
-module NuGet.ProjectAssetsJsonSpec
-  ( spec
-  ) where
+module NuGet.ProjectAssetsJsonSpec (
+  spec,
+) where
 
 import Data.Aeson
-import qualified Data.ByteString as BS
-import qualified Data.Map.Strict as M
+import Data.ByteString qualified as BS
+import Data.Map.Strict qualified as M
 import DepTypes
 import GraphUtil
 import Strategy.NuGet.ProjectAssetsJson
 import Test.Hspec
 
 dependencyOne :: Dependency
-dependencyOne = Dependency { dependencyType = NuGetType
-                        , dependencyName = "one"
-                        , dependencyVersion = Just (CEq "1.0.0")
-                        , dependencyLocations = []
-                        , dependencyEnvironments = []
-                        , dependencyTags = M.empty
-                        }
+dependencyOne =
+  Dependency
+    { dependencyType = NuGetType
+    , dependencyName = "one"
+    , dependencyVersion = Just (CEq "1.0.0")
+    , dependencyLocations = []
+    , dependencyEnvironments = []
+    , dependencyTags = M.empty
+    }
 
 dependencyTwo :: Dependency
-dependencyTwo = Dependency { dependencyType = NuGetType
-                        , dependencyName = "two"
-                        , dependencyVersion = Just (CEq "2.0.0")
-                        , dependencyLocations = []
-                        , dependencyEnvironments = []
-                        , dependencyTags = M.empty
-                        }
+dependencyTwo =
+  Dependency
+    { dependencyType = NuGetType
+    , dependencyName = "two"
+    , dependencyVersion = Just (CEq "2.0.0")
+    , dependencyLocations = []
+    , dependencyEnvironments = []
+    , dependencyTags = M.empty
+    }
 
 dependencyThree :: Dependency
-dependencyThree = Dependency { dependencyType = NuGetType
-                        , dependencyName = "three"
-                        , dependencyVersion = Just (CEq "3.0.0")
-                        , dependencyLocations = []
-                        , dependencyEnvironments = []
-                        , dependencyTags = M.empty
-                        }
+dependencyThree =
+  Dependency
+    { dependencyType = NuGetType
+    , dependencyName = "three"
+    , dependencyVersion = Just (CEq "3.0.0")
+    , dependencyLocations = []
+    , dependencyEnvironments = []
+    , dependencyTags = M.empty
+    }
 
 dependencyFour :: Dependency
-dependencyFour = Dependency { dependencyType = NuGetType
-                        , dependencyName = "four"
-                        , dependencyVersion = Just (CEq "4.0.0")
-                        , dependencyLocations = []
-                        , dependencyEnvironments = []
-                        , dependencyTags = M.empty
-                        }
+dependencyFour =
+  Dependency
+    { dependencyType = NuGetType
+    , dependencyName = "four"
+    , dependencyVersion = Just (CEq "4.0.0")
+    , dependencyLocations = []
+    , dependencyEnvironments = []
+    , dependencyTags = M.empty
+    }
 
 spec :: Spec
 spec = do
@@ -54,8 +62,8 @@ spec = do
     it "reads a file and constructs an accurate graph" $ do
       case eitherDecodeStrict testFile of
         Right res -> do
-              let graph = buildGraph res
-              expectDeps [dependencyOne, dependencyTwo, dependencyThree, dependencyFour] graph
-              expectDirect [dependencyOne, dependencyTwo, dependencyFour] graph
-              expectEdges [ (dependencyOne, dependencyThree) ] graph
+          let graph = buildGraph res
+          expectDeps [dependencyOne, dependencyTwo, dependencyThree, dependencyFour] graph
+          expectDirect [dependencyOne, dependencyTwo, dependencyFour] graph
+          expectEdges [(dependencyOne, dependencyThree)] graph
         Left _ -> expectationFailure "failed to parse"

--- a/test/NuGet/ProjectJsonSpec.hs
+++ b/test/NuGet/ProjectJsonSpec.hs
@@ -1,41 +1,47 @@
-module NuGet.ProjectJsonSpec
-  ( spec
-  ) where
+module NuGet.ProjectJsonSpec (
+  spec,
+) where
 
 import Data.Aeson
-import qualified Data.ByteString as BS
-import qualified Data.Map.Strict as M
+import Data.ByteString qualified as BS
+import Data.Map.Strict qualified as M
 import DepTypes
 import GraphUtil
 import Strategy.NuGet.ProjectJson
 import Test.Hspec
 
 dependencyOne :: Dependency
-dependencyOne = Dependency { dependencyType = NuGetType
-                        , dependencyName = "one"
-                        , dependencyVersion = Just (CEq "1.0.0")
-                        , dependencyLocations = []
-                        , dependencyEnvironments = []
-                        , dependencyTags = M.empty
-                        }
+dependencyOne =
+  Dependency
+    { dependencyType = NuGetType
+    , dependencyName = "one"
+    , dependencyVersion = Just (CEq "1.0.0")
+    , dependencyLocations = []
+    , dependencyEnvironments = []
+    , dependencyTags = M.empty
+    }
 
 dependencyTwo :: Dependency
-dependencyTwo = Dependency { dependencyType = NuGetType
-                        , dependencyName = "two"
-                        , dependencyVersion = Just (CCompatible "2.*")
-                        , dependencyLocations = []
-                        , dependencyEnvironments = []
-                        , dependencyTags = M.empty
-                        }
+dependencyTwo =
+  Dependency
+    { dependencyType = NuGetType
+    , dependencyName = "two"
+    , dependencyVersion = Just (CCompatible "2.*")
+    , dependencyLocations = []
+    , dependencyEnvironments = []
+    , dependencyTags = M.empty
+    }
 
 dependencyThree :: Dependency
-dependencyThree = Dependency { dependencyType = NuGetType
-                        , dependencyName = "three"
-                        , dependencyVersion = Just (CEq "3.0.0")
-                        , dependencyLocations = []
-                        , dependencyEnvironments = []
-                        , dependencyTags = M.fromList [ ("type", ["sometype"]) ]
-                        }
+dependencyThree =
+  Dependency
+    { dependencyType = NuGetType
+    , dependencyName = "three"
+    , dependencyVersion = Just (CEq "3.0.0")
+    , dependencyLocations = []
+    , dependencyEnvironments = []
+    , dependencyTags = M.fromList [("type", ["sometype"])]
+    }
 
 spec :: Spec
 spec = do
@@ -45,8 +51,8 @@ spec = do
     it "reads a file and constructs an accurate graph" $ do
       case eitherDecodeStrict testFile of
         Right res -> do
-              let graph = buildGraph res
-              expectDeps [dependencyOne, dependencyTwo, dependencyThree] graph
-              expectDirect [dependencyOne, dependencyTwo, dependencyThree] graph
-              expectEdges [] graph
+          let graph = buildGraph res
+          expectDeps [dependencyOne, dependencyTwo, dependencyThree] graph
+          expectDirect [dependencyOne, dependencyTwo, dependencyThree] graph
+          expectEdges [] graph
         Left _ -> expectationFailure "failed to parse"

--- a/test/Python/PipenvSpec.hs
+++ b/test/Python/PipenvSpec.hs
@@ -1,101 +1,127 @@
-module Python.PipenvSpec
-  ( spec
-  ) where
+module Python.PipenvSpec (
+  spec,
+) where
 
-import qualified Data.Map.Strict as M
+import Data.Aeson (eitherDecodeStrict)
+import Data.ByteString qualified as BS
+import Data.Map.Strict qualified as M
 import DepTypes
 import GraphUtil
 import Strategy.Python.Pipenv
 import Test.Hspec hiding (xit)
-import Data.Aeson (eitherDecodeStrict)
-import qualified Data.ByteString as BS
 
 pipfileLock :: PipfileLock
-pipfileLock = PipfileLock
-  { fileMeta    = PipfileMeta
-    [ PipfileSource { sourceName = "package-index"
-                    , sourceUrl  = "https://my-package-index/"
-                    }
-    ]
-
-  , fileDefault = M.fromList
-    [ ("pkgTwo", PipfileDep { fileDepVersion = Just "==2.0.0"
-                            , fileDepIndex = Just "package-index"
-                            })
-    , ("pkgThree", PipfileDep { fileDepVersion = Just "==3.0.0"
-                              , fileDepIndex = Nothing
-                              })
-    , ("pkgFour", PipfileDep { fileDepVersion = Nothing
-                              , fileDepIndex = Nothing
-                              })
-    ]
-
-  , fileDevelop = M.fromList
-    [ ("pkgOne", PipfileDep { fileDepVersion = Just "==1.0.0"
-                            , fileDepIndex = Nothing
-                            })
-    ]
-  }
+pipfileLock =
+  PipfileLock
+    { fileMeta =
+        PipfileMeta
+          [ PipfileSource
+              { sourceName = "package-index"
+              , sourceUrl = "https://my-package-index/"
+              }
+          ]
+    , fileDefault =
+        M.fromList
+          [
+            ( "pkgTwo"
+            , PipfileDep
+                { fileDepVersion = Just "==2.0.0"
+                , fileDepIndex = Just "package-index"
+                }
+            )
+          ,
+            ( "pkgThree"
+            , PipfileDep
+                { fileDepVersion = Just "==3.0.0"
+                , fileDepIndex = Nothing
+                }
+            )
+          ,
+            ( "pkgFour"
+            , PipfileDep
+                { fileDepVersion = Nothing
+                , fileDepIndex = Nothing
+                }
+            )
+          ]
+    , fileDevelop =
+        M.fromList
+          [
+            ( "pkgOne"
+            , PipfileDep
+                { fileDepVersion = Just "==1.0.0"
+                , fileDepIndex = Nothing
+                }
+            )
+          ]
+    }
 
 pipenvOutput :: [PipenvGraphDep]
 pipenvOutput =
-  [ PipenvGraphDep { depName         = "pkgOne"
-                   , depInstalled    = "1.0.0"
-                   , depRequired     = "==1.0.0"
-                   , depDependencies = []
-                   }
-  , PipenvGraphDep { depName = "pkgTwo"
-                   , depInstalled = "2.0.0"
-                   , depRequired = "==2.0.0"
-                   , depDependencies =
-                     [ PipenvGraphDep { depName      = "pkgThree"
-                                      , depInstalled = "3.0.0"
-                                      , depRequired  = "==3.0.0"
-                                      , depDependencies = []
-                                      }
-                     ]
-                   }
+  [ PipenvGraphDep
+      { depName = "pkgOne"
+      , depInstalled = "1.0.0"
+      , depRequired = "==1.0.0"
+      , depDependencies = []
+      }
+  , PipenvGraphDep
+      { depName = "pkgTwo"
+      , depInstalled = "2.0.0"
+      , depRequired = "==2.0.0"
+      , depDependencies =
+          [ PipenvGraphDep
+              { depName = "pkgThree"
+              , depInstalled = "3.0.0"
+              , depRequired = "==3.0.0"
+              , depDependencies = []
+              }
+          ]
+      }
   ]
 
 depOne :: Dependency
-depOne = Dependency
-  { dependencyType = PipType
-  , dependencyName = "pkgOne"
-  , dependencyVersion = Just (CEq "1.0.0")
-  , dependencyLocations = []
-  , dependencyEnvironments = [EnvDevelopment]
-  , dependencyTags = M.empty
-  }
+depOne =
+  Dependency
+    { dependencyType = PipType
+    , dependencyName = "pkgOne"
+    , dependencyVersion = Just (CEq "1.0.0")
+    , dependencyLocations = []
+    , dependencyEnvironments = [EnvDevelopment]
+    , dependencyTags = M.empty
+    }
 
 depTwo :: Dependency
-depTwo = Dependency
-  { dependencyType = PipType
-  , dependencyName = "pkgTwo"
-  , dependencyVersion = Just (CEq "2.0.0")
-  , dependencyLocations = ["https://my-package-index/"]
-  , dependencyEnvironments = [EnvProduction]
-  , dependencyTags = M.empty
-  }
+depTwo =
+  Dependency
+    { dependencyType = PipType
+    , dependencyName = "pkgTwo"
+    , dependencyVersion = Just (CEq "2.0.0")
+    , dependencyLocations = ["https://my-package-index/"]
+    , dependencyEnvironments = [EnvProduction]
+    , dependencyTags = M.empty
+    }
 
 depThree :: Dependency
-depThree = Dependency
-  { dependencyType = PipType
-  , dependencyName = "pkgThree"
-  , dependencyVersion = Just (CEq "3.0.0")
-  , dependencyLocations = []
-  , dependencyEnvironments = [EnvProduction]
-  , dependencyTags = M.empty
-  }
+depThree =
+  Dependency
+    { dependencyType = PipType
+    , dependencyName = "pkgThree"
+    , dependencyVersion = Just (CEq "3.0.0")
+    , dependencyLocations = []
+    , dependencyEnvironments = [EnvProduction]
+    , dependencyTags = M.empty
+    }
 
 depFour :: Dependency
-depFour = Dependency
-  { dependencyType = PipType
-  , dependencyName = "pkgFour"
-  , dependencyVersion = Nothing
-  , dependencyLocations = []
-  , dependencyEnvironments = [EnvProduction]
-  , dependencyTags = M.empty
-  }
+depFour =
+  Dependency
+    { dependencyType = PipType
+    , dependencyName = "pkgFour"
+    , dependencyVersion = Nothing
+    , dependencyLocations = []
+    , dependencyEnvironments = [EnvProduction]
+    , dependencyTags = M.empty
+    }
 
 xit :: String -> Expectation -> SpecWith (Arg Expectation)
 xit _ _ = it "is an ignored test" $ () `shouldBe` ()

--- a/test/Python/ReqTxtSpec.hs
+++ b/test/Python/ReqTxtSpec.hs
@@ -1,10 +1,10 @@
 {-# LANGUAGE QuasiQuotes #-}
 
-module Python.ReqTxtSpec
-  ( spec
-  ) where
+module Python.ReqTxtSpec (
+  spec,
+) where
 
-import qualified Data.Map.Strict as M
+import Data.Map.Strict qualified as M
 import Text.URI.QQ (uri)
 
 import DepTypes
@@ -16,38 +16,53 @@ import Test.Hspec
 
 setupPyInput :: [Req]
 setupPyInput =
-  [ NameReq "pkgOne" Nothing (Just [ Version OpGtEq "1.0.0"
-                                   , Version OpLt   "2.0.0"
-                                   ]) Nothing
+  [ NameReq
+      "pkgOne"
+      Nothing
+      ( Just
+          [ Version OpGtEq "1.0.0"
+          , Version OpLt "2.0.0"
+          ]
+      )
+      Nothing
   , NameReq "pkgTwo" Nothing Nothing Nothing
   , UrlReq "pkgThree" Nothing [uri|https://example.com|] Nothing
   ]
 
 expected :: Graphing Dependency
 expected = run . evalGrapher $ do
-  direct $ Dependency { dependencyType = PipType
-                      , dependencyName = "pkgOne"
-                      , dependencyVersion =
-                          Just (CAnd (CGreaterOrEq "1.0.0")
-                                     (CLess "2.0.0"))
-                      , dependencyLocations = []
-                      , dependencyEnvironments = []
-                      , dependencyTags = M.empty
-                      }
-  direct $ Dependency { dependencyType = PipType
-                      , dependencyName = "pkgTwo"
-                      , dependencyVersion = Nothing
-                      , dependencyLocations = []
-                      , dependencyEnvironments = []
-                      , dependencyTags = M.empty
-                      }
-  direct $ Dependency { dependencyType = PipType
-                      , dependencyName = "pkgThree"
-                      , dependencyVersion = Just (CURI "https://example.com")
-                      , dependencyLocations = []
-                      , dependencyEnvironments = []
-                      , dependencyTags = M.empty
-                      }
+  direct $
+    Dependency
+      { dependencyType = PipType
+      , dependencyName = "pkgOne"
+      , dependencyVersion =
+          Just
+            ( CAnd
+                (CGreaterOrEq "1.0.0")
+                (CLess "2.0.0")
+            )
+      , dependencyLocations = []
+      , dependencyEnvironments = []
+      , dependencyTags = M.empty
+      }
+  direct $
+    Dependency
+      { dependencyType = PipType
+      , dependencyName = "pkgTwo"
+      , dependencyVersion = Nothing
+      , dependencyLocations = []
+      , dependencyEnvironments = []
+      , dependencyTags = M.empty
+      }
+  direct $
+    Dependency
+      { dependencyType = PipType
+      , dependencyName = "pkgThree"
+      , dependencyVersion = Just (CURI "https://example.com")
+      , dependencyLocations = []
+      , dependencyEnvironments = []
+      , dependencyTags = M.empty
+      }
 
 spec :: Spec
 spec =

--- a/test/Python/RequirementsSpec.hs
+++ b/test/Python/RequirementsSpec.hs
@@ -1,81 +1,88 @@
-module Python.RequirementsSpec
-  ( spec,
-  )
-where
+module Python.RequirementsSpec (
+  spec,
+) where
 
-import Data.Foldable ( traverse_ )
+import Data.Foldable (traverse_)
+import Data.Map.Strict qualified as M
 import Data.Text (Text)
-import Strategy.Python.Util (requirementParser, buildGraph)
+import Data.Text.IO qualified as TIO
+import DepTypes
+import GraphUtil (expectDeps)
 import Strategy.Python.ReqTxt (requirementsTxtParser)
+import Strategy.Python.Util (buildGraph, requirementParser)
+import Test.Hspec qualified as T
 import Test.Hspec.Megaparsec
 import Text.Megaparsec
 import Prelude
-import DepTypes
-import qualified Data.Map.Strict as M
-import qualified Data.Text.IO as TIO
-import qualified Test.Hspec as T
-import GraphUtil (expectDeps)
 
 examples :: [Text]
 examples =
-  [ "A",
-    "A.B-C_D",
-    "aa",
-    "name",
-    "name<=1",
-    "name>=3",
-    "name>=3,<2",
-    "name@http://foo.com",
-    "name [fred,bar] @ http://foo.com ; python_version=='2.7'",
-    "name[quux, strange];python_version<'2.7' and platform_version=='2'",
-    "name; os_name=='a' or os_name=='b'",
-    "name; os_name=='a' and os_name=='b' or os_name=='c'",
-    "name; os_name=='a' and (os_name=='b' or os_name=='c')",
-    "name; os_name=='a' or os_name=='b' and os_name=='c'",
-    "name; (os_name=='a' or os_name=='b') and os_name=='c'"
+  [ "A"
+  , "A.B-C_D"
+  , "aa"
+  , "name"
+  , "name<=1"
+  , "name>=3"
+  , "name>=3,<2"
+  , "name@http://foo.com"
+  , "name [fred,bar] @ http://foo.com ; python_version=='2.7'"
+  , "name[quux, strange];python_version<'2.7' and platform_version=='2'"
+  , "name; os_name=='a' or os_name=='b'"
+  , "name; os_name=='a' and os_name=='b' or os_name=='c'"
+  , "name; os_name=='a' and (os_name=='b' or os_name=='c')"
+  , "name; os_name=='a' or os_name=='b' and os_name=='c'"
+  , "name; (os_name=='a' or os_name=='b') and os_name=='c'"
   ]
 
 depOne :: Dependency
-depOne = Dependency { dependencyType = PipType
-                        , dependencyName = "one"
-                        , dependencyVersion = Just (CEq "1.0")
-                        , dependencyLocations = []
-                        , dependencyEnvironments = []
-                        , dependencyTags = M.empty
-                        }
+depOne =
+  Dependency
+    { dependencyType = PipType
+    , dependencyName = "one"
+    , dependencyVersion = Just (CEq "1.0")
+    , dependencyLocations = []
+    , dependencyEnvironments = []
+    , dependencyTags = M.empty
+    }
 
 depTwo :: Dependency
-depTwo = Dependency { dependencyType = PipType
-                        , dependencyName = "two"
-                        , dependencyVersion = Just (CLessOrEq "2.0.0")
-                        , dependencyLocations = []
-                        , dependencyEnvironments = []
-                        , dependencyTags = M.empty
-                        }
+depTwo =
+  Dependency
+    { dependencyType = PipType
+    , dependencyName = "two"
+    , dependencyVersion = Just (CLessOrEq "2.0.0")
+    , dependencyLocations = []
+    , dependencyEnvironments = []
+    , dependencyTags = M.empty
+    }
 
 depThree :: Dependency
-depThree = Dependency { dependencyType = PipType
-                        , dependencyName = "three"
-                        , dependencyVersion = Just (CEq "3.0.0")
-                        , dependencyLocations = []
-                        , dependencyEnvironments = []
-                        , dependencyTags = M.empty
-                        }
+depThree =
+  Dependency
+    { dependencyType = PipType
+    , dependencyName = "three"
+    , dependencyVersion = Just (CEq "3.0.0")
+    , dependencyLocations = []
+    , dependencyEnvironments = []
+    , dependencyTags = M.empty
+    }
 
 depFour :: Dependency
-depFour = Dependency { dependencyType = PipType
-                        , dependencyName = "four"
-                        , dependencyVersion = Just (CEq "4.0.0")
-                        , dependencyLocations = []
-                        , dependencyEnvironments = []
-                        , dependencyTags = M.empty
-                        }
+depFour =
+  Dependency
+    { dependencyType = PipType
+    , dependencyName = "four"
+    , dependencyVersion = Just (CEq "4.0.0")
+    , dependencyLocations = []
+    , dependencyEnvironments = []
+    , dependencyTags = M.empty
+    }
 
 spec :: T.Spec
 spec = do
-  T.describe "requirementParser"
-    $ T.it "can parse the edge case examples"
-    $ traverse_ (\input -> runParser requirementParser "" `shouldSucceedOn` input) examples
+  T.describe "requirementParser" $
+    T.it "can parse the edge case examples" $
+      traverse_ (\input -> runParser requirementParser "" `shouldSucceedOn` input) examples
 
   requirementsTextFile <- T.runIO (TIO.readFile "test/Python/testdata/req.txt")
   T.describe "req file" $

--- a/test/Python/SetupPySpec.hs
+++ b/test/Python/SetupPySpec.hs
@@ -1,10 +1,10 @@
 {-# LANGUAGE QuasiQuotes #-}
 
-module Python.SetupPySpec
-  ( spec
-  ) where
+module Python.SetupPySpec (
+  spec,
+) where
 
-import qualified Data.Map.Strict as M
+import Data.Map.Strict qualified as M
 import Text.URI.QQ (uri)
 
 import DepTypes
@@ -16,38 +16,53 @@ import Test.Hspec
 
 setupPyInput :: [Req]
 setupPyInput =
-  [ NameReq "pkgOne" Nothing (Just [ Version OpGtEq "1.0.0"
-                                   , Version OpLt   "2.0.0"
-                                   ]) Nothing
+  [ NameReq
+      "pkgOne"
+      Nothing
+      ( Just
+          [ Version OpGtEq "1.0.0"
+          , Version OpLt "2.0.0"
+          ]
+      )
+      Nothing
   , NameReq "pkgTwo" Nothing Nothing Nothing
   , UrlReq "pkgThree" Nothing [uri|https://example.com|] Nothing
   ]
 
 expected :: Graphing Dependency
 expected = run . evalGrapher $ do
-  direct $ Dependency { dependencyType = PipType
-                      , dependencyName = "pkgOne"
-                      , dependencyVersion =
-                          Just (CAnd (CGreaterOrEq "1.0.0")
-                                     (CLess "2.0.0"))
-                      , dependencyLocations = []
-                      , dependencyEnvironments = []
-                      , dependencyTags = M.empty
-                      }
-  direct $ Dependency { dependencyType = PipType
-                      , dependencyName = "pkgTwo"
-                      , dependencyVersion = Nothing
-                      , dependencyLocations = []
-                      , dependencyEnvironments = []
-                      , dependencyTags = M.empty
-                      }
-  direct $ Dependency { dependencyType = PipType
-                      , dependencyName = "pkgThree"
-                      , dependencyVersion = Just (CURI "https://example.com")
-                      , dependencyLocations = []
-                      , dependencyEnvironments = []
-                      , dependencyTags = M.empty
-                      }
+  direct $
+    Dependency
+      { dependencyType = PipType
+      , dependencyName = "pkgOne"
+      , dependencyVersion =
+          Just
+            ( CAnd
+                (CGreaterOrEq "1.0.0")
+                (CLess "2.0.0")
+            )
+      , dependencyLocations = []
+      , dependencyEnvironments = []
+      , dependencyTags = M.empty
+      }
+  direct $
+    Dependency
+      { dependencyType = PipType
+      , dependencyName = "pkgTwo"
+      , dependencyVersion = Nothing
+      , dependencyLocations = []
+      , dependencyEnvironments = []
+      , dependencyTags = M.empty
+      }
+  direct $
+    Dependency
+      { dependencyType = PipType
+      , dependencyName = "pkgThree"
+      , dependencyVersion = Just (CURI "https://example.com")
+      , dependencyLocations = []
+      , dependencyEnvironments = []
+      , dependencyTags = M.empty
+      }
 
 spec :: Spec
 spec =

--- a/test/RPM/SpecFileSpec.hs
+++ b/test/RPM/SpecFileSpec.hs
@@ -1,15 +1,14 @@
-module RPM.SpecFileSpec
-  ( spec,
-  )
-where
+module RPM.SpecFileSpec (
+  spec,
+) where
 
 import Data.Maybe (listToMaybe)
 import Data.Text (Text)
-import qualified Data.Text.IO as TIO
+import Data.Text.IO qualified as TIO
 import DepTypes
 import GraphUtil
 import Strategy.RPM
-import qualified Test.Hspec as Test
+import Test.Hspec qualified as Test
 
 mkUnVerDep :: Text -> RPMDependency
 mkUnVerDep name = RPMDependency name Nothing
@@ -52,16 +51,16 @@ tacpDep = mkUnVerDep "tacp"
 
 buildDeps :: [RPMDependency]
 buildDeps =
-  [ boostDep,
-    cmakeDep,
-    jsoncppDep,
-    gtestDep,
-    libeventDep,
-    libvirtDep,
-    opensslDep,
-    libxml2Dep,
-    xzDep,
-    gmockDep
+  [ boostDep
+  , cmakeDep
+  , jsoncppDep
+  , gtestDep
+  , libeventDep
+  , libvirtDep
+  , opensslDep
+  , libxml2Dep
+  , xzDep
+  , gmockDep
   ]
 
 spec :: Test.Spec
@@ -73,11 +72,11 @@ spec = do
       depBuildRequires deps `Test.shouldMatchList` buildDeps
       listToMaybe (depRuntimeRequires deps) `Test.shouldBe` Just tacpDep
   --
-  Test.describe "line parser"
-    $ Test.it "should parse single lines correctly"
-    $ do
-      getTypeFromLine "BuildRequires: xz = 1" `Test.shouldBe` Just (BuildRequires $ mkVerDep "xz" $ CEq "1")
-      getTypeFromLine "Requires: xz = 1" `Test.shouldBe` Just (RuntimeRequires $ mkVerDep "xz" $ CEq "1")
+  Test.describe "line parser" $
+    Test.it "should parse single lines correctly" $
+      do
+        getTypeFromLine "BuildRequires: xz = 1" `Test.shouldBe` Just (BuildRequires $ mkVerDep "xz" $ CEq "1")
+        getTypeFromLine "Requires: xz = 1" `Test.shouldBe` Just (RuntimeRequires $ mkVerDep "xz" $ CEq "1")
   --
   Test.describe "rpm dependency grapher" $
     Test.it "should produce flat RuntimeRequires" $ do

--- a/test/Ruby/BundleShowSpec.hs
+++ b/test/Ruby/BundleShowSpec.hs
@@ -1,9 +1,9 @@
-module Ruby.BundleShowSpec
-  ( spec
-  ) where
+module Ruby.BundleShowSpec (
+  spec,
+) where
 
-import qualified Data.Map.Strict as M
-import qualified Data.Text.IO as TIO
+import Data.Map.Strict qualified as M
+import Data.Text.IO qualified as TIO
 import Text.Megaparsec
 
 import DepTypes
@@ -15,31 +15,35 @@ import Test.Hspec
 
 expected :: Graphing Dependency
 expected = run . evalGrapher $ do
-  direct $ Dependency { dependencyType = GemType
-                      , dependencyName = "pkgOne"
-                      , dependencyVersion = Just (CEq "1.0.0")
-                      , dependencyLocations = []
-                      , dependencyEnvironments = []
-                      , dependencyTags = M.empty
-                      }
-  direct $ Dependency { dependencyType = GemType
-                      , dependencyName = "pkgTwo"
-                      , dependencyVersion = Just (CEq "2.0.0")
-                      , dependencyLocations = []
-                      , dependencyEnvironments = []
-                      , dependencyTags = M.empty
-                      }
+  direct $
+    Dependency
+      { dependencyType = GemType
+      , dependencyName = "pkgOne"
+      , dependencyVersion = Just (CEq "1.0.0")
+      , dependencyLocations = []
+      , dependencyEnvironments = []
+      , dependencyTags = M.empty
+      }
+  direct $
+    Dependency
+      { dependencyType = GemType
+      , dependencyName = "pkgTwo"
+      , dependencyVersion = Just (CEq "2.0.0")
+      , dependencyLocations = []
+      , dependencyEnvironments = []
+      , dependencyTags = M.empty
+      }
 
 bundleShowOutput :: [BundleShowDep]
 bundleShowOutput =
   [ BundleShowDep
-    { depName = "pkgOne"
-    , depVersion = "1.0.0"
-    }
+      { depName = "pkgOne"
+      , depVersion = "1.0.0"
+      }
   , BundleShowDep
-    { depName = "pkgTwo"
-    , depVersion = "2.0.0"
-    }
+      { depName = "pkgTwo"
+      , depVersion = "2.0.0"
+      }
   ]
 
 spec :: Spec

--- a/test/Ruby/GemfileLockSpec.hs
+++ b/test/Ruby/GemfileLockSpec.hs
@@ -1,69 +1,89 @@
-module Ruby.GemfileLockSpec
-  ( spec
-  ) where
+module Ruby.GemfileLockSpec (
+  spec,
+) where
 
-import qualified Data.Map.Strict as M
-import qualified Data.Text.IO as TIO
+import Data.Map.Strict qualified as M
+import Data.Text.IO qualified as TIO
 import DepTypes
 import GraphUtil
 import Strategy.Ruby.GemfileLock
-import qualified Test.Hspec as T
+import Test.Hspec qualified as T
 import Text.Megaparsec
 
 dependencyOne :: Dependency
-dependencyOne = Dependency { dependencyType = GemType
-                        , dependencyName = "dep-one"
-                        , dependencyVersion = Just (CEq "1.0.0")
-                        , dependencyLocations = ["temp@12345"]
-                        , dependencyEnvironments = []
-                        , dependencyTags = M.empty
-                        }
+dependencyOne =
+  Dependency
+    { dependencyType = GemType
+    , dependencyName = "dep-one"
+    , dependencyVersion = Just (CEq "1.0.0")
+    , dependencyLocations = ["temp@12345"]
+    , dependencyEnvironments = []
+    , dependencyTags = M.empty
+    }
 
 dependencyTwo :: Dependency
-dependencyTwo = Dependency { dependencyType = GemType
-                        , dependencyName = "dep-two"
-                        , dependencyVersion = Just (CEq "2.0.0")
-                        , dependencyLocations = ["remote"]
-                        , dependencyEnvironments = []
-                        , dependencyTags = M.empty
-                        }
+dependencyTwo =
+  Dependency
+    { dependencyType = GemType
+    , dependencyName = "dep-two"
+    , dependencyVersion = Just (CEq "2.0.0")
+    , dependencyLocations = ["remote"]
+    , dependencyEnvironments = []
+    , dependencyTags = M.empty
+    }
 
 dependencyThree :: Dependency
-dependencyThree = Dependency { dependencyType = GemType
-                        , dependencyName = "dep-three"
-                        , dependencyVersion = Just (CEq "3.0.0")
-                        , dependencyLocations = ["remote"]
-                        , dependencyEnvironments = []
-                        , dependencyTags = M.empty
-                        }
+dependencyThree =
+  Dependency
+    { dependencyType = GemType
+    , dependencyName = "dep-three"
+    , dependencyVersion = Just (CEq "3.0.0")
+    , dependencyLocations = ["remote"]
+    , dependencyEnvironments = []
+    , dependencyTags = M.empty
+    }
 
 gitSection :: Section
-gitSection = GitSection "temp" (Just "12345") (Just "branch") [ Spec { specVersion = "1.0.0"
-                                                , specName = "dep-one"
-                                                , specDeps = [ SpecDep { depName = "dep-three" }
-                                                            , SpecDep { depName = "dep-two"}
-                                                            ]
-                                                }
-                                             ]
+gitSection =
+  GitSection
+    "temp"
+    (Just "12345")
+    (Just "branch")
+    [ Spec
+        { specVersion = "1.0.0"
+        , specName = "dep-one"
+        , specDeps =
+            [ SpecDep{depName = "dep-three"}
+            , SpecDep{depName = "dep-two"}
+            ]
+        }
+    ]
 
 gemSection :: Section
-gemSection = GemSection "remote" [ Spec { specVersion = "2.0.0"
-                                        , specName = "dep-two"
-                                        , specDeps = [ SpecDep { depName = "dep-three" } ]
-                                        }
-                                 , Spec { specVersion = "3.0.0"
-                                        , specName = "dep-three"
-                                        , specDeps = []
-                                        }
-                                 ]
+gemSection =
+  GemSection
+    "remote"
+    [ Spec
+        { specVersion = "2.0.0"
+        , specName = "dep-two"
+        , specDeps = [SpecDep{depName = "dep-three"}]
+        }
+    , Spec
+        { specVersion = "3.0.0"
+        , specName = "dep-three"
+        , specDeps = []
+        }
+    ]
 
 dependencySection :: Section
-dependencySection = DependencySection [ DirectDep { directName = "dep-one" }
-                                      , DirectDep { directName = "dep-two" }
-                                      ]
+dependencySection =
+  DependencySection
+    [ DirectDep{directName = "dep-one"}
+    , DirectDep{directName = "dep-two"}
+    ]
 
 gemfileLockSection :: [Section]
-gemfileLockSection = [gitSection , gemSection, dependencySection]
+gemfileLockSection = [gitSection, gemSection, dependencySection]
 
 spec :: T.Spec
 spec = do
@@ -75,16 +95,18 @@ spec = do
 
       expectDeps [dependencyOne, dependencyTwo, dependencyThree] graph
       expectDirect [dependencyOne, dependencyTwo] graph
-      expectEdges [ (dependencyOne, dependencyTwo)
-                  , (dependencyOne, dependencyThree)
-                  , (dependencyTwo, dependencyThree)
-                  ] graph
+      expectEdges
+        [ (dependencyOne, dependencyTwo)
+        , (dependencyOne, dependencyThree)
+        , (dependencyTwo, dependencyThree)
+        ]
+        graph
 
   T.describe "gemfile lock parser" $ do
     T.it "parses error messages into an empty list" $ do
       case runParser findSections "" gemfileLock of
         Left _ -> T.expectationFailure "failed to parse"
         Right result -> do
-            result `T.shouldContain` [gitSection]
-            result `T.shouldContain` [dependencySection]
-            result `T.shouldContain` [gemSection]
+          result `T.shouldContain` [gitSection]
+          result `T.shouldContain` [dependencySection]
+          result `T.shouldContain` [gemSection]


### PR DESCRIPTION
As a followup to making fourmolu a requirement in https://github.com/fossas/spectrometer/pull/249, this PR runs the formatter over all source files in the project.

The command I ran to do this is:
```
find src test -type f -name '*.hs' -exec fourmolu -m inplace --ghc-opt -XImportQualifiedPost --ghc-opt -XTypeApplications {} \;
```

Importantly, running that command a second time results in no modified files (so running fourmolu on our codebase is guaranteed to be an idempotent operation)