### PR TITLE
Fix fossa test always fail

### DIFF
--- a/src/App/Fossa/Report.hs
+++ b/src/App/Fossa/Report.hs
@@ -10,7 +10,6 @@ import App.Types
 import Control.Carrier.Diagnostics
 import Control.Carrier.StickyLogger (logSticky, runStickyLogger)
 import Data.Aeson qualified as Aeson
-import Data.Functor (void)
 import Data.String.Conversion (decodeUtf8)
 import Data.Text (Text)
 import Data.Text.IO (hPutStrLn)
@@ -73,8 +72,8 @@ reportMain (BaseDir basedir) apiOpts logSeverity timeoutSeconds reportType overr
 
       logStdout . decodeUtf8 $ Aeson.encode jsonValue
 
-  case result of
-    Nothing -> pure ()
-    _ -> do
+  case result of 
+    Just _ -> pure ()
+    Nothing -> do
       hPutStrLn stderr "Timed out while waiting for build/issues scan"
       exitFailure

--- a/src/App/Fossa/Report.hs
+++ b/src/App/Fossa/Report.hs
@@ -49,7 +49,7 @@ reportMain (BaseDir basedir) apiOpts logSeverity timeoutSeconds reportType overr
   * Timeout over `IO a` (easy to move, but where do we move it?)
   * CLI command refactoring as laid out in https://github.com/fossas/issues/issues/129
   -}
-  void . timeout timeoutSeconds . withDefaultLogger logSeverity . runStickyLogger SevInfo $
+  result <- timeout timeoutSeconds . withDefaultLogger logSeverity . runStickyLogger SevInfo $
     logWithExit_ . runReadFSIO $ do
       revision <- mergeOverride override <$> (inferProjectFromVCS basedir <||> inferProjectCached basedir <||> inferProjectDefault basedir)
 
@@ -73,5 +73,8 @@ reportMain (BaseDir basedir) apiOpts logSeverity timeoutSeconds reportType overr
 
       logStdout . decodeUtf8 $ Aeson.encode jsonValue
 
-  hPutStrLn stderr "Timed out while waiting for build/issues scan"
-  exitFailure
+  case result of
+    Nothing -> pure ()
+    _ -> do
+      hPutStrLn stderr "Timed out while waiting for build/issues scan"
+      exitFailure

--- a/src/App/Fossa/Test.hs
+++ b/src/App/Fossa/Test.hs
@@ -35,7 +35,7 @@ testMain ::
   OverrideProject ->
   IO ()
 testMain (BaseDir basedir) apiOpts logSeverity timeoutSeconds outputType override = do
-  void . timeout timeoutSeconds . withDefaultLogger logSeverity . runStickyLogger SevInfo $
+  result <- timeout timeoutSeconds . withDefaultLogger logSeverity . runStickyLogger SevInfo $
     logWithExit_ . runReadFSIO $ do
       revision <- mergeOverride override <$> (inferProjectFromVCS basedir <||> inferProjectCached basedir <||> inferProjectDefault basedir)
 
@@ -66,5 +66,8 @@ testMain (BaseDir basedir) apiOpts logSeverity timeoutSeconds outputType overrid
 
   -- we call exitSuccess/exitFailure in each branch above. the only way we get
   -- here is if we time out
-  hPutStrLn stderr "Timed out while waiting for issues scan"
-  exitFailure
+  case result of 
+    Nothing -> pure ()
+    _ -> do
+      hPutStrLn stderr "Timed out while waiting for issues scan"
+      exitFailure

--- a/src/App/Fossa/Test.hs
+++ b/src/App/Fossa/Test.hs
@@ -10,7 +10,6 @@ import Control.Carrier.Diagnostics hiding (fromMaybe)
 import Control.Carrier.StickyLogger (logSticky, runStickyLogger)
 import Control.Effect.Lift (sendIO)
 import Data.Aeson qualified as Aeson
-import Data.Functor (void)
 import Data.String.Conversion (decodeUtf8)
 import Data.Text.IO (hPutStrLn)
 import Effect.Logger
@@ -67,7 +66,7 @@ testMain (BaseDir basedir) apiOpts logSeverity timeoutSeconds outputType overrid
   -- we call exitSuccess/exitFailure in each branch above. the only way we get
   -- here is if we time out
   case result of 
-    Nothing -> pure ()
-    _ -> do
+    Just _ -> pure ()
+    Nothing -> do
       hPutStrLn stderr "Timed out while waiting for issues scan"
       exitFailure

--- a/src/App/Fossa/VPS/Report.hs
+++ b/src/App/Fossa/VPS/Report.hs
@@ -12,7 +12,6 @@ import App.Types
 import Control.Carrier.Diagnostics
 import Control.Carrier.StickyLogger (logSticky, runStickyLogger)
 import Data.Aeson qualified as Aeson
