### PR TITLE
update vendor_download.sh to work with new basis release process

### DIFF
--- a/vendor_download.sh
+++ b/vendor_download.sh
@@ -59,8 +59,6 @@ FILTER=".name == \"scotland_yard-wiggins-$ASSET_POSTFIX_WITH_ARCHITECTURE\""
 jq -c ".assets | map({url: .url, name: .name}) | map(select($FILTER)) | .[]" $WIGGINS_RELEASE_JSON | while read ASSET; do
   URL="$(echo $ASSET | jq -c -r '.url')"
   NAME="$(echo $ASSET | jq -c -r '.name')"
-  echo "asset postfix with architecture: $ASSET_POSTFIX_WITH_ARCHITECTURE"
-  echo "NAME: $NAME"
   OUTPUT="$(echo vendor/$NAME | sed 's/scotland_yard-//' | sed 's/-'$ASSET_POSTFIX_WITH_ARCHITECTURE'//')"
 
   echo "Downloading '$NAME' to '$OUTPUT'"

--- a/vendor_download.sh
+++ b/vendor_download.sh
@@ -45,8 +45,7 @@ esac
 TAG="latest"
 echo "Downloading asset information from latest tag for architecture '$ASSET_POSTFIX'"
 
-# TODO: Update this to the latest release before merging and after the new basis release process has been merged into master on Basis
-WIGGINS_TAG="testing-2021-07-20-ea676a2"
+WIGGINS_TAG="2021-07-23-b23c980"
 echo "Downloading wiggins binary"
 echo "Using wiggins release: $WIGGINS_TAG"
 WIGGINS_RELEASE_JSON=vendor/wiggins-release.json

