### PR TITLE
Use local installer for dep-scan CI job

### DIFF
--- a/.github/workflows/dependency-scan.yml
+++ b/.github/workflows/dependency-scan.yml
@@ -20,7 +20,6 @@ jobs:
           cabal update
 
       - name: Install spectrometer from github
-        # To get this to work, we have to run the local script and then change it after.
         run: |
           ./install.sh -d
 


### PR DESCRIPTION
I don't see any benefit in downloading the latest master installer in our CI, since we can test the upcoming installer just as easy.
