### PR TITLE
Support `fossa-deps.json`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Fix an issue when referenced-dependencies are not being uploaded ([#262](https://github.com/fossas/spectrometer/pull/262))
+- Adds support for `fossa-deps.json` ([#261](https://github.com/fossas/spectrometer/pull/261))
 - Adds support for `vendored-dependencies` to be licensed scanned ([#257](https://github.com/fossas/spectrometer/pull/257))
 
 ## 2.8.0

--- a/docs/userguide.md
+++ b/docs/userguide.md
@@ -191,22 +191,6 @@ referenced-dependencies:
   version: 2.1.7
 ```
 
-We also support json-formatted dependencies:
-
-```json
-{
-  "referenced-dependencies": [
-    {
-      "type": "gem",
-      "name": "iron"
-    }, {
-      "type": "pypi",
-      "name": "Django",
-      "version": "2.1.7"
-    }
-  ]
-}
-
 The `name` and `type` fields are required and specify the name of the dependency and where to find it. The `version` field is optional and specifies the preferred version of dependency.
 
 Supported dependency types:
@@ -283,6 +267,7 @@ If you see an error message that isn't clear, file an issue in this repository! 
 Fossa offers the ability to license scan your code directly. This is used primarily if a package manager is not yet supported or if you are vendoring dependencies. Using the license scanning feature will allow you to capture the licenses for dependencies that may otherwise be missed from normal fossa analysis that relies on package manager information.
 
 In order to specify a file path, modify your `fossa-deps.yml` file and add a `vendored-dependencies` section like the following:
+
 ```yml
 # Example full `fossa.deps.yml` file.
 referenced-dependencies:
@@ -296,8 +281,46 @@ vendored-dependencies:
   version: 3.4.16 # revision will be set to the MD5 hash of the filepath if left unspecified.
 ```
 
-
 > Note: License scanning currently operates by uploading the files at the specified path to a secure S3 bucket. All files that do not contain licenses are then removed after 2 weeks.
+
+We also support json-formatted dependencies:
+
+```json
+{
+  "referenced-dependencies": [
+    {
+      "type": "gem",
+      "name": "iron"
+    }, {
+      "type": "pypi",
+      "name": "Django",
+      "version": "2.1.7"
+    }
+  ],
+  "custom-dependencies": [
+    {
+      "name": "foo",
+      "version": "1.2.3",
+      "license": "MIT"
+    }, {
+      "name": "foo-wrapper",
+      "version": "1.0.2",
+      "license": "MIT or Apache-2.0",
+      "description": "Provides a help wrapper for foo-related tasks",
+      "url": "https://foo-project.org/homepage"
+    }
+  ],
+  "vendored-dependencies": [
+    {
+      "name": "lodash",
+      "path": "lodash-4.17.21"
+    }, {
+      "name": "winston",
+      "path": "vendor/winston.tar.gz",
+      "version": "5.0.0-alpha"
+    }
+  ]
+}
 
 ## `fossa test`
 

--- a/docs/userguide.md
+++ b/docs/userguide.md
@@ -191,6 +191,22 @@ referenced-dependencies:
   version: 2.1.7
 ```
 
+We also support json-formatted dependencies:
+
+```json
+{
+  "referenced-dependencies": [
+    {
+      "type": "gem",
+      "name": "iron"
+    }, {
+      "type": "pypi",
+      "name": "Django",
+      "version": "2.1.7"
+    }
+  ]
+}
+
 The `name` and `type` fields are required and specify the name of the dependency and where to find it. The `version` field is optional and specifies the preferred version of dependency.
 
 Supported dependency types:
@@ -210,7 +226,7 @@ Supported dependency types:
 - `cocoapods` - Swift and Objective-C dependencies found at [Cocoapods.org](https://cocoapods.org/).
 - `url` - The URL type allows you to specify only the download location of an archive (e.g.: `.zip`, .`tar.gz`, etc.) in the `name` field and the FOSSA backend will attempt to download and scan it. Example for a github source dependency `https://github.com/fossas/spectrometer/archive/refs/tags/v2.7.2.tar.gz`. The `version` field will be silently ignored for `url` type dependencies.
 
-### User-defined dependencies
+### Custom dependencies
 
 FOSSA supports users that have dependencies that can't be automatically discovered or identified, by offering the ability to define new dependencies.
 

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -143,6 +143,7 @@ library
     App.Fossa.FossaAPIV1
     App.Fossa.ListTargets
     App.Fossa.Main
+    App.Fossa.ManualDeps
     App.Fossa.ProjectInference
     App.Fossa.Report
     App.Fossa.Report.Attribution
@@ -156,7 +157,6 @@ library
     App.Fossa.VPS.Scan.ScotlandYard
     App.Fossa.VPS.Test
     App.Fossa.VPS.Types
-    App.Fossa.YamlDeps
     App.OptionExtensions
     App.Pathfinder.Main
     App.Pathfinder.Scan
@@ -303,7 +303,7 @@ test-suite unit-tests
     App.Fossa.Configuration.ConfigurationSpec
     App.Fossa.Report.AttributionSpec
     App.Fossa.VPS.NinjaGraphSpec
-    App.Fossa.YamlDepsSpec
+    App.Fossa.ManualDepsSpec
     Cargo.MetadataSpec
     Carthage.CarthageSpec
     Clojure.ClojureSpec

--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -14,8 +14,8 @@ import App.Fossa.Analyze.GraphMangler (graphingToGraph)
 import App.Fossa.Analyze.Project (ProjectResult (..), mkResult)
 import App.Fossa.Analyze.Record (AnalyzeEffects (..), AnalyzeJournal (..), loadReplayLog, saveReplayLog)
 import App.Fossa.FossaAPIV1 (UploadResponse (..), uploadAnalysis, uploadContributors)
+import App.Fossa.ManualDeps (analyzeFossaDepsFile)
 import App.Fossa.ProjectInference (inferProjectDefault, inferProjectFromVCS, mergeOverride, saveRevision)
-import App.Fossa.YamlDeps (analyzeFossaDepsYaml)
 import App.Types
 import App.Util (validateDir)
 import Control.Carrier.AtomicCounter (AtomicCounter, runAtomicCounter)
@@ -235,7 +235,7 @@ analyze (BaseDir basedir) destination override unpackArchives enableVSI filters 
         OutputStdout -> Nothing
         UploadScan opts _ -> Just opts
 
-  manualSrcUnits <- analyzeFossaDepsYaml basedir apiOpts
+  manualSrcUnits <- analyzeFossaDepsFile basedir apiOpts
 
   (projectResults, ()) <-
     runOutput @ProjectResult

--- a/src/App/Fossa/ManualDeps.hs
+++ b/src/App/Fossa/ManualDeps.hs
@@ -37,8 +37,8 @@ import Path
 import Srclib.Converter (depTypeToFetcher)
 import Srclib.Types (AdditionalDepData (..), Locator (..), SourceUnit (..), SourceUnitBuild (..), SourceUnitDependency (SourceUnitDependency), SourceUserDefDep (..))
 
-data FoundDepsFile = 
-  ManualYaml (Path Abs File)
+data FoundDepsFile
+  = ManualYaml (Path Abs File)
   | ManualJSON (Path Abs File)
 
 analyzeFossaDepsFile :: (Has Diagnostics sig m, Has ReadFS sig m, Has (Lift IO) sig m) => Path Abs Dir -> Maybe ApiOpts -> m (Maybe SourceUnit)
@@ -59,7 +59,7 @@ findFossaDepsFile root = do
   let ymlFile = root </> $(mkRelFile "fossa-deps.yml")
       yamlFile = root </> $(mkRelFile "fossa-deps.yaml")
       jsonFile = root </> $(mkRelFile "fossa-deps.json")
-      multipleFound = fatalText "Found multiple fossa-deps files.  Only one of ('.json', '.yml', and '.yaml') extensions are allowed" 
+      multipleFound = fatalText "Found multiple fossa-deps files.  Only one of ('.json', '.yml', and '.yaml') extensions are allowed"
   ymlExists <- doesFileExist ymlFile
   yamlExists <- doesFileExist yamlFile
   jsonExists <- doesFileExist jsonFile

--- a/src/App/Fossa/ManualDeps.hs
+++ b/src/App/Fossa/ManualDeps.hs
@@ -75,6 +75,7 @@ findFossaDepsFile root = do
 
 toSourceUnit :: (Has (Lift IO) sig m, Has Diagnostics sig m) => Path Abs Dir -> ManualDependencies -> Maybe ApiOpts -> m SourceUnit
 toSourceUnit root manualDeps@ManualDependencies{..} maybeApiOpts = do
+  -- If the file exists and we have no dependencies to report, that's a failure.
   when (hasNoDeps manualDeps) $ fatalText "No dependencies found in fossa-deps file"
   archiveLocators <- case maybeApiOpts of
     Nothing -> pure $ archiveNoUploadSourceUnit vendoredDependencies

--- a/src/App/Fossa/ManualDeps.hs
+++ b/src/App/Fossa/ManualDeps.hs
@@ -3,12 +3,13 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeApplications #-}
 
-module App.Fossa.YamlDeps (
+module App.Fossa.ManualDeps (
   CustomDependency (..),
   ReferencedDependency (..),
   VendoredDependency (..),
-  YamlDependencies (..),
-  analyzeFossaDepsYaml,
+  ManualDependencies (..),
+  FoundDepsFile (..),
+  analyzeFossaDepsFile,
 ) where
 
 import Control.Effect.Diagnostics (Diagnostics, context, fatalText)
@@ -30,37 +31,51 @@ import Data.List.NonEmpty qualified as NE
 import Data.String.Conversion (toText)
 import Data.Text (Text, unpack)
 import DepTypes (DepType (..))
-import Effect.ReadFS (ReadFS, doesFileExist, readContentsYaml)
+import Effect.ReadFS (ReadFS, doesFileExist, readContentsYaml, readContentsJson)
 import Fossa.API.Types
 import Path
 import Srclib.Converter (depTypeToFetcher)
 import Srclib.Types (AdditionalDepData (..), Locator (..), SourceUnit (..), SourceUnitBuild (..), SourceUnitDependency (SourceUnitDependency), SourceUserDefDep (..))
 
-analyzeFossaDepsYaml :: (Has Diagnostics sig m, Has ReadFS sig m, Has (Lift IO) sig m) => Path Abs Dir -> Maybe ApiOpts -> m (Maybe SourceUnit)
-analyzeFossaDepsYaml root maybeApiOpts = do
+data FoundDepsFile = 
+  ManualYaml (Path Abs File)
+  | ManualJSON (Path Abs File)
+
+analyzeFossaDepsFile :: (Has Diagnostics sig m, Has ReadFS sig m, Has (Lift IO) sig m) => Path Abs Dir -> Maybe ApiOpts -> m (Maybe SourceUnit)
+analyzeFossaDepsFile root maybeApiOpts = do
   maybeDepsFile <- findFossaDepsFile root
   case maybeDepsFile of
     Nothing -> pure Nothing
     Just depsFile -> do
-      yamldeps <- context "Reading fossa-deps file" $ readContentsYaml depsFile
-      context "Converting fossa-deps to partial API payload" $ Just <$> toSourceUnit root yamldeps maybeApiOpts
+      manualDeps <- context "Reading fossa-deps file" $ readFoundDeps depsFile
+      context "Converting fossa-deps to partial API payload" $ Just <$> toSourceUnit root manualDeps maybeApiOpts
 
-findFossaDepsFile :: (Has Diagnostics sig m, Has ReadFS sig m) => Path Abs Dir -> m (Maybe (Path Abs File))
+readFoundDeps :: (Has Diagnostics sig m, Has ReadFS sig m) => FoundDepsFile -> m ManualDependencies
+readFoundDeps (ManualJSON path) = readContentsJson path
+readFoundDeps (ManualYaml path) = readContentsYaml path
+
+findFossaDepsFile :: (Has Diagnostics sig m, Has ReadFS sig m) => Path Abs Dir -> m (Maybe FoundDepsFile)
 findFossaDepsFile root = do
   let ymlFile = root </> $(mkRelFile "fossa-deps.yml")
       yamlFile = root </> $(mkRelFile "fossa-deps.yaml")
+      jsonFile = root </> $(mkRelFile "fossa-deps.json")
+      multipleFound = fatalText "Found multiple fossa-deps files.  Only one of ('.json', '.yml', and '.yaml') extensions are allowed" 
   ymlExists <- doesFileExist ymlFile
   yamlExists <- doesFileExist yamlFile
-  case (ymlExists, yamlExists) of
-    (True, True) -> fatalText "Found '.yml' and '.yaml' files when searching for fossa-deps, only one is permitted if present."
-    (True, False) -> pure $ Just ymlFile
-    (False, True) -> pure $ Just yamlFile
-    (False, False) -> pure Nothing
+  jsonExists <- doesFileExist jsonFile
+  case (ymlExists, yamlExists, jsonExists) of
+    -- Allow 0 or 1 files, not multiple
+    (True, True, _) -> multipleFound
+    (_, True, True) -> multipleFound
+    (True, _, True) -> multipleFound
+    (True, _, _) -> pure $ Just $ ManualYaml ymlFile
+    (_, True, _) -> pure $ Just $ ManualYaml yamlFile
+    (_, _, True) -> pure $ Just $ ManualJSON jsonFile
+    (False, False, False) -> pure Nothing
 
-toSourceUnit :: (Has Diagnostics sig m, Has (Lift IO) sig m) => Path Abs Dir -> YamlDependencies -> Maybe ApiOpts -> m SourceUnit
-toSourceUnit root yamlDeps@YamlDependencies{..} maybeApiOpts = do
-  -- If the file exists and we have no dependencies to report, that's a failure.
-  when (hasNoDeps yamlDeps) $ fatalText "No dependencies found in fossa-deps file"
+toSourceUnit :: (Has (Lift IO) sig m, Has Diagnostics sig m) => Path Abs Dir -> ManualDependencies -> Maybe ApiOpts -> m SourceUnit
+toSourceUnit root manualDeps@ManualDependencies{..} maybeApiOpts = do
+  when (hasNoDeps manualDeps) $ fatalText "No dependencies found in fossa-deps file"
   archiveLocators <- case maybeApiOpts of
     Nothing -> pure $ archiveNoUploadSourceUnit vendoredDependencies
     Just apiOpts -> archiveUploadSourceUnit root apiOpts vendoredDependencies
@@ -110,10 +125,10 @@ toAdditionalData deps = AdditionalDepData{userDefinedDeps = map toSrc $ NE.toLis
         , srcUserDepUrl = customUrl
         }
 
-hasNoDeps :: YamlDependencies -> Bool
-hasNoDeps YamlDependencies{..} = null referencedDependencies && null customDependencies && null vendoredDependencies
+hasNoDeps :: ManualDependencies -> Bool
+hasNoDeps ManualDependencies{..} = null referencedDependencies && null customDependencies && null vendoredDependencies
 
-data YamlDependencies = YamlDependencies
+data ManualDependencies = ManualDependencies
   { referencedDependencies :: [ReferencedDependency]
   , customDependencies :: [CustomDependency]
   , vendoredDependencies :: [VendoredDependency]
@@ -136,9 +151,9 @@ data CustomDependency = CustomDependency
   }
   deriving (Eq, Ord, Show)
 
-instance FromJSON YamlDependencies where
-  parseJSON = withObject "YamlDependencies" $ \obj ->
-    YamlDependencies <$ (obj .:? "version" >>= isMissingOr1)
+instance FromJSON ManualDependencies where
+  parseJSON = withObject "ManualDependencies" $ \obj ->
+    ManualDependencies <$ (obj .:? "version" >>= isMissingOr1)
       <*> (obj .:? "referenced-dependencies" .!= [])
       <*> (obj .:? "custom-dependencies" .!= [])
       <*> (obj .:? "vendored-dependencies" .!= [])

--- a/test/App/Fossa/ManualDepsSpec.hs
+++ b/test/App/Fossa/ManualDepsSpec.hs
@@ -2,14 +2,14 @@ module App.Fossa.ManualDepsSpec (
   spec,
 ) where
 
-import Data.Aeson qualified as Json
 import App.Fossa.ManualDeps (
   CustomDependency (CustomDependency),
-  ReferencedDependency (ReferencedDependency),
   VendoredDependency (VendoredDependency),
   ManualDependencies (ManualDependencies),
+  ReferencedDependency (ReferencedDependency),
  )
 import Control.Effect.Exception (displayException)
+import Data.Aeson qualified as Json
 import Data.ByteString qualified as BS
 import Data.Yaml qualified as Yaml
 import DepTypes (DepType (..))

--- a/test/App/Fossa/ManualDepsSpec.hs
+++ b/test/App/Fossa/ManualDepsSpec.hs
@@ -1,16 +1,17 @@
-module App.Fossa.YamlDepsSpec (
+module App.Fossa.ManualDepsSpec (
   spec,
 ) where
 
-import App.Fossa.YamlDeps (
+import Data.Aeson qualified as Json
+import App.Fossa.ManualDeps (
   CustomDependency (CustomDependency),
   ReferencedDependency (ReferencedDependency),
   VendoredDependency (VendoredDependency),
-  YamlDependencies (YamlDependencies),
+  ManualDependencies (ManualDependencies),
  )
 import Control.Effect.Exception (displayException)
 import Data.ByteString qualified as BS
-import Data.Yaml (decodeEither')
+import Data.Yaml qualified as Yaml
 import DepTypes (DepType (..))
 import Test.Hspec (Expectation, Spec, describe, expectationFailure, it, runIO, shouldBe, shouldContain)
 import Test.Hspec.Core.Spec (SpecM)
@@ -18,8 +19,8 @@ import Test.Hspec.Core.Spec (SpecM)
 getTestDataFile :: String -> SpecM a BS.ByteString
 getTestDataFile name = runIO . BS.readFile $ "test/App/Fossa/testdata/" <> name
 
-theWorks :: YamlDependencies
-theWorks = YamlDependencies references customs vendors
+theWorks :: ManualDependencies
+theWorks = ManualDependencies references customs vendors
   where
     references =
       [ ReferencedDependency "one" GemType Nothing
@@ -35,17 +36,24 @@ theWorks = YamlDependencies references customs vendors
       ]
 
 exceptionContains :: BS.ByteString -> String -> Expectation
-exceptionContains yamlBytes partial = case decodeEither' @YamlDependencies yamlBytes of
+exceptionContains yamlBytes partial = case Yaml.decodeEither' @ManualDependencies yamlBytes of
   -- Ethics issue: right is wrong
   Right _ -> expectationFailure $ "Expected to fail with message containing: " <> partial
   Left exc -> displayException exc `shouldContain` partial
 
 spec :: Spec
-spec =
-  describe "fossa-deps parser" $ do
+spec = do
+  describe "fossa-deps json parser" $ do
+    theWorksBS <- getTestDataFile "the-works.json"
+    it "should parse json correctly" $
+      case Json.eitherDecodeStrict' theWorksBS of
+        Left err -> expectationFailure err
+        Right jsonDeps -> jsonDeps `shouldBe` theWorks
+
+  describe "fossa-deps yaml parser" $ do
     theWorksBS <- getTestDataFile "the-works.yml"
     it "should successfully parse all possible inputs" $
-      case decodeEither' theWorksBS of
+      case Yaml.decodeEither' theWorksBS of
         Left err -> expectationFailure $ displayException err
         Right yamlDeps -> yamlDeps `shouldBe` theWorks
 

--- a/test/App/Fossa/testdata/the-works.json
+++ b/test/App/Fossa/testdata/the-works.json
@@ -1,0 +1,27 @@
+{
+   "referenced-dependencies": [
+      {
+         "name": "one",
+         "type": "gem"
+      },
+      {
+         "type": "url",
+         "name": "two",
+         "version": "1.0.0"
+      }
+   ],
+   "custom-dependencies": [
+      {
+         "name": "hello",
+         "version": "1.2.3",
+         "license": "MIT"
+      },
+      {
+         "name": "full",
+         "version": "3.2.1",
+         "license": "GPL-3.0",
+         "description": "description for full",
+         "url": "we don't validate url's"
+      }
+   ]
+}

--- a/test/App/Fossa/testdata/the-works.json
+++ b/test/App/Fossa/testdata/the-works.json
@@ -23,5 +23,16 @@
          "description": "description for full",
          "url": "we don't validate url's"
       }
+   ],
+   "vendored-dependencies": [
+      {
+         "name": "vendored",
+         "path": "path"
+      },
+      {
+         "name": "versioned",
+         "path": "path/to/dep",
+         "version": "2.1.0"
+      }
    ]
 }


### PR DESCRIPTION
# Overview

We should allow JSON-formatted files when reading manual dependencies.  This change allows `fossa-deps.json` to be used instead of `fossa-deps.yml`.

## Acceptance criteria

- Yaml deps continue to work with no changes
- Json deps report identical results to yaml (see new unit test)
- only one of `json`, `yml`, and `yaml` extensions is allowed (if present)
- without file, analysis still succeeds

## Testing plan

- [x] run with identical files, see identical results. (use `the-works.(yml|json)` for testing)
- [x] run with multiple files, see error message
- [x] run with no files, see normal analysis behavior

## References

Closes fossas/team-analysis#580

## Checklist

- [x] I added tests for this PR's change.
- [x] I linted and formatted (via `haskell-language-server`) any files I touched in this PR.
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] I linked this PR to any referenced GitHub issues.
