### PR TITLE
Exclusion targets: monorepo interop

### DIFF
--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -160,9 +160,9 @@ analyzeMain workdir recordMode logSeverity destination project unpackArchives js
 
 -- vsiDiscoverFunc is appended to discoverFuncs during analyze.
 -- It's not added to discoverFuncs because it requires more information than other discoverFuncs.
-vsiDiscoverFunc :: (TaskEffs sig m, TaskEffs rsig run) => VSIAnalysisMode -> ScanDestination -> Path Abs Dir -> m [DiscoveredProject run]
-vsiDiscoverFunc VSIAnalysisEnabled (UploadScan apiOpts _) = VSI.discover apiOpts
-vsiDiscoverFunc _ _ = const $ pure []
+vsiDiscoverFunc :: (TaskEffs sig m, TaskEffs rsig run) => VSIAnalysisMode -> ScanDestination -> AllFilters -> Path Abs Dir -> m [DiscoveredProject run]
+vsiDiscoverFunc VSIAnalysisEnabled (UploadScan apiOpts _) filters = VSI.discover filters apiOpts
+vsiDiscoverFunc _ _ _ = const $ pure []
 
 discoverFuncs :: (TaskEffs sig m, TaskEffs rsig run) => [Path Abs Dir -> m [DiscoveredProject run]]
 discoverFuncs =
@@ -242,7 +242,7 @@ analyze (BaseDir basedir) destination override unpackArchives jsonOutput enableV
   capabilities <- sendIO getNumCapabilities
   -- When running analysis, append the vsi discover function to the end of the discover functions list.
   -- This is done because the VSI discover function requires more information than other discover functions do, and only matters for analysis.
-  let discoverFuncs' = discoverFuncs ++ [vsiDiscoverFunc enableVSI destination]
+  let discoverFuncs' = discoverFuncs ++ [vsiDiscoverFunc enableVSI destination filters]
       apiOpts = case destination of
         OutputStdout -> Nothing
         UploadScan opts _ -> Just opts

--- a/src/App/Fossa/Main.hs
+++ b/src/App/Fossa/Main.hs
@@ -157,7 +157,7 @@ appMain = do
       if analyzeOutput
         then die "Monorepo analysis does not support the `--output` flag"
         else do
-          filters <- monorepoFilters analyzeOptions
+          filters <- pathFilters analyzeOptions
           key <- requireKey maybeApiKey
           let apiOpts = ApiOpts optBaseUrl key
           let metadata = maybe analyzeMetadata (mergeFileCmdMetadata analyzeMetadata) fileConfig
@@ -166,10 +166,10 @@ appMain = do
           basedir <- parseAbsDir analyzeBaseDir
           monorepoMain (BaseDir basedir) monorepoAnalysisOpts logSeverity apiOpts metadata analyzeOverride filters
       where
-        monorepoFilters :: AnalyzeOptions -> IO (MonorepoFilters)
-        monorepoFilters AnalyzeOptions{analyzeBuildTargetFilters = [], analyzeExcludeTargets = [], analyzeOnlyTargets = []} = pure (toMonorepoFilters $ normalizedFilters fileConfig analyzeOptions)
-        monorepoFilters AnalyzeOptions{analyzeBuildTargetFilters = []} = die "The --only-target and --exclude-target options are invalid for monorepo projects. Instead use --only-path and/or --exclude-path to control which paths are scanned"
-        monorepoFilters _ = die "The --filter option is invalid for monorepo projects. Refer to the new path exclusion feature for how to filter monorepo project files. --filter will be removed by v2.20.0"
+        pathFilters :: AnalyzeOptions -> IO (PathFilters)
+        pathFilters AnalyzeOptions{analyzeBuildTargetFilters = [], analyzeExcludeTargets = [], analyzeOnlyTargets = []} = pure (toPathFilters $ normalizedFilters fileConfig analyzeOptions)
+        pathFilters AnalyzeOptions{analyzeBuildTargetFilters = []} = die "The --only-target and --exclude-target options are invalid for monorepo projects. Instead use --only-path and/or --exclude-path to control which paths are scanned"
+        pathFilters _ = die "The --filter option is invalid for monorepo projects. Refer to the new path exclusion feature for how to filter monorepo project files. --filter will be removed by v2.20.0"
     --
     AnalyzeCommand analyzeOptions@AnalyzeOptions{..} -> do
       -- The branch override needs to be set here rather than above to preserve