-import Data.Functor (void)
 import Data.String.Conversion (decodeUtf8)
 import Data.Text (Text)
 import Data.Text.IO (hPutStrLn)
@@ -77,7 +76,7 @@ reportMain (BaseDir basedir) apiOpts logSeverity timeoutSeconds reportType overr
       logStdout . decodeUtf8 $ Aeson.encode jsonValue
 
   case result of 
-    Nothing -> pure ()
-    _ -> do
+    Just _ -> pure ()
+    Nothing -> do
       hPutStrLn stderr "Timed out while waiting for build/issues scan"
       exitFailure

--- a/src/App/Fossa/VPS/Report.hs
+++ b/src/App/Fossa/VPS/Report.hs
@@ -51,7 +51,7 @@ reportMain (BaseDir basedir) apiOpts logSeverity timeoutSeconds reportType overr
   * Timeout over `IO a` (easy to move, but where do we move it?)
   * CLI command refactoring as laid out in https://github.com/fossas/issues/issues/129
   -}
-  void . timeout timeoutSeconds . withDefaultLogger logSeverity . runStickyLogger SevInfo $
+  result <- timeout timeoutSeconds . withDefaultLogger logSeverity . runStickyLogger SevInfo $
     logWithExit_ . runReadFSIO $ do
       revision <- mergeOverride override <$> (inferProjectFromVCS basedir <||> inferProjectCached basedir <||> inferProjectDefault basedir)
 
@@ -76,5 +76,8 @@ reportMain (BaseDir basedir) apiOpts logSeverity timeoutSeconds reportType overr
 
       logStdout . decodeUtf8 $ Aeson.encode jsonValue
 
-  hPutStrLn stderr "Timed out while waiting for build/issues scan"
-  exitFailure
+  case result of 
+    Nothing -> pure ()
+    _ -> do
+      hPutStrLn stderr "Timed out while waiting for build/issues scan"
+      exitFailure

--- a/src/App/Fossa/VPS/Test.hs
+++ b/src/App/Fossa/VPS/Test.hs
@@ -73,8 +73,8 @@ testMain (BaseDir basedir) apiOpts logSeverity timeoutSeconds outputType overrid
 
   -- we call exitSuccess/exitFailure in each branch above. the only way we get
   -- here is if we time out
-  case result of
-    Nothing -> pure ()
-    _ -> do
+  case result of 
+    Just _ -> pure ()
+    Nothing -> do
       hPutStrLn stderr "Timed out while waiting for issues scan"
       exitFailure

--- a/src/App/Fossa/VPS/Test.hs
+++ b/src/App/Fossa/VPS/Test.hs
@@ -37,7 +37,7 @@ testMain ::
   OverrideProject ->
   IO ()
 testMain (BaseDir basedir) apiOpts logSeverity timeoutSeconds outputType override = do
-  _ <- timeout timeoutSeconds . withDefaultLogger logSeverity . runStickyLogger SevInfo $
+  result <- timeout timeoutSeconds . withDefaultLogger logSeverity . runStickyLogger SevInfo $
     logWithExit_ . runReadFSIO $ do
       revision <- mergeOverride override <$> (inferProjectFromVCS basedir <||> inferProjectCached basedir <||> inferProjectDefault basedir)
 
@@ -73,5 +73,8 @@ testMain (BaseDir basedir) apiOpts logSeverity timeoutSeconds outputType overrid
 
   -- we call exitSuccess/exitFailure in each branch above. the only way we get
   -- here is if we time out
-  hPutStrLn stderr "Timed out while waiting for issues scan"
-  exitFailure
+  case result of
+    Nothing -> pure ()
+    _ -> do
+      hPutStrLn stderr "Timed out while waiting for issues scan"
+      exitFailure


### PR DESCRIPTION
# Overview

When fixing an issue related to container analysis not exiting with a success message, we regressed `fossa test` by adding `logWithExit` but not returning a success. This fix addressed the issues, but since `logWithExit` returns `()` on success, we always hit the `exitFailure` at the bottom of the file.

This PR further reinforces the need for improved integration testing. https://github.com/fossas/team-analysis/issues/437

## Acceptance criteria

This PR is making sure that we 

## Testing plan

I built a binary locally with the changes and validated that when running fossa test I got an exit code of 0. Testing with the current spectrometer binary is recommended as well to observe the changes

```
fossa analyze
fossa test
$? 
```

`$?` should show that the exit code was `0`.

## Risks

I don't believe there are any risks associated with this.

## References

https://teamfossa.slack.com/archives/G01DUC2JW3B/p1625589871002400

## Checklist

- [X ] I added tests for this PR's change (or confirmed tests are not viable).
- [ ] I linted and formatted (via `haskell-language-server`) any haskell files I touched in this PR.
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ X] I linked this PR to any referenced GitHub issues, if they exist.
