### PR TITLE
Monorepo integration

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,12 @@
 
 - Support HTTP endpoints for archive uploads ([#276](https://github.com/fossas/spectrometer/pull/276))
 
+## v2.10.3
+
+- Deprecate `fossa vps` subcommands.
+- Add `--experimental-enable-monorepo` and other associated flags to `fossa analyze`, which enables experimental monorepo support.
+  Monorepo flags are only used with support from FOSSA engineering, and are experimental while we build robust support for monorepo projects with FOSSA partners.
+
 ## v2.10.2
 
 - Fixes an issue where some `fossa` commands (including `fossa test`) would exit non-zero on success ([#278](https://github.com/fossas/spectrometer/pull/278)).

--- a/docs/userguide.md
+++ b/docs/userguide.md
@@ -17,6 +17,7 @@
 5. [Frequently-Asked Questions](#frequently-asked-questions)
     - [`fossa analyze`: Why wasn't my project found?](#fossa-analyze-why-wasnt-my-project-found)
     - [When are you adding support for (some buildtool/language)](#when-are-you-adding-support-for-some-buildtoollanguage)
+    - [What are these experimental monorepo flags?](#what-are-these-experimental-monorepo-flags)
 
 ## Quick Start
 
@@ -478,3 +479,8 @@ In your bug report, please include:
 ### When are you adding support for (some buildtool/language)?
 
 If we don't support your choice of language/buildtool, please [open an issue](https://github.com/fossas/spectrometer/issues/new) to express interest
+
+### What are these experimental monorepo flags?
+
+Monorepo flags are only used with support from FOSSA engineering, and are experimental while we build robust support for monorepo projects with FOSSA partners.
+If you’re interested, reach out to our sales team!

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -145,6 +145,7 @@ library
     App.Fossa.ListTargets
     App.Fossa.Main
     App.Fossa.ManualDeps
+    App.Fossa.Monorepo
     App.Fossa.ProjectInference
     App.Fossa.Report
     App.Fossa.Report.Attribution

--- a/src/App/Fossa/Main.hs
+++ b/src/App/Fossa/Main.hs
@@ -85,7 +85,7 @@ appMain = do
           }
 
   case optCommand of
-    AnalyzeCommand AnalyzeOptions{analyzeOutput, analyzeBranch, analyzeMetadata, monorepoAnalysisOpts = (MonorepoAnalysisOpts (Just monorepoAnalysisType) monorepoFollowSymlinks monorepoScanFileFilters), analyzeBaseDir} -> do
+    AnalyzeCommand AnalyzeOptions{analyzeOutput, analyzeBranch, analyzeMetadata, monorepoAnalysisOpts = (MonorepoAnalysisOpts (Just monorepoAnalysisType)), analyzeBaseDir} -> do
       dieOnWindows "Monorepo analysis is not supported on Windows"
       if analyzeOutput
         then die "Monorepo analysis does not support stdout scan destination"
@@ -93,7 +93,7 @@ appMain = do
           key <- requireKey maybeApiKey
           let apiOpts = ApiOpts optBaseUrl key
           let metadata = maybe analyzeMetadata (mergeFileCmdMetadata analyzeMetadata) fileConfig
-          let monorepoAnalysisOpts = MonorepoAnalysisOpts (Just monorepoAnalysisType) monorepoFollowSymlinks monorepoScanFileFilters
+          let monorepoAnalysisOpts = MonorepoAnalysisOpts (Just monorepoAnalysisType)
           let analyzeOverride = override{overrideBranch = analyzeBranch <|> ((fileConfig >>= configRevision) >>= configBranch)}
           basedir <- parseAbsDir analyzeBaseDir
           monorepoMain (BaseDir basedir) monorepoAnalysisOpts logSeverity apiOpts metadata analyzeOverride
@@ -315,8 +315,6 @@ monorepoOpts :: Parser MonorepoAnalysisOpts
 monorepoOpts =
   MonorepoAnalysisOpts
     <$> optional (strOption (long "experimental-enable-monorepo" <> metavar "MODE" <> help "scan the project in the experimental monorepo mode. Supported modes: aosp"))
-    <*> switch (long "experimental-monorepo-follow-symlinks" <> help "if enabled, monorepo scans follow symbolic links. Does not protect against link loops.")
-    <*> (FilterExpressions <$> jsonOption (long "experimental-monorepo-file-filters" <> metavar "REGEXPS" <> help "JSON encoded array of RE2 regular expressions used to filter scanned paths during monorepo scans" <> value []))
 
 metadataOpts :: Parser ProjectMetadata
 metadataOpts =

--- a/src/App/Fossa/Main.hs
+++ b/src/App/Fossa/Main.hs
@@ -4,7 +4,7 @@ module App.Fossa.Main (
   appMain,
 ) where
 
-import App.Fossa.Analyze (RecordMode (..), ScanDestination (..), UnpackArchives (..), JsonOutput (..), VSIAnalysisMode (..), analyzeMain)
+import App.Fossa.Analyze (JsonOutput (..), RecordMode (..), ScanDestination (..), UnpackArchives (..), VSIAnalysisMode (..), analyzeMain)
 import App.Fossa.Compatibility (Argument, argumentParser, compatibilityMain)
 import App.Fossa.Configuration
 import App.Fossa.Container (ImageText (..), dumpSyftScanMain, imageTextArg, parseSyftOutputMain)
@@ -91,7 +91,7 @@ appMain = do
           doAnalyze destination = analyzeMain analyzeBaseDir analyzeRecordMode logSeverity destination analyzeOverride analyzeUnpackArchives analyzeJsonOutput analyzeVSIMode analyzeBuildTargetFilters
 
       if analyzeOutput
-        then doAnalyze OutputStdout 
+        then doAnalyze OutputStdout
         else do
           key <- requireKey maybeApiKey
           let apiOpts = ApiOpts optBaseUrl key
@@ -121,6 +121,7 @@ appMain = do
     VPSCommand VPSOptions{..} -> do
       apikey <- requireKey maybeApiKey
       let apiOpts = ApiOpts optBaseUrl apikey
+      withDefaultLogger logSeverity $ logWarn "vps commands are deprecated and will be removed in a future version. Please contact FOSSA for migration steps."
       case vpsCommand of
         VPSAnalyzeCommand VPSAnalyzeOptions{..} -> do
           when (SysInfo.os == windowsOsName) $ unless (fromFlag SkipIPRScan skipIprScan) $ die "Windows VPS scans require skipping IPR.  Please try `fossa vps analyze --skip-ipr-scan DIR`"

--- a/src/App/Fossa/Main.hs
+++ b/src/App/Fossa/Main.hs
@@ -88,7 +88,7 @@ appMain = do
     AnalyzeCommand AnalyzeOptions{analyzeOutput, analyzeBranch, analyzeMetadata, monorepoAnalysisOpts = (MonorepoAnalysisOpts (Just monorepoAnalysisType)), analyzeBaseDir} -> do
       dieOnWindows "Monorepo analysis is not supported on Windows"
       if analyzeOutput
-        then die "Monorepo analysis does not support stdout scan destination"
+        then die "Monorepo analysis does not support the `--output` flag"
         else do
           key <- requireKey maybeApiKey
           let apiOpts = ApiOpts optBaseUrl key

--- a/src/App/Fossa/Main.hs
+++ b/src/App/Fossa/Main.hs
@@ -276,6 +276,7 @@ analyzeOpts =
     <*> metadataOpts
     <*> many filterOpt
     <*> vsiAnalyzeOpt
+    <*> monorepoOpts
     <*> analyzeReplayOpt
     <*> baseDirArg
 
@@ -295,6 +296,9 @@ filterOpt = option (eitherReader parseFilter) (long "filter" <> help "Analysis-T
   where
     parseFilter :: String -> Either String BuildTargetFilter
     parseFilter = first errorBundlePretty . runParser filterParser "stdin" . T.pack
+
+monorepoOpts :: Parser MonorepoAnalysisOpts
+monorepoOpts = MonorepoAnalysisOpts <$> optional (strOption (long "experimental-enable-monorepo" <> help "scan the project in the experimental monorepo mode. Supported modes: aosp"))
 
 metadataOpts :: Parser ProjectMetadata
 metadataOpts =
@@ -518,6 +522,7 @@ data AnalyzeOptions = AnalyzeOptions
   , analyzeMetadata :: ProjectMetadata
   , analyzeBuildTargetFilters :: [BuildTargetFilter]
   , analyzeVSIMode :: VSIAnalysisMode
+  , monorepoAnalysisOpts :: MonorepoAnalysisOpts
   , analyzeRecordMode :: RecordMode
   , analyzeBaseDir :: FilePath
   }

--- a/src/App/Fossa/Main.hs
+++ b/src/App/Fossa/Main.hs
@@ -298,7 +298,11 @@ filterOpt = option (eitherReader parseFilter) (long "filter" <> help "Analysis-T
     parseFilter = first errorBundlePretty . runParser filterParser "stdin" . T.pack
 
 monorepoOpts :: Parser MonorepoAnalysisOpts
-monorepoOpts = MonorepoAnalysisOpts <$> optional (strOption (long "experimental-enable-monorepo" <> help "scan the project in the experimental monorepo mode. Supported modes: aosp"))
+monorepoOpts =
+  MonorepoAnalysisOpts
+    <$> optional (strOption (long "experimental-enable-monorepo" <> metavar "MODE" <> help "scan the project in the experimental monorepo mode. Supported modes: aosp"))
+    <*> switch (long "experimental-monorepo-follow-symlinks" <> help "if enabled, monorepo scans follow symbolic links. Does not protect against link loops.")
+    <*> (FilterExpressions <$> jsonOption (long "experimental-monorepo-file-filters" <> metavar "REGEXPS" <> help "JSON encoded array of regular expressions used to filter scanned paths" <> value []))
 
 metadataOpts :: Parser ProjectMetadata
 metadataOpts =

--- a/src/App/Fossa/Monorepo.hs
+++ b/src/App/Fossa/Monorepo.hs
@@ -5,22 +5,42 @@ module App.Fossa.Monorepo (
 ) where
 
 import App.Fossa.EmbeddedBinary
+import App.Fossa.ProjectInference
+import App.Fossa.VPS.Scan.RunWiggins
+import App.Fossa.VPS.Types
 import App.Types
 import Control.Carrier.Diagnostics
 import Control.Effect.Lift (Lift, sendIO)
 import Data.String.Conversion (toText)
+import Data.Text
+import Effect.Exec
 import Effect.Logger
 import Fossa.API.Types
 import System.Exit (exitFailure)
 
 monorepoMain :: BaseDir -> MonorepoAnalysisOpts -> Severity -> ApiOpts -> ProjectMetadata -> OverrideProject -> IO ()
-monorepoMain baseDir monoRepoAnalysisOpts logSeverity apiOpts projectMeta overrideProject = withDefaultLogger logSeverity $ do
-  result <- runDiagnostics $ withWigginsBinary $ monorepoScan baseDir monoRepoAnalysisOpts apiOpts projectMeta overrideProject
+monorepoMain basedir monoRepoAnalysisOpts logSeverity apiOpts projectMeta overrideProject = withDefaultLogger logSeverity $ do
+  result <- runDiagnostics $ withWigginsBinary $ monorepoScan basedir monoRepoAnalysisOpts logSeverity apiOpts projectMeta overrideProject
   case result of
     Left failure -> do
       logStdout $ toText $ show $ renderFailureBundle failure
       sendIO exitFailure
     Right _ -> pure ()
 
-monorepoScan :: (Has Diagnostics sig m, Has (Lift IO) sig m, Has Logger sig m) => BaseDir -> MonorepoAnalysisOpts -> ApiOpts -> ProjectMetadata -> OverrideProject -> BinaryPaths -> m ()
-monorepoScan = undefined
+monorepoScan :: (Has Diagnostics sig m, Has (Lift IO) sig m, Has Logger sig m) => BaseDir -> MonorepoAnalysisOpts -> Severity -> ApiOpts -> ProjectMetadata -> OverrideProject -> BinaryPaths -> m ()
+monorepoScan (BaseDir basedir) monorepoAnalysisOpts logSeverity apiOpts projectMeta projectOverride binaryPaths = do
+  projectRevision <- mergeOverride projectOverride <$> (inferProjectFromVCS basedir <||> inferProjectDefault basedir)
+  saveRevision projectRevision
+
+  -- todo: get (followSymlinks ScanType) and filterExpressions from user input
+  let scanType = ScanType True False False
+  let filterExpressions = FilterExpressions []
+  let wigginsOpts = generateWigginsMonorepoOpts basedir monorepoAnalysisOpts logSeverity projectRevision scanType filterExpressions apiOpts projectMeta
+
+  logInfo "Running monorepo scan"
+  stdout <- runExecIO $ runWiggins binaryPaths wigginsOpts
+  logInfo $ pretty stdout
+
+runWiggins :: (Has Exec sig m, Has Diagnostics sig m) => BinaryPaths -> WigginsOpts -> m Text
+runWiggins binaryPaths opts = do
+  execWiggins binaryPaths opts

--- a/src/App/Fossa/Monorepo.hs
+++ b/src/App/Fossa/Monorepo.hs
@@ -19,12 +19,7 @@ import System.Exit (exitFailure)
 
 monorepoMain :: BaseDir -> MonorepoAnalysisOpts -> Severity -> ApiOpts -> ProjectMetadata -> OverrideProject -> IO ()
 monorepoMain basedir monoRepoAnalysisOpts logSeverity apiOpts projectMeta overrideProject = withDefaultLogger logSeverity $ do
-  result <- runDiagnostics $ withWigginsBinary $ monorepoScan basedir monoRepoAnalysisOpts logSeverity apiOpts projectMeta overrideProject
-  case result of
-    Left failure -> do
-      logStdout $ toText $ show $ renderFailureBundle failure
-      sendIO exitFailure
-    Right _ -> pure ()
+  logWithExit_ $ withWigginsBinary $ monorepoScan basedir monoRepoAnalysisOpts logSeverity apiOpts projectMeta overrideProject
 
 monorepoScan :: (Has Diagnostics sig m, Has (Lift IO) sig m, Has Logger sig m) => BaseDir -> MonorepoAnalysisOpts -> Severity -> ApiOpts -> ProjectMetadata -> OverrideProject -> BinaryPaths -> m ()
 monorepoScan (BaseDir basedir) monorepoAnalysisOpts logSeverity apiOpts projectMeta projectOverride binaryPaths = do

--- a/src/App/Fossa/Monorepo.hs
+++ b/src/App/Fossa/Monorepo.hs
@@ -7,7 +7,6 @@ module App.Fossa.Monorepo (
 import App.Fossa.EmbeddedBinary
 import App.Fossa.ProjectInference
 import App.Fossa.VPS.Scan.RunWiggins
-import App.Fossa.VPS.Types
 import App.Types
 import Control.Carrier.Diagnostics
 import Control.Effect.Lift (Lift, sendIO)
@@ -32,10 +31,7 @@ monorepoScan (BaseDir basedir) monorepoAnalysisOpts logSeverity apiOpts projectM
   projectRevision <- mergeOverride projectOverride <$> (inferProjectFromVCS basedir <||> inferProjectDefault basedir)
   saveRevision projectRevision
 
-  -- todo: get (followSymlinks ScanType) and filterExpressions from user input
-  let scanType = ScanType True False False
-  let filterExpressions = FilterExpressions []
-  let wigginsOpts = generateWigginsMonorepoOpts basedir monorepoAnalysisOpts logSeverity projectRevision scanType filterExpressions apiOpts projectMeta
+  let wigginsOpts = generateWigginsMonorepoOpts basedir monorepoAnalysisOpts logSeverity projectRevision apiOpts projectMeta
 
   logInfo "Running monorepo scan"
   stdout <- runExecIO $ runWiggins binaryPaths wigginsOpts

--- a/src/App/Fossa/Monorepo.hs
+++ b/src/App/Fossa/Monorepo.hs
@@ -1,0 +1,26 @@
+{-# LANGUAGE RecordWildCards #-}
+
+module App.Fossa.Monorepo (
+  monorepoMain,
+) where
+
+import App.Fossa.EmbeddedBinary
+import App.Types
+import Control.Carrier.Diagnostics
+import Control.Effect.Lift (Lift, sendIO)
+import Data.String.Conversion (toText)
+import Effect.Logger
+import Fossa.API.Types
+import System.Exit (exitFailure)
+
+monorepoMain :: BaseDir -> MonorepoAnalysisOpts -> Severity -> ApiOpts -> ProjectMetadata -> OverrideProject -> IO ()
+monorepoMain baseDir monoRepoAnalysisOpts logSeverity apiOpts projectMeta overrideProject = withDefaultLogger logSeverity $ do
+  result <- runDiagnostics $ withWigginsBinary $ monorepoScan baseDir monoRepoAnalysisOpts apiOpts projectMeta overrideProject
+  case result of
+    Left failure -> do
+      logStdout $ toText $ show $ renderFailureBundle failure
+      sendIO exitFailure
+    Right _ -> pure ()
+
+monorepoScan :: (Has Diagnostics sig m, Has (Lift IO) sig m, Has Logger sig m) => BaseDir -> MonorepoAnalysisOpts -> ApiOpts -> ProjectMetadata -> OverrideProject -> BinaryPaths -> m ()
+monorepoScan = undefined

--- a/src/App/Fossa/Monorepo.hs
+++ b/src/App/Fossa/Monorepo.hs
@@ -9,13 +9,11 @@ import App.Fossa.ProjectInference
 import App.Fossa.VPS.Scan.RunWiggins
 import App.Types
 import Control.Carrier.Diagnostics
-import Control.Effect.Lift (Lift, sendIO)
-import Data.String.Conversion (toText)
+import Control.Effect.Lift (Lift)
 import Data.Text
 import Effect.Exec
 import Effect.Logger
 import Fossa.API.Types
-import System.Exit (exitFailure)
 
 monorepoMain :: BaseDir -> MonorepoAnalysisOpts -> Severity -> ApiOpts -> ProjectMetadata -> OverrideProject -> IO ()
 monorepoMain basedir monoRepoAnalysisOpts logSeverity apiOpts projectMeta overrideProject = withDefaultLogger logSeverity $ do

--- a/src/App/Fossa/Monorepo.hs
+++ b/src/App/Fossa/Monorepo.hs
@@ -34,9 +34,9 @@ monorepoScan (BaseDir basedir) monorepoAnalysisOpts logSeverity apiOpts projectM
   let wigginsOpts = generateWigginsMonorepoOpts basedir monorepoAnalysisOpts logSeverity projectRevision apiOpts projectMeta
 
   logInfo "Running monorepo scan"
-  stdout <- runExecIO $ runWiggins binaryPaths wigginsOpts
+  stdout <- context "Monorepo" $ runExecIO $ runWiggins binaryPaths wigginsOpts
   logInfo $ pretty stdout
 
 runWiggins :: (Has Exec sig m, Has Diagnostics sig m) => BinaryPaths -> WigginsOpts -> m Text
 runWiggins binaryPaths opts = do
-  execWiggins binaryPaths opts
+  context "Running monorepo binary" $ execWiggins binaryPaths opts

--- a/src/App/Fossa/VPS/Scan/RunWiggins.hs
+++ b/src/App/Fossa/VPS/Scan/RunWiggins.hs
@@ -6,6 +6,7 @@ module App.Fossa.VPS.Scan.RunWiggins (
   generateWigginsScanOpts,
   generateWigginsAOSPNoticeOpts,
   generateVSIStandaloneOpts,
+  generateWigginsMonorepoOpts,
   WigginsOpts (..),
   ScanType (..),
 ) where
@@ -53,6 +54,10 @@ generateWigginsAOSPNoticeOpts scanDir logSeverity apiOpts projectRevision ninjaS
 generateVSIStandaloneOpts :: Path Abs Dir -> ApiOpts -> WigginsOpts
 generateVSIStandaloneOpts scanDir apiOpts = WigginsOpts scanDir $ generateVSIStandaloneArgs apiOpts
 
+generateWigginsMonorepoOpts :: Path Abs Dir -> MonorepoAnalysisOpts -> Severity -> ProjectRevision -> ScanType -> FilterExpressions -> ApiOpts -> ProjectMetadata -> WigginsOpts
+generateWigginsMonorepoOpts scanDir monorepoAnalysisOpts logSeverity projectRevision scanType fileFilters apiOpts metadata =
+  WigginsOpts scanDir $ generateMonorepoArgs monorepoAnalysisOpts logSeverity projectRevision scanType fileFilters apiOpts metadata
+
 generateSpectrometerAOSPNoticeArgs :: Severity -> ApiOpts -> ProjectRevision -> NinjaScanID -> NinjaFilePaths -> [Text]
 generateSpectrometerAOSPNoticeArgs logSeverity ApiOpts{..} ProjectRevision{..} ninjaScanId ninjaInputFiles =
   ["aosp-notice-files"]
@@ -69,6 +74,24 @@ generateVSIStandaloneArgs ApiOpts{..} =
   "vsi-direct" :
   optMaybeText "-endpoint" (render <$> apiOptsUri)
     ++ ["-fossa-api-key", unApiKey apiOptsApiKey]
+    ++ ["."]
+
+generateMonorepoArgs :: MonorepoAnalysisOpts -> Severity -> ProjectRevision -> ScanType -> FilterExpressions -> ApiOpts -> ProjectMetadata -> [Text]
+generateMonorepoArgs MonorepoAnalysisOpts{..} logSeverity ProjectRevision{..} ScanType{..} fileFilters ApiOpts{..} ProjectMetadata{..} =
+  "monorepo" :
+  optMaybeText "-endpoint" (render <$> apiOptsUri)
+    ++ ["-fossa-api-key", unApiKey apiOptsApiKey]
+    ++ ["-project", projectName, "-revision", projectRevision]
+    ++ optMaybeText "-jira-project-key" projectJiraKey
+    ++ optMaybeText "-link" projectLink
+    ++ optMaybeText "-policy" projectPolicy
+    ++ optMaybeText "-project-url" projectUrl
+    ++ optMaybeText "-team" projectTeam
+    ++ optMaybeText "-title" projectTitle
+    ++ optBool "-follow" followSymlinks
+    ++ optBool "-debug" (logSeverity == SevDebug)
+    ++ optFilterExpressions fileFilters
+    ++ optMaybeText "-type" monorepoAnalysisType
     ++ ["."]
 
 generateSpectrometerScanArgs :: Severity -> ProjectRevision -> ScanType -> FilterExpressions -> ApiOpts -> ProjectMetadata -> [Text]

--- a/src/App/Fossa/VPS/Scan/RunWiggins.hs
+++ b/src/App/Fossa/VPS/Scan/RunWiggins.hs
@@ -88,9 +88,7 @@ generateMonorepoArgs MonorepoAnalysisOpts{..} logSeverity ProjectRevision{..} Ap
     ++ optMaybeText "-project-url" projectUrl
     ++ optMaybeText "-team" projectTeam
     ++ optMaybeText "-title" projectTitle
-    ++ optBool "-follow" monorepoFollowSymlinks
     ++ optBool "-debug" (logSeverity == SevDebug)
-    ++ optFilterExpressions monorepoScanFileFilters
     ++ optMaybeText "-type" monorepoAnalysisType
     ++ ["."]
 

--- a/src/App/Fossa/VPS/Scan/RunWiggins.hs
+++ b/src/App/Fossa/VPS/Scan/RunWiggins.hs
@@ -54,9 +54,9 @@ generateWigginsAOSPNoticeOpts scanDir logSeverity apiOpts projectRevision ninjaS
 generateVSIStandaloneOpts :: Path Abs Dir -> ApiOpts -> WigginsOpts
 generateVSIStandaloneOpts scanDir apiOpts = WigginsOpts scanDir $ generateVSIStandaloneArgs apiOpts
 
-generateWigginsMonorepoOpts :: Path Abs Dir -> MonorepoAnalysisOpts -> Severity -> ProjectRevision -> ScanType -> FilterExpressions -> ApiOpts -> ProjectMetadata -> WigginsOpts
-generateWigginsMonorepoOpts scanDir monorepoAnalysisOpts logSeverity projectRevision scanType fileFilters apiOpts metadata =
-  WigginsOpts scanDir $ generateMonorepoArgs monorepoAnalysisOpts logSeverity projectRevision scanType fileFilters apiOpts metadata
+generateWigginsMonorepoOpts :: Path Abs Dir -> MonorepoAnalysisOpts -> Severity -> ProjectRevision -> ApiOpts -> ProjectMetadata -> WigginsOpts
+generateWigginsMonorepoOpts scanDir monorepoAnalysisOpts logSeverity projectRevision apiOpts metadata =
+  WigginsOpts scanDir $ generateMonorepoArgs monorepoAnalysisOpts logSeverity projectRevision apiOpts metadata
 
 generateSpectrometerAOSPNoticeArgs :: Severity -> ApiOpts -> ProjectRevision -> NinjaScanID -> NinjaFilePaths -> [Text]
 generateSpectrometerAOSPNoticeArgs logSeverity ApiOpts{..} ProjectRevision{..} ninjaScanId ninjaInputFiles =
@@ -76,8 +76,8 @@ generateVSIStandaloneArgs ApiOpts{..} =
     ++ ["-fossa-api-key", unApiKey apiOptsApiKey]
     ++ ["."]
 
-generateMonorepoArgs :: MonorepoAnalysisOpts -> Severity -> ProjectRevision -> ScanType -> FilterExpressions -> ApiOpts -> ProjectMetadata -> [Text]
-generateMonorepoArgs MonorepoAnalysisOpts{..} logSeverity ProjectRevision{..} ScanType{..} fileFilters ApiOpts{..} ProjectMetadata{..} =
+generateMonorepoArgs :: MonorepoAnalysisOpts -> Severity -> ProjectRevision -> ApiOpts -> ProjectMetadata -> [Text]
+generateMonorepoArgs MonorepoAnalysisOpts{..} logSeverity ProjectRevision{..} ApiOpts{..} ProjectMetadata{..} =
   "monorepo" :
   optMaybeText "-endpoint" (render <$> apiOptsUri)
     ++ ["-fossa-api-key", unApiKey apiOptsApiKey]
@@ -88,9 +88,9 @@ generateMonorepoArgs MonorepoAnalysisOpts{..} logSeverity ProjectRevision{..} Sc
     ++ optMaybeText "-project-url" projectUrl
     ++ optMaybeText "-team" projectTeam
     ++ optMaybeText "-title" projectTitle
-    ++ optBool "-follow" followSymlinks
+    ++ optBool "-follow" monorepoFollowSymlinks
     ++ optBool "-debug" (logSeverity == SevDebug)
-    ++ optFilterExpressions fileFilters
+    ++ optFilterExpressions monorepoScanFileFilters
     ++ optMaybeText "-type" monorepoAnalysisType
     ++ ["."]
 

--- a/src/App/Types.hs
+++ b/src/App/Types.hs
@@ -7,6 +7,7 @@ module App.Types (
   MonorepoAnalysisOpts (..),
 ) where
 
+import App.Fossa.VPS.Types
 import Data.Text (Text)
 import Path
 
@@ -28,8 +29,10 @@ data ProjectMetadata = ProjectMetadata
   }
   deriving (Eq, Ord, Show)
 
-newtype MonorepoAnalysisOpts = MonorepoAnalysisOpts
+data MonorepoAnalysisOpts = MonorepoAnalysisOpts
   { monorepoAnalysisType :: Maybe Text
+  , monorepoFollowSymlinks :: Bool
+  , monorepoScanFileFilters :: FilterExpressions
   }
 
 data ProjectRevision = ProjectRevision

--- a/src/App/Types.hs
+++ b/src/App/Types.hs
@@ -4,6 +4,7 @@ module App.Types (
   OverrideProject (..),
   ProjectMetadata (..),
   ProjectRevision (..),
+  MonorepoAnalysisOpts (..),
 ) where
 
 import Data.Text (Text)
@@ -26,6 +27,10 @@ data ProjectMetadata = ProjectMetadata
   , projectPolicy :: Maybe Text
   }
   deriving (Eq, Ord, Show)
+
+newtype MonorepoAnalysisOpts = MonorepoAnalysisOpts
+  { monorepoAnalysisType :: Maybe String
+  }
 
 data ProjectRevision = ProjectRevision
   { projectName :: Text

--- a/src/App/Types.hs
+++ b/src/App/Types.hs
@@ -29,7 +29,7 @@ data ProjectMetadata = ProjectMetadata
   deriving (Eq, Ord, Show)
 
 newtype MonorepoAnalysisOpts = MonorepoAnalysisOpts
-  { monorepoAnalysisType :: Maybe String
+  { monorepoAnalysisType :: Maybe Text
   }
 
 data ProjectRevision = ProjectRevision

--- a/src/App/Types.hs
+++ b/src/App/Types.hs
@@ -7,7 +7,6 @@ module App.Types (
   MonorepoAnalysisOpts (..),
 ) where
 
-import App.Fossa.VPS.Types
 import Data.Text (Text)
 import Path
 
@@ -29,10 +28,8 @@ data ProjectMetadata = ProjectMetadata
   }
   deriving (Eq, Ord, Show)
 
-data MonorepoAnalysisOpts = MonorepoAnalysisOpts
+newtype MonorepoAnalysisOpts = MonorepoAnalysisOpts
   { monorepoAnalysisType :: Maybe Text
-  , monorepoFollowSymlinks :: Bool
-  , monorepoScanFileFilters :: FilterExpressions
   }
 
 data ProjectRevision = ProjectRevision


### PR DESCRIPTION
# Overview

### Deprecates `fossa vps` commands.

The "VPS Classic" product is deprecated. Instead we're splitting into Monorepo and VSI support.

### Adds a new flag to `fossa analyze`

`experimental-enable-monorepo`: Accept a string indicating the type of monorepo scan to run, with the only currently valid value of `aosp`. If not provided, the analysis command proceeds as normal without performing a monorepo scan.
Any provided string value is passed along to the monorepo plugin for validation; spectrometer doesn't do any validation on this value.

## Acceptance criteria

* Leave `fossa analysis` invocations that are not run with `--experimental-enable-monorepo` untouched.
* When `--experimental-enable-monorepo` is provided, do not run normal analysis; instead run a scan with the monorepo plugin.

## Testing plan

* I ran `cabal run fossa -- analyze --project quick -e 'http://localhost:9578' --fossa-api-key $FOSSA_API_KEY ~/projects/quick` and validated that the command worked the same as it did before this change.
* I ran `cabal run fossa -- analyze --experimental-enable-monorepo aosp -e 'http://localhost:9578' --fossa-api-key $FOSSA_API_KEY ~/projects/aosp-mini/` and validated that the scan worked in monorepo mode.
* I tried a few different arguments in both modes and things worked as expected.

## Risks

This could potentially keep standard `fossa analyze` commands from running properly if my new [branching pattern match](https://github.com/fossas/spectrometer/compare/monorepo-integration?expand=1#diff-f2fe846f526d80e94301cb1315b5a660dea9fee7efe2fb1be098fad1112200a8R88) is not well formed. Other than that I don't think this is very risky.

## References

Pivotal tracker: https://www.pivotaltracker.com/story/show/178806134

<details><summary>Reproduced ticket text</summary>
Remove the concept of the `vps` subcommand in Spectrometer, bringing monorepo support into the standard `analyze` process.

* Add a deprecation warning to the `fossa vps` subcommand.
* Add `--experimental-enable-monorepo` to `fossa analyze`:
  * Accepts a string.
  * Forwards the string to wiggins; leave validation logic there.
* When `fossa analyze` is run with `experimental-enable-monorepo`, run `wiggins monorepo` instead of the standard analysis flow.

When running `wiggins monorepo`, pass along flags as previously implemented for `fossa vps analyze`. Additionally, pass along the value for `--experimental-enable-monorepo` to wiggins' `-type` argument.
</details>

## Checklist

_Going to work through these, but since they're doc related only the PR is ready for review now._

- [x] I added tests for this PR's change (or confirmed tests are not viable).
- [x] I linted and formatted (via `haskell-language-server`) any haskell files I touched in this PR.
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] I linked this PR to any referenced GitHub issues, if they exist.