--- a/src/App/Fossa/Main.hs
+++ b/src/App/Fossa/Main.hs
@@ -152,18 +152,22 @@ appMain = do
           }
 
   case optCommand of
-    AnalyzeCommand AnalyzeOptions{analyzeOutput, analyzeBranch, analyzeMetadata, monorepoAnalysisOpts = (MonorepoAnalysisOpts (Just monorepoAnalysisType)), analyzeBaseDir} -> do
+    AnalyzeCommand analyzeOptions@AnalyzeOptions{analyzeOutput, analyzeBranch, analyzeMetadata, monorepoAnalysisOpts = (MonorepoAnalysisOpts (Just monorepoAnalysisType)), analyzeBaseDir, analyzeBuildTargetFilters} -> do
       dieOnWindows "Monorepo analysis is not supported on Windows"
       if analyzeOutput
         then die "Monorepo analysis does not support the `--output` flag"
-        else do
-          key <- requireKey maybeApiKey
-          let apiOpts = ApiOpts optBaseUrl key
-          let metadata = maybe analyzeMetadata (mergeFileCmdMetadata analyzeMetadata) fileConfig
-          let monorepoAnalysisOpts = MonorepoAnalysisOpts (Just monorepoAnalysisType)
-          let analyzeOverride = override{overrideBranch = analyzeBranch <|> ((fileConfig >>= configRevision) >>= configBranch)}
-          basedir <- parseAbsDir analyzeBaseDir
-          monorepoMain (BaseDir basedir) monorepoAnalysisOpts logSeverity apiOpts metadata analyzeOverride
+        else
+          if not $ null analyzeBuildTargetFilters
+            then die "The --filter option is invalid for monorepo projects. Refer to the new path exclusion feature for how to filter monorepo project files. --filter will be removed by v2.20.0"
+            else do
+              let filters = normalizedFilters fileConfig analyzeOptions
+              key <- requireKey maybeApiKey
+              let apiOpts = ApiOpts optBaseUrl key
+              let metadata = maybe analyzeMetadata (mergeFileCmdMetadata analyzeMetadata) fileConfig
+              let monorepoAnalysisOpts = MonorepoAnalysisOpts (Just monorepoAnalysisType)
+              let analyzeOverride = override{overrideBranch = analyzeBranch <|> ((fileConfig >>= configRevision) >>= configBranch)}
+              basedir <- parseAbsDir analyzeBaseDir
+              monorepoMain (BaseDir basedir) monorepoAnalysisOpts logSeverity apiOpts metadata analyzeOverride filters
     --
     AnalyzeCommand analyzeOptions@AnalyzeOptions{..} -> do
       -- The branch override needs to be set here rather than above to preserve

--- a/src/App/Fossa/Monorepo.hs
+++ b/src/App/Fossa/Monorepo.hs
@@ -5,20 +5,20 @@ module App.Fossa.Monorepo (
 ) where
 
 import App.Fossa.EmbeddedBinary
-import App.Fossa.ProjectInference
+import App.Fossa.ProjectInference (
+  inferProjectDefault,
+  inferProjectFromVCS,
+  mergeOverride,
+  saveRevision,
+ )
 import App.Fossa.VPS.Scan.RunWiggins
 import App.Types
 import Control.Carrier.Diagnostics
 import Control.Effect.Lift (Lift)
 import Data.Text
-import Discovery.Filters
 import Effect.Exec
 import Effect.Logger
 import Fossa.API.Types
-
--- Monorepo scans support a subset of AllFilters: specifically, target filters are not supported as monorepo scans do not have the concept of targets.
-toPathFilters :: AllFilters -> PathFilters
-toPathFilters AllFilters{includeFilters, excludeFilters} = PathFilters (combinedPaths includeFilters) (combinedPaths excludeFilters)
 
 monorepoMain :: BaseDir -> MonorepoAnalysisOpts -> Severity -> ApiOpts -> ProjectMetadata -> OverrideProject -> PathFilters -> IO ()
 monorepoMain basedir monoRepoAnalysisOpts logSeverity apiOpts projectMeta overrideProject filters = withDefaultLogger logSeverity $ do

