### PR TITLE
Maven: interpolate groupId/artifactId properties in dependencies

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Support `fossa test` and `fossa report` for monorepo projects ([#290](https://github.com/fossas/spectrometer/pull/290))
+- Maven `pom.xml`: Adds `${property}` substitution for `<groupId>` and `<artifactId>` fields in dependencies ([#282](https://github.com/fossas/spectrometer/pull/282))
 
 ## v2.10.3
 

--- a/src/Strategy/Maven/Pom.hs
+++ b/src/Strategy/Maven/Pom.hs
@@ -2,6 +2,8 @@ module Strategy.Maven.Pom (
   analyze',
   getLicenses,
   interpolateProperties,
+  buildMavenPackage,
+  MavenPackage (..),
 ) where
 
 import Algebra.Graph.AdjacencyMap qualified as AM
@@ -115,22 +117,7 @@ buildProjectGraph closure = run . withLabeling toDependency $ do
 
         addDep :: Has MavenGrapher sig m => (Group, Artifact) -> MvnDepBody -> m ()
         addDep (group, artifact) body = do
-          let interpolatedGroup :: Group
-              interpolatedGroup = interpolateProperties completePom group
-
-              interpolatedArtifact :: Artifact
-              interpolatedArtifact = interpolateProperties completePom artifact
-
-              interpolatedVersion :: Maybe Text
-              interpolatedVersion = classify . interpolateProperties completePom <$> depVersion body
-
-              -- maven classifiers are appended to the end of versions, e.g., 3.0.0 with a classifier
-              -- of "sources" would result in "3.0.0-sources"
-              classify :: Version -> Version
-              classify version = case depClassifier body of
-                Nothing -> version
-                Just classifier -> version <> "-" <> classifier
-              depPackage = MavenPackage interpolatedGroup interpolatedArtifact interpolatedVersion
+          let depPackage = buildMavenPackage completePom group artifact body
 
           edge (coordToPackage coord) depPackage
           traverse_ (label depPackage . MavenLabelScope) (depScope body)
@@ -141,9 +128,35 @@ buildProjectGraph closure = run . withLabeling toDependency $ do
           [ (childCoord, pom) | childCoord <- S.toList (AM.postSet coord (closureGraph closure)), Just (_, pom) <- [M.lookup childCoord (closurePoms closure)]
           ]
 
+-- | Build a MavenPackage for a dependency in a pom file
+--
+-- This does ${property} interpolation for dependency group/artifact/version
+-- and appends the dependency classifier to the version
+buildMavenPackage :: Pom -> Group -> Artifact -> MvnDepBody -> MavenPackage
+buildMavenPackage pom group artifact body = MavenPackage interpolatedGroup interpolatedArtifact interpolatedVersion
+  where
+    interpolatedGroup :: Group
+    interpolatedGroup = interpolateProperties pom group
+
+    interpolatedArtifact :: Artifact
+    interpolatedArtifact = interpolateProperties pom artifact
+
+    interpolatedVersion :: Maybe Text
+    interpolatedVersion = classify . interpolateProperties pom <$> depVersion body
+
+    -- maven classifiers are appended to the end of versions, e.g., 3.0.0 with a classifier
+    -- of "sources" would result in "3.0.0-sources"
+    classify :: Version -> Version
+    classify version = case depClassifier body of
+      Nothing -> version
+      Just classifier -> version <> "-" <> classifier
+
 coordToPackage :: MavenCoordinate -> MavenPackage
 coordToPackage coord = MavenPackage (coordGroup coord) (coordArtifact coord) (Just (coordVersion coord))
 
+-- | Reify dependencies in a pom file by overlaying information from the <dependencyManagement> section.
+--
+-- Notably, the dependencies in the resulting @Map@ _do not_ have their ${properties} interpolated
 reifyDeps :: Pom -> Map (Group, Artifact) MvnDepBody
 reifyDeps pom = M.mapWithKey overlayDepManagement (pomDependencies pom)
   where

--- a/test/Maven/PomStrategySpec.hs
+++ b/test/Maven/PomStrategySpec.hs
@@ -3,7 +3,7 @@ module Maven.PomStrategySpec (
 ) where
 
 import Data.Map.Strict qualified as M
-import Strategy.Maven.Pom (interpolateProperties)
+import Strategy.Maven.Pom (MavenPackage (..), buildMavenPackage, interpolateProperties)
 import Strategy.Maven.Pom.PomFile
 import Test.Hspec
 
@@ -25,3 +25,20 @@ spec = do
 
     it "should interpolate multiple properties" $ do
       interpolateProperties pom "${project.groupId}${project.artifactId}" `shouldBe` "MYGROUPMYARTIFACT"
+
+  describe "buildMavenPackage" $ do
+    let pom = Pom (MavenCoordinate "MYGROUP" "MYARTIFACT" "MYVERSION") Nothing M.empty M.empty M.empty []
+    it "should interpolate properties in groupId/artifactId/version" $ do
+      let result =
+            buildMavenPackage
+              pom
+              "${project.groupId}"
+              "${project.artifactId}"
+              ( MvnDepBody
+                  { depVersion = Just "${project.version}"
+                  , depClassifier = Nothing
+                  , depScope = Nothing
+                  , depOptional = Nothing
+                  }
+              )
+      result `shouldBe` MavenPackage "MYGROUP" "MYARTIFACT" (Just "MYVERSION")


### PR DESCRIPTION
# Overview

When declaring dependencies in a maven `pom.xml`, users can use `${mavenproperty}` syntax to substitute variables in the `groupId`/`artifactId`/`version` fields:
```xml
<dependencies>
  <dependency>
    <groupId>mygroupid</groupId>
    <artifactId>${foo.bar.property}</artifactId>
    <version>${project.version}</version>
  </dependency>
</dependencies>
```

Some properties are built-in, like `project.version`, and others are user-specified in the `<properties>` section of the pom.

Existing logic already did property interpolation for the `<version>` field in dependencies, and this PR adds property interpolation to the `groupId` and `artifactId` fields

## Acceptance criteria

Dependencies in analyzed `pom.xml` files have properties interpolated in their `groupId` and `artifactId` fields

## Testing plan

Added a test for this use case and manually verified against the customer's provided pom.xml

## Risks

None

## References

Resolves [ZD2867](https://fossa.zendesk.com/agent/tickets/2867)