### PR TITLE
Support --branch for container scans

### DIFF
--- a/src/App/Fossa/Container.hs
+++ b/src/App/Fossa/Container.hs
@@ -197,7 +197,7 @@ instance ToJSON ContainerArtifact where
       ]
 
 extractRevision :: OverrideProject -> ContainerScan -> ProjectRevision
-extractRevision OverrideProject{..} ContainerScan{..} = ProjectRevision name revision Nothing
+extractRevision OverrideProject{..} ContainerScan{..} = ProjectRevision name revision overrideBranch
   where
     name = fromMaybe imageTag overrideName
     revision = fromMaybe imageDigest overrideRevision

--- a/src/App/Fossa/Container/Analyze.hs
+++ b/src/App/Fossa/Container/Analyze.hs
@@ -7,18 +7,19 @@ import App.Fossa.Analyze (ScanDestination (..))
 import App.Fossa.Container (ImageText (..), extractRevision, runSyft, toContainerScan)
 import App.Fossa.FossaAPIV1 (UploadResponse (uploadError, uploadLocator), uploadContainerScan)
 import App.Types (OverrideProject (..), ProjectRevision (..))
-import Control.Carrier.Diagnostics
-    ( renderFailureBundle,
-      Diagnostics,
-      runDiagnostics )
+import Control.Carrier.Diagnostics (
+  Diagnostics,
+  renderFailureBundle,
+  runDiagnostics,
+ )
 import Control.Effect.Lift (Lift)
 import Control.Monad.IO.Class (MonadIO)
 import Data.Aeson
 import Data.Foldable (traverse_)
+import Data.Maybe (fromMaybe)
 import Data.String.Conversion (decodeUtf8)
 import Effect.Logger
 import Srclib.Types (parseLocator)
-import Data.Maybe (fromMaybe)
 
 analyzeMain :: ScanDestination -> Severity -> OverrideProject -> ImageText -> IO ()
 analyzeMain scanDestination logSeverity override image = withDefaultLogger logSeverity $ do

--- a/src/App/Fossa/Container/Analyze.hs
+++ b/src/App/Fossa/Container/Analyze.hs
@@ -8,6 +8,9 @@ import App.Fossa.Container (ImageText (..), extractRevision, runSyft, toContaine
 import App.Fossa.FossaAPIV1 (UploadResponse (uploadError, uploadLocator), uploadContainerScan)
 import App.Types (OverrideProject (..), ProjectRevision (..))
 import Control.Carrier.Diagnostics
+    ( renderFailureBundle,
+      Diagnostics,
+      runDiagnostics )
 import Control.Effect.Lift (Lift)
 import Control.Monad.IO.Class (MonadIO)
 import Data.Aeson
@@ -15,6 +18,7 @@ import Data.Foldable (traverse_)
 import Data.String.Conversion (decodeUtf8)
 import Effect.Logger
 import Srclib.Types (parseLocator)
+import Data.Maybe (fromMaybe)
 
 analyzeMain :: ScanDestination -> Severity -> OverrideProject -> ImageText -> IO ()
 analyzeMain scanDestination logSeverity override image = withDefaultLogger logSeverity $ do
@@ -42,6 +46,8 @@ analyze scanDestination override image = do
       let revision = extractRevision override containerScan
       logInfo ("Using project name: `" <> pretty (projectName revision) <> "`")
       logInfo ("Using project revision: `" <> pretty (projectRevision revision) <> "`")
+      let branchText = fromMaybe "No branch (detached HEAD)" $ projectBranch revision
+      logInfo ("Using branch: `" <> pretty branchText <> "`")
 
       resp <- uploadContainerScan apiOpts revision projectMeta containerScan
 

--- a/src/App/Fossa/FossaAPIV1.hs
+++ b/src/App/Fossa/FossaAPIV1.hs
@@ -130,6 +130,7 @@ uploadContainerScan apiOpts ProjectRevision{..} metadata scan = fossaReq $ do
         "locator" =: locator
           <> "cliVersion" =: cliVersion
           <> "managedBuild" =: True
+          <> maybe mempty ("branch" =:) projectBranch
           <> mkMetadataOpts metadata projectName
   resp <- req POST (containerUploadUrl baseUrl) (ReqBodyJson scan) jsonResponse (baseOpts <> opts)
   pure $ responseBody resp

--- a/src/App/Fossa/Main.hs
+++ b/src/App/Fossa/Main.hs
@@ -150,10 +150,11 @@ appMain = do
           if containerAnalyzeOutput
             then ContainerAnalyze.analyzeMain OutputStdout logSeverity override containerAnalyzeImage
             else do
+              let containerOverride = override {overrideBranch = containerBranch <|> ((fileConfig >>= configRevision) >>= configBranch)}
               apikey <- requireKey maybeApiKey
               let apiOpts = ApiOpts optBaseUrl apikey
               let metadata = maybe containerMetadata (mergeFileCmdMetadata containerMetadata) fileConfig
-              ContainerAnalyze.analyzeMain (UploadScan apiOpts metadata) logSeverity override containerAnalyzeImage
+              ContainerAnalyze.analyzeMain (UploadScan apiOpts metadata) logSeverity containerOverride containerAnalyzeImage
         ContainerTest ContainerTestOptions{..} -> do
           apikey <- requireKey maybeApiKey
           let apiOpts = ApiOpts optBaseUrl apikey
@@ -441,6 +442,7 @@ containerAnalyzeOpts :: Parser ContainerAnalyzeOptions
 containerAnalyzeOpts =
   ContainerAnalyzeOptions
     <$> switch (long "output" <> short 'o' <> help "Output results to stdout instead of uploading to fossa")
+    <*> optional (strOption (long "branch" <> help "this repository's current branch (default: current VCS branch)"))
     <*> metadataOpts
     <*> imageTextArg
 
@@ -559,6 +561,7 @@ data ContainerCommand
 
 data ContainerAnalyzeOptions = ContainerAnalyzeOptions
   { containerAnalyzeOutput :: Bool
+  , containerBranch :: Maybe Text
   , containerMetadata :: ProjectMetadata
   , containerAnalyzeImage :: ImageText
   }

--- a/src/App/Fossa/Main.hs
+++ b/src/App/Fossa/Main.hs
@@ -150,7 +150,7 @@ appMain = do
           if containerAnalyzeOutput
             then ContainerAnalyze.analyzeMain OutputStdout logSeverity override containerAnalyzeImage
             else do
-              let containerOverride = override {overrideBranch = containerBranch <|> ((fileConfig >>= configRevision) >>= configBranch)}
+              let containerOverride = override{overrideBranch = containerBranch <|> ((fileConfig >>= configRevision) >>= configBranch)}
               apikey <- requireKey maybeApiKey
               let apiOpts = ApiOpts optBaseUrl apikey
               let metadata = maybe containerMetadata (mergeFileCmdMetadata containerMetadata) fileConfig


### PR DESCRIPTION
# Overview

We can easily support `--branch` for container scanning, and we received a request to do so.

## Acceptance criteria

Container scans keep working and now support branches other than master

## Risks

None

## Checklist

- [] I added tests for this PR's change.
- [] I linted and formatted (via `haskell-language-server`) any files I touched in this PR.
- [] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [] I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [] I linked this PR to any referenced GitHub issues.
