### PR TITLE
Use types to enforce that the user supplies both releaseGroupName and releaseGroupRelease

### DIFF
--- a/src/App/Fossa/Configuration.hs
+++ b/src/App/Fossa/Configuration.hs
@@ -8,7 +8,6 @@ module App.Fossa.Configuration (
   ConfigFile (..),
   ConfigProject (..),
   ConfigRevision (..),
-  ConfigReleaseGroup (..),
   ConfigTargets (..),
   ConfigPaths (..),
 ) where
@@ -42,19 +41,13 @@ data ConfigProject = ConfigProject
   , configJiraKey :: Maybe Text
   , configUrl :: Maybe Text
   , configPolicy :: Maybe Text
-  , configReleaseGroup :: Maybe ConfigReleaseGroup
+  , configReleaseGroup :: Maybe ReleaseGroupMetadata
   }
   deriving (Eq, Ord, Show)
 
 data ConfigRevision = ConfigRevision
   { configCommit :: Maybe Text
   , configBranch :: Maybe Text
-  }
-  deriving (Eq, Ord, Show)
-
-data ConfigReleaseGroup = ConfigReleaseGroup
-  { configReleaseGroupName :: Maybe Text
-  , configReleaseGroupRelease :: Maybe Text
   }
   deriving (Eq, Ord, Show)
 
@@ -96,11 +89,6 @@ instance FromJSON ConfigRevision where
     ConfigRevision <$> obj .:? "commit"
       <*> obj .:? "branch"
 
-instance FromJSON ConfigReleaseGroup where
-  parseJSON = withObject "ConfigReleaseGroup" $ \obj ->
-    ConfigReleaseGroup <$> obj .:? "name"
-      <*> obj .:? "release"
-
 instance FromJSON ConfigTargets where
   parseJSON = withObject "ConfigTargets" $ \obj ->
     ConfigTargets <$> (obj .:? "only" .!= [])
@@ -141,6 +129,5 @@ mergeFileCmdMetadata meta file =
     , projectLink = projectLink meta <|> (configProject file >>= configLink)
     , projectTeam = projectTeam meta <|> (configProject file >>= configTeam)
     , projectPolicy = projectPolicy meta <|> (configProject file >>= configPolicy)
-    , projectReleaseGroupName = projectReleaseGroupName meta <|> (configProject file >>= configReleaseGroup >>= configReleaseGroupName)
-    , projectReleaseGroupRelease = projectReleaseGroupRelease meta <|> (configProject file >>= configReleaseGroup >>= configReleaseGroupRelease)
+    , projectReleaseGroup = projectReleaseGroup meta <|> (configProject file >>= configReleaseGroup)
     }

--- a/src/App/Fossa/FossaAPIV1.hs
+++ b/src/App/Fossa/FossaAPIV1.hs
@@ -199,8 +199,8 @@ mkMetadataOpts ProjectMetadata{..} projectName = mconcat $ catMaybes maybes
       , ("link" =:) <$> projectLink
       , ("team" =:) <$> projectTeam
       , ("policy" =:) <$> projectPolicy
-      , ("releaseGroup" =:) <$> projectReleaseGroupName
-      , ("releaseGroupRelease" =:) <$> projectReleaseGroupRelease
+      , ("releaseGroup" =:) . releaseGroupName <$> projectReleaseGroup
+      , ("releaseGroupRelease" =:) . releaseGroupRelease <$> projectReleaseGroup
       , ("title" =:) <$> title
       ]
 

--- a/src/App/Fossa/Main.hs
+++ b/src/App/Fossa/Main.hs
@@ -48,6 +48,7 @@ import App.Types (
     overrideRevision
   ),
   ProjectMetadata (..),
+  ReleaseGroupMetadata (..),
  )
 import App.Util (validateDir, validateFile)
 import App.Version (fullVersionDescription)
@@ -190,10 +191,6 @@ appMain = do
           key <- requireKey maybeApiKey
           let apiOpts = ApiOpts optBaseUrl key
           let metadata = maybe analyzeMetadata (mergeFileCmdMetadata analyzeMetadata) fileConfig
-          case (projectReleaseGroupName metadata, projectReleaseGroupRelease metadata) of
-            (Just _, Just _) -> pure ()
-            (Nothing, Nothing) -> pure ()
-            _ -> die "releaseGroup.release and releaseGroup.name must both be specified if you want to associate this project to a release group."
 
           doAnalyze (UploadScan apiOpts metadata)
 
@@ -438,8 +435,13 @@ metadataOpts =
     <*> optional (strOption (long "link" <> short 'L' <> help "a link to attach to the current build"))
     <*> optional (strOption (long "team" <> short 'T' <> help "this repository's team inside your organization"))
     <*> optional (strOption (long "policy" <> help "the policy to assign to this project in FOSSA"))
