### PR TITLE
Pass along project branch to wiggins

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,9 +5,9 @@
 - Support ReleaseGroup configuration ([#283](https://github.com/fossas/spectrometer/pull/283))
 - Support HTTP endpoints for archive uploads ([#276](https://github.com/fossas/spectrometer/pull/276))
 - Support VCS branches for `fossa analyze --experimental-enable-monorepo` invocations ([#289](https://github.com/fossas/spectrometer/pull/289))
-  - Deprecate `fossa vps` subcommands.
-  - Add `--experimental-enable-monorepo` and other associated flags to `fossa analyze`, which enables experimental monorepo support.
-    Monorepo flags are only used with support from FOSSA engineering, and are experimental while we build robust support for monorepo projects with FOSSA partners.
+- Add `--experimental-enable-monorepo` and other associated flags to `fossa analyze`, which enables experimental monorepo support ([#286](https://github.com/fossas/spectrometer/pull/286))
+  Monorepo flags are only used with support from FOSSA engineering, and are experimental while we build robust support for monorepo projects with FOSSA partners.
+- Deprecate `fossa vps` subcommands ([#286](https://github.com/fossas/spectrometer/pull/286))
 
 ## v2.10.2
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,7 @@
 
 - Support ReleaseGroup configuration ([#283](https://github.com/fossas/spectrometer/pull/283))
 - Support HTTP endpoints for archive uploads ([#276](https://github.com/fossas/spectrometer/pull/276))
+- Support VCS branches for `fossa analyze --experimental-enable-monorepo` invocations ([#289](https://github.com/fossas/spectrometer/pull/289))
 
 ## v2.10.3
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,16 +1,14 @@
 # Spectrometer Changelog
 
-## Unreleased 
+## v2.10.3
 
 - Support ReleaseGroup configuration ([#283](https://github.com/fossas/spectrometer/pull/283))
 - Support HTTP endpoints for archive uploads ([#276](https://github.com/fossas/spectrometer/pull/276))
 - Support VCS branches for `fossa analyze --experimental-enable-monorepo` invocations ([#289](https://github.com/fossas/spectrometer/pull/289))
-
-## v2.10.3
-
 - Deprecate `fossa vps` subcommands.
 - Add `--experimental-enable-monorepo` and other associated flags to `fossa analyze`, which enables experimental monorepo support.
   Monorepo flags are only used with support from FOSSA engineering, and are experimental while we build robust support for monorepo projects with FOSSA partners.
+- Support `--branch` (and inferred branch from VCS) when `--experimental-enable-monorepo` is enabled.
 
 ## v2.10.2
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -5,10 +5,9 @@
 - Support ReleaseGroup configuration ([#283](https://github.com/fossas/spectrometer/pull/283))
 - Support HTTP endpoints for archive uploads ([#276](https://github.com/fossas/spectrometer/pull/276))
 - Support VCS branches for `fossa analyze --experimental-enable-monorepo` invocations ([#289](https://github.com/fossas/spectrometer/pull/289))
-- Deprecate `fossa vps` subcommands.
-- Add `--experimental-enable-monorepo` and other associated flags to `fossa analyze`, which enables experimental monorepo support.
-  Monorepo flags are only used with support from FOSSA engineering, and are experimental while we build robust support for monorepo projects with FOSSA partners.
-- Support `--branch` (and inferred branch from VCS) when `--experimental-enable-monorepo` is enabled.
+  - Deprecate `fossa vps` subcommands.
+  - Add `--experimental-enable-monorepo` and other associated flags to `fossa analyze`, which enables experimental monorepo support.
+    Monorepo flags are only used with support from FOSSA engineering, and are experimental while we build robust support for monorepo projects with FOSSA partners.
 
 ## v2.10.2
 

--- a/src/App/Fossa/VPS/Scan/RunWiggins.hs
+++ b/src/App/Fossa/VPS/Scan/RunWiggins.hs
@@ -88,6 +88,7 @@ generateMonorepoArgs MonorepoAnalysisOpts{..} logSeverity ProjectRevision{..} Ap
     ++ optMaybeText "-project-url" projectUrl
     ++ optMaybeText "-team" projectTeam
     ++ optMaybeText "-title" projectTitle
+    ++ optMaybeText "-branch" projectBranch
     ++ optBool "-debug" (logSeverity == SevDebug)
     ++ optMaybeText "-type" monorepoAnalysisType
     ++ ["."]

--- a/vendor_download.sh
+++ b/vendor_download.sh
@@ -41,7 +41,7 @@ esac
 TAG="latest"
 echo "Downloading asset information from latest tag for architecture '$ASSET_POSTFIX'"
 
-WIGGINS_TAG="2021-07-15-ea4fc60"
+WIGGINS_TAG="2021-07-16-39ef825"
 echo "Downloading wiggins binary"
 echo "Using wiggins release: $WIGGINS_TAG"
 WIGGINS_RELEASE_JSON=vendor/wiggins-release.json


### PR DESCRIPTION
# Overview

Pass along project branch to Wiggins

## Acceptance criteria

Pass along the project branch (either inferred or via `--branch`) to Wiggins when invoking `fossa analyze --experimental-enable-monorepo aosp`.

## Testing plan

Right now monorepo projects don't actually _use_ this value server side, so to test it I moved an older version of wiggins into my `vendor` folder and ran with `--branch`. Wiggins exited with an error because we passed the branch flag, which this version didn't understand and I was hoping to see, so I believe this works properly.

## Risks

I don't think anything is particularly risky here.

## Checklist

- [x] I added tests for this PR's change (or confirmed tests are not viable).
- [x] I linted and formatted (via `haskell-language-server`) any haskell files I touched in this PR.
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] I linked this PR to any referenced GitHub issues, if they exist.
