### PR TITLE
Add support for short flags

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 # Spectrometer Changelog
 
+## Unreleased
+- Adds support for short flags to mirror CLI v1 commands ([#264](https://github.com/fossas/spectrometer/pull/264))
+
 ## v2.9.2
 - Adds JSON-formatted project information to the output of `fossa analyze` with `--json` ([#255](https://github.com/fossas/spectrometer/pull/255))
 

--- a/docs/userguide.md
+++ b/docs/userguide.md
@@ -132,15 +132,15 @@ For supported command-line flags, use `fossa analyze --help`
 
 In addition to the [usual FOSSA project flags](#common-fossa-project-flags) supported by all commands, the analyze command supports the following FOSSA-project-related flags:
 
-| Name | Description |
-| ---- | ----------- |
-| `--title 'some title'` | Set the title of the FOSSA project |
-| `--branch 'some branch'` | Override the detected FOSSA project branch |
-| `--project-url 'https://example.com'` | Add a URL to the FOSSA project |
-| `--jira-project-key 'some-key'` | Add a Jira project key to the FOSSA project |
-| `--link 'https://example.com'` | Attach a link to the current FOSSA build |
-| `--team 'some team'` | Specify a team within your FOSSA organization |
-| `--policy 'some policy'` | Assign a specific FOSSA policy to this project |
+| Name                                  | Short | Description                                    |
+| ------------------------------------- | ----- | ---------------------------------------------- |
+| `--title 'some title'`                | `-t`  | Set the title of the FOSSA project             |
+| `--branch 'some branch'`              | `-b`  | Override the detected FOSSA project branch     |
+| `--project-url 'https://example.com'` | `-P`  | Add a URL to the FOSSA project                 |
+| `--jira-project-key 'some-key'`       | `-j`  | Add a Jira project key to the FOSSA project    |
+| `--link 'https://example.com'`        | `-L`  | Attach a link to the current FOSSA build       |
+| `--team 'some team'`                  | `-T`  | Specify a team within your FOSSA organization  |
+| `--policy 'some policy'`              |       | Assign a specific FOSSA policy to this project |
 
 ### Printing results without uploading to FOSSA
 
@@ -403,12 +403,12 @@ fossa report attribtion --json
 
 All `fossa` commands support the following FOSSA-project-related flags:
 
-| Name | Description |
-| ---- | ----------- |
-| `--project 'some project'` | Override the detected project name |
-| `--revision 'some revision'` | Override the detected project revision |
-| `--fossa-api-key 'my-api-key'` | An alternative to using the `FOSSA_API_KEY` environment variable to specify a FOSSA API key |
-| `--endpoint 'https://example.com'` | Override the FOSSA API server base URL |
+| Name                               | Short | Description                                                                                 |
+| ---------------------------------- | ----- | ------------------------------------------------------------------------------------------- |
+| `--project 'some project'`         | `-p`  | Override the detected project name                                                          |
+| `--revision 'some revision'`       | `-r`  | -Override the detected project revision                                                     |
+| `--fossa-api-key 'my-api-key'`     |       | An alternative to using the `FOSSA_API_KEY` environment variable to specify a FOSSA API key |
+| `--endpoint 'https://example.com'` | `-e`  | Override the FOSSA API server base URL                                                      |
 
 ## Frequently-Asked Questions
 

--- a/src/App/Fossa/Main.hs
+++ b/src/App/Fossa/Main.hs
@@ -193,9 +193,9 @@ opts :: Parser CmdOptions
 opts =
   CmdOptions
     <$> switch (long "debug" <> help "Enable debug logging")
-    <*> optional (uriOption (long "endpoint" <> metavar "URL" <> help "The FOSSA API server base URL (default: https://app.fossa.com)"))
-    <*> optional (strOption (long "project" <> help "this repository's URL or VCS endpoint (default: VCS remote 'origin')"))
-    <*> optional (strOption (long "revision" <> help "this repository's current revision hash (default: VCS hash HEAD)"))
+    <*> optional (uriOption (long "endpoint" <> short 'e' <> metavar "URL" <> help "The FOSSA API server base URL (default: https://app.fossa.com)"))
+    <*> optional (strOption (long "project" <> short 'p' <> help "this repository's URL or VCS endpoint (default: VCS remote 'origin')"))
+    <*> optional (strOption (long "revision" <> short 'r' <> help "this repository's current revision hash (default: VCS hash HEAD)"))
     <*> optional (strOption (long "fossa-api-key" <> help "the FOSSA API server authentication key (default: FOSSA_API_KEY from env)"))
     <*> (commands <|> hiddenCommands)
     <**> infoOption (T.unpack fullVersionDescription) (long "version" <> short 'V' <> help "show version text")
@@ -271,7 +271,7 @@ analyzeOpts =
     <$> switch (long "output" <> short 'o' <> help "Output results to stdout instead of uploading to fossa")
     <*> flagOpt UnpackArchives (long "unpack-archives" <> help "Recursively unpack and analyze discovered archives")
     <*> flagOpt JsonOutput (long "json" <> help "Output project metadata as json to the console. Useful for communicating with the FOSSA API")
-    <*> optional (strOption (long "branch" <> help "this repository's current branch (default: current VCS branch)"))
+    <*> optional (strOption (long "branch" <> short "b" <> help "this repository's current branch (default: current VCS branch)"))
     <*> metadataOpts
     <*> many filterOpt
     <*> vsiAnalyzeOpt
@@ -298,11 +298,11 @@ filterOpt = option (eitherReader parseFilter) (long "filter" <> help "Analysis-T
 metadataOpts :: Parser ProjectMetadata
 metadataOpts =
   ProjectMetadata
-    <$> optional (strOption (long "title" <> help "the title of the FOSSA project. (default: the project name)"))
-    <*> optional (strOption (long "project-url" <> help "this repository's home page"))
-    <*> optional (strOption (long "jira-project-key" <> help "this repository's JIRA project key"))
-    <*> optional (strOption (long "link" <> help "a link to attach to the current build"))
-    <*> optional (strOption (long "team" <> help "this repository's team inside your organization"))
+    <$> optional (strOption (long "title" <> short 't' <> help "the title of the FOSSA project. (default: the project name)"))
+    <*> optional (strOption (long "project-url" <> short 'P' <> help "this repository's home page"))
+    <*> optional (strOption (long "jira-project-key" <> short 'j' <> help "this repository's JIRA project key"))
+    <*> optional (strOption (long "link" <> short 'L' <> help "a link to attach to the current build"))
+    <*> optional (strOption (long "team" <> short 'T' <> help "this repository's team inside your organization"))
     <*> optional (strOption (long "policy" <> help "the policy to assign to this project in FOSSA"))
 
 reportOpts :: Parser ReportOptions
@@ -444,7 +444,7 @@ containerAnalyzeOpts :: Parser ContainerAnalyzeOptions
 containerAnalyzeOpts =
   ContainerAnalyzeOptions
     <$> switch (long "output" <> short 'o' <> help "Output results to stdout instead of uploading to fossa")
-    <*> optional (strOption (long "branch" <> help "this repository's current branch (default: current VCS branch)"))
+    <*> optional (strOption (long "branch" <> short 'b' <> help "this repository's current branch (default: current VCS branch)"))
     <*> metadataOpts
     <*> imageTextArg
 

--- a/src/App/Fossa/Main.hs
+++ b/src/App/Fossa/Main.hs
@@ -271,7 +271,7 @@ analyzeOpts =
     <$> switch (long "output" <> short 'o' <> help "Output results to stdout instead of uploading to fossa")
     <*> flagOpt UnpackArchives (long "unpack-archives" <> help "Recursively unpack and analyze discovered archives")
     <*> flagOpt JsonOutput (long "json" <> help "Output project metadata as json to the console. Useful for communicating with the FOSSA API")
-    <*> optional (strOption (long "branch" <> short "b" <> help "this repository's current branch (default: current VCS branch)"))
+    <*> optional (strOption (long "branch" <> short 'b' <> help "this repository's current branch (default: current VCS branch)"))
     <*> metadataOpts
     <*> many filterOpt
     <*> vsiAnalyzeOpt


### PR DESCRIPTION
# Overview

Users upgrading from CLI v1 have found compatibility issues with their command when using short flags. Further overview about this ticket is located in the github issue.

## Acceptance criteria

Allow short flags that were supported by CLI v1.

## Testing plan

Build the CLI and validate that the short flags work.

## Risks

User's commands become less clear as they choose to use the short flags. If we were starting from scratch I may not support adding the short flags, but due to the need for making upgrades seamless, I believe we need to. For this reason, I am not going to omit documentation in the user guide for short flags. They show up when running `-h` on the command line.

## References

Closes https://github.com/fossas/team-analysis/issues/596.

## Checklist

- [X] I linted and formatted (via `haskell-language-server`) any files I touched in this PR.
- [X] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [X] I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [X] I linked this PR to any referenced GitHub issues.