--- a/vendor_download.sh
+++ b/vendor_download.sh
@@ -21,24 +21,23 @@ rm -f vendor/*
 mkdir -p vendor
 
 ASSET_POSTFIX=""
-ASSET_POSTFIX_WITH_ARCHITECTURE=""
+WIGGINS_ASSET_POSTFIX=""
 OS_WINDOWS=false
-# case "$(uname -s)" in
-case "Windows" in
+case "$(uname -s)" in
   Darwin)
     ASSET_POSTFIX="darwin"
-    ASSET_POSTFIX_WITH_ARCHITECTURE="darwin-amd64"
+    WIGGINS_ASSET_POSTFIX="darwin-amd64"
     ;;
 
   Linux)
     ASSET_POSTFIX="linux"
-    ASSET_POSTFIX_WITH_ARCHITECTURE="linux-amd64"
+    WIGGINS_ASSET_POSTFIX="linux-amd64"
     ;;
 
   *)
     echo "Warn: Assuming $(uname -s) is Windows"
     ASSET_POSTFIX="windows.exe"
-    ASSET_POSTFIX_WITH_ARCHITECTURE="windows-amd64.exe"
+    WIGGINS_ASSET_POSTFIX="windows-amd64"
     OS_WINDOWS=true
     ;;
 esac
@@ -47,7 +46,7 @@ TAG="latest"
 echo "Downloading asset information from latest tag for architecture '$ASSET_POSTFIX'"
 
 # TODO: Update this to the latest release before merging and after the new basis release process has been merged into master on Basis
-WIGGINS_TAG="testing-2021-07-20-02735a4"
+WIGGINS_TAG="testing-2021-07-20-ea676a2"
 echo "Downloading wiggins binary"
 echo "Using wiggins release: $WIGGINS_TAG"
 WIGGINS_RELEASE_JSON=vendor/wiggins-release.json
@@ -57,11 +56,11 @@ curl -sSL \
     api.github.com/repos/fossas/basis/releases/tags/$WIGGINS_TAG > $WIGGINS_RELEASE_JSON
 
 WIGGINS_TAG=$(jq -cr ".name" $WIGGINS_RELEASE_JSON)
-FILTER=".name == \"scotland_yard-wiggins-$ASSET_POSTFIX_WITH_ARCHITECTURE\""
+FILTER=".name == \"scotland_yard-wiggins-$WIGGINS_ASSET_POSTFIX\""
 jq -c ".assets | map({url: .url, name: .name}) | map(select($FILTER)) | .[]" $WIGGINS_RELEASE_JSON | while read ASSET; do
   URL="$(echo $ASSET | jq -c -r '.url')"
   NAME="$(echo $ASSET | jq -c -r '.name')"
-  OUTPUT="$(echo vendor/$NAME | sed 's/scotland_yard-//' | sed 's/-'$ASSET_POSTFIX_WITH_ARCHITECTURE'$//')"
+  OUTPUT="$(echo vendor/$NAME | sed 's/scotland_yard-//' | sed 's/-'$WIGGINS_ASSET_POSTFIX'$//')"
 
   echo "Downloading '$NAME' to '$OUTPUT'"
   curl -sL -H "Authorization: token $GITHUB_TOKEN" -H "Accept: application/octet-stream" -s $URL > $OUTPUT

--- a/vendor_download.sh
+++ b/vendor_download.sh
@@ -23,7 +23,8 @@ mkdir -p vendor
 ASSET_POSTFIX=""
 ASSET_POSTFIX_WITH_ARCHITECTURE=""
 OS_WINDOWS=false
-case "$(uname -s)" in
+# case "$(uname -s)" in
+case "Windows" in
   Darwin)
     ASSET_POSTFIX="darwin"
     ASSET_POSTFIX_WITH_ARCHITECTURE="darwin-amd64"
@@ -60,7 +61,7 @@ FILTER=".name == \"scotland_yard-wiggins-$ASSET_POSTFIX_WITH_ARCHITECTURE\""
 jq -c ".assets | map({url: .url, name: .name}) | map(select($FILTER)) | .[]" $WIGGINS_RELEASE_JSON | while read ASSET; do
   URL="$(echo $ASSET | jq -c -r '.url')"
   NAME="$(echo $ASSET | jq -c -r '.name')"
-  OUTPUT="$(echo vendor/$NAME | sed 's/scotland_yard-//' | sed 's/-'$ASSET_POSTFIX_WITH_ARCHITECTURE'//')"
+  OUTPUT="$(echo vendor/$NAME | sed 's/scotland_yard-//' | sed 's/-'$ASSET_POSTFIX_WITH_ARCHITECTURE'$//')"
 
   echo "Downloading '$NAME' to '$OUTPUT'"
   curl -sL -H "Authorization: token $GITHUB_TOKEN" -H "Accept: application/octet-stream" -s $URL > $OUTPUT

--- a/vendor_download.sh
+++ b/vendor_download.sh
@@ -45,6 +45,7 @@ esac
 TAG="latest"
 echo "Downloading asset information from latest tag for architecture '$ASSET_POSTFIX'"
 
+# TODO: Update this to the latest release before merging and after the new basis release process has been merged into master on Basis
 WIGGINS_TAG="testing-2021-07-20-ea676a2"
 echo "Downloading wiggins binary"
 echo "Using wiggins release: $WIGGINS_TAG"

--- a/vendor_download.sh
+++ b/vendor_download.sh
@@ -46,7 +46,7 @@ TAG="latest"
 echo "Downloading asset information from latest tag for architecture '$ASSET_POSTFIX'"
 
 # TODO: Update this to the latest release before merging and after the new basis release process has been merged into master on Basis
-WIGGINS_TAG="testing-2021-07-20-ea676a2"
+WIGGINS_TAG="testing-2021-07-20-02735a4"
 echo "Downloading wiggins binary"
 echo "Using wiggins release: $WIGGINS_TAG"
 WIGGINS_RELEASE_JSON=vendor/wiggins-release.json

--- a/vendor_download.sh
+++ b/vendor_download.sh
@@ -21,19 +21,23 @@ rm -f vendor/*
 mkdir -p vendor
 
 ASSET_POSTFIX=""
+ASSET_POSTFIX_WITH_ARCHITECTURE=""
 OS_WINDOWS=false
 case "$(uname -s)" in
   Darwin)
     ASSET_POSTFIX="darwin"
+    ASSET_POSTFIX_WITH_ARCHITECTURE="darwin-amd64"
     ;;
 
   Linux)
     ASSET_POSTFIX="linux"
+    ASSET_POSTFIX_WITH_ARCHITECTURE="linux-amd64"
     ;;
-  
+
   *)
     echo "Warn: Assuming $(uname -s) is Windows"
     ASSET_POSTFIX="windows.exe"
+    ASSET_POSTFIX_WITH_ARCHITECTURE="windows-amd64.exe"
     OS_WINDOWS=true
     ;;
 esac
@@ -41,7 +45,7 @@ esac
 TAG="latest"
 echo "Downloading asset information from latest tag for architecture '$ASSET_POSTFIX'"
 
-WIGGINS_TAG="2021-07-16-39ef825"
+WIGGINS_TAG="testing-2021-07-20-ea676a2"
 echo "Downloading wiggins binary"
 echo "Using wiggins release: $WIGGINS_TAG"
 WIGGINS_RELEASE_JSON=vendor/wiggins-release.json
@@ -51,11 +55,13 @@ curl -sSL \
     api.github.com/repos/fossas/basis/releases/tags/$WIGGINS_TAG > $WIGGINS_RELEASE_JSON
 
 WIGGINS_TAG=$(jq -cr ".name" $WIGGINS_RELEASE_JSON)
-FILTER=".name == \"wiggins-$ASSET_POSTFIX\""
+FILTER=".name == \"scotland_yard-wiggins-$ASSET_POSTFIX_WITH_ARCHITECTURE\""
 jq -c ".assets | map({url: .url, name: .name}) | map(select($FILTER)) | .[]" $WIGGINS_RELEASE_JSON | while read ASSET; do
   URL="$(echo $ASSET | jq -c -r '.url')"
   NAME="$(echo $ASSET | jq -c -r '.name')"
-  OUTPUT=vendor/${NAME%"-$ASSET_POSTFIX"}
+  echo "asset postfix with architecture: $ASSET_POSTFIX_WITH_ARCHITECTURE"
+  echo "NAME: $NAME"
+  OUTPUT="$(echo vendor/$NAME | sed 's/scotland_yard-//' | sed 's/-'$ASSET_POSTFIX_WITH_ARCHITECTURE'//')"
 
   echo "Downloading '$NAME' to '$OUTPUT'"
   curl -sL -H "Authorization: token $GITHUB_TOKEN" -H "Accept: application/octet-stream" -s $URL > $OUTPUT


### PR DESCRIPTION
# Overview

This Basis PR changes the filenames the binaries in a basis release: https://github.com/fossas/basis/pull/1519

To account for this we need to update the `vendor_download.sh` script to account for that change.

The `wiggins` binary is now called `scotland_yard-wiggins-<platform>-amd64`, where `<platform>` is "linux", "windows" or "darwin".


## Acceptance criteria

`vendor_download.sh` should download the binary for `wiggins` generated by the new release process and put it in `vendor/wiggins`.

All other binaries should be downloaded properly as well.

## Testing plan

Run `./vendor_download.sh` on a Linux, MacOS and Windows platform. The `wiggins` binary should be downloaded and placed in `vendor/wiggins` for each of them. The rest of the binaries should still be downloaded as well.

I "simulated" being on each platform by editing the case statement on line 26 of `vendor_download.sh`. 

The original line looks like this:

```
case "$(uname -s)" in
```

To be in Linux, I edited the line to look like this:

```
case "Linux" in
```

And for windows:

```
case "Windows" in
```

I did the following for each platform:

```
rm -rf vendor
./vendor_download.sh
ls -l vendor
```

## Risks

## References

## Checklist

- [ ] I added tests for this PR's change (or confirmed tests are not viable).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] I linked this PR to any referenced GitHub issues, if they exist.
