### PR TITLE
Fix logstdout

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fix an issue with logStdout ([#263](https://github.com/fossas/spectrometer/pull/263))
 - Fix an issue when referenced-dependencies are not being uploaded ([#262](https://github.com/fossas/spectrometer/pull/262))
 - Adds support for `vendored-dependencies` to be licensed scanned ([#257](https://github.com/fossas/spectrometer/pull/257))
 

--- a/src/App/Fossa/Main.hs
+++ b/src/App/Fossa/Main.hs
@@ -42,6 +42,7 @@ import System.Exit (die)
 import System.Info qualified as SysInfo
 import Text.Megaparsec (errorBundlePretty, runParser)
 import Text.URI (URI, mkURI)
+import System.Console.Concurrent
 
 windowsOsName :: String
 windowsOsName = "mingw32"
@@ -67,7 +68,7 @@ mergeFileCmdConfig cmd file =
     }
 
 appMain :: IO ()
-appMain = do
+appMain = withConcurrentOutput $ do
   cmdConfig <- customExecParser mainPrefs (info (opts <**> helper) (fullDesc <> header "fossa-cli - Flexible, performant dependency analysis"))
   fileConfig <- readConfigFileIO
 

--- a/src/App/Fossa/Main.hs
+++ b/src/App/Fossa/Main.hs
@@ -37,12 +37,12 @@ import Effect.Logger
 import Fossa.API.Types (ApiKey (..), ApiOpts (..))
 import Options.Applicative
 import Path
+import System.Console.Concurrent
 import System.Environment (lookupEnv)
 import System.Exit (die)
 import System.Info qualified as SysInfo
 import Text.Megaparsec (errorBundlePretty, runParser)
 import Text.URI (URI, mkURI)
-import System.Console.Concurrent
 
 windowsOsName :: String
 windowsOsName = "mingw32"


### PR DESCRIPTION
# Overview

Log stdout is not currently writing to output and I have traced the cause down to us not running `flushConcurrentOutput` after all `logStdout`s have been run. Adding `withConcurrentOutput` to the start of main ensures that `flush` gets called at the very end of the function.

I tested adding `withConcurrentOutput` into `logStdout` but for some reason, this caused the program to hang and I'm not entirely sure why.

## Acceptance criteria

This PR is trying to 
## Testing plan

I ran `fossa report attribution --json` and saw that with my changes, the JSON output appears.

## Risks

There shouldn't be any risks here since we are fixing something that is broken.

## Checklist

- [X] I linted and formatted (via `haskell-language-server`) any files I touched in this PR.
- [X] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [X] I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [X] I linked this PR to any referenced GitHub issues.

## Notes
I am going to create a followup ticket for this because we really should be testing this in some sort of integration test.