--- a/src/App/Fossa/Monorepo.hs
+++ b/src/App/Fossa/Monorepo.hs
@@ -1,7 +1,7 @@
 module App.Fossa.Monorepo (
   monorepoMain,
-  toMonorepoFilters,
-  MonorepoFilters (..),
+  toPathFilters,
+  PathFilters (..),
 ) where
 
 import App.Fossa.EmbeddedBinary
@@ -17,14 +17,14 @@ import Effect.Logger
 import Fossa.API.Types
 
 -- Monorepo scans support a subset of AllFilters: specifically, target filters are not supported as monorepo scans do not have the concept of targets.
-toMonorepoFilters :: AllFilters -> MonorepoFilters
-toMonorepoFilters AllFilters{includeFilters, excludeFilters} = MonorepoFilters (combinedPaths includeFilters) (combinedPaths excludeFilters)
+toPathFilters :: AllFilters -> PathFilters
+toPathFilters AllFilters{includeFilters, excludeFilters} = PathFilters (combinedPaths includeFilters) (combinedPaths excludeFilters)
 
-monorepoMain :: BaseDir -> MonorepoAnalysisOpts -> Severity -> ApiOpts -> ProjectMetadata -> OverrideProject -> MonorepoFilters -> IO ()
+monorepoMain :: BaseDir -> MonorepoAnalysisOpts -> Severity -> ApiOpts -> ProjectMetadata -> OverrideProject -> PathFilters -> IO ()
 monorepoMain basedir monoRepoAnalysisOpts logSeverity apiOpts projectMeta overrideProject filters = withDefaultLogger logSeverity $ do
   logWithExit_ $ withWigginsBinary $ monorepoScan basedir monoRepoAnalysisOpts filters logSeverity apiOpts projectMeta overrideProject
 
-monorepoScan :: (Has Diagnostics sig m, Has (Lift IO) sig m, Has Logger sig m) => BaseDir -> MonorepoAnalysisOpts -> MonorepoFilters -> Severity -> ApiOpts -> ProjectMetadata -> OverrideProject -> BinaryPaths -> m ()
+monorepoScan :: (Has Diagnostics sig m, Has (Lift IO) sig m, Has Logger sig m) => BaseDir -> MonorepoAnalysisOpts -> PathFilters -> Severity -> ApiOpts -> ProjectMetadata -> OverrideProject -> BinaryPaths -> m ()
 monorepoScan (BaseDir basedir) monorepoAnalysisOpts filters logSeverity apiOpts projectMeta projectOverride binaryPaths = do
   projectRevision <- mergeOverride projectOverride <$> (inferProjectFromVCS basedir <||> inferProjectDefault basedir)
   saveRevision projectRevision

--- a/src/App/Fossa/Monorepo.hs
+++ b/src/App/Fossa/Monorepo.hs
@@ -9,12 +9,13 @@ import App.Types
 import Control.Carrier.Diagnostics
 import Control.Effect.Lift (Lift)
 import Data.Text
+import Discovery.Filters
 import Effect.Exec
 import Effect.Logger
 import Fossa.API.Types
 
-monorepoMain :: BaseDir -> MonorepoAnalysisOpts -> Severity -> ApiOpts -> ProjectMetadata -> OverrideProject -> IO ()
-monorepoMain basedir monoRepoAnalysisOpts logSeverity apiOpts projectMeta overrideProject = withDefaultLogger logSeverity $ do
+monorepoMain :: BaseDir -> MonorepoAnalysisOpts -> Severity -> ApiOpts -> ProjectMetadata -> OverrideProject -> AllFilters -> IO ()
+monorepoMain basedir monoRepoAnalysisOpts logSeverity apiOpts projectMeta overrideProject filters = withDefaultLogger logSeverity $ do
   logWithExit_ $ withWigginsBinary $ monorepoScan basedir monoRepoAnalysisOpts logSeverity apiOpts projectMeta overrideProject
 
 monorepoScan :: (Has Diagnostics sig m, Has (Lift IO) sig m, Has Logger sig m) => BaseDir -> MonorepoAnalysisOpts -> Severity -> ApiOpts -> ProjectMetadata -> OverrideProject -> BinaryPaths -> m ()

--- a/src/App/Fossa/VPS/Scan/RunWiggins.hs
+++ b/src/App/Fossa/VPS/Scan/RunWiggins.hs
@@ -9,7 +9,7 @@ module App.Fossa.VPS.Scan.RunWiggins (
   generateWigginsMonorepoOpts,
   WigginsOpts (..),
   ScanType (..),
-  MonorepoFilters (..),
+  PathFilters (..),
 ) where
 
 import App.Fossa.EmbeddedBinary
