### PR TITLE
Monorepo `fossa test` and `fossa report` fix

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Spectrometer Changelog
 
+## Unreleased
+
+- Support `fossa test` and `fossa report` for monorepo projects ([#290](https://github.com/fossas/spectrometer/pull/290))
+
 ## v2.10.3
 
 - Support ReleaseGroup configuration ([#283](https://github.com/fossas/spectrometer/pull/283))

--- a/src/App/Fossa/Report.hs
+++ b/src/App/Fossa/Report.hs
@@ -59,7 +59,7 @@ reportMain (BaseDir basedir) apiOpts logSeverity timeoutSeconds reportType overr
 
       logSticky "[ Waiting for build completion... ]"
 
-      waitForBuild apiOpts revision
+      waitForBuild apiOpts revision <||> waitForMonorepoScan apiOpts revision
 
       logSticky "[ Waiting for issue scan completion... ]"
 

--- a/src/App/Fossa/Report/Attribution.hs
+++ b/src/App/Fossa/Report/Attribution.hs
@@ -63,8 +63,8 @@ instance FromJSON Attribution where
   parseJSON = withObject "Attribution" $ \obj ->
     Attribution
       <$> obj .: "project"
-      <*> obj .: "directDependencies"
-      <*> obj .: "deepDependencies"
+      <*> obj .:? "directDependencies" .!= []
+      <*> obj .:? "deepDependencies" .!= []
       <*> obj .: "licenses"
 
 instance ToJSON Attribution where

--- a/src/App/Fossa/Test.hs
+++ b/src/App/Fossa/Test.hs
@@ -45,7 +45,7 @@ testMain (BaseDir basedir) apiOpts logSeverity timeoutSeconds outputType overrid
 
       logSticky "[ Waiting for build completion... ]"
 
-      waitForBuild apiOpts revision
+      waitForBuild apiOpts revision <||> waitForMonorepoScan apiOpts revision
 
       logSticky "[ Waiting for issue scan completion... ]"
       issues <- waitForIssues apiOpts revision


### PR DESCRIPTION
# Overview

Update `fossa test` and `fossa report` to work with monorepo projects:

* When waiting for build, also wait for a monorepo build. Move on when either a standard or monorepo build completes.
* Make dependencies optional when parsing attribution report JSON from the server.

## Acceptance criteria

* Support `fossa test` for monorepo projects.
* Support `fossa report` for monorepo projects.

## Testing plan

Ran `fossa report` against a monorepo project in staging: 
```shell
cabal run fossa -- report attribution --json --endpoint '<url>'  --fossa-api-key <key> --project 'aosp-mini' --revision 1625264228
```

This reported expected results:
```json
{"project":{"name":"aosp-mini (enricozb)","revision":"1625264228"},"directDependencies":[],"licenses":{"Apache-2.0":"This license is not associated with a known package in your project.","MIT-CMU":"This license is not associated with a known package in your project.","BSD-3-Clause":"This license is not associated with a known package in your project.","GPL-3.0+":"This license is not associated with a known package in your project.","MIT":"This license is not associated with a known package in your project.","GPL-2.0":"This license is not associated with a known package in your project.","BSD-4-Clause-UC":"This license is not associated with a known package in your project.","Public-domain":"This license is not associated with a known package in your project.","BSD-4-Clause":"This license is not associated with a known package in your project.","ISC":"This license is not associated with a known package in your project.","Bison-exception-2.2":"This license is not associated with a known package in your project.","BSD-2-Clause":"This license is not associated with a known package in your project."},"deepDependencies":[]}
````

Ran `fossa test` against a monorepo project in staging:
```shell
cabal run fossa -- test --endpoint '<url>'  --fossa-api-key <key> --project 'aosp-mini' --revision 1625264228
```

This correctly failed the test and denied with four issues.

I then tested both commands with a non-monorepo project and they similarly worked as expected.

## Risks

Touching this area of the code could cause issues with `fossa test` and `fossa report` on non-monorepo projects, but I think that the changes are defensive enough that this is unlikely.

## Checklist

- [x] I added tests for this PR's change (or confirmed tests are not viable).
- [x] I linted and formatted (via `haskell-language-server`) any haskell files I touched in this PR.
- [x] I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] I linked this PR to any referenced GitHub issues, if they exist.
