### PR TITLE
Fix scanning with no reference dependencies

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fix an issue when referenced-dependencies are not being uploaded ([#262](https://github.com/fossas/spectrometer/pull/262))
 - Adds support for `vendored-dependencies` to be licensed scanned ([#257](https://github.com/fossas/spectrometer/pull/257))
 
 ## 2.8.0

--- a/src/App/Fossa/ArchiveUploader.hs
+++ b/src/App/Fossa/ArchiveUploader.hs
@@ -26,7 +26,7 @@ import Data.Text (Text)
 import Data.Text qualified as T
 import Fossa.API.Types
 import Path hiding ((</>))
-import Srclib.Types (Locator (..), SourceUnit (..), SourceUnitBuild (..), SourceUnitDependency (SourceUnitDependency))
+import Srclib.Types (Locator (..))
 import System.FilePath.Posix
 
 data VendoredDependency = VendoredDependency

--- a/src/App/Fossa/ArchiveUploader.hs
+++ b/src/App/Fossa/ArchiveUploader.hs
@@ -62,7 +62,7 @@ compressAndUpload apiOpts arcDir tmpDir dependency = do
 
 -- archiveUploadSourceUnit receives a list of vendored dependencies, a root path, and API settings.
 -- Using this information, it uploads each vendored dependency and queues a build for the dependency.
-archiveUploadSourceUnit :: (Has Diag.Diagnostics sig m, Has (Lift IO) sig m) => Path Abs Dir -> ApiOpts -> [VendoredDependency] -> m (Maybe SourceUnit)
+archiveUploadSourceUnit :: (Has Diag.Diagnostics sig m, Has (Lift IO) sig m) => Path Abs Dir -> ApiOpts -> [VendoredDependency] -> m SourceUnit
 archiveUploadSourceUnit baseDir apiOpts vendoredDeps = do
   archives <- withSystemTempDir "fossa-temp" (uploadArchives apiOpts vendoredDeps baseDir)
 
@@ -78,12 +78,11 @@ archiveUploadSourceUnit baseDir apiOpts vendoredDeps = do
       updateArcName updateText arc = arc{archiveName = updateText <> "/" <> archiveName arc}
       archivesWithOrganization = updateArcName (T.pack $ show orgId) <$> archives
 
-  pure $ Just $ archivesToSourceUnit archivesWithOrganization
-
+  pure $ archivesToSourceUnit archivesWithOrganization
 
 -- archiveNoUploadSourceUnit exists for when users run `fossa analyze -o` and do not upload their source units.
-archiveNoUploadSourceUnit :: [VendoredDependency] -> Maybe SourceUnit
-archiveNoUploadSourceUnit deps = Just . archivesToSourceUnit $ map forceVendoredToArchive deps
+archiveNoUploadSourceUnit :: [VendoredDependency] -> SourceUnit
+archiveNoUploadSourceUnit deps = archivesToSourceUnit $ map forceVendoredToArchive deps
 
 forceVendoredToArchive :: VendoredDependency -> Archive
 forceVendoredToArchive dep = Archive (vendoredName dep) (fromMaybe "" $ vendoredVersion dep)

--- a/src/App/Fossa/YamlDeps.hs
+++ b/src/App/Fossa/YamlDeps.hs
@@ -43,7 +43,6 @@ analyzeFossaDepsYaml root maybeApiOpts = do
     Nothing -> pure Nothing
     Just depsFile -> do
       yamldeps <- context "Reading fossa-deps file" $ readContentsYaml depsFile
-      -- If the file exists and we have no dependencies to report, that's a failure.
       context "Converting fossa-deps to partial API payload" $ Just <$> toSourceUnit root yamldeps maybeApiOpts
 
 findFossaDepsFile :: (Has Diagnostics sig m, Has ReadFS sig m) => Path Abs Dir -> m (Maybe (Path Abs File))
@@ -60,6 +59,7 @@ findFossaDepsFile root = do
 
 toSourceUnit :: (Has Diagnostics sig m, Has (Lift IO) sig m) => Path Abs Dir -> YamlDependencies -> Maybe ApiOpts -> m SourceUnit
 toSourceUnit root yamlDeps@YamlDependencies{..} maybeApiOpts = do
+  -- If the file exists and we have no dependencies to report, that's a failure.
   when (hasNoDeps yamlDeps) $ fatalText "No dependencies found in fossa-deps file"
   archiveLocators <- case maybeApiOpts of
     Nothing -> pure $ archiveNoUploadSourceUnit vendoredDependencies

--- a/src/App/Fossa/YamlDeps.hs
+++ b/src/App/Fossa/YamlDeps.hs
@@ -68,23 +68,23 @@ toSourceUnit root YamlDependencies{..} maybeApiOpts = do
   let renderedPath = toText root
       referenceLocators = refToLocator <$> referencedDependencies
       additional = toAdditionalData <$> NE.nonEmpty customDependencies
-      build = toBuildData $ referenceLocators <> archiveLocators
+      build = toBuildData <$> NE.nonEmpty (referenceLocators <> archiveLocators)
   pure $
     SourceUnit
       { sourceUnitName = renderedPath
       , sourceUnitManifest = renderedPath
       , sourceUnitType = "user-specific-yaml"
-      , sourceUnitBuild = Just build
+      , sourceUnitBuild = build
       , additionalData = additional
       }
 
-toBuildData :: [Locator] -> SourceUnitBuild
+toBuildData :: NE.NonEmpty Locator -> SourceUnitBuild
 toBuildData locators =
   SourceUnitBuild
     { buildArtifact = "default"
     , buildSucceeded = True
-    , buildImports = locators
-    , buildDependencies = map addEmptyDep locators
+    , buildImports = NE.toList locators
+    , buildDependencies = map addEmptyDep $ NE.toList locators
     }
 
 refToLocator :: ReferencedDependency -> Locator
@@ -99,9 +99,9 @@ addEmptyDep :: Locator -> SourceUnitDependency
 addEmptyDep loc = SourceUnitDependency loc []
 
 toAdditionalData :: NE.NonEmpty CustomDependency -> AdditionalDepData
-toAdditionalData deps = AdditionalDepData{userDefinedDeps = map tosrc $ NE.toList deps}
+toAdditionalData deps = AdditionalDepData{userDefinedDeps = map toSrc $ NE.toList deps}
   where
-    tosrc CustomDependency{..} =
+    toSrc CustomDependency{..} =
       SourceUserDefDep
         { srcUserDepName = customName
         , srcUserDepVersion = customVersion


### PR DESCRIPTION
# Overview

If custom or archive dependencies are found, but no reference dependencies are found, the backend build will fail. This is due to the fact that the upload has an upload with the following format that has a `null` `Build` field. This causes a backend failure and instead should be uploaded as `[]` if we need this build to pass. I am still looking into if there is a better value to return.
```
    {
      "Build": null,
      "Manifest": "/Users/zachlavallee/Programming/Fossa-Tools/spectrometer/user-deps-test/",
      "Name": "/Users/zachlavallee/Programming/Fossa-Tools/spectrometer/user-deps-test/",
      "AdditionalDependencyData": null,
      "Type": "user-specific-yaml"
    },
```

## Acceptance criteria

Scans that do not have `referenced-dependencies` succeed.

## Testing plan

I validated that these changes work by building a new binary and testing on a few different variations of `fossa-deps.yaml` file.
- Only archive
- Only ref
- Only custom
- Arc and custom
- Arc and ref
- Ref and custom

## Risks

None, this PR only fixes something that's broken.

## Checklist

- [X] I linted and formatted (via `haskell-language-server`) any files I touched in this PR.
- [X] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [X] I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [X] I linked this PR to any referenced GitHub issues.
