### PR TITLE
Add simpler effect interpreter machinery

### DIFF
--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -36,6 +36,7 @@ common lang
     ImportQualifiedPost
     InstanceSigs
     KindSignatures
+    LambdaCase
     MultiParamTypeClasses
     NamedFieldPuns
     NamedWildCards
@@ -171,6 +172,7 @@ library
     Control.Carrier.Diagnostics.StickyContext
     Control.Carrier.Finally
     Control.Carrier.Output.IO
+    Control.Carrier.Simple
     Control.Carrier.StickyLogger
     Control.Carrier.TaskPool
     Control.Carrier.Threaded

--- a/src/App/Fossa/Analyze/GraphBuilder.hs
+++ b/src/App/Fossa/Analyze/GraphBuilder.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE GADTs #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 -- | Legacy/deprecated GraphBuilder interface. Kept for compatibility with old code
@@ -14,8 +13,8 @@ module App.Fossa.Analyze.GraphBuilder (
 
 import App.Fossa.Analyze.Graph qualified as G
 import Control.Algebra
+import Control.Carrier.Simple
 import Control.Carrier.State.Strict
-import Control.Monad.IO.Class (MonadIO)
 import Data.Kind (Type)
 import DepTypes
 
@@ -36,18 +35,13 @@ addEdge parent child = send (AddEdge parent child)
 addDirect :: Has GraphBuilder sig m => G.DepRef -> m ()
 addDirect direct = send (AddDirect direct)
 
-runGraphBuilder :: G.Graph -> GraphBuilderC m a -> m (G.Graph, a)
-runGraphBuilder start = runState start . runGraphBuilderC
+type GraphBuilderC m = SimpleStateC G.Graph GraphBuilder m
 
-evalGraphBuilder :: Functor m => G.Graph -> GraphBuilderC m a -> m G.Graph
-evalGraphBuilder start = execState start . runGraphBuilderC
+runGraphBuilder :: Algebra sig m => G.Graph -> GraphBuilderC m a -> m (G.Graph, a)
+runGraphBuilder start = interpretState start $ \case
+  AddNode dep -> state (G.addNode dep)
+  AddEdge parent child -> modify (G.addEdge parent child)
+  AddDirect dep -> modify (G.addDirect dep)
 
-newtype GraphBuilderC m a = GraphBuilderC {runGraphBuilderC :: StateC G.Graph m a}
-  deriving (Functor, Applicative, Monad, MonadIO)
-
-instance Algebra sig m => Algebra (GraphBuilder :+: sig) (GraphBuilderC m) where
-  alg hdl sig ctx = GraphBuilderC $ case sig of
-    R other -> alg (runGraphBuilderC . hdl) (R other) ctx
-    L (AddNode dep) -> (<$ ctx) <$> state (G.addNode dep)
-    L (AddEdge parent child) -> (<$ ctx) <$> modify (G.addEdge parent child)
-    L (AddDirect dep) -> (<$ ctx) <$> modify (G.addDirect dep)
+evalGraphBuilder :: Algebra sig m => G.Graph -> GraphBuilderC m a -> m G.Graph
+evalGraphBuilder start = fmap fst . runGraphBuilder start

--- a/src/App/Fossa/Container.hs
+++ b/src/App/Fossa/Container.hs
@@ -39,7 +39,7 @@ import Data.Text (Text, pack)
 import Data.Text.Extra (breakOnAndRemove)
 import Effect.Exec (AllowErr (Never), Command (..), Exec, execJson, execThrow, runExecIO)
 import Effect.Logger
-import Effect.ReadFS (ReadFS, ReadFSIOC (runReadFSIO), readContentsJson, resolveFile)
+import Effect.ReadFS (ReadFS, runReadFSIO, readContentsJson, resolveFile)
 import Options.Applicative (Parser, argument, help, metavar, str)
 import Path (Dir, Rel, reldir, toFilePath)
 import Path.IO (getCurrentDir)

--- a/src/App/Fossa/FossaAPIV1.hs
+++ b/src/App/Fossa/FossaAPIV1.hs
@@ -1,6 +1,4 @@
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE UndecidableInstances #-}
 

--- a/src/App/Fossa/ProjectInference.hs
+++ b/src/App/Fossa/ProjectInference.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TemplateHaskell #-}

--- a/src/App/Fossa/VPS/NinjaGraph.hs
+++ b/src/App/Fossa/VPS/NinjaGraph.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE RecordWildCards #-}
 
 module App.Fossa.VPS.NinjaGraph (

--- a/src/Control/Carrier/Output/IO.hs
+++ b/src/Control/Carrier/Output/IO.hs
@@ -1,35 +1,27 @@
 {-# LANGUAGE GADTs #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Control.Carrier.Output.IO (
-  OutputC (..),
+  OutputC,
   runOutput,
   module X,
 ) where
 
-import Control.Applicative (Alternative)
 import Control.Carrier.Reader
+import Control.Carrier.Simple
 import Control.Effect.Lift (Lift, sendIO)
 import Control.Effect.Output as X
-import Control.Monad.IO.Class
-import Control.Monad.Trans (MonadTrans)
 import Data.IORef
+
+type OutputC o = SimpleC (Output o)
 
 runOutput :: forall o sig m a. Has (Lift IO) sig m => OutputC o m a -> m ([o], a)
 runOutput act = do
   ref <- sendIO $ newIORef []
-  res <- runReader ref (runOutputC act)
+  res <- runOutputRef ref act
   outputs <- sendIO $ readIORef ref
   pure (outputs, res)
 
-newtype OutputC o m a = OutputC {runOutputC :: ReaderC (IORef [o]) m a}
-  deriving (Functor, Applicative, Alternative, Monad, MonadIO, MonadFail, MonadTrans)
-
-instance Has (Lift IO) sig m => Algebra (Output o :+: sig) (OutputC o m) where
-  alg hdl sig ctx = OutputC $ case sig of
-    L (Output o) -> do
-      ref <- ask
-      sendIO (atomicModifyIORef' ref (\xs -> (o : xs, ())))
-      pure ctx
-    R other -> alg (runOutputC . hdl) (R other) ctx
+runOutputRef :: Has (Lift IO) sig m => IORef [o] -> OutputC o m a -> m a
+runOutputRef ref = interpret $ \case
+  Output o -> sendIO (atomicModifyIORef' ref (\xs -> (o : xs, ())))

--- a/src/Control/Carrier/Simple.hs
+++ b/src/Control/Carrier/Simple.hs
@@ -1,7 +1,115 @@
 {-# LANGUAGE UndecidableInstances #-}
 
+-- | A friendlier interface for implementing effects
+--
+-- Creating effects and effect handlers ("carriers") is intimidating and
+-- needlessly complex for most effect types. This module (mostly) solves that
+-- problem.
+--
+-- = Defining effects
+--
+-- == Datatype
+--
+-- Effects are defined with a datatype describing its operations. For example, a
+-- datatype for filesystem read/write operations could look like this:
+--
+-- @
+--     data Filesystem m a where
+--       ReadFile :: FilePath -> Filesystem m String
+--       WriteFile :: FilePath -> String -> Filesystem m ()
+-- @
+--
+-- The @m@ in this type can be ignored; it's used only in complex effects.
+--
+-- @ReadFile@ and @WriteFile@ are data constructors for @Filesystem@. They
+-- describe the arguments and "result types" of each operation:
+--
+-- @
+--     -- When reading a file, a string is returned
+--     example1 :: Filesystem m String
+--     example1 = ReadFile "/path/to/file"
+--
+--     -- When writing to a file, nothing is returned
+--     example2 :: Filesystem m ()
+--     example2 = WriteFile "/path/to/file" "content"
+-- @
+--
+-- == Effect functions
+--
+-- 'Control.Algebra.send' is used to "invoke" effect operations:
+--
+-- @
+--     example3 :: Has Filesystem sig m => m String
+--     example3 = send (ReadFile "/path/to/file")
+--
+--     example4 :: Has Filesystem sig m => String -> m ()
+--     example4 content = send (WriteFile "/path/to/file" content)
+-- @
+--
+-- To make using your effect easier, create a helper function for each effect operation:
+-- @
+--     data Filesystem m a where
+--       ReadFile :: FilePath -> Filesystem m String
+--       WriteFile :: FilePath -> String -> Filesystem m ()
+--
+--     readFile :: Has Filesystem sig m => FilePath -> m String
+--     readFile file = send (ReadFile file)
+--
+--     writeFile :: Has Filesystem sig m => FilePath -> String -> m ()
+--     writeFile file content = send (WriteFile file content)
+-- @
+--
+-- Users can compose these functions to easily use your effect:
+-- @
+--     addNewlineToEndOfFile :: Has Filesystem sig m => FilePath -> m ()
+--     addNewlineToEndOfFile file = do
+--       content <- readFile file
+--       writeFile file (content ++ "\n")
+-- @
+--
+-- == Interpreting effects
+--
+-- To "run" an effect, we need to supply an interpreter. An interpreter tells us
+-- how to turn our effect calls (which are pure datatypes) into effectful
+-- actions.
+--
+-- Most commonly, we can do this with 'interpret':
+--
+-- @
+--     type FilesystemC = SimpleC Filesystem
+--
+--     runFilesystemIO :: Has (Lift IO) sig m => FilesystemC m a -> m a
+--     runFilesystemIO = interpret $ \case
+--       ReadFile file -> sendIO (Prelude.readFile file)
+--       WriteFile file content -> sendIO (Prelude.writeFile file content)
+--
+--     runFilesystemDumb :: Algebra sig m => FilesystemC m a -> m a
+--     runFilesystemDumb = interpret $ \case
+--       ReadFile _ -> pure "content!"
+--       WriteFile _ _ -> pure ()
+-- @
+--
+-- Here we define two interpreters: one that uses @IO@ actions, and another that
+-- doesn't do much of anything.
+--
+-- The function we pass to @interpret@ tells us how to handle each effect call.
+--
+-- @
+--     -- does the thing!
+--     example5 :: IO ()
+--     example5 = runM $ runFilesystemIO (addNewlineToEndOfFile "/path/to/file")
+--
+--     -- does nothing
+--     example6 :: ()
+--     example6 = run $ runFilesystemDumb (addNewlineToEndOfFile "/path/to/file")
+--
+--     -- "content!"
+--     example7 :: String
+--     example7 = run $ runFilesystemDumb (readFile "/path/to/file")
+-- @
 module Control.Carrier.Simple (
   SimpleC (..),
+  SimpleStateC,
   interpret,
   interpretState,
   module X,
@@ -10,44 +118,48 @@ module Control.Carrier.Simple (
 import Control.Algebra as X
 import Control.Applicative
 import Control.Carrier.Reader
+import Control.Carrier.State.Strict
 import Control.Monad.Trans
 import Data.Kind (Type)
 import Unsafe.Coerce (unsafeCoerce)
-import Control.Carrier.State.Strict
 
-newtype SimpleC (eff :: (Type -> Type) -> Type -> Type) m a = SimpleC {runSimpleC :: ReaderC (HandlerFor eff m) m a}
-  deriving (Functor, Applicative, Alternative, Monad, MonadFail, MonadIO)
+---------- Direct interpretation
 
-withReaderC :: (r' -> r) -> ReaderC r m a -> ReaderC r' m a
-withReaderC f act = ReaderC $ \r -> runReader (f r) act
-
-hoistReaderC :: (forall x. m x -> n x) -> ReaderC r m a -> ReaderC r n a
-hoistReaderC f = undefined
-
-instance MonadTrans (SimpleC eff) where
-  lift = SimpleC . lift
-
+-- | Given a function to turn effect calls @eff a@ into actions @m a@, interpret effect calls for @eff@
 interpret :: (forall x. eff Unused x -> m x) -> SimpleC eff m a -> m a
 interpret f = runReader (HandlerFor f) . runSimpleC
 
-interpretState :: Monad m => s -> (forall a. eff Unused a -> StateC s m a) -> SimpleC eff m b -> m (s,b)
-interpretState s f = undefined -- runState s . interpret f . hoistSimple lift
+---------- Stateful interpretation
 
-data Unused (a :: Type)
+-- | A convenient type alias for defining interpreters that need access to a state value
+type SimpleStateC s eff m = SimpleC eff (StateC s m)
 
+-- | A wrapper for 'interpret' that gives access to a state value ('get', 'put', 'modify', etc)
+interpretState :: s -> (forall a. eff Unused a -> StateC s m a) -> SimpleC eff (StateC s m) b -> m (s, b)
+interpretState s f = runState s . interpret f
+
+---------- Internals
+
+-- | A carrier for arbitrary "first-order" effects (i.e. those that don't use
+-- the @m@ in @data MyEffect m a@)
+newtype SimpleC (eff :: (Type -> Type) -> Type -> Type) m a = SimpleC {runSimpleC :: ReaderC (HandlerFor eff m) m a}
+  deriving (Functor, Applicative, Alternative, Monad, MonadFail, MonadIO)
+
+-- | A wrapper for an effect handler function
 data HandlerFor (eff :: (Type -> Type) -> Type -> Type) m where
   HandlerFor :: (eff Unused a -> m a) -> HandlerFor eff m
 
-hoistHandler :: (forall x. m x -> n x) -> HandlerFor eff m -> HandlerFor eff n
-hoistHandler f (HandlerFor g) = HandlerFor (f . g)
+-- | Like 'Data.Void.Void', but with kind @Type -> Type@
+data Unused (a :: Type)
 
--- HandlerFor eff m -> m a
+instance MonadTrans (SimpleC eff) where
+  lift = SimpleC . lift
 
 instance Algebra sig m => Algebra (eff :+: sig) (SimpleC eff m) where
   alg hdl sig ctx = SimpleC $ do
     case sig of
       L ours -> do
         HandlerFor g <- ask @(HandlerFor eff m)
-        res <- lift $ g (unsafeCoerce ours)
-        pure (unsafeCoerce res <$ ctx)
+        res <- lift $ unsafeCoerce g ours
+        pure (res <$ ctx)
       R other -> alg (runSimpleC . hdl) (R other) ctx

--- a/src/Control/Carrier/Simple.hs
+++ b/src/Control/Carrier/Simple.hs
@@ -1,0 +1,53 @@
+{-# LANGUAGE UndecidableInstances #-}
+
+module Control.Carrier.Simple (
+  SimpleC (..),
+  interpret,
+  interpretState,
+  module X,
+) where
+
+import Control.Algebra as X
+import Control.Applicative
+import Control.Carrier.Reader
+import Control.Monad.Trans
+import Data.Kind (Type)
+import Unsafe.Coerce (unsafeCoerce)
+import Control.Carrier.State.Strict
+
+newtype SimpleC (eff :: (Type -> Type) -> Type -> Type) m a = SimpleC {runSimpleC :: ReaderC (HandlerFor eff m) m a}
+  deriving (Functor, Applicative, Alternative, Monad, MonadFail, MonadIO)
+
+withReaderC :: (r' -> r) -> ReaderC r m a -> ReaderC r' m a
+withReaderC f act = ReaderC $ \r -> runReader (f r) act
+
+hoistReaderC :: (forall x. m x -> n x) -> ReaderC r m a -> ReaderC r n a
+hoistReaderC f = undefined
+
+instance MonadTrans (SimpleC eff) where
+  lift = SimpleC . lift
+
+interpret :: (forall x. eff Unused x -> m x) -> SimpleC eff m a -> m a
+interpret f = runReader (HandlerFor f) . runSimpleC
+
+interpretState :: Monad m => s -> (forall a. eff Unused a -> StateC s m a) -> SimpleC eff m b -> m (s,b)
+interpretState s f = undefined -- runState s . interpret f . hoistSimple lift
+
+data Unused (a :: Type)
+
+data HandlerFor (eff :: (Type -> Type) -> Type -> Type) m where
+  HandlerFor :: (eff Unused a -> m a) -> HandlerFor eff m
+
+hoistHandler :: (forall x. m x -> n x) -> HandlerFor eff m -> HandlerFor eff n
+hoistHandler f (HandlerFor g) = HandlerFor (f . g)
+
+-- HandlerFor eff m -> m a
+
+instance Algebra sig m => Algebra (eff :+: sig) (SimpleC eff m) where
+  alg hdl sig ctx = SimpleC $ do
+    case sig of
+      L ours -> do
+        HandlerFor g <- ask @(HandlerFor eff m)
+        res <- lift $ g (unsafeCoerce ours)
+        pure (unsafeCoerce res <$ ctx)
+      R other -> alg (runSimpleC . hdl) (R other) ctx

--- a/src/Control/Carrier/StickyLogger.hs
+++ b/src/Control/Carrier/StickyLogger.hs
@@ -10,30 +10,25 @@ module Control.Carrier.StickyLogger (
   module X,
 ) where
 
-import Console.Sticky (StickyRegion, setSticky', withStickyRegion)
+import Console.Sticky (setSticky', withStickyRegion)
 import Control.Carrier.Reader
+import Control.Carrier.Simple
 import Control.Effect.Lift (Lift)
 import Control.Effect.StickyLogger as X
-import Control.Monad.IO.Class (MonadIO)
-import Control.Monad.Trans (MonadTrans)
 import Effect.Logger (Logger, Severity)
 
 runStickyLogger ::
-  Has (Lift IO) sig m =>
+  (Has (Lift IO) sig m, Has Logger sig m) =>
   -- | Severity to use for log messages in ansi-incompatible terminals
   Severity ->
   StickyLoggerC m a ->
   m a
 runStickyLogger sev act = withStickyRegion sev $ \region ->
-  runReader region (runStickyLoggerC act)
+  interpret
+    ( \case
+        LogSticky' msg -> do
+          setSticky' region msg
+    )
+    act
 
-newtype StickyLoggerC m a = StickyLoggerC {runStickyLoggerC :: ReaderC StickyRegion m a}
-  deriving (Functor, Applicative, Monad, MonadIO, MonadTrans)
-
-instance (Has (Lift IO) sig m, Has Logger sig m) => Algebra (StickyLogger :+: sig) (StickyLoggerC m) where
-  alg hdl sig ctx = StickyLoggerC $ case sig of
-    L (LogSticky' msg) -> do
-      region <- ask
-      setSticky' region msg
-      pure ctx
-    R other -> alg (runStickyLoggerC . hdl) (R other) ctx
+type StickyLoggerC = SimpleC StickyLogger

--- a/src/Control/Effect/ConsoleRegion.hs
+++ b/src/Control/Effect/ConsoleRegion.hs
@@ -7,6 +7,7 @@ module Control.Effect.ConsoleRegion (
   closeConsoleRegion,
   finishConsoleRegion,
   getConsoleRegion,
+  withConcurrentOutput,
   module X,
 ) where
 
@@ -48,3 +49,8 @@ finishConsoleRegion region value = sendIO . R.liftRegion $ do
 -- | See @"System.Console.Regions".'R.getConsoleRegion'@.
 getConsoleRegion :: (Has (Lift IO) sig m) => R.ConsoleRegion -> m Text
 getConsoleRegion region = sendIO $ R.getConsoleRegion region
+
+-- | See @"System.Console.Concurrent".'C.withConcurrentOutput'
+withConcurrentOutput :: Has (Lift IO) sig m => m a -> m a
+withConcurrentOutput act = liftWith @IO $ \hdl ctx ->
+  C.withConcurrentOutput (hdl (act <$ ctx))

--- a/src/DepTypes.hs
+++ b/src/DepTypes.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE RecordWildCards #-}
 
 module DepTypes (

--- a/src/Fossa/API/Types.hs
+++ b/src/Fossa/API/Types.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE RecordWildCards #-}
 

--- a/src/Parse/XML.hs
+++ b/src/Parse/XML.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE LambdaCase #-}
 
 -- | This modules provides marshalling facilities from XML to datatypes
 --

--- a/src/Srclib/Converter.hs
+++ b/src/Srclib/Converter.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE RecordWildCards #-}
 
 module Srclib.Converter (

--- a/src/Strategy/Go/Types.hs
+++ b/src/Strategy/Go/Types.hs
@@ -34,7 +34,7 @@ mkGolangVersion :: Text -> GolangLabel
 mkGolangVersion = GolangLabelVersion . fixVersion
 
 -- | Monomorphic interpreter for @LabeledGrapher GolangPackage@ into a @Graphing Dependency@
-graphingGolang :: Monad m => LabeledGrapherC GolangPackage GolangLabel m a -> m (Graphing Dependency)
+graphingGolang :: Algebra sig m => LabeledGrapherC GolangPackage GolangLabel m a -> m (Graphing Dependency)
 graphingGolang = withLabeling golangPackageToDependency
 
 golangPackageToDependency :: GolangPackage -> Set GolangLabel -> Dependency

--- a/src/Strategy/Googlesource/RepoManifest.hs
+++ b/src/Strategy/Googlesource/RepoManifest.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}

--- a/src/Strategy/Python/Util.hs
+++ b/src/Strategy/Python/Util.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE LambdaCase #-}
-
 module Strategy.Python.Util (
   requirementParser,
   buildGraph,

--- a/src/Text/URI/Builder.hs
+++ b/src/Text/URI/Builder.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE BlockArguments #-}
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE LambdaCase #-}
 
 module Text.URI.Builder (
   Query (..),

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE RecordWildCards #-}
 
 module Types (


### PR DESCRIPTION
Effects are intimidating to implement and maintain; this makes it easier. Introduces `SimpleC`, `interpret`, `SimpleStateC`, `interpretState`.

See the haddocks in `Control.Carrier.Simple` for details.

This is the effect implemented in the `Control.Carrier.Simple` haddocks:
```hs
----- Effect

data Filesystem m a where
  ReadFile :: FilePath -> Filesystem m String
  WriteFile :: FilePath -> String -> Filesystem m ()

readFile :: Has Filesystem sig m => FilePath -> m String
readFile file = send (ReadFile file)

writeFile :: Has Filesystem sig m => FilePath -> String -> m ()
writeFile file content = send (WriteFile file content)

----- Interpreters

type FilesystemC = SimpleC Filesystem

runFilesystemIO :: Has (Lift IO) sig m => FilesystemC m a -> m a
runFilesystemIO = interpret $ \case
  ReadFile file -> sendIO (Prelude.readFile file)
  WriteFile file content -> sendIO (Prelude.writeFile file content)

runFilesystemDumb :: Algebra sig m => FilesystemC m a -> m a
runFilesystemDumb = interpret $ \case
  ReadFile _ -> pure "content!"
  WriteFile _ _ -> pure ()

----- Examples

addNewlineToEndOfFile :: Has Filesystem sig m => FilePath -> m ()
addNewlineToEndOfFile file = do
  content <- readFile file
  writeFile file (content ++ "\n")

-- does the thing!
example1 :: IO ()
example1 = runM $ runFilesystemIO (addNewlineToEndOfFile "/path/to/file")

-- does nothing
example2 :: ()
example2 = run $ runFilesystemDumb (addNewlineToEndOfFile "/path/to/file")

-- "content!"
example3 :: String
example3 = run $ runFilesystemDumb (readFile "/path/to/file")
```