### PR TITLE
fix: Reword the error message when no analysis targets are discovered

### DIFF
--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -255,7 +255,7 @@ analyze (BaseDir basedir) destination override unpackArchives jsonOutput enableV
 
   -- Need to check if vendored is empty as well, even if its a boolean that vendoredDeps exist
   case checkForEmptyUpload projectResults filteredProjects manualSrcUnits of
-    NoneDiscovered -> logError "No projects were discovered" >> sendIO exitFailure
+    NoneDiscovered -> logError "No analysis targets found in directory" >> sendIO exitFailure
     FilteredAll count -> do
       logError ("Filtered out all " <> pretty count <> " projects due to directory name, no manual deps found")
       for_ projectResults $ \project -> logDebug ("Excluded by directory name: " <> pretty (toFilePath $ projectResultPath project))


### PR DESCRIPTION
# Overview

This updates the wording for "analysis targets" in this error message to be consistent with other usages of "analysis targets".

## Acceptance criteria

Make vocabulary consistent across all user-visible messages:

- "Analysis targets", not "projects"
- "Strategies", not "languages" or "tools"
- "Tactics", not "fallbacks"

This tiny PR catches one of those cases.

## Testing plan

See that the automated tests pass. No logic should've changed here.

## Risks

I sure hope nobody is scripting against this. They shouldn't. It's an error case.

## Checklist

- [x] I added tests for this PR's change (or confirmed tests are not viable).
- [x] I linted and formatted (via `haskell-language-server`) any haskell files I touched in this PR.
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] I linked this PR to any referenced GitHub issues, if they exist.
