### PR TITLE
Use `Diag.logWithExit_` to prevent exiting 0 on failure.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,14 +1,21 @@
 # Spectrometer Changelog
 
+## v2.10.1
+
+- Fixes an issue where `fossa container analyze` returned 0 exit code on failure ([#275](https://github.com/fossas/spectrometer/pull/275))
+
 ## v2.10.0
+
 - Adds support for short flags to mirror CLI v1 commands ([#264](https://github.com/fossas/spectrometer/pull/264))
 - Added a `remote-dependencies` section in the `fossa-deps` file to support archives at remote locations ([#260](https://github.com/fossas/spectrometer/pull/260))
 - Modify the payload for `custom-dependencies` to include optional fields in a new `metadata` section ([#260](https://github.com/fossas/spectrometer/pull/260))
 
 ## v2.9.2
+
 - Adds JSON-formatted project information to the output of `fossa analyze` with `--json` ([#255](https://github.com/fossas/spectrometer/pull/255))
 
 ## v2.9.1
+
 - Bump wiggins - Updated vps aosp-notice-file subcommand to upload ninja files & trigger async task. ([#272](https://github.com/fossas/spectrometer/pull/272))
 
 ## v2.9.0

--- a/src/App/Fossa/Container/Analyze.hs
+++ b/src/App/Fossa/Container/Analyze.hs
@@ -7,14 +7,10 @@ import App.Fossa.Analyze (ScanDestination (..))
 import App.Fossa.Container (ImageText (..), extractRevision, runSyft, toContainerScan)
 import App.Fossa.FossaAPIV1 (UploadResponse (uploadError, uploadLocator), uploadContainerScan)
 import App.Types (OverrideProject (..), ProjectRevision (..))
-import Control.Carrier.Diagnostics (
-  Diagnostics,
-  renderFailureBundle,
-  runDiagnostics,
- )
+import Control.Carrier.Diagnostics (Diagnostics, logWithExit_)
 import Control.Effect.Lift (Lift)
 import Control.Monad.IO.Class (MonadIO)
-import Data.Aeson
+import Data.Aeson (encode)
 import Data.Foldable (traverse_)
 import Data.Maybe (fromMaybe)
 import Data.String.Conversion (decodeUtf8)
@@ -23,10 +19,7 @@ import Srclib.Types (parseLocator)
 
 analyzeMain :: ScanDestination -> Severity -> OverrideProject -> ImageText -> IO ()
 analyzeMain scanDestination logSeverity override image = withDefaultLogger logSeverity $ do
-  result <- runDiagnostics $ analyze scanDestination override image
-  case result of
-    Left err -> logError (renderFailureBundle err)
-    Right _ -> pure ()
+  logWithExit_ $ analyze scanDestination override image
 
 analyze ::
   ( Has Diagnostics sig m

--- a/src/App/Fossa/Report.hs
+++ b/src/App/Fossa/Report.hs
@@ -9,7 +9,6 @@ import App.Fossa.ProjectInference
 import App.Types
 import Control.Carrier.Diagnostics
 import Control.Carrier.StickyLogger (logSticky, runStickyLogger)
-import Control.Effect.Lift (sendIO)
 import Data.Aeson qualified as Aeson
 import Data.Functor (void)
 import Data.String.Conversion (decodeUtf8)
@@ -18,7 +17,7 @@ import Data.Text.IO (hPutStrLn)
 import Effect.Logger
 import Effect.ReadFS
 import Fossa.API.Types (ApiOpts)
-import System.Exit (exitFailure, exitSuccess)
+import System.Exit (exitFailure)
 import System.IO (stderr)
 
 data ReportType
@@ -50,8 +49,8 @@ reportMain (BaseDir basedir) apiOpts logSeverity timeoutSeconds reportType overr
   * Timeout over `IO a` (easy to move, but where do we move it?)
   * CLI command refactoring as laid out in https://github.com/fossas/issues/issues/129
   -}
-  void . timeout timeoutSeconds . withDefaultLogger logSeverity . runStickyLogger SevInfo $ do
-    result <- runDiagnostics . runReadFSIO $ do
+  void . timeout timeoutSeconds . withDefaultLogger logSeverity . runStickyLogger SevInfo $
+    logWithExit_ . runReadFSIO $ do
       revision <- mergeOverride override <$> (inferProjectFromVCS basedir <||> inferProjectCached basedir <||> inferProjectDefault basedir)
 
       logInfo ""
@@ -73,12 +72,6 @@ reportMain (BaseDir basedir) apiOpts logSeverity timeoutSeconds reportType overr
           Fossa.getAttribution apiOpts revision
 
       logStdout . decodeUtf8 $ Aeson.encode jsonValue
-
-    case result of
-      Left err -> do
-        logError $ renderFailureBundle err
-        sendIO exitFailure
-      Right _ -> sendIO exitSuccess
 
   hPutStrLn stderr "Timed out while waiting for build/issues scan"
   exitFailure


### PR DESCRIPTION
# Overview

During `fossa container analyze`, when syft fails, we exit with 0.  This is because our raw diagnostic handler does not control exiting values.  Using `Diag.logWithExit_`, we can safely handle errors which terminate the program, and automatically return non-zero exit codes.

This PR migrates all eligible entry points to using `Diag.logWithExit_`.

## Acceptance criteria

* Every entry point with the following pattern uses `Diag.logWithExit_`, instead of handling manually:
  * Returns `IO ()`
  * Reports error to stderr using default format/layout.
  * Diagnostic success/failure directly translates to program success/failure
  * A pre-existing logger is in use.

## Testing plan

Test all modified commands in failure mode, confirm non-zero exit code.

## References

Reported here http://fossa.zendesk.com/agent/tickets/2814
Closes fossas/team-analysis#626

## Checklist

- [x] I added tests for this PR's change (or confirmed tests are not viable).
- [x] I linted and formatted (via `haskell-language-server`) any haskell files I touched in this PR.
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] I linked this PR to any referenced GitHub issues, if they exist.