@@ -44,7 +44,7 @@ data WigginsOpts = WigginsOpts
   , spectrometerArgs :: [Text]
   }
 
-data MonorepoFilters = MonorepoFilters
+data PathFilters = PathFilters
   { onlyPaths :: [Path Rel Dir]
   , excludePaths :: [Path Rel Dir]
   }
@@ -60,7 +60,7 @@ generateWigginsAOSPNoticeOpts scanDir logSeverity apiOpts projectRevision ninjaS
 generateVSIStandaloneOpts :: Path Abs Dir -> ApiOpts -> WigginsOpts
 generateVSIStandaloneOpts scanDir apiOpts = WigginsOpts scanDir $ generateVSIStandaloneArgs apiOpts
 
-generateWigginsMonorepoOpts :: Path Abs Dir -> MonorepoAnalysisOpts -> MonorepoFilters -> Severity -> ProjectRevision -> ApiOpts -> ProjectMetadata -> WigginsOpts
+generateWigginsMonorepoOpts :: Path Abs Dir -> MonorepoAnalysisOpts -> PathFilters -> Severity -> ProjectRevision -> ApiOpts -> ProjectMetadata -> WigginsOpts
 generateWigginsMonorepoOpts scanDir monorepoAnalysisOpts filters logSeverity projectRevision apiOpts metadata =
   WigginsOpts scanDir $ generateMonorepoArgs monorepoAnalysisOpts filters logSeverity projectRevision apiOpts metadata
 
@@ -82,8 +82,8 @@ generateVSIStandaloneArgs ApiOpts{..} =
     ++ ["-fossa-api-key", unApiKey apiOptsApiKey]
     ++ ["."]
 
-generateMonorepoArgs :: MonorepoAnalysisOpts -> MonorepoFilters -> Severity -> ProjectRevision -> ApiOpts -> ProjectMetadata -> [Text]
-generateMonorepoArgs MonorepoAnalysisOpts{..} MonorepoFilters{..} logSeverity ProjectRevision{..} ApiOpts{..} ProjectMetadata{..} =
+generateMonorepoArgs :: MonorepoAnalysisOpts -> PathFilters -> Severity -> ProjectRevision -> ApiOpts -> ProjectMetadata -> [Text]
+generateMonorepoArgs MonorepoAnalysisOpts{..} PathFilters{..} logSeverity ProjectRevision{..} ApiOpts{..} ProjectMetadata{..} =
   "monorepo" :
   optMaybeText "-endpoint" (render <$> apiOptsUri)
     ++ ["-fossa-api-key", unApiKey apiOptsApiKey]

--- a/src/App/Fossa/VPS/Scan/RunWiggins.hs
+++ b/src/App/Fossa/VPS/Scan/RunWiggins.hs
@@ -95,8 +95,8 @@ generateMonorepoArgs MonorepoAnalysisOpts{..} MonorepoFilters{..} logSeverity Pr
     ++ optMaybeText "-team" projectTeam
     ++ optMaybeText "-title" projectTitle
     ++ optMaybeText "-branch" projectBranch
-    ++ optExplodeText "-only-paths" (T.pack . toFilePath <$> onlyPaths)
-    ++ optExplodeText "-exclude-paths" (T.pack . toFilePath <$> excludePaths)
+    ++ optExplodeText "-only-path" (T.pack . toFilePath <$> onlyPaths)
+    ++ optExplodeText "-exclude-path" (T.pack . toFilePath <$> excludePaths)
     ++ optBool "-debug" (logSeverity == SevDebug)
     ++ optMaybeText "-type" monorepoAnalysisType
     ++ ["."]

--- a/src/App/Fossa/VPS/Scan/RunWiggins.hs
+++ b/src/App/Fossa/VPS/Scan/RunWiggins.hs
@@ -25,6 +25,7 @@ import Control.Carrier.Error.Either
 import Control.Effect.Diagnostics
 import Data.Aeson
 import Data.ByteString.Lazy qualified as BL
+import Data.String.Conversion
 import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Text.Encoding (decodeUtf8)
@@ -50,9 +51,6 @@ data PathFilters = PathFilters
   { onlyPaths :: [Path Rel Dir]
   , excludePaths :: [Path Rel Dir]
   }
