### PR TITLE
Hlint everything

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -1,1 +1,4 @@
 - arguments: [-XTypeApplications, -XNumericUnderscores]
+# Often, code is more readable with extra parens, or less readable with list comprehensions
+- ignore: {name: "Redundant bracket"}
+- ignore: {name: "Use list comprehension"}

--- a/src/App/Fossa/Main.hs
+++ b/src/App/Fossa/Main.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE RecordWildCards #-}
 
 module App.Fossa.Main (

--- a/src/App/Fossa/VPS/NinjaGraph.hs
+++ b/src/App/Fossa/VPS/NinjaGraph.hs
@@ -63,7 +63,7 @@ ninjaGraphMain apiOpts logSeverity overrideProject NinjaGraphCLIOptions{..} = do
     ninjaGraphInner basedir apiOpts ninjaGraphOpts
 
 ninjaGraphInner :: (Has Logger sig m, Has (Lift IO) sig m, Has Diagnostics sig m) => Path Abs Dir -> ApiOpts -> NinjaGraphOpts -> m ()
-ninjaGraphInner basedir apiOpts ninjaGraphOpts = getAndParseNinjaDeps basedir apiOpts ninjaGraphOpts
+ninjaGraphInner = getAndParseNinjaDeps 
 
 getAndParseNinjaDeps :: (Has Diagnostics sig m, Has (Lift IO) sig m, Has Logger sig m) => Path Abs Dir -> ApiOpts -> NinjaGraphOpts -> m ()
 getAndParseNinjaDeps dir apiOpts ninjaGraphOpts@NinjaGraphOpts{..} = do

--- a/src/Control/Carrier/Diagnostics.hs
+++ b/src/Control/Carrier/Diagnostics.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Control.Carrier.Diagnostics (

--- a/src/Control/Carrier/Output/IO.hs
+++ b/src/Control/Carrier/Output/IO.hs
@@ -30,6 +30,6 @@ instance Has (Lift IO) sig m => Algebra (Output o :+: sig) (OutputC o m) where
   alg hdl sig ctx = OutputC $ case sig of
     L (Output o) -> do
       ref <- ask
-      sendIO (atomicModifyIORef' ref (\xs -> ((o : xs), ())))
+      sendIO (atomicModifyIORef' ref (\xs -> (o : xs, ())))
       pure ctx
     R other -> alg (runOutputC . hdl) (R other) ctx

--- a/src/Control/Carrier/Threaded.hs
+++ b/src/Control/Carrier/Threaded.hs
@@ -11,7 +11,7 @@ import Control.Concurrent.Async qualified as Async
 import Control.Concurrent.STM
 import Control.Effect.Exception
 import Control.Monad.IO.Class
-import Data.Functor (void)
+import Data.Functor (void, ($>))
 import Prelude
 
 data Handle = Handle
@@ -26,7 +26,7 @@ fork m = liftWith @IO $ \hdl ctx -> do
   pure (Handle tid (readTMVar var) <$ ctx)
 
 kill :: Has (Lift IO) sig m => Handle -> m ()
-kill h = liftWith @IO $ \_ ctx -> liftIO (throwTo (handleTid h) Async.AsyncCancelled) *> pure ctx
+kill h = liftWith @IO $ \_ ctx -> liftIO (throwTo (handleTid h) Async.AsyncCancelled) $> ctx
 
 wait :: Has (Lift IO) sig m => Handle -> m ()
-wait h = liftWith @IO $ \_ ctx -> liftIO (atomically (handleWait h)) *> pure ctx
+wait h = liftWith @IO $ \_ ctx -> liftIO (atomically (handleWait h)) $> ctx

--- a/src/Data/Flag.hs
+++ b/src/Data/Flag.hs
@@ -9,7 +9,7 @@ module Data.Flag (
 import Options.Applicative (FlagFields, Mod, Parser, switch)
 
 -- | A Flag datatype with a phantom type argument. See link above for usage
-data Flag a = Flag {getFlag :: Bool}
+newtype Flag a = Flag {getFlag :: Bool}
   deriving (Eq, Ord, Show)
 
 fromFlag :: a -> Flag a -> Bool

--- a/src/Discovery/Filters.hs
+++ b/src/Discovery/Filters.hs
@@ -37,7 +37,7 @@ applyFilters :: [BuildTargetFilter] -> Text -> Path Rel Dir -> Set BuildTarget -
 applyFilters [] _ _ targets = Just targets
 applyFilters filters tool dir targets = do
   let individualResults = mapMaybe (\one -> applyFilter one tool dir targets) filters
-  successful <- NE.nonEmpty $ individualResults
+  successful <- NE.nonEmpty individualResults
 
   pure (sconcat successful)
 

--- a/src/Discovery/Walk.hs
+++ b/src/Discovery/Walk.hs
@@ -66,7 +66,7 @@ walk' ::
   Path Abs Dir ->
   m o
 walk' f base = do
-  foo <- runWriter (\w a -> pure (w, a)) $ walk mangled base
+  foo <- runWriter (curry pure) $ walk mangled base
   pure (fst foo)
   where
     mangled :: Path Abs Dir -> [Path Abs Dir] -> [Path Abs File] -> WriterC o m WalkStep

--- a/src/Effect/Grapher.hs
+++ b/src/Effect/Grapher.hs
@@ -34,6 +34,7 @@ import Control.Algebra as X
 import Control.Carrier.Diagnostics (ToDiagnostic (..))
 import Control.Carrier.State.Strict
 import Control.Monad.IO.Class (MonadIO)
+import Data.Functor (($>))
 import Data.Kind (Type)
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as M
@@ -66,8 +67,8 @@ newtype GrapherC ty m a = GrapherC {runGrapherC :: StateC (G.Graphing ty) m a}
 
 instance (Algebra sig m, Ord ty) => Algebra (Grapher ty :+: sig) (GrapherC ty m) where
   alg hdl sig ctx = GrapherC $ case sig of
-    L (Direct ty) -> modify (G.direct ty) *> pure ctx
-    L (Edge parent child) -> modify (G.edge parent child) *> pure ctx
+    L (Direct ty) -> modify (G.direct ty) $> ctx
+    L (Edge parent child) -> modify (G.edge parent child) $> ctx
     R other -> alg (runGrapherC . hdl) (R other) ctx
 
 ----- Labeling

--- a/src/Parse/XML.hs
+++ b/src/Parse/XML.hs
@@ -101,7 +101,7 @@ newtype Parser a = Parser {unParser :: ReaderC ParsePath (ErrorC ParseError Iden
   deriving (Functor, Applicative, Monad)
 
 instance Alternative Parser where
-  ma <|> mb = Parser $ (unParser ma `catchError` (\(_ :: ParseError) -> unParser mb))
+  ma <|> mb = Parser (unParser ma `catchError` (\(_ :: ParseError) -> unParser mb))
   empty = Parser $ ask >>= \path -> throwError (UnknownError path "Parser.empty")
 
 instance MonadFail Parser where

--- a/src/Strategy/Googlesource/RepoManifest.hs
+++ b/src/Strategy/Googlesource/RepoManifest.hs
@@ -57,7 +57,7 @@ findProjects = walk' $ \_ _ files -> do
         then pure ([RepoManifestProject file], WalkSkipAll)
         else pure ([], WalkContinue)
 
-data RepoManifestProject = RepoManifestProject
+newtype RepoManifestProject = RepoManifestProject
   { repoManifestXml :: Path Abs File
   }
   deriving (Eq, Ord, Show)
@@ -178,7 +178,7 @@ data ManifestProject = ManifestProject
   }
   deriving (Eq, Ord, Show)
 
-data ManifestInclude = ManifestInclude {includeName :: Text} deriving (Eq, Ord, Show)
+newtype ManifestInclude = ManifestInclude {includeName :: Text} deriving (Eq, Ord, Show)
 
 data ValidatedProject = ValidatedProject
   { validatedProjectName :: Text

--- a/src/Strategy/Maven/PluginStrategy.hs
+++ b/src/Strategy/Maven/PluginStrategy.hs
@@ -50,7 +50,7 @@ buildGraph PluginOutput{..} = run $
         , dependencyName = artifactGroupId <> ":" <> artifactArtifactId
         , dependencyVersion = Just (CEq artifactVersion)
         , dependencyLocations = []
-        , dependencyEnvironments = if "test" `elem` artifactScopes then [EnvTesting] else []
+        , dependencyEnvironments = [EnvTesting | "test" `elem` artifactScopes]
         , dependencyTags =
             M.fromList $
               ("scopes", artifactScopes) :

--- a/src/Strategy/Ruby/GemfileLock.hs
+++ b/src/Strategy/Ruby/GemfileLock.hs
@@ -126,10 +126,7 @@ findSections :: Parser [Section]
 findSections = manyTill (try gitSectionParser <|> try gemSectionParser <|> try pathSectionParser <|> try dependenciesSectionParser <|> unknownSection) eof
 
 unknownSection :: Parser Section
-unknownSection = do
-  scn
-  line <- restOfLine
-  pure $ UnknownSection line
+unknownSection = UnknownSection <$ scn <*> restOfLine
 
 restOfLine :: Parser Text
 restOfLine = takeWhileP (Just "ignored") (not . isEndLine)
@@ -227,7 +224,7 @@ specParser = L.indentBlock scn p
     p = do
       name <- findDep
       version <- findVersion
-      return (L.IndentMany Nothing (\specs -> pure $ Spec version name specs) specDepParser)
+      return (L.IndentMany Nothing (pure . Spec version name) specDepParser)
 
 specDepParser :: Parser SpecDep
 specDepParser = do
@@ -258,7 +255,7 @@ dependenciesSectionParser :: Parser Section
 dependenciesSectionParser = L.nonIndented scn $
   L.indentBlock scn $ do
     _ <- chunk "DEPENDENCIES"
-    pure $ L.IndentMany Nothing (\deps -> pure $ DependencySection deps) findDependency
+    pure $ L.IndentMany Nothing (pure . DependencySection) findDependency
 
 findDependency :: Parser DirectDep
 findDependency = do

--- a/test/Go/GoListSpec.hs
+++ b/test/Go/GoListSpec.hs
@@ -23,7 +23,7 @@ import Test.Hspec
 runConstExec :: BL.ByteString -> ConstExecC m a -> m a
 runConstExec output = runReader output . runConstExecC
 
-newtype ConstExecC m a = ConstExecC {runConstExecC :: ReaderC (BL.ByteString) m a}
+newtype ConstExecC m a = ConstExecC {runConstExecC :: ReaderC BL.ByteString m a}
   deriving (Functor, Applicative, Monad)
 
 instance Algebra sig m => Algebra (Exec :+: sig) (ConstExecC m) where

--- a/test/Googlesource/RepoManifestSpec.hs
+++ b/test/Googlesource/RepoManifestSpec.hs
@@ -219,7 +219,7 @@ validatedProjectList = [validatedProjectOne, validatedProjectTwo, validatedProje
 spec :: Spec
 spec = do
   let runIt = runIO . runDiagnostics . runReadFSIO
-  currentDir <- runIO $ getCurrentDir
+  currentDir <- runIO getCurrentDir
   basicManifest <- runIO (TIO.readFile "test/Googlesource/testdata/manifest.xml")
   noDefaultRemoteManifest <- runIO (TIO.readFile "test/Googlesource/testdata/manifest-no-default-remote.xml")
   noDefaultRevisionManifest <- runIO (TIO.readFile "test/Googlesource/testdata/manifest-no-default-revision.xml")

--- a/test/Haskell/CabalSpec.hs
+++ b/test/Haskell/CabalSpec.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE RecordWildCards #-}
-
 module Haskell.CabalSpec (
   spec,
 ) where

--- a/test/Haskell/StackSpec.hs
+++ b/test/Haskell/StackSpec.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE RecordWildCards #-}
-
 module Haskell.StackSpec (
   spec,
 ) where


### PR DESCRIPTION
# Overview

We should keep the code linted at all times.  This PR removes all outstanding lint errors, and updates the config file to ignore the invalid ones.

We are not checking for:
* `Redundant bracket` -> Extra parenthesis can make code easier to read, so we allow it.
  * A good example is when using named infix functions: ```hello darkness `my` old friend``` as opposed to ```(hello darkness) `my` (old friend)```.  With the unnecessary parens, it's a lot easier to immediately understand the groupings.
* `Use list comprehension` -> Some list comprehensions are harder to read than their `if a then b else c` counterparts.
  * Compare `\x -> if x > 0 then [x -2] else []` to hlint's suggestion `\x -> [x -2 | x > 0]`.  Nearly unreadable without an already-ingrained instinct for haskell's list comprehension syntax.

## Acceptance criteria

Code builds, no real semantic changes.

## Risks
If there are any risks, then this is a bad change

## References

Closes fossas/team-analysis#584

## Checklist

- [x] I added tests for this PR's change.
- [x] I linted and formatted (via `haskell-language-server`) any files I touched in this PR.
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] I linked this PR to any referenced GitHub issues.
