### PR TITLE
CPAN support in manual dependencies

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,11 @@
 # Spectrometer Changelog
 
+## v2.11.1
+
+- Support CPAN deps in the fossa-deps file ([#296](https://github.com/fossas/spectrometer/pull/296)) 
+
 ## v2.11.0
+
 - Analysis target configuration ([#273](https://github.com/fossas/spectrometer/pull/273))
 - Support `fossa test` and `fossa report` for monorepo projects ([#290](https://github.com/fossas/spectrometer/pull/290))
 - Maven `pom.xml`: Adds `${property}` substitution for `<groupId>` and `<artifactId>` fields in dependencies ([#282](https://github.com/fossas/spectrometer/pull/282))

--- a/docs/userguide.md
+++ b/docs/userguide.md
@@ -210,6 +210,7 @@ Supported dependency types:
 - `cargo` - Rust dependencies that are typically found at [crates.io](https://crates.io/).
 - `carthage` - Dependencies as specified by the [Carthage](https://github.com/Carthage/Carthage) package manager.
 - `composer` - Dependencies specified by the PHP package manager [Composer](https://getcomposer.org/), which are located on [Packagist](https://packagist.org/).
+- `cpan` - Dependencies located on the [CPAN package manager](https://www.cpan.org/).
 - `gem` - Dependencies which can be found at [RubyGems.org](https://rubygems.org/).
 - `git` - Github projects (which appear as dependencies in many package managers). Specified as the full github repository `https://github.com/fossas/spectrometer`.
 - `go` - Golang specific dependency. Many golang dependencies are located on Github, but there are some which look like the following `go.mongodb.org/mongo-driver` that have custom golang URLs.

--- a/src/App/Fossa/ManualDeps.hs
+++ b/src/App/Fossa/ManualDeps.hs
@@ -234,6 +234,7 @@ depTypeFromText text = case text of
   "cargo" -> Just CargoType
   "carthage" -> Just CarthageType
   "composer" -> Just ComposerType
+  "cpan" -> Just CpanType
   "gem" -> Just GemType
   "git" -> Just GitType
   "go" -> Just GoType

--- a/src/DepTypes.hs
+++ b/src/DepTypes.hs
@@ -56,6 +56,8 @@ data DepType
     ComposerType
   | -- | Conda dependency
     CondaType
+  | -- | CPAN dependency
+    CpanType
   | -- | Repository in Github
     GitType
   | -- | Gem registry

--- a/src/Srclib/Converter.hs
+++ b/src/Srclib/Converter.hs
@@ -96,22 +96,23 @@ verConstraintToRevision = \case
 depTypeToFetcher :: DepType -> Text
 depTypeToFetcher = \case
   ArchiveType -> "archive"
-  SubprojectType -> "mvn" -- FIXME. I knew SubprojectType would come back to bite us.
-  GooglesourceType -> "git" -- FIXME. Yet another thing that's coming back to bite us
-  GitType -> "git"
+  CarthageType -> "cart"
+  CargoType -> "cargo"
+  ComposerType -> "comp"
+  CondaType -> "conda"
+  CpanType -> "cpan"
   GemType -> "gem"
+  GitType -> "git"
+  GooglesourceType -> "git" -- FIXME. Yet another thing that's coming back to bite us
+  GoType -> "go"
+  HackageType -> "hackage"
   HexType -> "hex"
   MavenType -> "mvn"
   NodeJSType -> "npm"
   NuGetType -> "nuget"
   PipType -> "pip"
   PodType -> "pod"
-  GoType -> "go"
-  CarthageType -> "cart"
-  CargoType -> "cargo"
   RPMType -> "rpm"
+  SubprojectType -> "mvn" -- FIXME. I knew SubprojectType would come back to bite us.
   URLType -> "url"
   UserType -> "user"
-  ComposerType -> "comp"
-  HackageType -> "hackage"
-  CondaType -> "conda"


### PR DESCRIPTION
# Overview

A user wants to be able to manually specify CPAN dependencies (which are supported by fossa.com) but cannot because we enforce that the dependency type is known.

## Acceptance criteria

Allow users to manually specify CPAN dependencies that come from Perl projects.

## Testing plan

I added a Perl/CPAN  dependency to a `fossa-deps.yaml` file and uploaded it.

## Risks

Customers may think we now support Perl. I don't think this is a big issue because it provides them a workaround.

## References

_List any referenced GitHub issues. If PR references tickets in other systems (e.g. Zendesk), they should probably be mirrored as a GitHub Issue._

_Make sure to use keywords to link this PR to GitHub issues ([GitHub Docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))._

_Example:_ Closes org/repo#123.

## Checklist

- [ ] I added tests for this PR's change (or confirmed tests are not viable).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] I linked this PR to any referenced GitHub issues, if they exist.