-    <*> optional (strOption (long "release-group-name" <> help "the name of the release group to add this project to"))
-    <*> optional (strOption (long "release-group-release" <> help "the release of the release group to add this project to"))
+    <*> optional releaseGroupMetadataOpts
+
+releaseGroupMetadataOpts :: Parser ReleaseGroupMetadata
+releaseGroupMetadataOpts =
+  ReleaseGroupMetadata
+    <$> strOption (long "release-group-name" <> help "the name of the release group to add this project to")
+    <*> strOption (long "release-group-release" <> help "the release of the release group to add this project to")
 
 reportOpts :: Parser ReportOptions
 reportOpts =

--- a/src/App/Types.hs
+++ b/src/App/Types.hs
@@ -3,12 +3,14 @@ module App.Types (
   NinjaGraphCLIOptions (..),
   OverrideProject (..),
   ProjectMetadata (..),
+  ReleaseGroupMetadata (..),
   ProjectRevision (..),
   MonorepoAnalysisOpts (..),
 ) where
 
+import Data.Aeson (FromJSON (parseJSON), withObject, (.:))
 import Data.Text (Text)
-import Path
+import Path (Abs, Dir, Path)
 
 newtype BaseDir = BaseDir {unBaseDir :: Path Abs Dir} deriving (Eq, Ord, Show)
 
@@ -25,10 +27,20 @@ data ProjectMetadata = ProjectMetadata
   , projectLink :: Maybe Text
   , projectTeam :: Maybe Text
   , projectPolicy :: Maybe Text
-  , projectReleaseGroupName :: Maybe Text
-  , projectReleaseGroupRelease :: Maybe Text
+  , projectReleaseGroup :: Maybe ReleaseGroupMetadata
   }
   deriving (Eq, Ord, Show)
+
+data ReleaseGroupMetadata = ReleaseGroupMetadata
+  { releaseGroupName :: Text
+  , releaseGroupRelease :: Text
+  }
+  deriving (Eq, Ord, Show)
+
+instance FromJSON ReleaseGroupMetadata where
+  parseJSON = withObject "ReleaseGroupMetadata" $ \obj ->
+    ReleaseGroupMetadata <$> obj .: "name"
+      <*> obj .: "release"
 
 newtype MonorepoAnalysisOpts = MonorepoAnalysisOpts
   { monorepoAnalysisType :: Maybe Text

--- a/test/App/Fossa/Configuration/ConfigurationSpec.hs
+++ b/test/App/Fossa/Configuration/ConfigurationSpec.hs
@@ -6,12 +6,12 @@ module App.Fossa.Configuration.ConfigurationSpec (
 ) where
 
 import App.Fossa.Configuration
+import App.Types (ReleaseGroupMetadata (..))
 import Control.Carrier.Diagnostics qualified as Diag
 import Effect.ReadFS
 import Path
 import Test.Hspec qualified as T
 import Types (BuildTarget (..), TargetFilter (..))
-import App.Types (ReleaseGroupMetadata(..))
 
 expectedConfigFile :: ConfigFile
 expectedConfigFile =

--- a/test/App/Fossa/Configuration/ConfigurationSpec.hs
+++ b/test/App/Fossa/Configuration/ConfigurationSpec.hs
@@ -11,6 +11,7 @@ import Effect.ReadFS
 import Path
 import Test.Hspec qualified as T
 import Types (BuildTarget (..), TargetFilter (..))
+import App.Types (ReleaseGroupMetadata(..))
 
 expectedConfigFile :: ConfigFile
 expectedConfigFile =
@@ -44,11 +45,11 @@ expectedConfigRevision =
     , configBranch = Just "master"
     }
 
-expectedReleaseGroup :: ConfigReleaseGroup
+expectedReleaseGroup :: ReleaseGroupMetadata
 expectedReleaseGroup =
-  ConfigReleaseGroup
-    { configReleaseGroupName = Just "test-release"
-    , configReleaseGroupRelease = Just "123"
+  ReleaseGroupMetadata
+    { releaseGroupName = "test-release"
+    , releaseGroupRelease = "123"
     }
 
 expectedConfigTargets :: ConfigTargets


### PR DESCRIPTION
Rather than parsing the release group `name` and `release` separately as `(Maybe Text, Maybe Text)`, combine the parse into `Maybe (Text, Text)` to enforce that the user supplies both or none. This removes the manual check that both are supplied from here: https://github.com/fossas/spectrometer/compare/release-group-config-cleanup?expand=1#diff-f2fe846f526d80e94301cb1315b5a660dea9fee7efe2fb1be098fad1112200a8L113-L116

When the user only supplies one, they receive an error message on top of the usage/help text:
```
$ fossa analyze --release-group-name foo
Missing: --release-group-release ARG

Usage: fossa analyze [-o|--output] [--unpack-archives] [--json]
                     [-b|--branch ARG] [-t|--title ARG] [-P|--project-url ARG]
                     [-j|--jira-project-key ARG] [-L|--link ARG] [-T|--team ARG]
                     [--policy ARG]
                     [--release-group-name ARG --release-group-release ARG]
                     [--filter ANALYSIS-TARGET]
                     [--experimental-enable-monorepo MODE] [DIR]
  Scan for projects and their dependencies

Available options:
[...]
```