-
-toText :: Path a b -> Text
-toText = T.pack . toFilePath
 
 toPathFilters :: AllFilters -> PathFilters
 toPathFilters AllFilters{includeFilters, excludeFilters} = PathFilters (combinedPaths includeFilters) (combinedPaths excludeFilters)

--- a/src/App/Fossa/VPS/Scan/RunWiggins.hs
+++ b/src/App/Fossa/VPS/Scan/RunWiggins.hs
@@ -25,7 +25,7 @@ import Control.Carrier.Error.Either
 import Control.Effect.Diagnostics
 import Data.Aeson
 import Data.ByteString.Lazy qualified as BL
-import Data.String.Conversion
+import Data.String.Conversion (toText)
 import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Text.Encoding (decodeUtf8)

--- a/vendor_download.sh
+++ b/vendor_download.sh
@@ -45,7 +45,7 @@ esac
 TAG="latest"
 echo "Downloading asset information from latest tag for architecture '$ASSET_POSTFIX'"
 
-WIGGINS_TAG="2021-07-23-b23c980"
+WIGGINS_TAG="2021-07-28-a2b6708"
 echo "Downloading wiggins binary"
 echo "Using wiggins release: $WIGGINS_TAG"
 WIGGINS_RELEASE_JSON=vendor/wiggins-release.json


### PR DESCRIPTION
# Overview

Update monorepo code to work with the new exclusion and inclusion paths functionality.

_Blocked on monorepo plugin support landing (in PR)_

## Acceptance criteria

* Accept `--only-path` and `--exclude-path` arguments, passing them along to the monorepo plugin
* Error on combination of `--experimental-enable-monorepo aosp` and `--filter`, because monorepo scans don't have targets
* Error on combination of `--experimental-enable-monorepo aosp` and `--exclude-target` or `--include-target`, because monorepo scans don't have targets

## Testing plan

Prior to building filter support in the monorepo plugin, I ran the following sets of commands with the attached results, which were all what I wanted to see.

_Demonstrates passing paths successfully:_
```shell
$ cabal run fossa -- analyze --experimental-enable-monorepo aosp -e '<url>' --fossa-api-key <key> --only-path foo --only-path foo2 --exclude-path bar <dir>
[ INFO] Running monorepo scan
[ERROR] ----------
  An error occurred:

      Command execution failed:
          command: /private/var/folders/qj/b_t4_wcx6j50zt70r7drqbn00000gn/T/fossa-vendor/vsi-plugin
          args: [ monorepo
                , -endpoint
                , http://localhost:9578
                , -fossa-api-key
                , 2dd3cf1d3e0a76eb78f9d33d4572cbac
                , -project
                , aosp-mini
                , -revision
                , 1626742024
                , -only-paths
                , foo/
                , -only-paths
                , foo2/
                , -exclude-paths
                , bar/
                , -type
                , aosp
                , . ]
          dir: /Users/kit/projects/aosp-mini/
          exit: ExitFailure 2
          stdout:

          stderr:
            2021/07/19 17:47:05 maxprocs: Leaving GOMAXPROCS=12: CPU quota undefined
            flag provided but not defined: -only-paths
```

_Demonstrates error on `--only-target`_
```shell
$ cabal run fossa -- analyze --experimental-enable-monorepo aosp -e '<url>' --fossa-api-key <key> --only-path foo --exclude-path bar --only-target x <dir>
The --only-target and --exclude-target options are invalid for monorepo projects. Instead use --only-path and/or --exclude-path to control which paths are scanned
```

_Demonstrates error on `--filter`_
```shell
$ cabal run fossa -- analyze --experimental-enable-monorepo aosp -e '<url>' --fossa-api-key <key> --only-path foo --exclude-path bar --filter vsi@. <dir>
The --filter option is invalid for monorepo projects. Refer to the new path exclusion feature for how to filter monorepo project files. --filter will be removed by v2.20.0
```

After building support in the pluin, I used different sets of filters to exclude directories from scans and they worked as expected.

## Risks

I don't think there's much risk here, we're just reading some data already being parsed by the base PR.

## Checklist

- [x] I added tests for this PR's change (or confirmed tests are not viable).
- [x] I linted and formatted (via `haskell-language-server`) any haskell files I touched in this PR.
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] I linked this PR to any referenced GitHub issues, if they exist.
