### PR TITLE
Support HTTP urls for archive uploads

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Spectrometer Changelog
 
+## Unreleased 
+
+- Support HTTP endpoints for archive uploads ([#276](https://github.com/fossas/spectrometer/pull/276))
+
 ## v2.10.2
 
 - Fixes an issue where some `fossa` commands (including `fossa test`) would exit non-zero on success ([#278](https://github.com/fossas/spectrometer/pull/278)).


### PR DESCRIPTION
# Overview

When building the archive uploader I did not consider that users may need to upload to HTTP hosted S3 sites. The most common use cases where this is an issue are with local testing and on-prem deployments.

## Acceptance Criteria

The only criteria is that HTTP and HTTPS uploads work properly.

## Testing Plan

I manually tested that HTTPS endpoints work by uploading to fossa core which defaults to S3.
I manually tested that HTTP works by successfully sending and HTTP request with the `uploadArchiveRequest` function.

## Risks

No risks as long as HTTP and HTTPS uploads work as tested.

## References

Closes https://github.com/fossas/team-analysis/issues/624

## Checklist

- [X] I added tests for this PR's change (or confirmed tests are not viable).
- [X] I linted and formatted (via `haskell-language-server`) any haskell files I touched in this PR.
- [X] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [X] I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [X] I linked this PR to any referenced GitHub issues, if they exist.
