### PR TITLE
`fossa analyze`: Output project information to stdout

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,26 +1,31 @@
 # Spectrometer Changelog
 
-## 2.9.0
-
+## v2.9.2
 - Adds JSON-formatted project information to the output of `fossa analyze` with `--json` ([#255](https://github.com/fossas/spectrometer/pull/255))
+
+## v2.9.1
+- Bump wiggins - Updated vps aosp-notice-file subcommand to upload ninja files & trigger async task. ([#272](https://github.com/fossas/spectrometer/pull/272))
+
+## v2.9.0
+
 - Fix an issue where stdout doesn't always flush to the console ([#265](https://github.com/fossas/spectrometer/pull/265))
 - Fix an issue when referenced-dependencies are not being uploaded ([#262](https://github.com/fossas/spectrometer/pull/262))
 - Adds support for `fossa-deps.json` ([#261](https://github.com/fossas/spectrometer/pull/261))
 - Adds support for `vendored-dependencies` to be licensed scanned ([#257](https://github.com/fossas/spectrometer/pull/257))
 
-## 2.8.0
+## v2.8.0
 
 - Adds support for `--branch` flag on `fossa container analyze` command ([#253](https://github.com/fossas/spectrometer/pull/253))
 - Adds support and documentation for user-defined dependencies ([#245](https://github.com/fossas/spectrometer/pull/245))
 - Allows using `.yml` or `.yaml` extensions for `fossa-deps` file, but not both ([#245](https://github.com/fossas/spectrometer/pull/245))
 - `fossa-deps` file is checked before running discovery/analysis, and is no longer run in parallel with other analysis functions ([#245](https://github.com/fossas/spectrometer/pull/245))
 
-## 2.7.2
+## v2.7.2
 
 - Updates the VSI Plugin.
 - Adds support for VSI powered dependency discovery as a strategy.
 
-## 2.7.1
+## v2.7.1
 
 - Adds support for Yarn v2 lockfiles ([#244](https://github.com/fossas/spectrometer/pull/244))
 - Fixes the dependency version parser for `.csproj`, `.vbproj`, and similar .NET files ([#247](https://github.com/fossas/spectrometer/pull/247))

--- a/Changelog.md
+++ b/Changelog.md
@@ -13,6 +13,7 @@
 - Adds support and documentation for user-defined dependencies ([#245](https://github.com/fossas/spectrometer/pull/245))
 - Allows using `.yml` or `.yaml` extensions for `fossa-deps` file, but not both ([#245](https://github.com/fossas/spectrometer/pull/245))
 - `fossa-deps` file is checked before running discovery/analysis, and is no longer run in parallel with other analysis functions ([#245](https://github.com/fossas/spectrometer/pull/245))
+- Adds JSON-formatted project information to the output of `fossa analyze` ([#255](https://github.com/fossas/spectrometer/pull/255))
 
 ## 2.7.2
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,7 @@
 
 ## 2.9.0
 
+- Adds JSON-formatted project information to the output of `fossa analyze` with `--json` ([#255](https://github.com/fossas/spectrometer/pull/255))
 - Fix an issue where stdout doesn't always flush to the console ([#265](https://github.com/fossas/spectrometer/pull/265))
 - Fix an issue when referenced-dependencies are not being uploaded ([#262](https://github.com/fossas/spectrometer/pull/262))
 - Adds support for `fossa-deps.json` ([#261](https://github.com/fossas/spectrometer/pull/261))
@@ -13,7 +14,6 @@
 - Adds support and documentation for user-defined dependencies ([#245](https://github.com/fossas/spectrometer/pull/245))
 - Allows using `.yml` or `.yaml` extensions for `fossa-deps` file, but not both ([#245](https://github.com/fossas/spectrometer/pull/245))
 - `fossa-deps` file is checked before running discovery/analysis, and is no longer run in parallel with other analysis functions ([#245](https://github.com/fossas/spectrometer/pull/245))
-- Adds JSON-formatted project information to the output of `fossa analyze` ([#255](https://github.com/fossas/spectrometer/pull/255))
 
 ## 2.7.2
 

--- a/docs/userguide.md
+++ b/docs/userguide.md
@@ -150,6 +150,17 @@ The `--output` flag can be used to print projects and dependency graph informati
 fossa analyze --output
 ```
 
+### Printing project metadata
+
+The `--json` flag can be used to print project metadata after running `fossa analyze` successfully. This metadata can be used to reference your project when integrating with the FOSSA API.
+
+```sh
+fossa analyze --json
+```
+```json
+{"project":{"name":"custom@new-project","branch":"master","revision":"123","url":"https://app.fossa.com/projects/custom+<org-id>/new-project/refs/branch/master/123","locator":"custom+<org-id>/new-project$123"}}
+```
+
 ### Running in a specific directory
 
 ```sh

--- a/docs/userguide.md
+++ b/docs/userguide.md
@@ -158,7 +158,7 @@ The `--json` flag can be used to print project metadata after running `fossa ana
 fossa analyze --json
 ```
 ```json
-{"project":{"name":"custom@new-project","branch":"master","revision":"123","url":"https://app.fossa.com/projects/custom+<org-id>/new-project/refs/branch/master/123","locator":"custom+<org-id>/new-project$123"}}
+{"project":{"name":"custom@new-project","branch":"master","revision":"123","url":"https://app.fossa.com/projects/custom+<org-id>/new-project/refs/branch/master/123","id":"custom+<org-id>/new-project$123"}}
 ```
 
 ### Running in a specific directory

--- a/docs/userguide.md
+++ b/docs/userguide.md
@@ -187,7 +187,7 @@ We support the following archive formats:
 
 FOSSA offers a way to manually upload dependencies provided we support the dependency type. Manually specifying dependencies is very helpful in the event your package manager is unsupported or you are using a custom and nonstandard dependency management solution.
 
-The FOSSA CLI will automatically read `fossa-deps.yml` in the root directory (usually the current working directory) when `fossa analyze` is run and parse dependencies from it.
+The FOSSA CLI will automatically read a `fossa-deps.yml` or a `fossa-deps.json` file in the root directory (usually the current working directory) when `fossa analyze` is run and parse dependencies from it. These dependencies will be added to the dependencies that are normally found when `fossa analyze` is run in the directory.
 
 > Tip: Use a script to generate this file before running `fossa analyze` to keep your results updated.
 
@@ -332,6 +332,7 @@ We also support json-formatted dependencies:
     }
   ]
 }
+```
 
 ## `fossa test`
 

--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -391,7 +391,7 @@ buildProjectSummary project projectLocator projectUrl =
           [ "name" .= projectName project
           , "revision" .= projectRevision project
           , "branch" .= projectBranch project
-          , "locator" .= projectLocator
+          , "id" .= projectLocator
           , "url" .= projectUrl
           ]
     ]

--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -138,8 +138,8 @@ analyzeMain workdir recordMode logSeverity destination project unpackArchives js
       RecordModeRecord -> do
         basedir <- sendIO $ validateDir workdir
         (execLogs, (readFSLogs, ())) <-
-          runRecord @Exec . runRecord @ReadFS 
-          $ doAnalyze basedir
+          runRecord @Exec . runRecord @ReadFS $
+            doAnalyze basedir
         sendIO $ saveReplayLog readFSLogs execLogs "fossa.debug.json"
       RecordModeReplay file -> do
         basedir <- BaseDir <$> P.resolveDir' workdir
@@ -151,8 +151,8 @@ analyzeMain workdir recordMode logSeverity destination project unpackArchives js
             runReplay @ReadFS (effectsReadFS effects)
               . runReplay @Exec (effectsExec effects)
               $ doAnalyze basedir
-    where
-      doAnalyze basedir = analyze basedir destination project unpackArchives jsonOutput enableVSI filters
+  where
+    doAnalyze basedir = analyze basedir destination project unpackArchives jsonOutput enableVSI filters
 
 -- vsiDiscoverFunc is appended to discoverFuncs during analyze.
 -- It's not added to discoverFuncs because it requires more information than other discoverFuncs.
@@ -301,8 +301,8 @@ uploadSuccessfulAnalysis (BaseDir basedir) apiOpts metadata jsonOutput override 
   -- Warn on contributor errors, never fail
   void . Diag.recover . runExecIO $ tryUploadContributors basedir apiOpts (uploadLocator uploadResult)
 
-  if fromFlag JsonOutput jsonOutput 
-    then logStdout . decodeUtf8 . Aeson.encode $ buildProjectSummary revision (uploadLocator uploadResult) buildUrl 
+  if fromFlag JsonOutput jsonOutput
+    then logStdout . decodeUtf8 . Aeson.encode $ buildProjectSummary revision (uploadLocator uploadResult) buildUrl
     else pure ()
 
 data CountedResult
@@ -386,14 +386,11 @@ tryUploadContributors baseDir apiOpts locator = do
 buildProjectSummary :: ProjectRevision -> Text -> Text -> Aeson.Value
 buildProjectSummary project projectLocator projectUrl =
   Aeson.object
-    [ "project"
-        .= Aeson.object
-          [ "name" .= projectName project
-          , "revision" .= projectRevision project
-          , "branch" .= projectBranch project
-          , "id" .= projectLocator
-          , "url" .= projectUrl
-          ]
+    [ "project" .= projectName project
+    , "revision" .= projectRevision project
+    , "branch" .= projectBranch project
+    , "url" .= projectUrl
+    , "id" .= projectLocator
     ]
 
 buildResult :: Maybe SourceUnit -> [ProjectResult] -> Aeson.Value

--- a/src/App/Fossa/Main.hs
+++ b/src/App/Fossa/Main.hs
@@ -4,7 +4,7 @@ module App.Fossa.Main (
   appMain,
 ) where
 
-import App.Fossa.Analyze (RecordMode (..), ScanDestination (..), UnpackArchives (..), PrintMetadata (..), VSIAnalysisMode (..), analyzeMain)
+import App.Fossa.Analyze (RecordMode (..), ScanDestination (..), UnpackArchives (..), JsonOutput (..), VSIAnalysisMode (..), analyzeMain)
 import App.Fossa.Compatibility (Argument, argumentParser, compatibilityMain)
 import App.Fossa.Configuration
 import App.Fossa.Container (ImageText (..), dumpSyftScanMain, imageTextArg, parseSyftOutputMain)
@@ -89,12 +89,12 @@ appMain = do
       -- the preference for command line options.
       let analyzeOverride = override{overrideBranch = analyzeBranch <|> ((fileConfig >>= configRevision) >>= configBranch)}
       if analyzeOutput
-        then analyzeMain analyzeBaseDir analyzeRecordMode logSeverity OutputStdout analyzeOverride analyzeUnpackArchives analyzePrintMetadata analyzeVSIMode analyzeBuildTargetFilters
+        then analyzeMain analyzeBaseDir analyzeRecordMode logSeverity OutputStdout analyzeOverride analyzeUnpackArchives analyzeJsonOutput analyzeVSIMode analyzeBuildTargetFilters
         else do
           key <- requireKey maybeApiKey
           let apiOpts = ApiOpts optBaseUrl key
           let metadata = maybe analyzeMetadata (mergeFileCmdMetadata analyzeMetadata) fileConfig
-          analyzeMain analyzeBaseDir analyzeRecordMode logSeverity (UploadScan apiOpts metadata) analyzeOverride analyzeUnpackArchives analyzePrintMetadata analyzeVSIMode analyzeBuildTargetFilters
+          analyzeMain analyzeBaseDir analyzeRecordMode logSeverity (UploadScan apiOpts metadata) analyzeOverride analyzeUnpackArchives analyzeJsonOutput analyzeVSIMode analyzeBuildTargetFilters
     --
     TestCommand TestOptions{..} -> do
       baseDir <- validateDir testBaseDir
@@ -268,7 +268,7 @@ analyzeOpts =
   AnalyzeOptions
     <$> switch (long "output" <> short 'o' <> help "Output results to stdout instead of uploading to fossa")
     <*> flagOpt UnpackArchives (long "unpack-archives" <> help "Recursively unpack and analyze discovered archives")
-    <*> flagOpt PrintMetadata (long "print-metadata" <> help "Output project metadata. Useful for communicating with the FOSSA API")
+    <*> flagOpt JsonOutput (long "json" <> help "Output project metadata as json to the console. Useful for communicating with the FOSSA API")
     <*> optional (strOption (long "branch" <> help "this repository's current branch (default: current VCS branch)"))
     <*> metadataOpts
     <*> many filterOpt
@@ -510,7 +510,7 @@ data ReportOptions = ReportOptions
 data AnalyzeOptions = AnalyzeOptions
   { analyzeOutput :: Bool
   , analyzeUnpackArchives :: Flag UnpackArchives
-  , analyzePrintMetadata :: Flag PrintMetadata
+  , analyzeJsonOutput :: Flag JsonOutput
   , analyzeBranch :: Maybe Text
   , analyzeMetadata :: ProjectMetadata
   , analyzeBuildTargetFilters :: [BuildTargetFilter]

--- a/src/App/Fossa/Main.hs
+++ b/src/App/Fossa/Main.hs
@@ -88,13 +88,15 @@ appMain = do
       -- The branch override needs to be set here rather than above to preserve
       -- the preference for command line options.
       let analyzeOverride = override{overrideBranch = analyzeBranch <|> ((fileConfig >>= configRevision) >>= configBranch)}
+          doAnalyze destination = analyzeMain analyzeBaseDir analyzeRecordMode logSeverity destination analyzeOverride analyzeUnpackArchives analyzeJsonOutput analyzeVSIMode analyzeBuildTargetFilters
+
       if analyzeOutput
-        then analyzeMain analyzeBaseDir analyzeRecordMode logSeverity OutputStdout analyzeOverride analyzeUnpackArchives analyzeJsonOutput analyzeVSIMode analyzeBuildTargetFilters
+        then doAnalyze OutputStdout 
         else do
           key <- requireKey maybeApiKey
           let apiOpts = ApiOpts optBaseUrl key
           let metadata = maybe analyzeMetadata (mergeFileCmdMetadata analyzeMetadata) fileConfig
-          analyzeMain analyzeBaseDir analyzeRecordMode logSeverity (UploadScan apiOpts metadata) analyzeOverride analyzeUnpackArchives analyzeJsonOutput analyzeVSIMode analyzeBuildTargetFilters
+          doAnalyze (UploadScan apiOpts metadata)
     --
     TestCommand TestOptions{..} -> do
       baseDir <- validateDir testBaseDir


### PR DESCRIPTION
# Overview

`fossa analyze` (in non-`--output` mode) with the `--json` flag outputs project information (revision, project name, fossa url, etc) in a user-friendly textual format.

To make this information programmatically accessible, these changes output the same information to stdout in JSON format:
```json
{"project":{"name":"tmp28","branch":null,"revision":"1623707515","url":"https://app.fossa.com/projects/custom+23784%2ftmp28/refs/branch/master/1623707515","locator":"custom+23784/tmp28$1623707515"}}
```

## Acceptance criteria

Fossa project information is programmatically accessible from the output of `fossa analyze --json`

## Testing plan

Manual testing: to ensure the output is programmatically accessible, pipe the output of `fossa analyze --json` to `jq`. This should succeed without error

## Risks

None -- our other logging takes place on stderr (through our `Logger` effect), and this project information is the only thing being output to stdout

## References

Closes https://github.com/fossas/team-analysis/issues/441