### PR TITLE
Linting Rules Additions - Proposal

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -2,3 +2,17 @@
 # Often, code is more readable with extra parens, or less readable with list comprehensions
 - ignore: {name: "Redundant bracket"}
 - ignore: {name: "Use list comprehension"}
+
+# Import Preferences
+- modules:
+  - {name: Data.Set, as: Set, message: "Use complete name for qualified import of Set"}
+  - {name: Data.Map, as: Map, message: "Use complete name for qualified import of Map"}
+  - {name: Data.Text, as: Text, message: "Use complete name for qualified import of Text"}
+
+# Styling Preferences
+- suggest: {lhs: "asum [x, y]", rhs: x <|> y}
+- suggest: {lhs: return x, rhs: pure x}
+- suggest: {lhs: () <$ x, rhs: Control.Monad.void x}
+- suggest: {lhs: x <&> f, rhs: f <$> x}
+- suggest: {lhs: Data.Text.pack x, rhs: Data.String.Conversion.toText x, note: "For consistency use, Data.String.Conversion module instead!"}
+- suggest: {lhs: Data.Text.unpack x, rhs: Data.String.Conversion.toString x, note: "For consistency use, Data.String.Conversion module instead!"}

--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -7,6 +7,7 @@
 - modules:
   - {name: Data.Set, as: Set, message: "Use complete name for qualified import of Set"}
   - {name: Data.Map, as: Map, message: "Use complete name for qualified import of Map"}
+  - {name: Data.Map.Strict, as: Map, message: "Use complete name for qualified import of Strict Map"}
   - {name: Data.Text, as: Text, message: "Use complete name for qualified import of Text"}
 
 # Styling Preferences
@@ -14,5 +15,5 @@
 - suggest: {lhs: return x, rhs: pure x}
 - suggest: {lhs: () <$ x, rhs: Control.Monad.void x}
 - suggest: {lhs: x <&> f, rhs: f <$> x}
-- suggest: {lhs: Data.Text.pack x, rhs: Data.String.Conversion.toText x, note: "For consistency use, Data.String.Conversion module instead!"}
-- suggest: {lhs: Data.Text.unpack x, rhs: Data.String.Conversion.toString x, note: "For consistency use, Data.String.Conversion module instead!"}
+- suggest: {lhs: Data.Text.pack x, rhs: Data.String.Conversion.toText x}
+- suggest: {lhs: Data.Text.unpack x, rhs: Data.String.Conversion.toString x}

--- a/src/Algebra/Graph/AdjacencyMap/Extra.hs
+++ b/src/Algebra/Graph/AdjacencyMap/Extra.hs
@@ -3,7 +3,7 @@ module Algebra.Graph.AdjacencyMap.Extra (
 ) where
 
 import Algebra.Graph.AdjacencyMap qualified as AM
-import Data.Set qualified as S
+import Data.Set qualified as Set
 
 -- | It's 'traverse', but for graphs
 --
@@ -16,4 +16,4 @@ gtraverse ::
 gtraverse f = fmap mkAdjacencyMap . traverse (\(a, xs) -> (,) <$> f a <*> traverse f xs) . AM.adjacencyList
   where
     mkAdjacencyMap :: Ord c => [(c, [c])] -> AM.AdjacencyMap c
-    mkAdjacencyMap = AM.fromAdjacencySets . fmap (fmap S.fromList)
+    mkAdjacencyMap = AM.fromAdjacencySets . fmap (fmap Set.fromList)

--- a/src/App/Fossa/Analyze/GraphMangler.hs
+++ b/src/App/Fossa/Analyze/GraphMangler.hs
@@ -8,8 +8,8 @@ import Algebra.Graph.ToGraph (dfs)
 import Control.Algebra
 import Data.Foldable (traverse_)
 import Data.Map.Strict (Map)
-import Data.Map.Strict qualified as M
-import Data.Set qualified as S
+import Data.Map.Strict qualified as Map
+import Data.Set qualified as Set
 
 import App.Fossa.Analyze.Graph qualified as G
 import App.Fossa.Analyze.GraphBuilder
@@ -19,15 +19,15 @@ import Graphing (Graphing (..))
 graphingToGraph :: Graphing Dependency -> G.Graph
 graphingToGraph graphing = run . evalGraphBuilder G.empty $ do
   let depAmap = graphingAdjacent graphing
-      depDirect = S.toList (graphingDirect graphing)
+      depDirect = Set.toList (graphingDirect graphing)
 
       nodes = dfs depDirect depAmap
 
-  refs <- M.fromList <$> traverse addingNode nodes
+  refs <- Map.fromList <$> traverse addingNode nodes
 
   traverse_ (visitNode refs depAmap) nodes
 
-  traverse_ (\dep -> traverse_ addDirect (M.lookup dep refs)) depDirect
+  traverse_ (\dep -> traverse_ addDirect (Map.lookup dep refs)) depDirect
   where
     -- add a node with GraphBuilder
     addingNode :: Has GraphBuilder sig m => Dependency -> m (Dependency, G.DepRef)
@@ -37,14 +37,14 @@ graphingToGraph graphing = run . evalGraphBuilder G.empty $ do
 
     -- visit a node, adding edges between it and all of its dependencies
     visitNode :: Has GraphBuilder sig m => Map Dependency G.DepRef -> AdjacencyMap Dependency -> Dependency -> m ()
-    visitNode refs amap node = traverse_ (visitEdge refs node) (S.toList $ AM.postSet node amap)
+    visitNode refs amap node = traverse_ (visitEdge refs node) (Set.toList $ AM.postSet node amap)
 
     -- visit an edge by adding it to the graph
     visitEdge :: Has GraphBuilder sig m => Map Dependency G.DepRef -> Dependency -> Dependency -> m ()
     visitEdge refs parent child = do
       let edgeRefs = do
-            parentRef <- M.lookup parent refs
-            childRef <- M.lookup child refs
+            parentRef <- Map.lookup parent refs
+            childRef <- Map.lookup child refs
             pure (parentRef, childRef)
 
       traverse_ (uncurry addEdge) edgeRefs

--- a/src/App/Fossa/Analyze/Project.hs
+++ b/src/App/Fossa/Analyze/Project.hs
@@ -3,7 +3,7 @@ module App.Fossa.Analyze.Project (
   mkResult,
 ) where
 
-import Data.Set qualified as S
+import Data.Set qualified as Set
 import Data.Text (Text)
 import DepTypes
 import Graphing (Graphing)
@@ -22,7 +22,7 @@ mkResult project graphResults =
         -- their dependencies would be filtered out. The real fix to this is to
         -- have a separate designation for "reachable" vs "direct" on nodes in a
         -- Graphing, where direct deps are inherently reachable.
-        if S.null (Graphing.graphingDirect graph)
+        if Set.null (Graphing.graphingDirect graph)
           then graph
           else Graphing.pruneUnreachable graph
     , projectResultGraphBreadth = graphBreadth

--- a/src/App/Fossa/ArchiveUploader.hs
+++ b/src/App/Fossa/ArchiveUploader.hs
@@ -23,7 +23,6 @@ import Data.Functor.Extra ((<$$>))
 import Data.Maybe (fromMaybe)
 import Data.String.Conversion
 import Data.Text (Text)
-import Data.Text qualified as T
 import Fossa.API.Types
 import Path hiding ((</>))
 import Srclib.Types (Locator (..))
@@ -48,7 +47,7 @@ uploadArchives apiOpts deps arcDir tmpDir = traverse (compressAndUpload apiOpts 
 
 compressAndUpload :: (Has Diag.Diagnostics sig m, Has (Lift IO) sig m) => ApiOpts -> Path Abs Dir -> Path Abs Dir -> VendoredDependency -> m Archive
 compressAndUpload apiOpts arcDir tmpDir dependency = do
-  compressedFile <- sendIO $ compressFile tmpDir arcDir (T.unpack $ vendoredPath dependency)
+  compressedFile <- sendIO $ compressFile tmpDir arcDir (toString $ vendoredPath dependency)
 
   depVersion <- case vendoredVersion dependency of
     Nothing -> sendIO $ hashFile compressedFile
@@ -76,7 +75,7 @@ archiveUploadSourceUnit baseDir apiOpts vendoredDeps = do
 
   let updateArcName :: Text -> Archive -> Archive
       updateArcName updateText arc = arc{archiveName = updateText <> "/" <> archiveName arc}
-      archivesWithOrganization = updateArcName (T.pack $ show orgId) <$> archives
+      archivesWithOrganization = updateArcName (toText $ show orgId) <$> archives
 
   pure $ arcToLocator <$> archivesWithOrganization
 
@@ -110,4 +109,4 @@ md5 = hashlazy
 hashFile :: FilePath -> IO Text
 hashFile fileToHash = do
   fileContent <- BS.readFile fileToHash
-  pure . T.pack . show $ md5 fileContent
+  pure . toText . show $ md5 fileContent

--- a/src/App/Fossa/Container.hs
+++ b/src/App/Fossa/Container.hs
@@ -34,7 +34,7 @@ import Data.List (nub)
 import Data.Map.Lazy qualified as LMap
 import Data.Map.Strict (Map)
 import Data.Maybe (fromMaybe, listToMaybe)
-import Data.String.Conversion (decodeUtf8)
+import Data.String.Conversion (decodeUtf8, toText)
 import Data.Text (Text, pack)
 import Data.Text.Extra (breakOnAndRemove)
 import Effect.Exec (AllowErr (Never), Command (..), Exec, execJson, execThrow, runExecIO)
@@ -258,7 +258,7 @@ parseSyftOutput :: (Has Diagnostics sig m, Has ReadFS sig m, Has (Lift IO) sig m
 parseSyftOutput filepath = do
   curdir <- sendIO getCurrentDir
   logDebug "Resolving file"
-  path <- resolveFile curdir $ pack filepath
+  path <- resolveFile curdir $ toText filepath
   logDebug "Reading JSON file"
   rawvalue <- readContentsJson @Value path
   logDebug "Parsing JSON contents"

--- a/src/App/Fossa/FossaAPIV1.hs
+++ b/src/App/Fossa/FossaAPIV1.hs
@@ -41,8 +41,9 @@ import Data.ByteString.Char8 qualified as C
 import Data.List.NonEmpty qualified as NE
 import Data.Map (Map)
 import Data.Maybe (catMaybes, fromMaybe)
+import Data.String.Conversion (toText)
 import Data.Text (Text)
-import Data.Text qualified as T
+import Data.Text qualified as Text
 import Data.Word (Word8)
 import Effect.Logger
 import Fossa.API.Types (ApiOpts, ArchiveComponents, Issues, SignedURL, signedURL, useApiOpts)
@@ -102,22 +103,22 @@ uploadUrl baseurl = baseurl /: "api" /: "builds" /: "custom"
 -- | This renders an organization + locator into a path piece for the fossa API
 renderLocatorUrl :: Int -> Locator -> Text
 renderLocatorUrl orgId Locator{..} =
-  locatorFetcher <> "+" <> T.pack (show orgId) <> "/" <> normalizeGitProjectName locatorProject <> "$" <> fromMaybe "" locatorRevision
+  locatorFetcher <> "+" <> toText (show orgId) <> "/" <> normalizeGitProjectName locatorProject <> "$" <> fromMaybe "" locatorRevision
 
 -- | The fossa backend treats http git locators in a specific way for the issues and builds endpoints.
 -- This normalizes a project name to conform to what the API expects
 normalizeGitProjectName :: Text -> Text
 normalizeGitProjectName project
-  | "http" `T.isPrefixOf` project = dropPrefix "http://" . dropPrefix "https://" . dropSuffix ".git" $ project
+  | "http" `Text.isPrefixOf` project = dropPrefix "http://" . dropPrefix "https://" . dropSuffix ".git" $ project
   | otherwise = project
   where
     -- like Text.stripPrefix, but with a non-Maybe result (defaults to the original text)
     dropPrefix :: Text -> Text -> Text
-    dropPrefix pre txt = fromMaybe txt (T.stripPrefix pre txt)
+    dropPrefix pre txt = fromMaybe txt (Text.stripPrefix pre txt)
 
     -- like Text.stripSuffix, but with a non-Maybe result (defaults to the original text)
     dropSuffix :: Text -> Text -> Text
-    dropSuffix suf txt = fromMaybe txt (T.stripSuffix suf txt)
+    dropSuffix suf txt = fromMaybe txt (Text.stripSuffix suf txt)
 
 data UploadResponse = UploadResponse
   { uploadLocator :: Text
@@ -326,7 +327,7 @@ archiveUpload signedArcURI arcFile = fossaReq $ do
   let arcURL = URI.mkURI $ signedURL signedArcURI
 
   uri <- fromMaybeText ("Invalid URL: " <> signedURL signedArcURI) arcURL
-  validatedURI <- fromMaybeText ("Invalid URI: " <> T.pack (show uri)) (useURI uri)
+  validatedURI <- fromMaybeText ("Invalid URI: " <> toText (show uri)) (useURI uri)
 
   _ <- context "Uploading project archive" $ case validatedURI of
     Left (url, options) -> uploadArchiveRequest url options

--- a/src/App/Fossa/ListTargets.hs
+++ b/src/App/Fossa/ListTargets.hs
@@ -13,7 +13,7 @@ import Control.Carrier.StickyLogger (StickyLogger, logSticky', runStickyLogger)
 import Control.Carrier.TaskPool
 import Control.Concurrent (getNumCapabilities)
 import Data.Foldable (for_)
-import Data.Set qualified as S
+import Data.Set qualified as Set
 import Data.Set.NonEmpty
 import Discovery.Projects (withDiscoveredProjects)
 import Effect.Exec
@@ -56,7 +56,7 @@ listTargetsMain (BaseDir basedir) = do
                     <> pretty (projectType project)
                     <> "@"
                     <> pretty (toFilePath rel)
-              FoundTargets targets -> for_ (S.toList $ toSet targets) $ \target -> do
+              FoundTargets targets -> for_ (Set.toList $ toSet targets) $ \target -> do
                 logInfo $
                   "Found target: "
                     <> pretty (projectType project)

--- a/src/App/Fossa/Main.hs
+++ b/src/App/Fossa/Main.hs
@@ -57,8 +57,9 @@ import Data.Bool (bool)
 import Data.Flag (Flag, flagOpt, fromFlag)
 import Data.Foldable (for_)
 import Data.Functor.Extra ((<$$>))
+import Data.String.Conversion (toString, toText)
 import Data.Text (Text)
-import Data.Text qualified as T
+import Data.Text qualified as Text
 import Discovery.Filters (AllFilters (..), FilterCombination (..), targetFilterParser)
 import Effect.Logger (
   Severity (SevDebug, SevInfo),
@@ -291,7 +292,7 @@ dieOnWindows :: String -> IO ()
 dieOnWindows op = when (SysInfo.os == windowsOsName) $ die $ "Operation is not supported on Windows: " <> op
 
 parseCommaSeparatedFileArg :: Text -> IO [Path Abs File]
-parseCommaSeparatedFileArg arg = sequence (validateFile . T.unpack <$> T.splitOn "," arg)
+parseCommaSeparatedFileArg arg = sequence (validateFile . toString <$> Text.splitOn "," arg)
 
 requireKey :: Maybe ApiKey -> IO ApiKey
 requireKey (Just key) = pure key
@@ -301,7 +302,7 @@ requireKey Nothing = die "A FOSSA API key is required to run this command"
 checkAPIKey :: Maybe Text -> IO (Maybe ApiKey)
 checkAPIKey key = case key of
   Just key' -> pure . Just $ ApiKey key'
-  Nothing -> ApiKey . T.pack <$$> lookupEnv "FOSSA_API_KEY"
+  Nothing -> ApiKey . toText <$$> lookupEnv "FOSSA_API_KEY"
 
 baseDirArg :: Parser String
 baseDirArg = argument str (metavar "DIR" <> help "Set the base directory for scanning (default: current directory)" <> value ".")
@@ -315,7 +316,7 @@ opts =
     <*> optional (strOption (long "revision" <> short 'r' <> help "this repository's current revision hash (default: VCS hash HEAD)"))
     <*> optional (strOption (long "fossa-api-key" <> help "the FOSSA API server authentication key (default: FOSSA_API_KEY from env)"))
     <*> (commands <|> hiddenCommands)
-    <**> infoOption (T.unpack fullVersionDescription) (long "version" <> short 'V' <> help "show version text")
+    <**> infoOption (toString fullVersionDescription) (long "version" <> short 'V' <> help "show version text")
 
 commands :: Parser Command
 commands =
@@ -415,7 +416,7 @@ filterOpt :: Parser TargetFilter
 filterOpt = option (eitherReader parseFilter) (long "filter" <> help "(deprecated) Analysis-Target filters (default: none)" <> metavar "ANALYSIS-TARGET")
   where
     parseFilter :: String -> Either String TargetFilter
-    parseFilter = first errorBundlePretty . runParser targetFilterParser "stdin" . T.pack
+    parseFilter = first errorBundlePretty . runParser targetFilterParser "stdin" . toText
 
 monorepoOpts :: Parser MonorepoAnalysisOpts
 monorepoOpts =
@@ -426,7 +427,7 @@ pathOpt :: String -> Either String (Path Rel Dir)
 pathOpt = first show . parseRelDir
 
 targetOpt :: String -> Either String TargetFilter
-targetOpt = first errorBundlePretty . runParser targetFilterParser "stdin" . T.pack
+targetOpt = first errorBundlePretty . runParser targetFilterParser "stdin" . toText
 
 metadataOpts :: Parser ProjectMetadata
 metadataOpts =

--- a/src/App/Fossa/ManualDeps.hs
+++ b/src/App/Fossa/ManualDeps.hs
@@ -30,8 +30,8 @@ import Data.Aeson.Extra
 import Data.Aeson.Types (Parser)
 import Data.Functor.Extra ((<$$>))
 import Data.List.NonEmpty qualified as NE
-import Data.String.Conversion (toText)
-import Data.Text (Text, unpack)
+import Data.String.Conversion (toString, toText)
+import Data.Text (Text)
 import DepTypes (DepType (..))
 import Effect.ReadFS (ReadFS, doesFileExist, readContentsJson, readContentsYaml)
 import Fossa.API.Types
@@ -198,7 +198,7 @@ instance FromJSON ManualDependencies where
 depTypeParser :: Text -> Parser DepType
 depTypeParser text = case depTypeFromText text of
   Just t -> pure t
-  Nothing -> fail $ "dep type: " <> unpack text <> " not supported"
+  Nothing -> fail $ "dep type: " <> toString text <> " not supported"
 
 instance FromJSON ReferencedDependency where
   parseJSON = withObject "ReferencedDependency" $ \obj ->

--- a/src/App/Fossa/VPS/NinjaGraph.hs
+++ b/src/App/Fossa/VPS/NinjaGraph.hs
@@ -19,8 +19,8 @@ import Data.ByteString (ByteString)
 import Data.ByteString qualified as BS
 import Data.ByteString.Lazy qualified as BL
 import Data.Maybe (fromMaybe)
+import Data.String.Conversion (toString, toText)
 import Data.Text (Text)
-import Data.Text qualified as T
 import Data.Text.Encoding (decodeUtf8)
 import Effect.Exec
 import Effect.Logger hiding (line)
@@ -100,11 +100,11 @@ generateNinjaDeps baseDir NinjaGraphOpts{..} = do
   (exitcode, stdout, stderr) <- sendIO $ PROC.readProcess (setWorkingDir (fromAbsDir baseDir) (PROC.shell commandString))
   case (exitcode, stdout, stderr) of
     (ExitSuccess, _, _) -> pure stdout
-    (_, _, err) -> fatal (ErrorRunningNinja (T.pack (show err)))
+    (_, _, err) -> fatal (ErrorRunningNinja (toText (show err)))
   where
     commandString = case lunchTarget of
       Nothing -> "cd " ++ show baseDir ++ " && NINJA_ARGS=\"-t deps\" make"
-      Just lunch -> "cd " ++ show baseDir ++ " && source ./build/envsetup.sh && lunch " ++ T.unpack lunch ++ " && NINJA_ARGS=\"-t deps\" make"
+      Just lunch -> "cd " ++ show baseDir ++ " && source ./build/envsetup.sh && lunch " ++ toString lunch ++ " && NINJA_ARGS=\"-t deps\" make"
 
 correctedTarget :: DepsTarget -> DepsTarget
 correctedTarget target@DepsTarget{targetDependencies = []} =
@@ -137,7 +137,7 @@ correctTargetWithLeadingTxtDeps target =
         corrected = target{targetDependencies = leadingTxtDeps ++ remainingDeps, targetInputs = [firstNonTxtDep]}
   where
     splitBasenameExt :: Text -> (String, String)
-    splitBasenameExt = FP.splitExtension . FP.takeFileName . T.unpack
+    splitBasenameExt = FP.splitExtension . FP.takeFileName . toString
 
     depsPathIsTxtAndBasenameDoesNotMatch :: String -> DepsDependency -> Bool
     depsPathIsTxtAndBasenameDoesNotMatch targetBasename dep =

--- a/src/App/Fossa/VPS/Scan/Core.hs
+++ b/src/App/Fossa/VPS/Scan/Core.hs
@@ -14,7 +14,8 @@ import Control.Carrier.Trace.Printing
 import Control.Effect.Diagnostics
 import Control.Effect.Lift (Lift)
 import Data.Aeson
-import Data.Text (Text, pack)
+import Data.String.Conversion (toText)
+import Data.Text (Text)
 import Fossa.API.Types (ApiOpts (..), useApiOpts)
 import Network.HTTP.Req
 import Prelude
@@ -35,7 +36,7 @@ instance FromJSON SherlockInfo where
 newtype Locator = Locator {unLocator :: Text}
 
 createLocator :: Text -> Int -> Locator
-createLocator projectName organizationId = Locator $ "custom+" <> pack (show organizationId) <> "/" <> projectName
+createLocator projectName organizationId = Locator $ "custom+" <> toText (show organizationId) <> "/" <> projectName
 
 newtype RevisionLocator = RevisionLocator {unRevisionLocator :: Text}
 

--- a/src/App/Fossa/VPS/Scan/RunWiggins.hs
+++ b/src/App/Fossa/VPS/Scan/RunWiggins.hs
@@ -27,7 +27,7 @@ import Data.Aeson
 import Data.ByteString.Lazy qualified as BL
 import Data.String.Conversion (toText)
 import Data.Text (Text)
-import Data.Text qualified as T
+import Data.Text qualified as Text
 import Data.Text.Encoding (decodeUtf8)
 import Discovery.Filters
 import Effect.Exec
@@ -79,7 +79,7 @@ generateSpectrometerAOSPNoticeArgs logSeverity ApiOpts{..} ProjectRevision{..} n
     ++ ["-scan-id", unNinjaScanID ninjaScanId]
     ++ ["-name", projectName]
     ++ ["."]
-    ++ (T.pack . toFilePath <$> unNinjaFilePaths ninjaInputFiles)
+    ++ (toText . toFilePath <$> unNinjaFilePaths ninjaInputFiles)
 
 generateVSIStandaloneArgs :: ApiOpts -> PathFilters -> [Text]
 generateVSIStandaloneArgs ApiOpts{..} PathFilters{..} =
@@ -148,7 +148,7 @@ optExplodeText flag (a : as) = [flag, a] ++ optExplodeText flag as
 -- Path Rel Dir renders with a trailing /, but wiggins needs it to not have that trailing slash when used as an exclude or include-only filter.
 -- Strip the / postfix from the returned value.
 optPathAsFilter :: Path Rel Dir -> Text
-optPathAsFilter p = T.init (toText p)
+optPathAsFilter p = Text.init (toText p)
 
 execWiggins :: (Has Exec sig m, Has Diagnostics sig m) => BinaryPaths -> WigginsOpts -> m Text
 execWiggins binaryPaths opts = decodeUtf8 . BL.toStrict <$> execThrow (scanDir opts) (wigginsCommand binaryPaths opts)
@@ -159,7 +159,7 @@ execWigginsJson opts binaryPaths = execJson (scanDir opts) (wigginsCommand binar
 wigginsCommand :: BinaryPaths -> WigginsOpts -> Command
 wigginsCommand bin WigginsOpts{..} = do
   Command
-    { cmdName = T.pack $ fromAbsFile $ toExecutablePath bin
+    { cmdName = toText $ fromAbsFile $ toExecutablePath bin
     , cmdArgs = spectrometerArgs
     , cmdAllowErr = Never
     }

--- a/src/App/OptionExtensions.hs
+++ b/src/App/OptionExtensions.hs
@@ -2,7 +2,7 @@ module App.OptionExtensions (uriOption, jsonOption) where
 
 import Data.Aeson
 import Data.String
-import Data.Text qualified as T
+import Data.String.Conversion (toText)
 import Options.Applicative
 import Text.URI (URI, mkURI)
 
@@ -10,7 +10,7 @@ uriOption :: Mod OptionFields URI -> Parser URI
 uriOption = option parseUri
   where
     parseUri :: ReadM URI
-    parseUri = maybeReader (mkURI . T.pack)
+    parseUri = maybeReader (mkURI . toText)
 
 jsonOption :: FromJSON a => Mod OptionFields a -> Parser a
 jsonOption = option (eitherReader (eitherDecode . fromString))

--- a/src/App/Version.hs
+++ b/src/App/Version.hs
@@ -7,8 +7,9 @@ module App.Version (
 ) where
 
 import App.Version.TH (getCurrentTag)
+import Data.String.Conversion (toText)
 import Data.Text (Text)
-import Data.Text qualified as T
+import Data.Text qualified as Text
 import Data.Version (showVersion)
 import GitHash (GitInfo, giBranch, giDirty, giHash, tGitInfoCwd)
 import System.Info (compilerName, compilerVersion)
@@ -20,13 +21,13 @@ info :: GitInfo
 info = $$(tGitInfoCwd)
 
 currentBranch :: Text
-currentBranch = T.pack $ giBranch info
+currentBranch = toText $ giBranch info
 
 currentCommit :: Text
-currentCommit = T.pack $ giHash info
+currentCommit = toText $ giHash info
 
 shortCommit :: Text
-shortCommit = T.take 12 currentCommit
+shortCommit = Text.take 12 currentCommit
 
 isDirty :: Bool
 isDirty = giDirty info
@@ -34,11 +35,11 @@ isDirty = giDirty info
 compilerId :: Text
 compilerId = name <> "-" <> version
   where
-    name = T.pack compilerName
-    version = T.pack $ showVersion compilerVersion
+    name = toText compilerName
+    version = toText $ showVersion compilerVersion
 
 fullVersionDescription :: Text
-fullVersionDescription = T.concat items
+fullVersionDescription = Text.concat items
   where
     version :: Text
     version =

--- a/src/Control/Carrier/Diagnostics/StickyContext.hs
+++ b/src/Control/Carrier/Diagnostics/StickyContext.hs
@@ -14,7 +14,7 @@ import Control.Effect.Sum (Member (inj))
 import Control.Monad.IO.Class (MonadIO)
 import Control.Monad.Trans.Class (MonadTrans (..))
 import Data.List (intersperse)
-import Data.Text qualified as T
+import Data.Text qualified as Text
 import Effect.Logger
 
 stickyDiag :: (Has AtomicCounter sig m, Has (Lift IO) sig m) => StickyDiagC m a -> m a
@@ -25,7 +25,7 @@ stickyDiag act = do
 
 data StickyCtx = StickyCtx
   { ctxTaskId :: TaskId
-  , ctxBacktrace :: [T.Text]
+  , ctxBacktrace :: [Text.Text]
   , ctxRegion :: Sticky.StickyRegion
   }
 

--- a/src/Control/Effect/Diagnostics.hs
+++ b/src/Control/Effect/Diagnostics.hs
@@ -42,8 +42,8 @@ import Data.List (intersperse)
 import Data.List.NonEmpty qualified as NE
 import Data.Maybe (catMaybes)
 import Data.Semigroup (sconcat)
+import Data.String.Conversion (toText)
 import Data.Text (Text)
-import Data.Text qualified as T
 import Data.Text.Prettyprint.Doc
 import Data.Text.Prettyprint.Doc.Render.Terminal
 import Prelude
@@ -118,7 +118,7 @@ fromEither = either fatal pure
 
 -- | Lift an Either result into the Diagnostics effect, given a Show instance for the error type
 fromEitherShow :: (Show err, Has Diagnostics sig m) => Either err a -> m a
-fromEitherShow = either (fatal . T.pack . show) pure
+fromEitherShow = either (fatal . toText . show) pure
 
 -- | Lift a Maybe result into Diagnostics, with the given diagnostic thrown for @Nothing@
 fromMaybe :: (ToDiagnostic err, Has Diagnostics sig m) => err -> Maybe a -> m a

--- a/src/Data/Aeson/Extra.hs
+++ b/src/Data/Aeson/Extra.hs
@@ -7,9 +7,8 @@ import Control.Applicative ((<|>))
 import Data.Aeson.Types (FromJSON (parseJSON), Object, Parser)
 import Data.Foldable (traverse_)
 import Data.HashMap.Strict (member)
-import Data.String.Conversion (toString)
+import Data.String.Conversion (toString, toText)
 import Data.Text (Text)
-import Data.Text qualified as T
 
 -- | A Text-like field
 --
@@ -32,8 +31,8 @@ instance FromJSON TextLike where
   parseJSON val = parseAsText <|> parseAsInt <|> parseAsDouble
     where
       parseAsText = TextLike <$> parseJSON val
-      parseAsInt = TextLike . T.pack . show <$> parseJSON @Int val
-      parseAsDouble = TextLike . T.pack . show <$> parseJSON @Double val
+      parseAsInt = TextLike . toText . show <$> parseJSON @Int val
+      parseAsDouble = TextLike . toText . show <$> parseJSON @Double val
 
 -- | Parser insert to prevent specific fields from being used in parsers
 -- Primarily useful for rejecting aeson fields which should be reported with custom error messages

--- a/src/Data/Set/NonEmpty.hs
+++ b/src/Data/Set/NonEmpty.hs
@@ -4,7 +4,7 @@ module Data.Set.NonEmpty (
   toSet,
 ) where
 
-import Data.Set qualified as S
+import Data.Set qualified as Set
 
 -- | A non empty set. Inspired by non empty list.
 --
@@ -13,12 +13,12 @@ import Data.Set qualified as S
 --
 -- Use nonEmpty to create the NonEmptySet from a Set.
 -- USe toSet to retrieve the Set to access any Set operations.
-nonEmpty :: S.Set a -> Maybe (NonEmptySet a)
+nonEmpty :: Set.Set a -> Maybe (NonEmptySet a)
 nonEmpty s
-  | S.null s = Nothing
+  | Set.null s = Nothing
   | otherwise = Just (NonEmptySet s)
 
-toSet :: NonEmptySet a -> S.Set a
+toSet :: NonEmptySet a -> Set.Set a
 toSet = unEmptySet
 
-newtype NonEmptySet a = NonEmptySet {unEmptySet :: S.Set a} deriving (Eq, Ord, Show, Semigroup)
+newtype NonEmptySet a = NonEmptySet {unEmptySet :: Set.Set a} deriving (Eq, Ord, Show, Semigroup)

--- a/src/Data/String/Conversion.hs
+++ b/src/Data/String/Conversion.hs
@@ -13,7 +13,7 @@ module Data.String.Conversion (
 
 import Data.ByteString qualified as BS
 import Data.ByteString.Lazy qualified as BL
-import Data.Text qualified as T
+import Data.Text qualified as Text
 import Data.Text.Encoding qualified as TE
 import Data.Text.Encoding.Error qualified as TE
 import Data.Text.Lazy qualified as TL
@@ -29,18 +29,18 @@ class ConvertUtf8 a b where
   decodeUtf8 :: b -> a
 
 instance ConvertUtf8 String BS.ByteString where
-  encodeUtf8 = TE.encodeUtf8 . T.pack
-  decodeUtf8 = T.unpack . TE.decodeUtf8With TE.lenientDecode
+  encodeUtf8 = TE.encodeUtf8 . Text.pack
+  decodeUtf8 = Text.unpack . TE.decodeUtf8With TE.lenientDecode
 
 instance ConvertUtf8 String BL.ByteString where
   encodeUtf8 = TLE.encodeUtf8 . TL.pack
   decodeUtf8 = TL.unpack . TLE.decodeUtf8With TE.lenientDecode
 
-instance ConvertUtf8 T.Text BS.ByteString where
+instance ConvertUtf8 Text.Text BS.ByteString where
   encodeUtf8 = TE.encodeUtf8
   decodeUtf8 = TE.decodeUtf8With TE.lenientDecode
 
-instance ConvertUtf8 T.Text BL.ByteString where
+instance ConvertUtf8 Text.Text BL.ByteString where
   encodeUtf8 = BL.fromStrict . TE.encodeUtf8
   decodeUtf8 = TE.decodeUtf8With TE.lenientDecode . BL.toStrict
 
@@ -55,12 +55,12 @@ instance ConvertUtf8 TL.Text BL.ByteString where
 ----- ToText
 
 class ToText a where
-  toText :: a -> T.Text
+  toText :: a -> Text.Text
 
 instance ToText String where
-  toText = T.pack
+  toText = Text.pack
 
-instance ToText T.Text where
+instance ToText Text.Text where
   toText = id
 
 instance ToText TL.Text where
@@ -83,7 +83,7 @@ class ToLText a where
 instance ToLText String where
   toLText = TL.pack
 
-instance ToLText T.Text where
+instance ToLText Text.Text where
   toLText = TL.fromStrict
 
 instance ToLText TL.Text where
@@ -103,8 +103,8 @@ instance ToLText (Path b t) where
 class ToString a where
   toString :: a -> String
 
-instance ToString T.Text where
-  toString = T.unpack
+instance ToString Text.Text where
+  toString = Text.unpack
 
 instance ToString TL.Text where
   toString = TL.unpack
@@ -161,6 +161,6 @@ instance LazyStrict BL.ByteString BS.ByteString where
   toLazy = BL.fromStrict
   toStrict = BL.toStrict
 
-instance LazyStrict TL.Text T.Text where
+instance LazyStrict TL.Text Text.Text where
   toLazy = TL.fromStrict
   toStrict = TL.toStrict

--- a/src/Data/Text/Extra.hs
+++ b/src/Data/Text/Extra.hs
@@ -9,23 +9,23 @@ module Data.Text.Extra (
 
 import Data.ByteString (ByteString)
 import Data.Maybe (fromMaybe)
-import Data.String.Conversion (decodeUtf8, encodeUtf8)
+import Data.String.Conversion (decodeUtf8, encodeUtf8, toText)
 import Data.Text (Text)
-import Data.Text qualified as T
+import Data.Text qualified as Text
 
 splitOnceOn :: Text -> Text -> (Text, Text)
 splitOnceOn needle haystack = (first, strippedRemaining)
   where
-    len = T.length needle
-    (first, remaining) = T.breakOn needle haystack
-    strippedRemaining = T.drop len remaining
+    len = Text.length needle
+    (first, remaining) = Text.breakOn needle haystack
+    strippedRemaining = Text.drop len remaining
 
 splitOnceOnEnd :: Text -> Text -> (Text, Text)
 splitOnceOnEnd needle haystack = (strippedInitial, end)
   where
-    len = T.length needle
-    (initial, end) = T.breakOnEnd needle haystack
-    strippedInitial = T.dropEnd len initial
+    len = Text.length needle
+    (initial, end) = Text.breakOnEnd needle haystack
+    strippedInitial = Text.dropEnd len initial
 
 -- | Like Text.breakOn, but with two differences:
 -- 1. This removes the text that was broken on, e.g., `Text.breakOn "foo" "foobar" == ("", "foobar")` `breakOnAndRemove "foo" "foobar" == ("", "bar")`
@@ -38,16 +38,16 @@ splitOnceOnEnd needle haystack = (strippedInitial, end)
 -- Nothing
 breakOnAndRemove :: Text -> Text -> Maybe (Text, Text)
 breakOnAndRemove needle haystack
-  | (before, after) <- T.breakOn needle haystack
-    , T.isPrefixOf needle after =
-    Just (before, T.drop (T.length needle) after)
+  | (before, after) <- Text.breakOn needle haystack
+    , Text.isPrefixOf needle after =
+    Just (before, Text.drop (Text.length needle) after)
   | otherwise = Nothing
 
 underBS :: (ByteString -> ByteString) -> Text -> Text
 underBS f = decodeUtf8 . f . encodeUtf8
 
 showT :: Show a => a -> Text
-showT = T.pack . show
+showT = toText . show
 
 dropPrefix :: Text -> Text -> Text
-dropPrefix pre txt = fromMaybe txt (T.stripPrefix pre txt)
+dropPrefix pre txt = fromMaybe txt (Text.stripPrefix pre txt)

--- a/src/DepTypes.hs
+++ b/src/DepTypes.hs
@@ -12,7 +12,7 @@ module DepTypes (
 
 import Data.Aeson
 import Data.Map.Strict (Map)
-import Data.Map.Strict qualified as M
+import Data.Map.Strict qualified as Map
 import Data.Text (Text)
 import GHC.Generics (Generic)
 
@@ -33,7 +33,7 @@ insertEnvironment :: DepEnvironment -> Dependency -> Dependency
 insertEnvironment env dep = dep{dependencyEnvironments = env : dependencyEnvironments dep}
 
 insertTag :: Text -> Text -> Dependency -> Dependency
-insertTag key value dep = dep{dependencyTags = M.insertWith (++) key [value] (dependencyTags dep)}
+insertTag key value dep = dep{dependencyTags = Map.insertWith (++) key [value] (dependencyTags dep)}
 
 insertLocation :: Text -> Dependency -> Dependency
 insertLocation loc dep = dep{dependencyLocations = loc : dependencyLocations dep}

--- a/src/Discovery/Filters.hs
+++ b/src/Discovery/Filters.hs
@@ -12,10 +12,10 @@ import Data.List ((\\))
 import Data.List.NonEmpty qualified as NE
 import Data.Maybe (fromMaybe)
 import Data.Semigroup (sconcat)
-import Data.Set qualified as S
+import Data.Set qualified as Set
 import Data.Set.NonEmpty (nonEmpty, toSet)
+import Data.String.Conversion (toText)
 import Data.Text (Text)
-import Data.Text qualified as Text
 import Data.Void (Void)
 import Path (Dir, Path, Rel, isProperPrefixOf, parseRelDir)
 import Text.Megaparsec (
@@ -52,8 +52,8 @@ filterFoundTargets :: FilterResult -> FoundTargets -> Maybe FoundTargets
 filterFoundTargets ResultNone _ = Nothing
 filterFoundTargets _ ProjectWithoutTargets = Just ProjectWithoutTargets
 filterFoundTargets ResultAll targets = Just targets
-filterFoundTargets (ResultInclude found) (FoundTargets targets) = FoundTargets <$> nonEmpty (S.intersection (toSet targets) $ S.fromList $ NE.toList found)
-filterFoundTargets (ResultExclude found) (FoundTargets targets) = FoundTargets <$> nonEmpty (S.difference (toSet targets) $ S.fromList $ NE.toList found)
+filterFoundTargets (ResultInclude found) (FoundTargets targets) = FoundTargets <$> nonEmpty (Set.intersection (toSet targets) $ Set.fromList $ NE.toList found)
+filterFoundTargets (ResultExclude found) (FoundTargets targets) = FoundTargets <$> nonEmpty (Set.difference (toSet targets) $ Set.fromList $ NE.toList found)
 
 -- (buildTargetFilters-only `union` pathFilters-only)
 --   `subtract` (buildTargetFilters-exclude `union` pathFilters-exclude)
@@ -130,7 +130,7 @@ targetFilterParser = (try targetFilter <|> try projectFilter <|> typeFilter) <* 
     typeFilter = TypeTarget <$> buildtool
 
     buildtool :: Parser Text
-    buildtool = Text.pack <$> some alphaNumChar
+    buildtool = toText <$> some alphaNumChar
 
     path :: Parser (Path Rel Dir)
     path = do

--- a/src/Fossa/API/Types.hs
+++ b/src/Fossa/API/Types.hs
@@ -20,11 +20,11 @@ import Data.Aeson
 import Data.Coerce (coerce)
 import Data.List.Extra ((!?))
 import Data.Map.Strict (Map)
-import Data.Map.Strict qualified as M
+import Data.Map.Strict qualified as Map
 import Data.Maybe (fromMaybe)
 import Data.String.Conversion (encodeUtf8)
 import Data.Text (Text)
-import Data.Text qualified as T
+import Data.Text qualified as Text
 import Data.Text.Prettyprint.Doc
 import Network.HTTP.Req
 import Text.URI (URI, render)
@@ -189,7 +189,7 @@ renderedIssues issues = rendered
     issuesList = issuesIssues issues
 
     categorize :: Ord k => (v -> k) -> [v] -> Map k [v]
-    categorize f = M.fromListWith (++) . map (\v -> (f v, [v]))
+    categorize f = Map.fromListWith (++) . map (\v -> (f v, [v]))
 
     issuesByType :: Map IssueType [Issue]
     issuesByType = categorize issueType issuesList
@@ -201,7 +201,7 @@ renderedIssues issues = rendered
     rendered :: Doc ann
     rendered =
       vsep
-        [renderSection issueType rawIssues | (issueType, rawIssues) <- M.toList issuesByType]
+        [renderSection issueType rawIssues | (issueType, rawIssues) <- Map.toList issuesByType]
 
     renderHeader :: IssueType -> Doc ann
     renderHeader ty =
@@ -223,7 +223,7 @@ renderedIssues issues = rendered
         format :: Text -> Doc ann
         format = fill padding . pretty
 
-        locatorSplit = T.split (\c -> c == '$' || c == '+') (issueRevisionId issue)
+        locatorSplit = Text.split (\c -> c == '$' || c == '+') (issueRevisionId issue)
 
         name = fromMaybe (issueRevisionId issue) (locatorSplit !? 1)
         revision = fromMaybe "" (locatorSplit !? 2)

--- a/src/Srclib/Converter.hs
+++ b/src/Srclib/Converter.hs
@@ -11,8 +11,8 @@ import Algebra.Graph.AdjacencyMap qualified as AM
 import App.Fossa.Analyze.Project
 import Control.Applicative ((<|>))
 import Data.Set qualified as Set
+import Data.String.Conversion (toText)
 import Data.Text (Text)
-import Data.Text qualified as Text
 import DepTypes
 import Graphing (Graphing)
 import Graphing qualified
@@ -37,7 +37,7 @@ toSourceUnit ProjectResult{..} =
     , additionalData = Nothing
     }
   where
-    renderedPath = Text.pack (toFilePath projectResultPath)
+    renderedPath = toText (toFilePath projectResultPath)
 
     filteredGraph :: Graphing Dependency
     filteredGraph = Graphing.filter (\d -> shouldPublishDep d && isSupportedType d) projectResultGraph

--- a/src/Srclib/Types.hs
+++ b/src/Srclib/Types.hs
@@ -15,7 +15,7 @@ module Srclib.Types (
 import Data.Aeson
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
-import Data.Text qualified as T
+import Data.Text qualified as Text
 import Types (GraphBreadth (..))
 
 data SourceUnit = SourceUnit
@@ -82,11 +82,11 @@ renderLocator Locator{..} =
   locatorFetcher <> "+" <> locatorProject <> "$" <> fromMaybe "" locatorRevision
 
 parseLocator :: Text -> Locator
-parseLocator raw = Locator fetcher project (if T.null revision then Nothing else Just revision)
+parseLocator raw = Locator fetcher project (if Text.null revision then Nothing else Just revision)
   where
-    (fetcher, xs) = T.breakOn "+" raw
-    (project, xs') = T.breakOn "$" (T.drop 1 xs)
-    revision = T.drop 1 xs'
+    (fetcher, xs) = Text.breakOn "+" raw
+    (project, xs') = Text.breakOn "$" (Text.drop 1 xs)
+    revision = Text.drop 1 xs'
 
 instance ToJSON SourceUnit where
   toJSON SourceUnit{..} =

--- a/src/Strategy/Cargo.hs
+++ b/src/Strategy/Cargo.hs
@@ -15,9 +15,9 @@ module Strategy.Cargo (
 import Control.Effect.Diagnostics
 import Data.Aeson.Types
 import Data.Foldable (for_, traverse_)
-import Data.Map.Strict qualified as M
+import Data.Map.Strict qualified as Map
 import Data.Set (Set)
-import Data.Text qualified as T
+import Data.Text qualified as Text
 import Discovery.Walk
 import Effect.Exec
 import Effect.Grapher
@@ -31,32 +31,32 @@ newtype CargoLabel
   deriving (Eq, Ord, Show)
 
 data PackageId = PackageId
-  { pkgIdName :: T.Text
-  , pkgIdVersion :: T.Text
-  , pkgIdSource :: T.Text
+  { pkgIdName :: Text.Text
+  , pkgIdVersion :: Text.Text
+  , pkgIdSource :: Text.Text
   }
   deriving (Eq, Ord, Show)
 
 data PackageDependency = PackageDependency
-  { pkgDepName :: T.Text
-  , pkgDepReq :: T.Text
-  , pkgDepKind :: Maybe T.Text
+  { pkgDepName :: Text.Text
+  , pkgDepReq :: Text.Text
+  , pkgDepKind :: Maybe Text.Text
   }
   deriving (Eq, Ord, Show)
 
 data Package = Package
-  { pkgName :: T.Text
-  , pkgVersion :: T.Text
+  { pkgName :: Text.Text
+  , pkgVersion :: Text.Text
   , pkgId :: PackageId
-  , pkgLicense :: Maybe T.Text
-  , pkgLicenseFile :: Maybe T.Text
+  , pkgLicense :: Maybe Text.Text
+  , pkgLicenseFile :: Maybe Text.Text
   , pkgDependencies :: [PackageDependency]
   }
   deriving (Eq, Ord, Show)
 
 data NodeDepKind = NodeDepKind
-  { nodeDepKind :: Maybe T.Text
-  , nodeDepTarget :: Maybe T.Text
+  { nodeDepKind :: Maybe Text.Text
+  , nodeDepTarget :: Maybe Text.Text
   }
   deriving (Eq, Ord, Show)
 
@@ -198,7 +198,7 @@ toDependency pkg =
       , dependencyVersion = Just $ CEq $ pkgIdVersion pkg
       , dependencyLocations = []
       , dependencyEnvironments = []
-      , dependencyTags = M.empty
+      , dependencyTags = Map.empty
       }
   where
     applyLabel :: CargoLabel -> Dependency -> Dependency
@@ -208,7 +208,7 @@ toDependency pkg =
 -- Null refers to productions, while dev and build refer to development-time dependencies
 -- Cargo does not differentiate test dependencies and dev dependencies,
 -- so we just simplify it to Development.
-kindToLabel :: Maybe T.Text -> CargoLabel
+kindToLabel :: Maybe Text.Text -> CargoLabel
 kindToLabel (Just _) = CargoDepKind EnvDevelopment
 kindToLabel Nothing = CargoDepKind EnvProduction
 
@@ -230,8 +230,8 @@ buildGraph meta = stripRoot $
     traverse_ direct $ metadataWorkspaceMembers meta
     traverse_ addEdge $ resolvedNodes $ metadataResolve meta
 
-parsePkgId :: T.Text -> Parser PackageId
+parsePkgId :: Text.Text -> Parser PackageId
 parsePkgId t =
-  case T.splitOn " " t of
+  case Text.splitOn " " t of
     [a, b, c] -> pure $ PackageId a b c
     _ -> fail "malformed Package ID"

--- a/src/Strategy/Cocoapods/Podfile.hs
+++ b/src/Strategy/Cocoapods/Podfile.hs
@@ -12,9 +12,9 @@ module Strategy.Cocoapods.Podfile (
 import Control.Effect.Diagnostics
 import Data.Functor (void)
 import Data.Map.Strict (Map)
-import Data.Map.Strict qualified as M
+import Data.Map.Strict qualified as Map
+import Data.String.Conversion (toText)
 import Data.Text (Text)
-import Data.Text qualified as T
 import Data.Void (Void)
 import DepTypes
 import Effect.ReadFS
@@ -39,11 +39,11 @@ buildGraph podfile = Graphing.fromList (map toDependency direct)
         { dependencyType = PodType
         , dependencyName = name
         , dependencyVersion = CEq <$> version
-        , dependencyLocations = case M.lookup SourceProperty properties of
+        , dependencyLocations = case Map.lookup SourceProperty properties of
             Just repo -> [repo]
             _ -> [source podfile]
         , dependencyEnvironments = []
-        , dependencyTags = M.empty
+        , dependencyTags = Map.empty
         }
 
 type Parser = Parsec Void Text
@@ -92,10 +92,10 @@ podParser = do
   version <- optional (try (comma *> stringLiteral))
   properties <- many property
   _ <- restOfLine
-  pure [PodLine $ Pod name version (M.fromList properties)]
+  pure [PodLine $ Pod name version (Map.fromList properties)]
 
 comma :: Parser ()
-comma = () <$ symbol ","
+comma = void $ symbol ","
 
 property :: Parser (PropertyType, Text)
 property = do
@@ -118,7 +118,7 @@ lexeme :: Parser a -> Parser a
 lexeme = L.lexeme sc
 
 stringLiteral :: Parser Text
-stringLiteral = T.pack <$> go
+stringLiteral = toText <$> go
   where
     go =
       (char '"' *> manyTill L.charLiteral (char '"'))

--- a/src/Strategy/Cocoapods/PodfileLock.hs
+++ b/src/Strategy/Cocoapods/PodfileLock.hs
@@ -12,10 +12,10 @@ import Data.Char qualified as C
 import Data.Foldable (traverse_)
 import Data.Functor (void)
 import Data.Map.Strict (Map)
-import Data.Map.Strict qualified as M
+import Data.Map.Strict qualified as Map
 import Data.Set (Set)
 import Data.Text (Text)
-import Data.Text qualified as T
+import Data.Text qualified as Text
 import Data.Void (Void)
 import DepTypes
 import Effect.Grapher
@@ -51,7 +51,7 @@ toDependency pkg = foldr applyLabel start
         , dependencyVersion = Nothing
         , dependencyLocations = []
         , dependencyEnvironments = []
-        , dependencyTags = M.empty
+        , dependencyTags = Map.empty
         }
 
     applyLabel :: PodfileLabel -> Dependency -> Dependency
@@ -135,13 +135,13 @@ sectionParser :: Text -> ([a] -> Section) -> Parser a -> Parser Section
 sectionParser sectionName lambda parser = nonIndented $
   indentBlock $ do
     _ <- chunk sectionName
-    return (L.IndentMany Nothing (pure . lambda) parser)
+    pure (L.IndentMany Nothing (pure . lambda) parser)
 
 externalDepsParser :: Parser SourceDep
 externalDepsParser = indentBlock $ do
   name <- lexeme (takeWhileP (Just "external dep parser") (/= ':'))
   _ <- restOfLine
-  return (L.IndentMany Nothing (pure . SourceDep name . M.fromList) tagParser)
+  pure (L.IndentMany Nothing (pure . SourceDep name . Map.fromList) tagParser)
 
 tagParser :: Parser (Text, Text)
 tagParser = do
@@ -154,7 +154,7 @@ tagParser = do
 remoteParser :: Parser Remote
 remoteParser = indentBlock $ do
   location <- restOfLine
-  pure (L.IndentMany Nothing (pure . Remote (T.dropWhileEnd (== ':') location)) depParser)
+  pure (L.IndentMany Nothing (pure . Remote (Text.dropWhileEnd (== ':') location)) depParser)
 
 podParser :: Parser Pod
 podParser = indentBlock $ do

--- a/src/Strategy/Composer.hs
+++ b/src/Strategy/Composer.hs
@@ -9,7 +9,7 @@ import Control.Effect.Diagnostics hiding (fromMaybe)
 import Data.Aeson.Types
 import Data.Foldable (traverse_)
 import Data.Map.Strict (Map)
-import Data.Map.Strict qualified as M
+import Data.Map.Strict qualified as Map
 import Data.Maybe (fromMaybe)
 import Data.Set (Set)
 import Data.Text (Text)
@@ -106,7 +106,7 @@ buildGraph lock = run . withLabeling toDependency $ do
     addDeps :: Has CompGrapher sig m => DepEnvironment -> CompDep -> m ()
     addDeps env dep = do
       let pkg = CompPkg (depName dep)
-      _ <- M.traverseWithKey (addEdge pkg) (fromMaybe M.empty $ depRequire dep)
+      _ <- Map.traverseWithKey (addEdge pkg) (fromMaybe Map.empty $ depRequire dep)
       label pkg (DepVersion $ depVersion dep)
       label pkg (CompEnv env)
       direct pkg
@@ -123,7 +123,7 @@ buildGraph lock = run . withLabeling toDependency $ do
           , dependencyVersion = Nothing
           , dependencyLocations = []
           , dependencyEnvironments = []
-          , dependencyTags = M.empty
+          , dependencyTags = Map.empty
           }
 
     addLabel :: CompLabel -> Dependency -> Dependency

--- a/src/Strategy/Conda/CondaList.hs
+++ b/src/Strategy/Conda/CondaList.hs
@@ -9,7 +9,7 @@ module Strategy.Conda.CondaList (
 
 import Control.Carrier.Diagnostics hiding (fromMaybe)
 import Data.Aeson
-import Data.Map.Strict qualified as M
+import Data.Map.Strict qualified as Map
 import Data.Text (Text)
 import Effect.Exec
 import Graphing (Graphing, fromList)
@@ -36,7 +36,7 @@ buildGraph deps = Graphing.fromList (map toDependency deps)
         , dependencyVersion = CEq <$> listVersion
         , dependencyLocations = []
         , dependencyEnvironments = []
-        , dependencyTags = M.empty
+        , dependencyTags = Map.empty
         }
 
 analyze ::

--- a/src/Strategy/Conda/EnvironmentYml.hs
+++ b/src/Strategy/Conda/EnvironmentYml.hs
@@ -10,10 +10,10 @@ module Strategy.Conda.EnvironmentYml (
 import Control.Carrier.Diagnostics hiding (fromMaybe)
 import Data.Aeson
 import Data.List.Extra ((!?))
-import Data.Map.Strict qualified as M
+import Data.Map.Strict qualified as Map
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
-import Data.Text qualified as T
+import Data.Text qualified as Text
 import Effect.ReadFS
 import Graphing (Graphing, fromList)
 import Path
@@ -31,7 +31,7 @@ buildGraph envYmlFile = Graphing.fromList (map toDependency allDeps)
         , dependencyVersion = CEq <$> depVersion -- todo - properly handle version constraints
         , dependencyLocations = []
         , dependencyEnvironments = []
-        , dependencyTags = M.empty
+        , dependencyTags = Map.empty
         }
 
 analyze ::
@@ -55,7 +55,7 @@ getCondaDepFromText rcd =
     , depFullVersion = fullVersion
     }
   where
-    depSplit = T.split (== '=') rcd
+    depSplit = Text.split (== '=') rcd
 
     name = fromMaybe rcd (depSplit !? 0)
     version = depSplit !? 1 -- TODO: this may contain constraints that we need to parse

--- a/src/Strategy/Erlang/ConfigParser.hs
+++ b/src/Strategy/Erlang/ConfigParser.hs
@@ -23,8 +23,9 @@ module Strategy.Erlang.ConfigParser (
 import Data.Aeson.Types (ToJSON (toJSON))
 import Data.Char qualified as C
 import Data.Functor (($>))
+import Data.String.Conversion (toText)
 import Data.Text (Text)
-import Data.Text qualified as T
+import Data.Text qualified as Text
 import Data.Void
 import GHC.Generics (Generic)
 import Text.Megaparsec
@@ -133,7 +134,7 @@ parseAtomText = AtomText <$> lexeme (rawAtom <|> quotedAtom)
     quotedAtom = enclosed "'" "'" $ takeWhile1P (Just "quoted Atom") (/= '\'')
     --
     rawAtom :: Parser Text
-    rawAtom = T.cons <$> firstChar <*> rawAtomTail
+    rawAtom = Text.cons <$> firstChar <*> rawAtomTail
     isRawAtomChar :: Char -> Bool
     isRawAtomChar c = C.isAlphaNum c || c == '_' || c == '@'
     firstChar :: Parser Char
@@ -145,7 +146,7 @@ parseErlArray :: Parser ErlValue
 parseErlArray = ErlArray <$> enclosed "[" "]" (parseErlValue `sepBy` symbol ",")
 
 parseErlString :: Parser ErlValue
-parseErlString = ErlString . T.pack . concat <$> some (lexeme quotedString)
+parseErlString = ErlString . toText . concat <$> some (lexeme quotedString)
 
 quotedString :: Parser String
 quotedString = char '\"' >> manyTill L.charLiteral (char '\"')

--- a/src/Strategy/Go/GlideLock.hs
+++ b/src/Strategy/Go/GlideLock.hs
@@ -10,9 +10,9 @@ module Strategy.Go.GlideLock (
 import Control.Applicative ((<|>))
 import Control.Effect.Diagnostics
 import Data.Aeson
-import Data.Map.Strict qualified as M
+import Data.Map.Strict qualified as Map
+import Data.String.Conversion (toText)
 import Data.Text (Text)
-import Data.Text qualified as T
 import DepTypes
 import Effect.ReadFS
 import Graphing (Graphing)
@@ -37,7 +37,7 @@ buildGraph lockfile = Graphing.fromList (map toDependency direct)
         , dependencyVersion = Just (CEq depVersion)
         , dependencyLocations = []
         , dependencyEnvironments = []
-        , dependencyTags = M.empty
+        , dependencyTags = Map.empty
         }
 
 data GlideLockfile = GlideLockfile
@@ -68,4 +68,4 @@ instance FromJSON GlideDep where
       <*> obj .:? "repo"
 
 intToText :: Int -> Text
-intToText = T.pack . show
+intToText = toText . show

--- a/src/Strategy/Go/GoList.hs
+++ b/src/Strategy/Go/GoList.hs
@@ -11,7 +11,7 @@ import Data.Foldable (traverse_)
 import Data.Maybe (mapMaybe)
 import Data.String.Conversion (decodeUtf8)
 import Data.Text (Text)
-import Data.Text qualified as T
+import Data.Text qualified as Text
 import DepTypes
 import Effect.Exec
 import Effect.Grapher
@@ -45,12 +45,12 @@ analyze' dir = do
   graph <- graphingGolang $ do
     stdout <- context "Getting direct dependencies" $ execThrow dir golistCmd
 
-    let gomodLines = drop 1 . T.lines . T.filter (/= '\r') . decodeUtf8 . BL.toStrict $ stdout -- the first line is our package
+    let gomodLines = drop 1 . Text.lines . Text.filter (/= '\r') . decodeUtf8 . BL.toStrict $ stdout -- the first line is our package
         requires = mapMaybe toRequire gomodLines
 
         toRequire :: Text -> Maybe Require
         toRequire line =
-          case T.splitOn " " line of
+          case Text.splitOn " " line of
             [package, version] -> Just (Require package version)
             _ -> Nothing
 

--- a/src/Strategy/Go/GopkgToml.hs
+++ b/src/Strategy/Go/GopkgToml.hs
@@ -13,7 +13,7 @@ import Control.Effect.Diagnostics
 import Data.Foldable (traverse_)
 import Data.Functor (void)
 import Data.Map.Strict (Map)
-import Data.Map.Strict qualified as M
+import Data.Map.Strict qualified as Map
 import Data.Text (Text)
 import DepTypes
 import Effect.Exec
@@ -71,7 +71,7 @@ analyze' file = graphingGolang $ do
   pure ()
 
 buildGraph :: Has GolangGrapher sig m => Gopkg -> m ()
-buildGraph = void . M.traverseWithKey go . resolve
+buildGraph = void . Map.traverseWithKey go . resolve
   where
     go :: Has GolangGrapher sig m => Text -> PkgConstraint -> m ()
     go name PkgConstraint{..} = do
@@ -92,7 +92,7 @@ resolve :: Gopkg -> Map Text PkgConstraint -- Map Package (Maybe Version)
 resolve gopkg = overridden
   where
     overridden = foldr inserting constraints (pkgOverrides gopkg)
-    constraints = foldr inserting M.empty (pkgConstraints gopkg)
+    constraints = foldr inserting Map.empty (pkgConstraints gopkg)
 
     inserting :: PkgConstraint -> Map Text PkgConstraint -> Map Text PkgConstraint
-    inserting constraint = M.insert (constraintName constraint) constraint
+    inserting constraint = Map.insert (constraintName constraint) constraint

--- a/src/Strategy/Go/Types.hs
+++ b/src/Strategy/Go/Types.hs
@@ -7,10 +7,10 @@ module Strategy.Go.Types (
   graphingGolang,
 ) where
 
-import Data.Map.Strict qualified as M
+import Data.Map.Strict qualified as Map
 import Data.Set (Set)
 import Data.Text (Text)
-import Data.Text qualified as T
+import Data.Text qualified as Text
 import DepTypes
 import Effect.Grapher
 import Graphing
@@ -48,7 +48,7 @@ golangPackageToDependency pkg = foldr applyLabel start
         , dependencyVersion = Nothing
         , dependencyLocations = []
         , dependencyEnvironments = []
-        , dependencyTags = M.empty
+        , dependencyTags = Map.empty
         }
 
     applyLabel :: GolangLabel -> Dependency -> Dependency
@@ -71,8 +71,8 @@ golangPackageToDependency pkg = foldr applyLabel start
 -- TODO: In `go.mod`, we handle this in the parser. Do we even need to handle
 -- this format in other Go analyzers? Can we just remove this code?
 fixVersion :: Text -> Text
-fixVersion = last . T.splitOn "-" . T.replace "+incompatible" ""
+fixVersion = last . Text.splitOn "-" . Text.replace "+incompatible" ""
 
 -- replace "github.com/A/B/vendor/github.com/X/Y" with "github.com/X/Y"
 unvendor :: Text -> Text
-unvendor = last . T.splitOn "/vendor/"
+unvendor = last . Text.splitOn "/vendor/"

--- a/src/Strategy/Haskell/Stack.hs
+++ b/src/Strategy/Haskell/Stack.hs
@@ -14,9 +14,9 @@ import Control.Effect.Diagnostics
 import Control.Monad (when)
 import Data.Aeson.Types
 import Data.Foldable (for_)
-import Data.Map.Strict qualified as M
+import Data.Map.Strict qualified as Map
+import Data.String.Conversion (toString)
 import Data.Text (Text)
-import Data.Text qualified as T
 import Discovery.Walk
 import Effect.Exec
 import Effect.Grapher
@@ -56,7 +56,7 @@ parseLocationType :: MonadFail m => Text -> m StackLocation
 parseLocationType txt
   | txt == "hackage" = pure Remote
   | txt `elem` ["project package", "archive"] = pure Local
-  | otherwise = fail $ "Bad location type: " ++ T.unpack txt
+  | otherwise = fail $ "Bad location type: " ++ toString txt
 
 discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has Exec rsig run, Has Diagnostics rsig run) => Path Abs Dir -> m [DiscoveredProject run]
 discover dir = context "Stack" $ do
@@ -125,7 +125,7 @@ toDependency dep =
     , dependencyVersion = Just $ CEq $ stackVersion dep
     , dependencyLocations = []
     , dependencyEnvironments = []
-    , dependencyTags = M.empty
+    , dependencyTags = Map.empty
     }
 
 buildGraph :: Has Diagnostics sig m => [StackDep] -> m (G.Graphing Dependency)

--- a/src/Strategy/Maven/Plugin.hs
+++ b/src/Strategy/Maven/Plugin.hs
@@ -19,8 +19,8 @@ import Data.ByteString (ByteString)
 import Data.ByteString qualified as BS
 import Data.FileEmbed (embedFile)
 import Data.Functor (void)
+import Data.String.Conversion (toText)
 import Data.Text (Text)
-import Data.Text qualified as T
 import Effect.Exec
 import Effect.ReadFS
 import Path
@@ -78,7 +78,7 @@ mavenInstallPluginCmd pluginFilePath =
         , "-DartifactId=" <> pluginArtifact
         , "-Dversion=" <> pluginVersion
         , "-Dpackaging=jar"
-        , "-Dfile=" <> T.pack pluginFilePath
+        , "-Dfile=" <> toText pluginFilePath
         ]
     , cmdAllowErr = Never
     }

--- a/src/Strategy/Maven/PluginStrategy.hs
+++ b/src/Strategy/Maven/PluginStrategy.hs
@@ -10,7 +10,7 @@ import Control.Effect.Diagnostics (Diagnostics, context)
 import Control.Effect.Lift (Lift)
 import Data.Foldable (traverse_)
 import Data.Map.Strict (Map)
-import Data.Map.Strict qualified as M
+import Data.Map.Strict qualified as Map
 import DepTypes (
   DepEnvironment (..),
   DepType (MavenType),
@@ -56,7 +56,7 @@ buildGraph PluginOutput{..} = run $
         byNumeric = indexBy artifactNumericId outArtifacts
 
     let depsByNumeric :: Map Int Dependency
-        depsByNumeric = M.map toDependency byNumeric
+        depsByNumeric = Map.map toDependency byNumeric
 
     traverse_ (visitEdge depsByNumeric) outEdges
   where
@@ -69,7 +69,7 @@ buildGraph PluginOutput{..} = run $
         , dependencyLocations = []
         , dependencyEnvironments = [EnvTesting | "test" `elem` artifactScopes]
         , dependencyTags =
-            M.fromList $
+            Map.fromList $
               ("scopes", artifactScopes) :
                 [("optional", ["true"]) | artifactOptional]
         }
@@ -77,11 +77,11 @@ buildGraph PluginOutput{..} = run $
     visitEdge :: Has (Grapher Dependency) sig m => Map Int Dependency -> Edge -> m ()
     visitEdge refsByNumeric Edge{..} = do
       let refs = do
-            parentRef <- M.lookup edgeFrom refsByNumeric
-            childRef <- M.lookup edgeTo refsByNumeric
+            parentRef <- Map.lookup edgeFrom refsByNumeric
+            childRef <- Map.lookup edgeTo refsByNumeric
             Just (parentRef, childRef)
 
       traverse_ (uncurry edge) refs
 
     indexBy :: Ord k => (v -> k) -> [v] -> Map k v
-    indexBy f = M.fromList . map (\v -> (f v, v))
+    indexBy f = Map.fromList . map (\v -> (f v, v))

--- a/src/Strategy/Maven/Pom/Closure.hs
+++ b/src/Strategy/Maven/Pom/Closure.hs
@@ -12,10 +12,10 @@ import Control.Effect.Diagnostics
 import Data.Foldable (traverse_)
 import Data.List (isSuffixOf)
 import Data.Map.Strict (Map)
-import Data.Map.Strict qualified as M
+import Data.Map.Strict qualified as Map
 import Data.Maybe (mapMaybe)
 import Data.Set (Set)
-import Data.Set qualified as S
+import Data.Set qualified as Set
 import Discovery.Walk
 import Effect.ReadFS
 import Path
@@ -40,13 +40,13 @@ findPomFiles dir = execState @[Path Abs File] [] $
 buildProjectClosures :: Path Abs Dir -> GlobalClosure -> [MavenProjectClosure]
 buildProjectClosures basedir global = closures
   where
-    closures = map (\(path, (coord, pom)) -> toClosure path coord pom) (M.toList projectRoots)
+    closures = map (\(path, (coord, pom)) -> toClosure path coord pom) (Map.toList projectRoots)
 
     toClosure :: Path Abs File -> MavenCoordinate -> Pom -> MavenProjectClosure
     toClosure path coord pom = MavenProjectClosure path coord pom reachableGraph reachablePomMap
       where
-        reachableGraph = AM.induce (`S.member` reachablePoms) $ globalGraph global
-        reachablePomMap = M.filterWithKey (\k _ -> S.member k reachablePoms) $ globalPoms global
+        reachableGraph = AM.induce (`Set.member` reachablePoms) $ globalGraph global
+        reachablePomMap = Map.filterWithKey (\k _ -> Set.member k reachablePoms) $ globalPoms global
         reachablePoms = bidirectionalReachable coord (globalGraph global)
 
     projectRoots :: Map (Path Abs File) (MavenCoordinate, Pom)
@@ -56,43 +56,43 @@ buildProjectClosures basedir global = closures
     graphRoots = sourceVertices (globalGraph global)
 
 -- Find reachable nodes both below (children, grandchildren, ...) and above (parents, grandparents) the node
-bidirectionalReachable :: Ord a => a -> AM.AdjacencyMap a -> S.Set a
-bidirectionalReachable node gr = S.fromList $ AM.reachable node gr ++ AM.reachable node (AM.transpose gr)
+bidirectionalReachable :: Ord a => a -> AM.AdjacencyMap a -> Set.Set a
+bidirectionalReachable node gr = Set.fromList $ AM.reachable node gr ++ AM.reachable node (AM.transpose gr)
 
 sourceVertices :: Ord a => AM.AdjacencyMap a -> [a]
-sourceVertices graph = [v | v <- AM.vertexList graph, S.null (AM.preSet v graph)]
+sourceVertices graph = [v | v <- AM.vertexList graph, Set.null (AM.preSet v graph)]
 
 determineProjectRoots :: Path Abs Dir -> GlobalClosure -> [MavenCoordinate] -> Map (Path Abs File) (MavenCoordinate, Pom)
-determineProjectRoots rootDir closure = go . S.fromList
+determineProjectRoots rootDir closure = go . Set.fromList
   where
     go :: Set MavenCoordinate -> Map (Path Abs File) (MavenCoordinate, Pom)
     go coordRoots
-      | S.null coordRoots = M.empty
-      | otherwise = M.union projects (go frontier)
+      | Set.null coordRoots = Map.empty
+      | otherwise = Map.union projects (go frontier)
       where
         inRoot :: Set (MavenCoordinate, Path Abs File, Pom)
         inRoot =
-          S.fromList $
+          Set.fromList $
             mapMaybe
               ( \coord -> do
-                  (abspath, pom) <- M.lookup coord (globalPoms closure)
+                  (abspath, pom) <- Map.lookup coord (globalPoms closure)
                   -- This ensures that the absolute path is relative to the root directory
                   _ <- PIO.makeRelative rootDir abspath
                   Just (coord, abspath, pom)
               )
-              (S.toList coordRoots)
+              (Set.toList coordRoots)
 
         inRootCoords :: Set MavenCoordinate
-        inRootCoords = S.map (\(c, _, _) -> c) inRoot
+        inRootCoords = Set.map (\(c, _, _) -> c) inRoot
 
         remainingCoords :: Set MavenCoordinate
-        remainingCoords = coordRoots S.\\ inRootCoords
+        remainingCoords = coordRoots Set.\\ inRootCoords
 
         projects :: Map (Path Abs File) (MavenCoordinate, Pom)
-        projects = M.fromList $ S.toList $ S.map (\(coord, path, pom) -> (path, (coord, pom))) inRoot
+        projects = Map.fromList $ Set.toList $ Set.map (\(coord, path, pom) -> (path, (coord, pom))) inRoot
 
         frontier :: Set MavenCoordinate
-        frontier = S.unions $ S.map (\coord -> AM.postSet coord (globalGraph closure)) remainingCoords
+        frontier = Set.unions $ Set.map (\coord -> AM.postSet coord (globalGraph closure)) remainingCoords
 
 data MavenProjectClosure = MavenProjectClosure
   { closurePath :: Path Abs File

--- a/src/Strategy/Maven/Pom/PomFile.hs
+++ b/src/Strategy/Maven/Pom/PomFile.hs
@@ -17,7 +17,7 @@ module Strategy.Maven.Pom.PomFile
 
 import Control.Applicative (optional, (<|>))
 import Data.Map.Strict (Map)
-import Data.Map.Strict qualified as M
+import Data.Map.Strict qualified as Map
 import Data.Text (Text)
 import Parse.XML
 
@@ -36,7 +36,7 @@ validatePom raw = do
   pure (Pom coord parentCoord properties dependencyManagement dependencies licenses)
 
 rawDepsToDeps :: [RawDependency] -> Map (Group, Artifact) MvnDepBody
-rawDepsToDeps = M.fromList . map (\dep -> (depToKey dep, depToBody dep))
+rawDepsToDeps = Map.fromList . map (\dep -> (depToKey dep, depToBody dep))
   where
     depToKey :: RawDependency -> (Group, Artifact)
     depToKey raw = (rawDependencyGroup raw, rawDependencyArtifact raw)
@@ -101,7 +101,7 @@ data MvnDepBody = MvnDepBody
   deriving (Eq, Ord, Show)
 
 instance Semigroup Pom where
-  -- left-biased, similar to M.union
+  -- left-biased, similar to Map.union
   --
   -- almost all fields are inherited -- and the only ones we're tracking are
   -- properties/dependencyManagement/dependencies
@@ -112,14 +112,14 @@ instance Semigroup Pom where
     Pom
       { pomCoord = pomCoord childPom
       , pomParentCoord = pomParentCoord childPom
-      , pomProperties = M.union (pomProperties childPom) (pomProperties parentPom)
-      , pomDependencyManagement = M.unionWith (<>) (pomDependencyManagement childPom) (pomDependencyManagement parentPom)
-      , pomDependencies = M.unionWith (<>) (pomDependencies childPom) (pomDependencies parentPom)
+      , pomProperties = Map.union (pomProperties childPom) (pomProperties parentPom)
+      , pomDependencyManagement = Map.unionWith (<>) (pomDependencyManagement childPom) (pomDependencyManagement parentPom)
+      , pomDependencies = Map.unionWith (<>) (pomDependencies childPom) (pomDependencies parentPom)
       , pomLicenses = pomLicenses childPom
       }
 
 instance Semigroup MvnDepBody where
-  -- left-biased, similar to M.union
+  -- left-biased, similar to Map.union
   left <> right =
     MvnDepBody
       { depVersion = depVersion left <|> depVersion right
@@ -174,7 +174,7 @@ instance FromXML RawPom where
       <*> optional (child "groupId" el)
       <*> child "artifactId" el
       <*> optional (child "version" el)
-      <*> optional (child "properties" el) `defaultsTo` M.empty
+      <*> optional (child "properties" el) `defaultsTo` Map.empty
       <*> optional (child "modules" el >>= children "module") `defaultsTo` []
       <*> optional (child "dependencyManagement" el >>= children "dependency") `defaultsTo` []
       <*> optional (child "dependencies" el >>= children "dependency") `defaultsTo` []

--- a/src/Strategy/Node/NpmList.hs
+++ b/src/Strategy/Node/NpmList.hs
@@ -5,7 +5,7 @@ module Strategy.Node.NpmList (
 import Control.Effect.Diagnostics
 import Data.Aeson
 import Data.Map.Strict (Map)
-import Data.Map.Strict qualified as M
+import Data.Map.Strict qualified as Map
 import Data.Text (Text)
 import DepTypes
 import Effect.Exec
@@ -28,8 +28,8 @@ analyze' dir = do
 buildGraph :: NpmOutput -> Graphing Dependency
 buildGraph top = unfold direct getDeps toDependency
   where
-    direct = M.toList $ outputDependencies top
-    getDeps (_, nodeOutput) = M.toList $ outputDependencies nodeOutput
+    direct = Map.toList $ outputDependencies top
+    getDeps (_, nodeOutput) = Map.toList $ outputDependencies nodeOutput
     toDependency (nodeName, nodeOutput) =
       Dependency
         { dependencyType = NodeJSType
@@ -37,7 +37,7 @@ buildGraph top = unfold direct getDeps toDependency
         , dependencyVersion = CEq <$> outputVersion nodeOutput
         , dependencyLocations = []
         , dependencyEnvironments = []
-        , dependencyTags = M.empty
+        , dependencyTags = Map.empty
         }
 
 data NpmOutput = NpmOutput
@@ -55,4 +55,4 @@ instance FromJSON NpmOutput where
       <*> obj .:? "version"
       <*> obj .:? "from"
       <*> obj .:? "resolved"
-      <*> obj .:? "dependencies" .!= M.empty
+      <*> obj .:? "dependencies" .!= Map.empty

--- a/src/Strategy/Node/NpmLock.hs
+++ b/src/Strategy/Node/NpmLock.hs
@@ -12,7 +12,7 @@ import Data.Aeson
 import Data.Foldable (traverse_)
 import Data.Functor (void)
 import Data.Map.Strict (Map)
-import Data.Map.Strict qualified as M
+import Data.Map.Strict qualified as Map
 import Data.Set (Set)
 import Data.Text (Text)
 import DepTypes
@@ -70,8 +70,8 @@ data NpmPackageLabel = NpmPackageEnv DepEnvironment | NpmPackageLocation Text
 
 buildGraph :: NpmPackageJson -> Graphing Dependency
 buildGraph packageJson = run . withLabeling toDependency $ do
-  _ <- M.traverseWithKey addDirect (packageDependencies packageJson)
-  _ <- M.traverseWithKey addDep (packageDependencies packageJson)
+  _ <- Map.traverseWithKey addDirect (packageDependencies packageJson)
+  _ <- Map.traverseWithKey addDep (packageDependencies packageJson)
   pure ()
   where
     addDirect :: Has NpmGrapher sig m => Text -> NpmDep -> m ()
@@ -91,13 +91,13 @@ buildGraph packageJson = run . withLabeling toDependency $ do
       case depRequires of
         Nothing -> pure ()
         Just required ->
-          void $ M.traverseWithKey (\reqName reqVer -> edge pkg (NpmPackage reqName reqVer)) required
+          void $ Map.traverseWithKey (\reqName reqVer -> edge pkg (NpmPackage reqName reqVer)) required
 
       -- add dependency nodes
       case depDependencies of
         Nothing -> pure ()
         Just deps ->
-          void $ M.traverseWithKey addDep deps
+          void $ Map.traverseWithKey addDep deps
 
     toDependency :: NpmPackage -> Set NpmPackageLabel -> Dependency
     toDependency pkg = foldr addLabel (start pkg)
@@ -114,5 +114,5 @@ buildGraph packageJson = run . withLabeling toDependency $ do
         , dependencyVersion = Just $ CEq pkgVersion
         , dependencyLocations = []
         , dependencyEnvironments = []
-        , dependencyTags = M.empty
+        , dependencyTags = Map.empty
         }

--- a/src/Strategy/Node/PackageJson.hs
+++ b/src/Strategy/Node/PackageJson.hs
@@ -9,7 +9,7 @@ module Strategy.Node.PackageJson (
 import Control.Effect.Diagnostics
 import Data.Aeson
 import Data.Map.Strict (Map)
-import Data.Map.Strict qualified as M
+import Data.Map.Strict qualified as Map
 import Data.Set (Set)
 import Data.Text (Text)
 import DepTypes
@@ -26,8 +26,8 @@ data PackageJson = PackageJson
 
 instance FromJSON PackageJson where
   parseJSON = withObject "PackageJson" $ \obj ->
-    PackageJson <$> obj .:? "dependencies" .!= M.empty
-      <*> obj .:? "devDependencies" .!= M.empty
+    PackageJson <$> obj .:? "dependencies" .!= Map.empty
+      <*> obj .:? "devDependencies" .!= Map.empty
 
 analyze' :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs File -> m (Graphing Dependency)
 analyze' file = do
@@ -48,8 +48,8 @@ newtype NodePackageLabel = NodePackageEnv DepEnvironment
 
 buildGraph :: PackageJson -> Graphing Dependency
 buildGraph PackageJson{..} = run . withLabeling toDependency $ do
-  _ <- M.traverseWithKey (addDep EnvProduction) packageDeps
-  _ <- M.traverseWithKey (addDep EnvDevelopment) packageDevDeps
+  _ <- Map.traverseWithKey (addDep EnvProduction) packageDeps
+  _ <- Map.traverseWithKey (addDep EnvDevelopment) packageDevDeps
   pure ()
   where
     addDep :: Has NodeGrapher sig m => DepEnvironment -> Text -> Text -> m ()
@@ -73,5 +73,5 @@ buildGraph PackageJson{..} = run . withLabeling toDependency $ do
         , dependencyVersion = Just (CCompatible pkgConstraint)
         , dependencyLocations = []
         , dependencyEnvironments = []
-        , dependencyTags = M.empty
+        , dependencyTags = Map.empty
         }

--- a/src/Strategy/NuGet/Nuspec.hs
+++ b/src/Strategy/NuGet/Nuspec.hs
@@ -16,9 +16,9 @@ import Control.Applicative (optional)
 import Control.Effect.Diagnostics
 import Data.Foldable (find)
 import Data.List qualified as L
-import Data.Map.Strict qualified as M
+import Data.Map.Strict qualified as Map
+import Data.String.Conversion (toString)
 import Data.Text (Text)
-import Data.Text qualified as T
 import DepTypes
 import Discovery.Walk
 import Effect.ReadFS
@@ -83,7 +83,7 @@ nuspecLicenses nuspec = url ++ licenseField
     licenseField = foldr (\a b -> b ++ [License (parseLicenseType $ nuspecLicenseType a) (nuspecLicenseValue a)]) [] (license nuspec)
 
 parseLicenseType :: Text -> LicenseType
-parseLicenseType rawType = case T.unpack rawType of
+parseLicenseType rawType = case toString rawType of
   "expression" -> LicenseSPDX
   "file" -> LicenseFile
   _ -> UnknownType
@@ -143,5 +143,5 @@ buildGraph project = Graphing.fromList (map toDependency direct)
         , dependencyVersion = Just (CEq depVersion)
         , dependencyLocations = []
         , dependencyEnvironments = []
-        , dependencyTags = M.empty
+        , dependencyTags = Map.empty
         }

--- a/src/Strategy/NuGet/PackageReference.hs
+++ b/src/Strategy/NuGet/PackageReference.hs
@@ -15,7 +15,7 @@ import Control.Applicative (optional, (<|>))
 import Control.Effect.Diagnostics
 import Data.Foldable (find)
 import Data.List qualified as L
-import Data.Map.Strict qualified as M
+import Data.Map.Strict qualified as Map
 import Data.Text (Text)
 import DepTypes
 import Discovery.Walk
@@ -106,5 +106,5 @@ buildGraph project = Graphing.fromList (map toDependency direct)
         , dependencyVersion = fmap CEq depVersion
         , dependencyLocations = []
         , dependencyEnvironments = []
-        , dependencyTags = M.empty
+        , dependencyTags = Map.empty
         }

--- a/src/Strategy/NuGet/PackagesConfig.hs
+++ b/src/Strategy/NuGet/PackagesConfig.hs
@@ -12,7 +12,7 @@ module Strategy.NuGet.PackagesConfig (
 
 import Control.Effect.Diagnostics
 import Data.Foldable (find)
-import Data.Map.Strict qualified as M
+import Data.Map.Strict qualified as Map
 import Data.Text (Text)
 import DepTypes
 import Discovery.Walk
@@ -87,5 +87,5 @@ buildGraph = Graphing.fromList . map toDependency . deps
         , dependencyVersion = Just (CEq depVersion)
         , dependencyLocations = []
         , dependencyEnvironments = []
-        , dependencyTags = M.empty
+        , dependencyTags = Map.empty
         }

--- a/src/Strategy/NuGet/Paket.hs
+++ b/src/Strategy/NuGet/Paket.hs
@@ -15,10 +15,10 @@ import Control.Monad (guard)
 import Data.Char qualified as C
 import Data.Foldable (traverse_)
 import Data.Functor (void)
-import Data.Map.Strict qualified as M
+import Data.Map.Strict qualified as Map
 import Data.Set (Set)
 import Data.Text (Text)
-import Data.Text qualified as T
+import Data.Text qualified as Text
 import Data.Void (Void)
 import DepTypes
 import Discovery.Walk
@@ -91,13 +91,13 @@ toDependency pkg = foldr applyLabel start
         , dependencyVersion = Nothing
         , dependencyLocations = []
         , dependencyEnvironments = []
-        , dependencyTags = M.empty
+        , dependencyTags = Map.empty
         }
 
     applyLabel :: PaketLabel -> Dependency -> Dependency
     applyLabel (PaketVersion ver) dep = dep{dependencyVersion = Just (CEq ver)}
-    applyLabel (GroupName name) dep = dep{dependencyTags = M.insertWith (++) "group" [name] (dependencyTags dep)}
-    applyLabel (DepLocation loc) dep = dep{dependencyTags = M.insertWith (++) "location" [loc] (dependencyTags dep)}
+    applyLabel (GroupName name) dep = dep{dependencyTags = Map.insertWith (++) "group" [name] (dependencyTags dep)}
+    applyLabel (DepLocation loc) dep = dep{dependencyTags = Map.insertWith (++) "location" [loc] (dependencyTags dep)}
     applyLabel (PaketRemote repo) dep = dep{dependencyLocations = repo : dependencyLocations dep}
 
 buildGraph :: [Section] -> Graphing Dependency
@@ -165,7 +165,7 @@ groupSection = do
 unknownSection :: Parser Section
 unknownSection = do
   emptyLine <- restOfLine
-  guard $ not $ "GROUP" `T.isPrefixOf` emptyLine
+  guard $ not $ "GROUP" `Text.isPrefixOf` emptyLine
   _ <- eol
   pure $ UnknownSection emptyLine
 
@@ -173,7 +173,7 @@ standardSectionParser :: Parser Section
 standardSectionParser = L.nonIndented scn $
   L.indentBlock scn $ do
     location <- chunk "HTTP" <|> "GITHUB" <|> "NUGET"
-    return $ L.IndentMany Nothing (pure . StandardSection location) remoteParser
+    pure $ L.IndentMany Nothing (pure . StandardSection location) remoteParser
 
 remoteParser :: Parser Remote
 remoteParser = L.indentBlock scn $ do

--- a/src/Strategy/NuGet/ProjectJson.hs
+++ b/src/Strategy/NuGet/ProjectJson.hs
@@ -13,9 +13,9 @@ import Control.Applicative ((<|>))
 import Control.Effect.Diagnostics
 import Data.Aeson.Types
 import Data.Map.Strict (Map)
-import Data.Map.Strict qualified as M
+import Data.Map.Strict qualified as Map
 import Data.Text (Text)
-import Data.Text qualified as T
+import Data.Text qualified as Text
 import DepTypes
 import Discovery.Walk
 import Effect.ReadFS
@@ -93,17 +93,17 @@ data NuGetDependency = NuGetDependency
 buildGraph :: ProjectJson -> Graphing Dependency
 buildGraph project = Graphing.fromList (map toDependency direct)
   where
-    direct = (\(name, dep) -> NuGetDependency name (depVersion dep) (depType dep)) <$> M.toList (dependencies project)
+    direct = (\(name, dep) -> NuGetDependency name (depVersion dep) (depType dep)) <$> Map.toList (dependencies project)
     toDependency NuGetDependency{..} =
       Dependency
         { dependencyType = NuGetType
         , dependencyName = name
-        , dependencyVersion = case T.find ('*' ==) version of
+        , dependencyVersion = case Text.find ('*' ==) version of
             Just '*' -> Just (CCompatible version)
             _ -> Just (CEq version)
         , dependencyLocations = []
         , dependencyEnvironments = []
         , dependencyTags = case dependencyType of
-            Nothing -> M.empty
-            Just depType -> M.insert "type" [depType] M.empty
+            Nothing -> Map.empty
+            Just depType -> Map.insert "type" [depType] Map.empty
         }

--- a/src/Strategy/Python/Poetry/PyProject.hs
+++ b/src/Strategy/Python/Poetry/PyProject.hs
@@ -19,9 +19,8 @@ import Data.Foldable (asum)
 import Data.Functor (void)
 import Data.Map (Map)
 import Data.Maybe (fromMaybe)
-import Data.String.Conversion (toString)
+import Data.String.Conversion (toString, toText)
 import Data.Text (Text)
-import Data.Text qualified as Text
 import Data.Void (Void)
 import DepTypes (
   VerConstraint (
@@ -217,7 +216,7 @@ parseVerConstraint :: Parser VerConstraint
 parseVerConstraint = do
   operator <- whitespaceOrTab *> parseConstraintOperator <* whitespaceOrTab
   versionText <- many (noneOf [andOperatorChar, orOperatorChar] <* whitespaceOrTab)
-  let v = Text.pack versionText
+  let v = toText versionText
   case operator of
     Equal -> pure $ CEq v
     NotEqual -> pure $ CNot v

--- a/src/Strategy/Python/ReqTxt.hs
+++ b/src/Strategy/Python/ReqTxt.hs
@@ -4,6 +4,7 @@ module Strategy.Python.ReqTxt (
 ) where
 
 import Control.Effect.Diagnostics
+import Control.Monad (void)
 import Data.Foldable (asum)
 import Data.Text (Text)
 import Data.Void (Void)
@@ -43,7 +44,7 @@ reqParser =
 
     -- ignore content until the end of the line
     ignored :: Parser ()
-    ignored = () <$ takeWhileP (Just "ignored") (not . isEndLine) <* takeWhileP (Just "end of line") isEndLine
+    ignored = void $ takeWhileP (Just "ignored") (not . isEndLine) <* takeWhileP (Just "end of line") isEndLine
 
     comment :: Parser ()
     comment = char '#' *> ignored

--- a/src/Strategy/RPM.hs
+++ b/src/Strategy/RPM.hs
@@ -14,10 +14,10 @@ module Strategy.RPM (
 import Control.Effect.Diagnostics
 import Control.Effect.Diagnostics qualified as Diag
 import Data.List (isSuffixOf)
-import Data.Map.Strict qualified as M
+import Data.Map.Strict qualified as Map
 import Data.Maybe (mapMaybe)
 import Data.Text (Text)
-import Data.Text qualified as T
+import Data.Text qualified as Text
 import Data.Text.Extra (splitOnceOn)
 import DepTypes
 import Discovery.Walk
@@ -98,7 +98,7 @@ toDependency pkg =
     , dependencyVersion = rpmConstraint pkg
     , dependencyLocations = []
     , dependencyEnvironments = []
-    , dependencyTags = M.empty
+    , dependencyTags = Map.empty
     }
 
 buildGraph :: Dependencies -> Graphing Dependency
@@ -107,9 +107,9 @@ buildGraph Dependencies{..} = G.gmap toDependency $ G.fromList depRuntimeRequire
 buildConstraint :: Text -> Maybe VerConstraint
 buildConstraint raw = constraint
   where
-    (comparatorStr, rawVersion) = splitOnceOn " " $ T.strip raw
-    version = T.strip rawVersion
-    constraint = case T.strip comparatorStr of
+    (comparatorStr, rawVersion) = splitOnceOn " " $ Text.strip raw
+    version = Text.strip rawVersion
+    constraint = case Text.strip comparatorStr of
       "<=" -> Just $ CLessOrEq version
       "<" -> Just $ CLess version
       ">=" -> Just $ CGreaterOrEq version
@@ -122,10 +122,10 @@ getTypeFromLine :: Text -> Maybe RequiresType
 getTypeFromLine line = safeReq
   where
     (header, value) = splitOnceOn ": " line
-    (pkgName, rawConstraint) = splitOnceOn " " $ T.strip value
+    (pkgName, rawConstraint) = splitOnceOn " " $ Text.strip value
     --
     isSafeName :: Text -> Bool
-    isSafeName name = not $ "%{" `T.isInfixOf` name
+    isSafeName name = not $ "%{" `Text.isInfixOf` name
     -- TODO: temporarily ignore names with macros, until we support expansion
     safeReq :: Maybe RequiresType
     safeReq = if isSafeName pkgName then req else Nothing
@@ -146,4 +146,4 @@ buildDependencies = foldr addDep blankDeps
     blankDeps = Dependencies [] []
 
 getSpecDeps :: Text -> Dependencies
-getSpecDeps = buildDependencies . mapMaybe getTypeFromLine . T.lines
+getSpecDeps = buildDependencies . mapMaybe getTypeFromLine . Text.lines

--- a/src/Strategy/Ruby/BundleShow.hs
+++ b/src/Strategy/Ruby/BundleShow.hs
@@ -8,7 +8,8 @@ module Strategy.Ruby.BundleShow (
 ) where
 
 import Control.Effect.Diagnostics
-import Data.Map.Strict qualified as M
+import Control.Monad (void)
+import Data.Map.Strict qualified as Map
 import Data.Text (Text)
 import Data.Void (Void)
 import DepTypes
@@ -42,7 +43,7 @@ buildGraph = Graphing.fromList . map toDependency
         , dependencyVersion = Just (CEq depVersion)
         , dependencyLocations = []
         , dependencyEnvironments = []
-        , dependencyTags = M.empty
+        , dependencyTags = Map.empty
         }
 
 data BundleShowDep = BundleShowDep
@@ -63,7 +64,7 @@ bundleShowParser = concat <$> ((line <|> ignoredLine) `sepBy` eol) <* eof
 
     -- ignore content until the end of the line
     ignored :: Parser ()
-    ignored = () <$ takeWhileP (Just "ignored") (not . isEndLine)
+    ignored = void $ takeWhileP (Just "ignored") (not . isEndLine)
 
     ignoredLine :: Parser [BundleShowDep]
     ignoredLine = do

--- a/src/Strategy/Scala.hs
+++ b/src/Strategy/Scala.hs
@@ -13,9 +13,9 @@ module Strategy.Scala (
 
 import Control.Carrier.Diagnostics
 import Data.Maybe (mapMaybe)
-import Data.String.Conversion (decodeUtf8)
+import Data.String.Conversion (decodeUtf8, toString, toText)
 import Data.Text (Text)
-import Data.Text qualified as T
+import Data.Text qualified as Text
 import Data.Text.Lazy qualified as TL
 import Discovery.Walk
 import Effect.Exec
@@ -58,7 +58,7 @@ mkProject basedir closure =
     }
 
 pathToText :: Path ar fd -> Text
-pathToText = T.pack . toFilePath
+pathToText = toText . toFilePath
 
 findProjects :: (Has Exec sig m, Has ReadFS sig m, Has Logger sig m, Has Diagnostics sig m) => Path Abs Dir -> m [MavenProjectClosure]
 findProjects = walk' $ \dir _ files -> do
@@ -100,16 +100,16 @@ genPoms projectDir = do
       stdout = TL.toStrict stdoutLText
       --
       stdoutLines :: [Text]
-      stdoutLines = T.lines stdout
+      stdoutLines = Text.lines stdout
       --
       pomLines :: [Text]
-      pomLines = mapMaybe (T.stripPrefix "[info] Wrote ") stdoutLines
+      pomLines = mapMaybe (Text.stripPrefix "[info] Wrote ") stdoutLines
       --
       pomLocations :: Maybe [Path Abs File]
-      pomLocations = traverse (parseAbsFile . T.unpack) pomLines
+      pomLocations = traverse (parseAbsFile . toString) pomLines
 
   case pomLocations of
-    Nothing -> fatalText ("Could not parse pom paths from:\n" <> T.unlines pomLines)
+    Nothing -> fatalText ("Could not parse pom paths from:\n" <> Text.unlines pomLines)
     Just [] -> fatalText "No sbt projects found"
     Just paths -> do
       globalClosure <- buildGlobalClosure paths

--- a/src/Strategy/VSI.hs
+++ b/src/Strategy/VSI.hs
@@ -13,7 +13,7 @@ import Control.Effect.Diagnostics (
 import Control.Effect.Lift
 import Control.Monad.IO.Class
 import Data.Aeson
-import Data.Text qualified as T
+import Data.Text qualified as Text
 import Discovery.Filters
 import Effect.Exec
 import Fossa.API.Types
@@ -30,17 +30,17 @@ newtype VSIProject = VSIProject
   deriving (Eq, Ord, Show)
 
 newtype VSILocator = VSILocator
-  { unVSILocator :: T.Text
+  { unVSILocator :: Text.Text
   }
   deriving (Eq, Ord, Show, Generic, FromJSON)
 
 data ValidVSILocator = ValidVSILocator
   { validType :: DepType
-  , validName :: T.Text
-  , validRevision :: Maybe T.Text
+  , validName :: Text.Text
+  , validRevision :: Maybe Text.Text
   }
 
-data VSIError = UnsupportedLocatorType Locator T.Text
+data VSIError = UnsupportedLocatorType Locator Text.Text
   deriving (Eq, Ord, Show)
 
 instance ToDiagnostic VSIError where

--- a/src/Strategy/Yarn/V1/YarnLock.hs
+++ b/src/Strategy/Yarn/V1/YarnLock.hs
@@ -7,7 +7,7 @@ import Control.Effect.Diagnostics
 import Data.Bifunctor (first)
 import Data.Foldable (for_)
 import Data.List.NonEmpty qualified as NE
-import Data.Map.Strict qualified as M
+import Data.Map.Strict qualified as Map
 import Data.MultiKeyedMap qualified as MKM
 import DepTypes
 import Effect.Grapher
@@ -53,5 +53,5 @@ buildGraph lockfile =
               YL.FileRemoteNoIntegrity url -> [url]
               YL.GitRemote url rev -> [url <> "@" <> rev]
         , dependencyEnvironments = []
-        , dependencyTags = M.empty
+        , dependencyTags = Map.empty
         }

--- a/src/Strategy/Yarn/V2/Lockfile.hs
+++ b/src/Strategy/Yarn/V2/Lockfile.hs
@@ -12,9 +12,9 @@ import Data.Aeson
 import Data.Aeson.Extra (TextLike (..))
 import Data.HashMap.Strict qualified as HM
 import Data.Map.Strict (Map)
-import Data.Map.Strict qualified as M
+import Data.Map.Strict qualified as Map
 import Data.Text (Text)
-import Data.Text qualified as T
+import Data.Text qualified as Text
 import Data.Void (Void)
 import Text.Megaparsec
 import Text.Megaparsec.Char
@@ -84,14 +84,14 @@ parsePackageKeys = traverse (tryParse descriptorP) . splitTrim ","
 
 -- | 'Data.Text.splitOn', but trims surrounding whitespace from the results
 splitTrim :: Text -> Text -> [Text]
-splitTrim needle = map T.strip . T.splitOn needle
+splitTrim needle = map Text.strip . Text.splitOn needle
 
 instance FromJSON PackageDescription where
   parseJSON = withObject "PackageDescription" $ \obj ->
     PackageDescription
       <$> obj .: "version"
       <*> obj .: "resolution"
-      <*> (obj .:? "dependencies" .!= M.empty >>= parseDependencyDescriptors . M.map unTextLike)
+      <*> (obj .:? "dependencies" .!= Map.empty >>= parseDependencyDescriptors . Map.map unTextLike)
 
 -- | Rather than storing dependencies as a flat list of Descriptors, the yarn
 -- lockfile stores them as key/value pairs, split on the last "@" in a
@@ -99,7 +99,7 @@ instance FromJSON PackageDescription where
 --
 -- We re-construct the raw descriptor by rejoining on "@" before running the parser
 parseDependencyDescriptors :: MonadFail m => Map Text Text -> m [Descriptor]
-parseDependencyDescriptors = traverse (\(name, range) -> tryParse descriptorP (name <> "@" <> range)) . M.toList
+parseDependencyDescriptors = traverse (\(name, range) -> tryParse descriptorP (name <> "@" <> range)) . Map.toList
 
 ---------- Text field Parsers
 

--- a/src/Strategy/Yarn/V2/Resolvers.hs
+++ b/src/Strategy/Yarn/V2/Resolvers.hs
@@ -30,9 +30,9 @@ module Strategy.Yarn.V2.Resolvers (
 import Control.Effect.Diagnostics
 import Data.Foldable (find)
 import Data.Map.Strict (Map)
-import Data.Map.Strict qualified as M
+import Data.Map.Strict qualified as Map
 import Data.Text (Text)
-import Data.Text qualified as T
+import Data.Text qualified as Text
 import Data.Text.Extra (dropPrefix, showT)
 import Data.Void (Void)
 import Strategy.Yarn.V2.Lockfile
@@ -98,7 +98,7 @@ workspaceResolver :: Resolver
 workspaceResolver =
   Resolver
     { resolverName = "WorkspaceResolver"
-    , resolverSupportsLocator = (workspaceProtocol `T.isPrefixOf`) . locatorReference
+    , resolverSupportsLocator = (workspaceProtocol `Text.isPrefixOf`) . locatorReference
     , resolverLocatorToPackage =
         Right
           . WorkspacePackage
@@ -133,9 +133,9 @@ npmResolver :: Resolver
 npmResolver =
   Resolver
     { resolverName = "NpmResolver"
-    , resolverSupportsLocator = (npmProtocol `T.isPrefixOf`) . locatorReference
+    , resolverSupportsLocator = (npmProtocol `Text.isPrefixOf`) . locatorReference
     , resolverLocatorToPackage = \loc ->
-        Right $ NpmPackage (locatorScope loc) (locatorName loc) (T.takeWhile (/= ':') (dropPrefix npmProtocol (locatorReference loc)))
+        Right $ NpmPackage (locatorScope loc) (locatorName loc) (Text.takeWhile (/= ':') (dropPrefix npmProtocol (locatorReference loc)))
     }
 
 ---------- GitResolver
@@ -160,7 +160,7 @@ gitResolver :: Resolver
 gitResolver =
   Resolver
     { resolverName = "GitResolver"
-    , resolverSupportsLocator = ("commit=" `T.isInfixOf`) . locatorReference
+    , resolverSupportsLocator = ("commit=" `Text.isInfixOf`) . locatorReference
     , resolverLocatorToPackage = gitResolverLocatorToPackage
     }
 
@@ -176,17 +176,17 @@ gitResolverLocatorToPackage loc = do
 
   commit <-
     tag ("Couldn't find commit in git metadata: " <> showT metaMap) $
-      M.lookup "commit" metaMap
+      Map.lookup "commit" metaMap
 
   Right $ GitPackage url commit
 
 tag :: a -> Maybe b -> Either a b
 tag a = maybe (Left a) Right
 
--- | T.splitOn, but only expects to split once
+-- | Text.splitOn, but only expects to split once
 splitSingle :: Text -> Text -> Maybe (Text, Text)
 splitSingle needle txt =
-  case T.splitOn needle txt of
+  case Text.splitOn needle txt of
     [a, b] -> pure (a, b)
     _ -> Nothing
 
@@ -194,7 +194,7 @@ splitSingle needle txt =
 --
 -- The metadata string is formatted as "key1=foo&key2=bar&key3=baz"
 parseGitMetadata :: Text -> Maybe (Map Text Text)
-parseGitMetadata = fmap M.fromList . traverse (splitSingle "=") . T.splitOn "&"
+parseGitMetadata = fmap Map.fromList . traverse (splitSingle "=") . Text.splitOn "&"
 
 ---------- TarResolver
 
@@ -276,6 +276,6 @@ unsupportedResolver :: Text -> Text -> (Text -> Package) -> Resolver
 unsupportedResolver name protocol constructor =
   Resolver
     { resolverName = name
-    , resolverSupportsLocator = (protocol `T.isPrefixOf`) . locatorReference
+    , resolverSupportsLocator = (protocol `Text.isPrefixOf`) . locatorReference
     , resolverLocatorToPackage = Right . constructor . dropPrefix protocol . locatorReference
     }

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -24,8 +24,8 @@ import Data.Aeson (
 
 import Data.Aeson.Types (Parser)
 import Data.Set.NonEmpty (NonEmptySet)
+import Data.String.Conversion (toString)
 import Data.Text (Text)
-import Data.Text qualified as T
 import DepTypes (
   DepEnvironment (..),
   DepType (..),
@@ -110,7 +110,7 @@ instance FromJSON TargetFilter where
 
 pathParser :: Text -> Parser (Path Rel Dir)
 pathParser input = do
-  case parseRelDir (T.unpack input) of
+  case parseRelDir (toString input) of
     Left err -> fail (show err)
     Right value -> pure value
 

--- a/test/App/Fossa/VPS/NinjaGraphSpec.hs
+++ b/test/App/Fossa/VPS/NinjaGraphSpec.hs
@@ -6,7 +6,6 @@ import App.Fossa.VPS.NinjaGraph
 import App.Fossa.VPS.Types
 import Control.Carrier.Diagnostics
 import Data.List qualified as List
-import Data.Text qualified as T
 import Data.Text.Encoding
 import Data.Text.IO qualified as TIO
 import Test.Hspec
@@ -158,17 +157,17 @@ spec = do
     it "parses a small ninja deps file and generates a dependency graph" $ do
       eitherScanned <- runDiagnostics $ scanNinjaDeps (encodeUtf8 smallNinjaDeps)
       case eitherScanned of
-        Left _ -> expectationFailure (T.unpack "could not parse ninja deps")
+        Left _ -> expectationFailure "could not parse ninja deps"
         Right scanned -> scanned `shouldMatchList` smallNinjaDepsTargets
 
   describe "scanNinjaDeps for a ninja deps file with weird targets" $ do
     it "finds the correct input for a target where the first dependency is a txt file" $ do
       eitherScanned <- runDiagnostics $ scanNinjaDeps (encodeUtf8 weirdNinjaDeps)
       case eitherScanned of
-        Left _ -> expectationFailure (T.unpack "could not parse ninja deps")
+        Left _ -> expectationFailure "could not parse ninja deps"
         Right scanned -> List.head scanned `shouldBe` targetWithFirstLevelWeirdnessFix
     it "finds the correct input for a target where the first and second dependencies are txt files" $ do
       eitherScanned <- runDiagnostics $ scanNinjaDeps (encodeUtf8 weirdNinjaDeps)
       case eitherScanned of
-        Left _ -> expectationFailure (T.unpack "could not parse ninja deps")
+        Left _ -> expectationFailure "could not parse ninja deps"
         Right scanned -> (scanned List.!! 1) `shouldBe` targetWithSecondLevelWeirdnessFix

--- a/test/Cargo/MetadataSpec.hs
+++ b/test/Cargo/MetadataSpec.hs
@@ -4,9 +4,9 @@ module Cargo.MetadataSpec (
 
 import Data.Aeson
 import Data.ByteString.Lazy qualified as BL
-import Data.Map.Strict qualified as M
+import Data.Map.Strict qualified as Map
 import Data.Text (Text)
-import Data.Text qualified as T
+import Data.Text qualified as Text
 import DepTypes
 import GraphUtil
 import Graphing
@@ -19,14 +19,14 @@ expectedMetadata = CargoMetadata [] [jfmtId] $ Resolve expectedResolveNodes
 expectedResolveNodes :: [ResolveNode]
 expectedResolveNodes = [ansiTermNode, clapNode, jfmtNode]
 
-registrySource :: T.Text
+registrySource :: Text.Text
 registrySource = "(registry+https://github.com/rust-lang/crates.io-index)"
 
-mkPkgId :: T.Text -> T.Text -> PackageId
+mkPkgId :: Text.Text -> Text.Text -> PackageId
 mkPkgId name ver = PackageId name ver registrySource
 
 mkDep :: Text -> Text -> [DepEnvironment] -> Dependency
-mkDep name version envs = Dependency CargoType name (Just $ CEq version) [] envs M.empty
+mkDep name version envs = Dependency CargoType name (Just $ CEq version) [] envs Map.empty
 
 ansiTermId :: PackageId
 ansiTermId = mkPkgId "ansi_term" "0.11.0"

--- a/test/Clojure/ClojureSpec.hs
+++ b/test/Clojure/ClojureSpec.hs
@@ -3,7 +3,7 @@ module Clojure.ClojureSpec (
 ) where
 
 import Data.EDN qualified as EDN
-import Data.Map.Strict qualified as M
+import Data.Map.Strict qualified as Map
 import Data.Text.IO qualified as TIO
 import DepTypes
 import GraphUtil
@@ -32,7 +32,7 @@ clojureComplete =
     , dependencyVersion = Just (CEq "0.2.5")
     , dependencyLocations = []
     , dependencyEnvironments = []
-    , dependencyTags = M.empty
+    , dependencyTags = Map.empty
     }
 
 -- [koan-engine "0.2.5"] {[fresh "1.0.2"] nil},
@@ -44,7 +44,7 @@ koanEngine =
     , dependencyVersion = Just (CEq "0.2.5")
     , dependencyLocations = []
     , dependencyEnvironments = []
-    , dependencyTags = M.empty
+    , dependencyTags = Map.empty
     }
 
 fresh :: Dependency
@@ -55,7 +55,7 @@ fresh =
     , dependencyVersion = Just (CEq "1.0.2")
     , dependencyLocations = []
     , dependencyEnvironments = []
-    , dependencyTags = M.empty
+    , dependencyTags = Map.empty
     }
 
 -- [lein-koan "0.1.5" :scope "test"] nil,
@@ -67,7 +67,7 @@ leinKoan =
     , dependencyVersion = Just (CEq "0.1.5")
     , dependencyLocations = []
     , dependencyEnvironments = [EnvTesting]
-    , dependencyTags = M.empty
+    , dependencyTags = Map.empty
     }
 
 -- [nrepl "0.6.0" :exclusions [[org.clojure/clojure]]] nil,
@@ -79,7 +79,7 @@ nrepl =
     , dependencyVersion = Just (CEq "0.6.0")
     , dependencyLocations = []
     , dependencyEnvironments = []
-    , dependencyTags = M.empty
+    , dependencyTags = Map.empty
     }
 
 -- [org.clojure/clojure "1.10.0"]
@@ -93,7 +93,7 @@ clojure =
     , dependencyVersion = Just (CEq "1.10.0")
     , dependencyLocations = []
     , dependencyEnvironments = []
-    , dependencyTags = M.empty
+    , dependencyTags = Map.empty
     }
 
 clojureSpecsAlpha :: Dependency
@@ -104,7 +104,7 @@ clojureSpecsAlpha =
     , dependencyVersion = Just (CEq "0.2.44")
     , dependencyLocations = []
     , dependencyEnvironments = []
-    , dependencyTags = M.empty
+    , dependencyTags = Map.empty
     }
 
 clojureSpecAlpha :: Dependency
@@ -115,5 +115,5 @@ clojureSpecAlpha =
     , dependencyVersion = Just (CEq "0.2.176")
     , dependencyLocations = []
     , dependencyEnvironments = []
-    , dependencyTags = M.empty
+    , dependencyTags = Map.empty
     }

--- a/test/Cocoapods/PodfileLockSpec.hs
+++ b/test/Cocoapods/PodfileLockSpec.hs
@@ -2,7 +2,7 @@ module Cocoapods.PodfileLockSpec (
   spec,
 ) where
 
-import Data.Map.Strict qualified as M
+import Data.Map.Strict qualified as Map
 import Data.Text.IO qualified as TIO
 import DepTypes
 import GraphUtil
@@ -18,7 +18,7 @@ dependencyOne =
     , dependencyVersion = Just (CEq "1.0.0")
     , dependencyLocations = []
     , dependencyEnvironments = []
-    , dependencyTags = M.empty
+    , dependencyTags = Map.empty
     }
 
 dependencyTwo :: Dependency
@@ -29,7 +29,7 @@ dependencyTwo =
     , dependencyVersion = Just (CEq "2.0.0")
     , dependencyLocations = []
     , dependencyEnvironments = []
-    , dependencyTags = M.empty
+    , dependencyTags = Map.empty
     }
 
 dependencyThree :: Dependency
@@ -40,7 +40,7 @@ dependencyThree =
     , dependencyVersion = Just (CEq "3.0.0")
     , dependencyLocations = []
     , dependencyEnvironments = []
-    , dependencyTags = M.empty
+    , dependencyTags = Map.empty
     }
 
 dependencyFour :: Dependency
@@ -51,7 +51,7 @@ dependencyFour =
     , dependencyVersion = Just (CEq "4.0.0")
     , dependencyLocations = []
     , dependencyEnvironments = []
-    , dependencyTags = M.empty
+    , dependencyTags = Map.empty
     }
 
 podSection :: Section

--- a/test/Cocoapods/PodfileSpec.hs
+++ b/test/Cocoapods/PodfileSpec.hs
@@ -2,7 +2,7 @@ module Cocoapods.PodfileSpec (
   spec,
 ) where
 
-import Data.Map.Strict qualified as M
+import Data.Map.Strict qualified as Map
 import Data.Text.IO qualified as TIO
 import DepTypes
 import GraphUtil
@@ -18,7 +18,7 @@ dependencyOne =
     , dependencyVersion = Just (CEq "1.0.0")
     , dependencyLocations = ["test.repo"]
     , dependencyEnvironments = []
-    , dependencyTags = M.empty
+    , dependencyTags = Map.empty
     }
 
 dependencyTwo :: Dependency
@@ -29,7 +29,7 @@ dependencyTwo =
     , dependencyVersion = Just (CEq "2.0.0")
     , dependencyLocations = ["custom.repo"]
     , dependencyEnvironments = []
-    , dependencyTags = M.empty
+    , dependencyTags = Map.empty
     }
 
 dependencyThree :: Dependency
@@ -40,7 +40,7 @@ dependencyThree =
     , dependencyVersion = Just (CEq "3.0.0")
     , dependencyLocations = ["test.repo"]
     , dependencyEnvironments = []
-    , dependencyTags = M.empty
+    , dependencyTags = Map.empty
     }
 
 dependencyFour :: Dependency
@@ -51,20 +51,20 @@ dependencyFour =
     , dependencyVersion = Nothing
     , dependencyLocations = ["test.repo"]
     , dependencyEnvironments = []
-    , dependencyTags = M.empty
+    , dependencyTags = Map.empty
     }
 
 podOne :: Pod
-podOne = Pod "one" (Just "1.0.0") M.empty
+podOne = Pod "one" (Just "1.0.0") Map.empty
 
 podTwo :: Pod
-podTwo = Pod "two" (Just "2.0.0") (M.fromList [(SourceProperty, "custom.repo")])
+podTwo = Pod "two" (Just "2.0.0") (Map.fromList [(SourceProperty, "custom.repo")])
 
 podThree :: Pod
-podThree = Pod "three" (Just "3.0.0") (M.fromList [(PathProperty, "internal/path")])
+podThree = Pod "three" (Just "3.0.0") (Map.fromList [(PathProperty, "internal/path")])
 
 podFour :: Pod
-podFour = Pod "four" Nothing (M.fromList [(GitProperty, "fossa/spectrometer"), (CommitProperty, "12345")])
+podFour = Pod "four" Nothing (Map.fromList [(GitProperty, "fossa/spectrometer"), (CommitProperty, "12345")])
 
 testPods :: [Pod]
 testPods = [podOne, podTwo, podThree, podFour]

--- a/test/Composer/ComposerLockSpec.hs
+++ b/test/Composer/ComposerLockSpec.hs
@@ -4,7 +4,7 @@ module Composer.ComposerLockSpec (
 
 import Data.Aeson
 import Data.ByteString qualified as BS
-import Data.Map.Strict qualified as M
+import Data.Map.Strict qualified as Map
 import DepTypes
 import GraphUtil
 import Strategy.Composer
@@ -18,7 +18,7 @@ dependencyOne =
     , dependencyVersion = Just (CEq "1.0.0")
     , dependencyLocations = []
     , dependencyEnvironments = [EnvProduction]
-    , dependencyTags = M.empty
+    , dependencyTags = Map.empty
     }
 
 dependencyTwo :: Dependency
@@ -29,7 +29,7 @@ dependencyTwo =
     , dependencyVersion = Just (CEq "2.0.0")
     , dependencyLocations = []
     , dependencyEnvironments = [EnvProduction]
-    , dependencyTags = M.empty
+    , dependencyTags = Map.empty
     }
 
 dependencyThree :: Dependency
@@ -40,7 +40,7 @@ dependencyThree =
     , dependencyVersion = Just (CEq "3.0.0")
     , dependencyLocations = []
     , dependencyEnvironments = [EnvProduction]
-    , dependencyTags = M.empty
+    , dependencyTags = Map.empty
     }
 
 dependencyFour :: Dependency
@@ -51,7 +51,7 @@ dependencyFour =
     , dependencyVersion = Just (CEq "4.0.0")
     , dependencyLocations = []
     , dependencyEnvironments = [EnvProduction]
-    , dependencyTags = M.empty
+    , dependencyTags = Map.empty
     }
 
 dependencyFive :: Dependency
@@ -62,7 +62,7 @@ dependencyFive =
     , dependencyVersion = Just (CEq "5.0.0")
     , dependencyLocations = []
     , dependencyEnvironments = [EnvDevelopment]
-    , dependencyTags = M.empty
+    , dependencyTags = Map.empty
     }
 
 dependencySourceless :: Dependency
@@ -73,7 +73,7 @@ dependencySourceless =
     , dependencyVersion = Just (CEq "5.0.0")
     , dependencyLocations = []
     , dependencyEnvironments = [EnvProduction]
-    , dependencyTags = M.empty
+    , dependencyTags = Map.empty
     }
 
 spec :: Spec

--- a/test/Conda/CondaListSpec.hs
+++ b/test/Conda/CondaListSpec.hs
@@ -5,7 +5,7 @@ module Conda.CondaListSpec (
 import Control.Carrier.Diagnostics
 import Data.Aeson
 import Data.ByteString qualified as BS
-import Data.Map.Strict qualified as M
+import Data.Map.Strict qualified as Map
 import DepTypes
 import Effect.Grapher
 import Graphing (Graphing)
@@ -22,7 +22,7 @@ expected = run . evalGrapher $ do
       , dependencyVersion = Just (CEq "1.78")
       , dependencyLocations = []
       , dependencyEnvironments = []
-      , dependencyTags = M.empty
+      , dependencyTags = Map.empty
       }
   direct $
     Dependency
@@ -31,7 +31,7 @@ expected = run . evalGrapher $ do
       , dependencyVersion = Just (CEq "1.0")
       , dependencyLocations = []
       , dependencyEnvironments = []
-      , dependencyTags = M.empty
+      , dependencyTags = Map.empty
       }
   direct $
     Dependency
@@ -40,7 +40,7 @@ expected = run . evalGrapher $ do
       , dependencyVersion = Just (CEq "2021.1.19")
       , dependencyLocations = []
       , dependencyEnvironments = []
-      , dependencyTags = M.empty
+      , dependencyTags = Map.empty
       }
 
 spec :: Spec

--- a/test/Conda/EnvironmentYmlSpec.hs
+++ b/test/Conda/EnvironmentYmlSpec.hs
@@ -3,7 +3,7 @@ module Conda.EnvironmentYmlSpec (
 ) where
 
 import Data.ByteString qualified as BS
-import Data.Map.Strict qualified as M
+import Data.Map.Strict qualified as Map
 import Data.Yaml (decodeEither', prettyPrintParseException)
 import DepTypes (
   DepType (CondaType),
@@ -25,7 +25,7 @@ dependencyOne =
     , dependencyVersion = Just (CEq "version1")
     , dependencyLocations = []
     , dependencyEnvironments = []
-    , dependencyTags = M.empty
+    , dependencyTags = Map.empty
     }
 
 dependencyTwo :: Dependency
@@ -36,7 +36,7 @@ dependencyTwo =
     , dependencyVersion = Just (CEq "version2")
     , dependencyLocations = []
     , dependencyEnvironments = []
-    , dependencyTags = M.empty
+    , dependencyTags = Map.empty
     }
 
 dependencyThree :: Dependency
@@ -47,7 +47,7 @@ dependencyThree =
     , dependencyVersion = Nothing
     , dependencyLocations = []
     , dependencyEnvironments = []
-    , dependencyTags = M.empty
+    , dependencyTags = Map.empty
     }
 
 expectedGraph :: Graphing Dependency
@@ -59,7 +59,7 @@ expectedGraph = run . evalGrapher $ do
       , dependencyVersion = Just (CEq "1.78")
       , dependencyLocations = []
       , dependencyEnvironments = []
-      , dependencyTags = M.empty
+      , dependencyTags = Map.empty
       }
   direct $
     Dependency
@@ -68,7 +68,7 @@ expectedGraph = run . evalGrapher $ do
       , dependencyVersion = Just (CEq "1.0")
       , dependencyLocations = []
       , dependencyEnvironments = []
-      , dependencyTags = M.empty
+      , dependencyTags = Map.empty
       }
   direct $
     Dependency
@@ -77,7 +77,7 @@ expectedGraph = run . evalGrapher $ do
       , dependencyVersion = Just (CEq "2021.1.19")
       , dependencyLocations = []
       , dependencyEnvironments = []
-      , dependencyTags = M.empty
+      , dependencyTags = Map.empty
       }
 
 envFile :: EnvironmentYmlFile

--- a/test/Discovery/FiltersSpec.hs
+++ b/test/Discovery/FiltersSpec.hs
@@ -5,9 +5,9 @@ module Discovery.FiltersSpec (
 ) where
 
 import Data.Foldable (traverse_)
-import Data.Set qualified as S
+import Data.Set qualified as Set
 import Data.Set.NonEmpty
-import Data.Text qualified as T
+import Data.Text qualified as Text
 import Discovery.Filters
 import Path
 import Test.Hspec
@@ -36,10 +36,10 @@ spec = do
         gradleFooBar = ("gradle", $(mkRelDir "foo/bar"))
         mvnFooBarBaz = ("mvn", $(mkRelDir "foo/bar/baz"))
         mvnQuux = ("mvn", $(mkRelDir "quux"))
-        gradleTargets = maybe ProjectWithoutTargets FoundTargets (nonEmpty $ S.fromList [BuildTarget "foo", BuildTarget "bar"])
-        fooTargetAssertion = (Just . FoundTargets) =<< nonEmpty (S.fromList [BuildTarget "foo"])
-        barTargetAssertion = (Just . FoundTargets) =<< nonEmpty (S.fromList [BuildTarget "bar"])
-        fooBarTargetAssertion = (Just . FoundTargets) =<< nonEmpty (S.fromList [BuildTarget "bar", BuildTarget "foo"])
+        gradleTargets = maybe ProjectWithoutTargets FoundTargets (nonEmpty $ Set.fromList [BuildTarget "foo", BuildTarget "bar"])
+        fooTargetAssertion = (Just . FoundTargets) =<< nonEmpty (Set.fromList [BuildTarget "foo"])
+        barTargetAssertion = (Just . FoundTargets) =<< nonEmpty (Set.fromList [BuildTarget "bar"])
+        fooBarTargetAssertion = (Just . FoundTargets) =<< nonEmpty (Set.fromList [BuildTarget "bar", BuildTarget "foo"])
 
     it "includes an entire directory" $ do
       let include =
@@ -225,7 +225,7 @@ spec = do
         , (mvnQuux, ProjectWithoutTargets, Nothing)
         ]
 
-testHarness :: FilterCombination -> FilterCombination -> [((T.Text, Path Rel Dir), FoundTargets, Maybe FoundTargets)] -> Expectation
+testHarness :: FilterCombination -> FilterCombination -> [((Text.Text, Path Rel Dir), FoundTargets, Maybe FoundTargets)] -> Expectation
 testHarness include exclude = traverse_ testSingle
   where
     testSingle ((buildtool, dir), targets, expected) = applyFilters (AllFilters [] include exclude) buildtool dir targets `shouldBe` expected

--- a/test/Erlang/Rebar3TreeSpec.hs
+++ b/test/Erlang/Rebar3TreeSpec.hs
@@ -2,7 +2,7 @@ module Erlang.Rebar3TreeSpec (
   spec,
 ) where
 
-import Data.Map.Strict qualified as M
+import Data.Map.Strict qualified as Map
 import Data.Text.IO qualified as TIO
 import Text.Megaparsec
 
@@ -21,7 +21,7 @@ dependencyOne =
     , dependencyVersion = Just (CEq "1.0.0")
     , dependencyLocations = []
     , dependencyEnvironments = []
-    , dependencyTags = M.empty
+    , dependencyTags = Map.empty
     }
 
 dependencyTwo :: Dependency
@@ -32,7 +32,7 @@ dependencyTwo =
     , dependencyVersion = Just (CEq "2.0.0")
     , dependencyLocations = []
     , dependencyEnvironments = []
-    , dependencyTags = M.empty
+    , dependencyTags = Map.empty
     }
 dependencyThree :: Dependency
 dependencyThree =
@@ -42,7 +42,7 @@ dependencyThree =
     , dependencyVersion = Just (CEq "3.0.0")
     , dependencyLocations = []
     , dependencyEnvironments = []
-    , dependencyTags = M.empty
+    , dependencyTags = Map.empty
     }
 
 dependencyFour :: Dependency
@@ -53,7 +53,7 @@ dependencyFour =
     , dependencyVersion = Just (CEq "4.0.0")
     , dependencyLocations = []
     , dependencyEnvironments = []
-    , dependencyTags = M.empty
+    , dependencyTags = Map.empty
     }
 
 dependencyFive :: Dependency
@@ -64,7 +64,7 @@ dependencyFive =
     , dependencyVersion = Just (CEq "5.0.0")
     , dependencyLocations = []
     , dependencyEnvironments = []
-    , dependencyTags = M.empty
+    , dependencyTags = Map.empty
     }
 
 depOne :: Rebar3Dep

--- a/test/Go/GlideLockSpec.hs
+++ b/test/Go/GlideLockSpec.hs
@@ -3,7 +3,7 @@ module Go.GlideLockSpec (
 ) where
 
 import Data.ByteString qualified as BS
-import Data.Map.Strict qualified as M
+import Data.Map.Strict qualified as Map
 import Data.Yaml
 
 import Control.Algebra
@@ -23,7 +23,7 @@ expected = run . evalGrapher $ do
       , dependencyVersion = Just (CEq "1234")
       , dependencyLocations = []
       , dependencyEnvironments = []
-      , dependencyTags = M.empty
+      , dependencyTags = Map.empty
       }
   direct $
     Dependency
@@ -32,7 +32,7 @@ expected = run . evalGrapher $ do
       , dependencyVersion = Just (CEq "4bd8")
       , dependencyLocations = []
       , dependencyEnvironments = []
-      , dependencyTags = M.empty
+      , dependencyTags = Map.empty
       }
 
 glideLockfile :: GlideLockfile

--- a/test/Go/GoListSpec.hs
+++ b/test/Go/GoListSpec.hs
@@ -11,7 +11,7 @@ import Control.Carrier.Diagnostics
 import Control.Carrier.Reader
 import Data.ByteString.Lazy qualified as BL
 import Data.Function ((&))
-import Data.Map.Strict qualified as M
+import Data.Map.Strict qualified as Map
 import DepTypes
 import Effect.Exec
 import Effect.Grapher
@@ -42,7 +42,7 @@ expected = run . evalGrapher $ do
       , dependencyVersion = Just (CEq "commithash")
       , dependencyLocations = []
       , dependencyEnvironments = []
-      , dependencyTags = M.empty
+      , dependencyTags = Map.empty
       }
   direct $
     Dependency
@@ -51,7 +51,7 @@ expected = run . evalGrapher $ do
       , dependencyVersion = Just (CEq "v2.0.0")
       , dependencyLocations = []
       , dependencyEnvironments = []
-      , dependencyTags = M.empty
+      , dependencyTags = Map.empty
       }
 
 spec :: Spec

--- a/test/Go/GomodSpec.hs
+++ b/test/Go/GomodSpec.hs
@@ -2,7 +2,7 @@ module Go.GomodSpec (spec) where
 
 import Control.Algebra (run)
 import Data.Function ((&))
-import Data.Map.Strict qualified as M
+import Data.Map.Strict qualified as Map
 import Data.SemVer (version)
 import Data.SemVer.Internal (Identifier (..))
 import Data.Text (Text)
@@ -29,7 +29,7 @@ dep name revision =
     , dependencyVersion = Just (CEq revision)
     , dependencyLocations = []
     , dependencyEnvironments = []
-    , dependencyTags = M.empty
+    , dependencyTags = Map.empty
     }
 
 -- Fixtures for testing.
@@ -43,8 +43,8 @@ trivialGomod =
         , Require "github.com/pkg/two/v2" (semver 2 0 0)
         , Require "github.com/pkg/three/v3" (semver 3 0 0)
         ]
-    , modReplaces = M.fromList [("github.com/pkg/two/v2", Require "github.com/pkg/overridden" (NonCanonical "overridden"))]
-    , modLocalReplaces = M.empty
+    , modReplaces = Map.fromList [("github.com/pkg/two/v2", Require "github.com/pkg/overridden" (NonCanonical "overridden"))]
+    , modLocalReplaces = Map.empty
     , modExcludes = []
     }
 
@@ -63,8 +63,8 @@ localReplaceGomod =
         , Require "github.com/pkg/two/v2" (semver 2 0 0)
         , Require "github.com/pkg/three/v3" (semver 3 0 0)
         ]
-    , modReplaces = M.empty
-    , modLocalReplaces = M.fromList [("github.com/pkg/two/v2", "./foo")]
+    , modReplaces = Map.empty
+    , modLocalReplaces = Map.fromList [("github.com/pkg/two/v2", "./foo")]
     , modExcludes = []
     }
 
@@ -86,14 +86,14 @@ edgeCaseGomod =
         , Require "repo/F_underscore" (semver 1 0 0)
         ]
     , modReplaces =
-        M.fromList
+        Map.fromList
           [ ("repo/B", Require "alias/repo/B" $ semver 0 1 0)
           , ("repo/C", Require "alias/repo/C" $ Pseudo "000000000003")
           , ("repo/E", Require "alias/repo/E" $ Pseudo "000000000005")
           , ("repo/F_underscore", Require "repo/F_underscore" $ semver 2 0 0)
           ]
     , modLocalReplaces =
-        M.fromList
+        Map.fromList
           [ ("foo", "../foo")
           , ("bar", "/foo/bar/baz")
           ]

--- a/test/Go/GopkgLockSpec.hs
+++ b/test/Go/GopkgLockSpec.hs
@@ -3,7 +3,7 @@ module Go.GopkgLockSpec (
 ) where
 
 import Data.Function ((&))
-import Data.Map.Strict qualified as M
+import Data.Map.Strict qualified as Map
 import Data.Text.IO qualified as TIO
 import DepTypes
 import Effect.Grapher
@@ -41,7 +41,7 @@ expected = run . evalGrapher $ do
       , dependencyVersion = Just (CEq "3012a1dbe2e4bd1391d42b32f0577cb7bbc7f005")
       , dependencyLocations = []
       , dependencyEnvironments = []
-      , dependencyTags = M.empty
+      , dependencyTags = Map.empty
       }
   direct $
     Dependency
@@ -50,7 +50,7 @@ expected = run . evalGrapher $ do
       , dependencyVersion = Just (CEq "12345")
       , dependencyLocations = []
       , dependencyEnvironments = []
-      , dependencyTags = M.empty
+      , dependencyTags = Map.empty
       }
   direct $
     Dependency
@@ -59,7 +59,7 @@ expected = run . evalGrapher $ do
       , dependencyVersion = Just (CEq "12345")
       , dependencyLocations = ["https://someotherlocation/"]
       , dependencyEnvironments = []
-      , dependencyTags = M.empty
+      , dependencyTags = Map.empty
       }
 
 spec :: Spec

--- a/test/Go/GopkgTomlSpec.hs
+++ b/test/Go/GopkgTomlSpec.hs
@@ -3,7 +3,7 @@ module Go.GopkgTomlSpec (
 ) where
 
 import Data.Function ((&))
-import Data.Map.Strict qualified as M
+import Data.Map.Strict qualified as Map
 import Data.Text.IO qualified as TIO
 import DepTypes
 import Effect.Grapher
@@ -66,7 +66,7 @@ expected = run . evalGrapher $ do
       , dependencyVersion = Just (CEq "v3.0.0")
       , dependencyLocations = ["https://someotherlocation/"]
       , dependencyEnvironments = []
-      , dependencyTags = M.empty
+      , dependencyTags = Map.empty
       }
   direct $
     Dependency
@@ -75,7 +75,7 @@ expected = run . evalGrapher $ do
       , dependencyVersion = Just (CEq "v1.0.0")
       , dependencyLocations = []
       , dependencyEnvironments = []
-      , dependencyTags = M.empty
+      , dependencyTags = Map.empty
       }
   direct $
     Dependency
@@ -84,7 +84,7 @@ expected = run . evalGrapher $ do
       , dependencyVersion = Just (CEq "overridebranch")
       , dependencyLocations = []
       , dependencyEnvironments = []
-      , dependencyTags = M.empty
+      , dependencyTags = Map.empty
       }
   direct $
     Dependency
@@ -93,7 +93,7 @@ expected = run . evalGrapher $ do
       , dependencyVersion = Just (CEq "branchname")
       , dependencyLocations = []
       , dependencyEnvironments = []
-      , dependencyTags = M.empty
+      , dependencyTags = Map.empty
       }
 
 spec :: Spec

--- a/test/Googlesource/RepoManifestSpec.hs
+++ b/test/Googlesource/RepoManifestSpec.hs
@@ -6,8 +6,8 @@ module Googlesource.RepoManifestSpec (
 ) where
 
 import Control.Carrier.Diagnostics hiding (withResult)
-import Data.Map.Strict qualified as M
-import Data.Text qualified as T
+import Data.Map.Strict qualified as Map
+import Data.String.Conversion (toString)
 import Data.Text.IO qualified as TIO
 import DepTypes
 import Effect.ReadFS
@@ -120,7 +120,7 @@ dependencyOne =
     , dependencyName = "platform/art"
     , dependencyVersion = Just (CEq "refs/tags/android-10.0.0_r29")
     , dependencyLocations = ["https://android.googlesource.com/platform/art"]
-    , dependencyTags = M.empty
+    , dependencyTags = Map.empty
     , dependencyEnvironments = [EnvProduction]
     }
 
@@ -131,7 +131,7 @@ dependencyTwo =
     , dependencyName = "platform/bionic"
     , dependencyVersion = Just (CEq "57b7d1574276f5e7f895c884df29f45859da74b6")
     , dependencyLocations = ["https://android.googlesource.com/platform/bionic"]
-    , dependencyTags = M.empty
+    , dependencyTags = Map.empty
     , dependencyEnvironments = [EnvProduction]
     }
 
@@ -142,7 +142,7 @@ dependencyThree =
     , dependencyName = "platform/bootable/recovery"
     , dependencyVersion = Just (CEq "google/android-6.0.1_r74")
     , dependencyLocations = ["https://android.othersource.com/platform/bootable/recovery"]
-    , dependencyTags = M.empty
+    , dependencyTags = Map.empty
     , dependencyEnvironments = [EnvProduction]
     }
 
@@ -153,7 +153,7 @@ dependencyFour =
     , dependencyName = "platform/cts"
     , dependencyVersion = Just (CEq "1111")
     , dependencyLocations = ["https://android.othersource.com/platform/cts"]
-    , dependencyTags = M.empty
+    , dependencyTags = Map.empty
     , dependencyEnvironments = [EnvProduction]
     }
 
@@ -164,7 +164,7 @@ dependencyFive =
     , dependencyName = "platform/dalvik"
     , dependencyVersion = Just (CEq "refs/tags/android-10.0.0_r29")
     , dependencyLocations = ["https://android.googlesource.com/platform/dalvik"]
-    , dependencyTags = M.empty
+    , dependencyTags = Map.empty
     , dependencyEnvironments = [EnvProduction]
     }
 
@@ -232,7 +232,7 @@ spec = do
             manifestProjects manifest `shouldMatchList` basicProjectList
             manifestDefault manifest `shouldBe` Just basicDefault
             manifestRemotes manifest `shouldMatchList` basicRemoteList
-          Left err -> expectationFailure (T.unpack ("could not parse repo manifest file: " <> xmlErrorPretty err))
+          Left err -> expectationFailure (toString ("could not parse repo manifest file: " <> xmlErrorPretty err))
 
     describe "for a manifest with no default remote" $
       it "reads a file and constructs a dependency list" $
@@ -240,7 +240,7 @@ spec = do
           Right manifest -> do
             manifestProjects manifest `shouldMatchList` [projectOne, projectTwoWithRemote, projectThree, projectFour, projectFive]
             manifestRemotes manifest `shouldMatchList` basicRemoteList
-          Left err -> expectationFailure (T.unpack ("could not parse repo manifest file: " <> xmlErrorPretty err))
+          Left err -> expectationFailure (toString ("could not parse repo manifest file: " <> xmlErrorPretty err))
 
     describe "for a manifest with no default revision" $
       it "reads a file and constructs a dependency list" $
@@ -248,7 +248,7 @@ spec = do
           Right manifest -> do
             manifestProjects manifest `shouldMatchList` basicProjectList
             manifestRemotes manifest `shouldMatchList` basicRemoteList
-          Left err -> expectationFailure (T.unpack ("could not parse repo manifest file: " <> xmlErrorPretty err))
+          Left err -> expectationFailure (toString ("could not parse repo manifest file: " <> xmlErrorPretty err))
 
   describe "repo manifest buildGraph" $ do
     describe "for a sane manifest" $
@@ -262,7 +262,7 @@ spec = do
             let vps = validateProject manifest <$> manifestProjects manifest
             vps `shouldMatchList` [Just validatedProjectOne, Just validatedProjectTwo, Just validatedProjectThree, Just validatedProjectFour, Just validatedProjectFive]
             expectDirect [dependencyOne, dependencyTwo, dependencyThree, dependencyFour, dependencyFive] graph
-          Left err -> expectationFailure (T.unpack ("could not parse repo manifest file: " <> xmlErrorPretty err))
+          Left err -> expectationFailure (toString ("could not parse repo manifest file: " <> xmlErrorPretty err))
 
     describe "for a manifest with no default remote" $
       it "returns nothing for validateProject on a project with no remote attr" $
@@ -270,7 +270,7 @@ spec = do
           Right manifest -> do
             let vps = validateProject manifest <$> manifestProjects manifest
             vps `shouldMatchList` [Just validatedProjectOne, Just validatedProjectTwo, Just validatedProjectThree, Just validatedProjectFour, Nothing]
-          Left err -> expectationFailure (T.unpack ("could not parse repo manifest file: " <> xmlErrorPretty err))
+          Left err -> expectationFailure (toString ("could not parse repo manifest file: " <> xmlErrorPretty err))
 
     describe "for a manifest with no default revision" $
       it "finds the projects with remotes specified" $
@@ -278,7 +278,7 @@ spec = do
           Right manifest -> do
             let vps = validateProject manifest <$> manifestProjects manifest
             vps `shouldMatchList` [Nothing, Just validatedProjectTwo, Just validatedProjectThree, Just validatedProjectFour, Nothing]
-          Left err -> expectationFailure $ T.unpack $ "could not parse repo manifest file: " <> xmlErrorPretty err
+          Left err -> expectationFailure $ toString $ "could not parse repo manifest file: " <> xmlErrorPretty err
 
     let withResult result f =
           case result of

--- a/test/Gradle/GradleSpec.hs
+++ b/test/Gradle/GradleSpec.hs
@@ -3,7 +3,7 @@ module Gradle.GradleSpec (
 ) where
 
 import Data.Map.Strict (Map)
-import Data.Map.Strict qualified as M
+import Data.Map.Strict qualified as Map
 import Data.Text (Text)
 import DepTypes
 import GraphUtil
@@ -19,7 +19,7 @@ projectOne =
     , dependencyVersion = Nothing
     , dependencyLocations = []
     , dependencyEnvironments = [EnvOther "config"]
-    , dependencyTags = M.empty
+    , dependencyTags = Map.empty
     }
 
 projectTwo :: Dependency
@@ -30,7 +30,7 @@ projectTwo =
     , dependencyVersion = Nothing
     , dependencyLocations = []
     , dependencyEnvironments = [EnvDevelopment, EnvOther "config"]
-    , dependencyTags = M.empty
+    , dependencyTags = Map.empty
     }
 
 projectThree :: Dependency
@@ -41,7 +41,7 @@ projectThree =
     , dependencyVersion = Nothing
     , dependencyLocations = []
     , dependencyEnvironments = [EnvDevelopment, EnvTesting]
-    , dependencyTags = M.empty
+    , dependencyTags = Map.empty
     }
 
 packageOne :: Dependency
@@ -52,7 +52,7 @@ packageOne =
     , dependencyVersion = Just (CEq "1.0.0")
     , dependencyLocations = []
     , dependencyEnvironments = [EnvDevelopment]
-    , dependencyTags = M.empty
+    , dependencyTags = Map.empty
     }
 
 packageTwo :: Dependency
@@ -63,12 +63,12 @@ packageTwo =
     , dependencyVersion = Just (CEq "2.0.0")
     , dependencyLocations = []
     , dependencyEnvironments = [EnvTesting]
-    , dependencyTags = M.empty
+    , dependencyTags = Map.empty
     }
 
 gradleOutput :: Map (Text, Text) [JsonDep]
 gradleOutput =
-  M.fromList
+  Map.fromList
     [ ((":projectOne", "config"), [ProjectDep ":projectTwo"])
     , ((":projectTwo", "compileOnly"), [ProjectDep ":projectThree", PackageDep "mygroup:packageOne" "1.0.0" []])
     , ((":projectThree", "testCompileOnly"), [PackageDep "mygroup:packageTwo" "2.0.0" []])
@@ -81,11 +81,11 @@ spec :: Spec
 spec = do
   describe "buildGraph" $ do
     it "should produce an empty graph for empty input" $ do
-      let graph = buildGraph M.empty
+      let graph = buildGraph Map.empty
       graph `shouldBe` (empty :: Graphing Dependency)
 
     it "should produce expected output" $ do
-      let graph = buildGraph $ M.mapKeys wrapKeys gradleOutput
+      let graph = buildGraph $ Map.mapKeys wrapKeys gradleOutput
       expectDeps [projectOne, projectTwo, projectThree, packageOne, packageTwo] graph
       expectDirect [projectOne, projectTwo, projectThree] graph
       expectEdges

--- a/test/Haskell/CabalSpec.hs
+++ b/test/Haskell/CabalSpec.hs
@@ -5,7 +5,7 @@ module Haskell.CabalSpec (
 import Control.Carrier.Diagnostics
 import Data.Aeson
 import Data.ByteString.Lazy qualified as BL
-import Data.Set qualified as S
+import Data.Set qualified as Set
 import DepTypes
 import GraphUtil
 import Graphing
@@ -25,13 +25,13 @@ spectrometerLibId = PlanId "spectrometer-0.1.0.0-inplace"
 withCompId = PlanId "with-components-1.0.2.3-efgh"
 
 aesonPlan, basePlan, deepDepPlan, rtsPlan, spectrometerFossaPlan, spectrometerLibPlan, withCompPlan :: InstallPlan
-aesonPlan = InstallPlan Configured aesonId "aeson" "1.5.2.0" (S.fromList [baseId, deepDepId]) (Just Global) mempty
-basePlan = InstallPlan PreExisting baseId "base" "4.13.0.0" (S.fromList [rtsId]) Nothing mempty
-deepDepPlan = InstallPlan Configured deepDepId "deepdep" "3.2.1.0" (S.fromList [baseId]) (Just Global) mempty
+aesonPlan = InstallPlan Configured aesonId "aeson" "1.5.2.0" (Set.fromList [baseId, deepDepId]) (Just Global) mempty
+basePlan = InstallPlan PreExisting baseId "base" "4.13.0.0" (Set.fromList [rtsId]) Nothing mempty
+deepDepPlan = InstallPlan Configured deepDepId "deepdep" "3.2.1.0" (Set.fromList [baseId]) (Just Global) mempty
 rtsPlan = InstallPlan PreExisting rtsId "rts" "1.0" mempty Nothing mempty
-spectrometerFossaPlan = InstallPlan Configured spectrometerFossaId "spectrometer" "0.1.0.0" (S.fromList [baseId, spectrometerLibId]) (Just Local) mempty
-spectrometerLibPlan = InstallPlan Configured spectrometerLibId "spectrometer" "0.1.0.0" (S.fromList [aesonId, baseId, withCompId]) (Just Local) mempty
-withCompPlan = InstallPlan Configured withCompId "with-components" "1.0.2.3" mempty (Just Global) (S.fromList [baseId, rtsId])
+spectrometerFossaPlan = InstallPlan Configured spectrometerFossaId "spectrometer" "0.1.0.0" (Set.fromList [baseId, spectrometerLibId]) (Just Local) mempty
+spectrometerLibPlan = InstallPlan Configured spectrometerLibId "spectrometer" "0.1.0.0" (Set.fromList [aesonId, baseId, withCompId]) (Just Local) mempty
+withCompPlan = InstallPlan Configured withCompId "with-components" "1.0.2.3" mempty (Just Global) (Set.fromList [baseId, rtsId])
 
 spec :: Test.Spec
 spec = do

--- a/test/Maven/PluginStrategySpec.hs
+++ b/test/Maven/PluginStrategySpec.hs
@@ -2,7 +2,7 @@ module Maven.PluginStrategySpec (
   spec,
 ) where
 
-import Data.Map.Strict qualified as M
+import Data.Map.Strict qualified as Map
 import DepTypes
 import GraphUtil
 import Strategy.Maven.Plugin
@@ -17,7 +17,7 @@ packageOne =
     , dependencyVersion = Just (CEq "1.0.0")
     , dependencyLocations = []
     , dependencyEnvironments = [EnvTesting]
-    , dependencyTags = M.fromList [("scopes", ["compile", "test"])]
+    , dependencyTags = Map.fromList [("scopes", ["compile", "test"])]
     }
 
 packageTwo :: Dependency
@@ -28,7 +28,7 @@ packageTwo =
     , dependencyVersion = Just (CEq "2.0.0")
     , dependencyLocations = []
     , dependencyEnvironments = []
-    , dependencyTags = M.fromList [("scopes", ["compile"]), ("optional", ["true"])]
+    , dependencyTags = Map.fromList [("scopes", ["compile"]), ("optional", ["true"])]
     }
 
 mavenOutput :: PluginOutput

--- a/test/Maven/PomStrategySpec.hs
+++ b/test/Maven/PomStrategySpec.hs
@@ -2,7 +2,7 @@ module Maven.PomStrategySpec (
   spec,
 ) where
 
-import Data.Map.Strict qualified as M
+import Data.Map.Strict qualified as Map
 import Strategy.Maven.Pom (MavenPackage (..), buildMavenPackage, interpolateProperties)
 import Strategy.Maven.Pom.PomFile
 import Test.Hspec
@@ -10,14 +10,14 @@ import Test.Hspec
 spec :: Spec
 spec = do
   describe "interpolateProperties" $ do
-    let pom = Pom (MavenCoordinate "MYGROUP" "MYARTIFACT" "MYVERSION") Nothing M.empty M.empty M.empty []
+    let pom = Pom (MavenCoordinate "MYGROUP" "MYARTIFACT" "MYVERSION") Nothing Map.empty Map.empty Map.empty []
     it "should work for built-in properties" $ do
       interpolateProperties pom "${project.groupId}" `shouldBe` "MYGROUP"
       interpolateProperties pom "${project.artifactId}" `shouldBe` "MYARTIFACT"
       interpolateProperties pom "${project.version}" `shouldBe` "MYVERSION"
 
     it "should prefer user-specified properties over computed ones" $ do
-      let pom' = pom{pomProperties = M.singleton "project.groupId" "OTHERGROUP"}
+      let pom' = pom{pomProperties = Map.singleton "project.groupId" "OTHERGROUP"}
       interpolateProperties pom' "${project.groupId}" `shouldBe` "OTHERGROUP"
 
     it "should work in the middle of strings" $ do
@@ -27,7 +27,7 @@ spec = do
       interpolateProperties pom "${project.groupId}${project.artifactId}" `shouldBe` "MYGROUPMYARTIFACT"
 
   describe "buildMavenPackage" $ do
-    let pom = Pom (MavenCoordinate "MYGROUP" "MYARTIFACT" "MYVERSION") Nothing M.empty M.empty M.empty []
+    let pom = Pom (MavenCoordinate "MYGROUP" "MYARTIFACT" "MYVERSION") Nothing Map.empty Map.empty Map.empty []
     it "should interpolate properties in groupId/artifactId/version" $ do
       let result =
             buildMavenPackage

--- a/test/Node/NpmLockSpec.hs
+++ b/test/Node/NpmLockSpec.hs
@@ -2,7 +2,7 @@ module Node.NpmLockSpec (
   spec,
 ) where
 
-import Data.Map.Strict qualified as M
+import Data.Map.Strict qualified as Map
 import DepTypes
 import GraphUtil
 import Strategy.Node.NpmLock
@@ -14,24 +14,24 @@ mockInput =
     { packageName = "example"
     , packageVersion = "1.0.0"
     , packageDependencies =
-        M.fromList
+        Map.fromList
           [
             ( "packageOne"
             , NpmDep
                 { depVersion = "1.0.0"
                 , depDev = Nothing
                 , depResolved = Just "https://example.com/one.tgz"
-                , depRequires = Just (M.fromList [("packageTwo", "2.0.0")])
+                , depRequires = Just (Map.fromList [("packageTwo", "2.0.0")])
                 , depDependencies =
                     Just
-                      ( M.fromList
+                      ( Map.fromList
                           [
                             ( "packageTwo"
                             , NpmDep
                                 { depVersion = "2.0.0"
                                 , depDev = Just True
                                 , depResolved = Just "https://example.com/two.tgz"
-                                , depRequires = Just (M.fromList [("packageThree", "3.0.0")])
+                                , depRequires = Just (Map.fromList [("packageThree", "3.0.0")])
                                 , depDependencies = Nothing
                                 }
                             )
@@ -45,7 +45,7 @@ mockInput =
                 { depVersion = "3.0.0"
                 , depDev = Just True
                 , depResolved = Nothing
-                , depRequires = Just (M.fromList [("packageOne", "1.0.0")])
+                , depRequires = Just (Map.fromList [("packageOne", "1.0.0")])
                 , depDependencies = Nothing
                 }
             )
@@ -60,7 +60,7 @@ packageOne =
     , dependencyVersion = Just (CEq "1.0.0")
     , dependencyLocations = ["https://example.com/one.tgz"]
     , dependencyEnvironments = [EnvProduction]
-    , dependencyTags = M.empty
+    , dependencyTags = Map.empty
     }
 
 packageTwo :: Dependency
@@ -71,7 +71,7 @@ packageTwo =
     , dependencyVersion = Just (CEq "2.0.0")
     , dependencyLocations = ["https://example.com/two.tgz"]
     , dependencyEnvironments = [EnvDevelopment]
-    , dependencyTags = M.empty
+    , dependencyTags = Map.empty
     }
 
 packageThree :: Dependency
@@ -82,7 +82,7 @@ packageThree =
     , dependencyVersion = Just (CEq "3.0.0")
     , dependencyLocations = []
     , dependencyEnvironments = [EnvDevelopment]
-    , dependencyTags = M.empty
+    , dependencyTags = Map.empty
     }
 
 spec :: Spec

--- a/test/Node/PackageJsonSpec.hs
+++ b/test/Node/PackageJsonSpec.hs
@@ -2,7 +2,7 @@ module Node.PackageJsonSpec (
   spec,
 ) where
 
-import Data.Map.Strict qualified as M
+import Data.Map.Strict qualified as Map
 import DepTypes
 import GraphUtil
 import Strategy.Node.PackageJson
@@ -11,8 +11,8 @@ import Test.Hspec
 mockInput :: PackageJson
 mockInput =
   PackageJson
-    { packageDeps = M.fromList [("packageOne", "^1.0.0")]
-    , packageDevDeps = M.fromList [("packageTwo", "^2.0.0")]
+    { packageDeps = Map.fromList [("packageOne", "^1.0.0")]
+    , packageDevDeps = Map.fromList [("packageTwo", "^2.0.0")]
     }
 
 packageOne :: Dependency
@@ -23,7 +23,7 @@ packageOne =
     , dependencyVersion = Just (CCompatible "^1.0.0")
     , dependencyLocations = []
     , dependencyEnvironments = [EnvProduction]
-    , dependencyTags = M.empty
+    , dependencyTags = Map.empty
     }
 
 packageTwo :: Dependency
@@ -34,7 +34,7 @@ packageTwo =
     , dependencyVersion = Just (CCompatible "^2.0.0")
     , dependencyLocations = []
     , dependencyEnvironments = [EnvDevelopment]
-    , dependencyTags = M.empty
+    , dependencyTags = Map.empty
     }
 
 spec :: Spec

--- a/test/NuGet/NuspecSpec.hs
+++ b/test/NuGet/NuspecSpec.hs
@@ -2,8 +2,8 @@ module NuGet.NuspecSpec (
   spec,
 ) where
 
-import Data.Map.Strict qualified as M
-import Data.Text qualified as T
+import Data.Map.Strict qualified as Map
+import Data.String.Conversion (toString)
 import Data.Text.IO qualified as TIO
 import DepTypes
 import GraphUtil
@@ -19,7 +19,7 @@ dependencyOne =
     , dependencyVersion = Just (CEq "1.0.0")
     , dependencyLocations = []
     , dependencyEnvironments = []
-    , dependencyTags = M.empty
+    , dependencyTags = Map.empty
     }
 
 dependencyTwo :: Dependency
@@ -30,7 +30,7 @@ dependencyTwo =
     , dependencyVersion = Just (CEq "2.0.0")
     , dependencyLocations = []
     , dependencyEnvironments = []
-    , dependencyTags = M.empty
+    , dependencyTags = Map.empty
     }
 
 dependencyThree :: Dependency
@@ -41,7 +41,7 @@ dependencyThree =
     , dependencyVersion = Just (CEq "3.0.0")
     , dependencyLocations = []
     , dependencyEnvironments = []
-    , dependencyTags = M.empty
+    , dependencyTags = Map.empty
     }
 
 nuspec :: Nuspec
@@ -75,7 +75,7 @@ spec = do
           (groups project) `shouldContain` groupList
           (license project) `shouldMatchList` [NuspecLicense "file" "license-file"]
           (licenseUrl project) `shouldBe` (Just "https://licence.location.com/LICENSE.md")
-        Left err -> expectationFailure (T.unpack ("could not parse nuspec file: " <> xmlErrorPretty err))
+        Left err -> expectationFailure (toString ("could not parse nuspec file: " <> xmlErrorPretty err))
 
     it "reads a file and extracts the correct license" $ do
       case parseXML singleLicense of
@@ -83,7 +83,7 @@ spec = do
           (groups project) `shouldBe` []
           (license project) `shouldMatchList` [NuspecLicense "file" "LICENSE.txt"]
           (licenseUrl project) `shouldBe` Nothing
-        Left err -> expectationFailure (T.unpack ("could not parse nuspec file: " <> xmlErrorPretty err))
+        Left err -> expectationFailure (toString ("could not parse nuspec file: " <> xmlErrorPretty err))
 
     it "reads a file with multiple licenses" $ do
       case parseXML multipleLicenses of
@@ -91,7 +91,7 @@ spec = do
           (groups project) `shouldBe` []
           (license project) `shouldMatchList` licenses
           (licenseUrl project) `shouldBe` (Just "test.com")
-        Left err -> expectationFailure (T.unpack ("could not parse nuspec file: " <> xmlErrorPretty err))
+        Left err -> expectationFailure (toString ("could not parse nuspec file: " <> xmlErrorPretty err))
 
     it "constructs an accurate graph" $ do
       let graph = buildGraph nuspec

--- a/test/NuGet/PackageReferenceSpec.hs
+++ b/test/NuGet/PackageReferenceSpec.hs
@@ -2,8 +2,8 @@ module NuGet.PackageReferenceSpec (
   spec,
 ) where
 
-import Data.Map.Strict qualified as M
-import Data.Text qualified as T
+import Data.Map.Strict qualified as Map
+import Data.String.Conversion (toString)
 import Data.Text.IO qualified as TIO
 import DepTypes
 import GraphUtil
@@ -19,7 +19,7 @@ dependencyOne =
     , dependencyVersion = Just (CEq "1.0.0")
     , dependencyLocations = []
     , dependencyEnvironments = []
-    , dependencyTags = M.empty
+    , dependencyTags = Map.empty
     }
 
 dependencyTwo :: Dependency
@@ -30,7 +30,7 @@ dependencyTwo =
     , dependencyVersion = Just (CEq "2.0.0")
     , dependencyLocations = []
     , dependencyEnvironments = []
-    , dependencyTags = M.empty
+    , dependencyTags = Map.empty
     }
 
 dependencyThree :: Dependency
@@ -41,7 +41,7 @@ dependencyThree =
     , dependencyVersion = Just (CEq "3.0.0")
     , dependencyLocations = []
     , dependencyEnvironments = []
-    , dependencyTags = M.empty
+    , dependencyTags = Map.empty
     }
 
 dependencyFour :: Dependency
@@ -52,7 +52,7 @@ dependencyFour =
     , dependencyVersion = Nothing
     , dependencyLocations = []
     , dependencyEnvironments = []
-    , dependencyTags = M.empty
+    , dependencyTags = Map.empty
     }
 
 packageReference :: PackageReference
@@ -81,7 +81,7 @@ spec = do
     it "reads a file and constructs an accurate list of item groups" $ do
       case parseXML refFile of
         Right project -> (groups project) `shouldContain` itemGroupList
-        Left err -> expectationFailure (T.unpack ("could not parse package reference file" <> xmlErrorPretty err))
+        Left err -> expectationFailure (toString ("could not parse package reference file" <> xmlErrorPretty err))
 
     it "constructs an accurate graph" $ do
       let graph = buildGraph packageReference

--- a/test/NuGet/PackagesConfigSpec.hs
+++ b/test/NuGet/PackagesConfigSpec.hs
@@ -2,8 +2,8 @@ module NuGet.PackagesConfigSpec (
   spec,
 ) where
 
-import Data.Map.Strict qualified as M
-import Data.Text qualified as T
+import Data.Map.Strict qualified as Map
+import Data.String.Conversion (toString)
 import Data.Text.IO qualified as TIO
 import DepTypes
 import GraphUtil
@@ -19,7 +19,7 @@ dependencyOne =
     , dependencyVersion = Just (CEq "1.0.0")
     , dependencyLocations = []
     , dependencyEnvironments = []
-    , dependencyTags = M.empty
+    , dependencyTags = Map.empty
     }
 
 dependencyTwo :: Dependency
@@ -30,7 +30,7 @@ dependencyTwo =
     , dependencyVersion = Just (CEq "2.0.0")
     , dependencyLocations = []
     , dependencyEnvironments = []
-    , dependencyTags = M.empty
+    , dependencyTags = Map.empty
     }
 
 packagesConfig :: PackagesConfig
@@ -47,7 +47,7 @@ spec = do
     it "reads a file and constructs an accurate graph" $ do
       case parseXML nuspecFile of
         Right project -> (deps project) `shouldContain` depList
-        Left err -> expectationFailure (T.unpack ("could not parse packages.config file" <> xmlErrorPretty err))
+        Left err -> expectationFailure (toString ("could not parse packages.config file" <> xmlErrorPretty err))
 
     it "constructs an accurate graph" $ do
       let graph = buildGraph packagesConfig

--- a/test/NuGet/PaketSpec.hs
+++ b/test/NuGet/PaketSpec.hs
@@ -2,7 +2,7 @@ module NuGet.PaketSpec (
   spec,
 ) where
 
-import Data.Map.Strict qualified as M
+import Data.Map.Strict qualified as Map
 import Data.Text.IO qualified as TIO
 import DepTypes
 import GraphUtil
@@ -18,7 +18,7 @@ dependencyOne =
     , dependencyVersion = Just (CEq "1.0.0")
     , dependencyLocations = ["nuget.com"]
     , dependencyEnvironments = []
-    , dependencyTags = M.fromList [("location", ["NUGET"]), ("group", ["MAIN"])]
+    , dependencyTags = Map.fromList [("location", ["NUGET"]), ("group", ["MAIN"])]
     }
 
 dependencyTwo :: Dependency
@@ -29,7 +29,7 @@ dependencyTwo =
     , dependencyVersion = Just (CEq "2.0.0")
     , dependencyLocations = ["nuget-v2.com", "nuget.com"]
     , dependencyEnvironments = []
-    , dependencyTags = M.fromList [("location", ["NUGET"]), ("group", ["MAIN", "TEST"])]
+    , dependencyTags = Map.fromList [("location", ["NUGET"]), ("group", ["MAIN", "TEST"])]
     }
 
 dependencyThree :: Dependency
@@ -40,7 +40,7 @@ dependencyThree =
     , dependencyVersion = Just (CEq "3.0.0")
     , dependencyLocations = ["custom-site.com"]
     , dependencyEnvironments = []
-    , dependencyTags = M.fromList [("location", ["HTTP"]), ("group", ["MAIN"])]
+    , dependencyTags = Map.fromList [("location", ["HTTP"]), ("group", ["MAIN"])]
     }
 
 dependencyFour :: Dependency
@@ -51,7 +51,7 @@ dependencyFour =
     , dependencyVersion = Just (CEq "4.0.0")
     , dependencyLocations = ["nuget-v2.com"]
     , dependencyEnvironments = []
-    , dependencyTags = M.fromList [("location", ["NUGET"]), ("group", ["TEST"])]
+    , dependencyTags = Map.fromList [("location", ["NUGET"]), ("group", ["TEST"])]
     }
 
 dependencyFive :: Dependency
@@ -62,7 +62,7 @@ dependencyFive =
     , dependencyVersion = Just (CEq "5.0.0")
     , dependencyLocations = ["nuget-v2.com"]
     , dependencyEnvironments = []
-    , dependencyTags = M.fromList [("location", ["NUGET"]), ("group", ["TEST"])]
+    , dependencyTags = Map.fromList [("location", ["NUGET"]), ("group", ["TEST"])]
     }
 
 dependencySix :: Dependency
@@ -73,7 +73,7 @@ dependencySix =
     , dependencyVersion = Just (CEq "6.0.0")
     , dependencyLocations = ["github.com"]
     , dependencyEnvironments = []
-    , dependencyTags = M.fromList [("location", ["GITHUB"]), ("group", ["TEST"])]
+    , dependencyTags = Map.fromList [("location", ["GITHUB"]), ("group", ["TEST"])]
     }
 
 nugetSection :: Section

--- a/test/NuGet/ProjectAssetsJsonSpec.hs
+++ b/test/NuGet/ProjectAssetsJsonSpec.hs
@@ -4,7 +4,7 @@ module NuGet.ProjectAssetsJsonSpec (
 
 import Data.Aeson
 import Data.ByteString qualified as BS
-import Data.Map.Strict qualified as M
+import Data.Map.Strict qualified as Map
 import DepTypes
 import GraphUtil
 import Strategy.NuGet.ProjectAssetsJson
@@ -18,7 +18,7 @@ dependencyOne =
     , dependencyVersion = Just (CEq "1.0.0")
     , dependencyLocations = []
     , dependencyEnvironments = []
-    , dependencyTags = M.empty
+    , dependencyTags = Map.empty
     }
 
 dependencyTwo :: Dependency
@@ -29,7 +29,7 @@ dependencyTwo =
     , dependencyVersion = Just (CEq "2.0.0")
     , dependencyLocations = []
     , dependencyEnvironments = []
-    , dependencyTags = M.empty
+    , dependencyTags = Map.empty
     }
 
 dependencyThree :: Dependency
@@ -40,7 +40,7 @@ dependencyThree =
     , dependencyVersion = Just (CEq "3.0.0")
     , dependencyLocations = []
     , dependencyEnvironments = []
-    , dependencyTags = M.empty
+    , dependencyTags = Map.empty
     }
 
 dependencyFour :: Dependency
@@ -51,7 +51,7 @@ dependencyFour =
     , dependencyVersion = Just (CEq "4.0.0")
     , dependencyLocations = []
     , dependencyEnvironments = []
-    , dependencyTags = M.empty
+    , dependencyTags = Map.empty
     }
 
 spec :: Spec

--- a/test/NuGet/ProjectJsonSpec.hs
+++ b/test/NuGet/ProjectJsonSpec.hs
@@ -4,7 +4,7 @@ module NuGet.ProjectJsonSpec (
 
 import Data.Aeson
 import Data.ByteString qualified as BS
-import Data.Map.Strict qualified as M
+import Data.Map.Strict qualified as Map
 import DepTypes
 import GraphUtil
 import Strategy.NuGet.ProjectJson
@@ -18,7 +18,7 @@ dependencyOne =
     , dependencyVersion = Just (CEq "1.0.0")
     , dependencyLocations = []
     , dependencyEnvironments = []
-    , dependencyTags = M.empty
+    , dependencyTags = Map.empty
     }
 
 dependencyTwo :: Dependency
@@ -29,7 +29,7 @@ dependencyTwo =
     , dependencyVersion = Just (CCompatible "2.*")
     , dependencyLocations = []
     , dependencyEnvironments = []
-    , dependencyTags = M.empty
+    , dependencyTags = Map.empty
     }
 
 dependencyThree :: Dependency
@@ -40,7 +40,7 @@ dependencyThree =
     , dependencyVersion = Just (CEq "3.0.0")
     , dependencyLocations = []
     , dependencyEnvironments = []
-    , dependencyTags = M.fromList [("type", ["sometype"])]
+    , dependencyTags = Map.fromList [("type", ["sometype"])]
     }
 
 spec :: Spec

--- a/test/Python/PipenvSpec.hs
+++ b/test/Python/PipenvSpec.hs
@@ -4,7 +4,7 @@ module Python.PipenvSpec (
 
 import Data.Aeson (eitherDecodeStrict)
 import Data.ByteString qualified as BS
-import Data.Map.Strict qualified as M
+import Data.Map.Strict qualified as Map
 import DepTypes
 import GraphUtil
 import Strategy.Python.Pipenv
@@ -21,7 +21,7 @@ pipfileLock =
               }
           ]
     , fileDefault =
-        M.fromList
+        Map.fromList
           [
             ( "pkgTwo"
             , PipfileDep
@@ -45,7 +45,7 @@ pipfileLock =
             )
           ]
     , fileDevelop =
-        M.fromList
+        Map.fromList
           [
             ( "pkgOne"
             , PipfileDep
@@ -87,7 +87,7 @@ depOne =
     , dependencyVersion = Just (CEq "1.0.0")
     , dependencyLocations = []
     , dependencyEnvironments = [EnvDevelopment]
-    , dependencyTags = M.empty
+    , dependencyTags = Map.empty
     }
 
 depTwo :: Dependency
@@ -98,7 +98,7 @@ depTwo =
     , dependencyVersion = Just (CEq "2.0.0")
     , dependencyLocations = ["https://my-package-index/"]
     , dependencyEnvironments = [EnvProduction]
-    , dependencyTags = M.empty
+    , dependencyTags = Map.empty
     }
 
 depThree :: Dependency
@@ -109,7 +109,7 @@ depThree =
     , dependencyVersion = Just (CEq "3.0.0")
     , dependencyLocations = []
     , dependencyEnvironments = [EnvProduction]
-    , dependencyTags = M.empty
+    , dependencyTags = Map.empty
     }
 
 depFour :: Dependency
@@ -120,7 +120,7 @@ depFour =
     , dependencyVersion = Nothing
     , dependencyLocations = []
     , dependencyEnvironments = [EnvProduction]
-    , dependencyTags = M.empty
+    , dependencyTags = Map.empty
     }
 
 xit :: String -> Expectation -> SpecWith (Arg Expectation)

--- a/test/Python/ReqTxtSpec.hs
+++ b/test/Python/ReqTxtSpec.hs
@@ -4,7 +4,7 @@ module Python.ReqTxtSpec (
   spec,
 ) where
 
-import Data.Map.Strict qualified as M
+import Data.Map.Strict qualified as Map
 import Text.URI.QQ (uri)
 
 import DepTypes
@@ -43,7 +43,7 @@ expected = run . evalGrapher $ do
             )
       , dependencyLocations = []
       , dependencyEnvironments = []
-      , dependencyTags = M.empty
+      , dependencyTags = Map.empty
       }
   direct $
     Dependency
@@ -52,7 +52,7 @@ expected = run . evalGrapher $ do
       , dependencyVersion = Nothing
       , dependencyLocations = []
       , dependencyEnvironments = []
-      , dependencyTags = M.empty
+      , dependencyTags = Map.empty
       }
   direct $
     Dependency
@@ -61,7 +61,7 @@ expected = run . evalGrapher $ do
       , dependencyVersion = Just (CURI "https://example.com")
       , dependencyLocations = []
       , dependencyEnvironments = []
-      , dependencyTags = M.empty
+      , dependencyTags = Map.empty
       }
 
 spec :: Spec

--- a/test/Python/RequirementsSpec.hs
+++ b/test/Python/RequirementsSpec.hs
@@ -3,7 +3,7 @@ module Python.RequirementsSpec (
 ) where
 
 import Data.Foldable (traverse_)
-import Data.Map.Strict qualified as M
+import Data.Map.Strict qualified as Map
 import Data.Text (Text)
 import Data.Text.IO qualified as TIO
 import DepTypes
@@ -42,7 +42,7 @@ depOne =
     , dependencyVersion = Just (CEq "1.0")
     , dependencyLocations = []
     , dependencyEnvironments = []
-    , dependencyTags = M.empty
+    , dependencyTags = Map.empty
     }
 
 depTwo :: Dependency
@@ -53,7 +53,7 @@ depTwo =
     , dependencyVersion = Just (CLessOrEq "2.0.0")
     , dependencyLocations = []
     , dependencyEnvironments = []
-    , dependencyTags = M.empty
+    , dependencyTags = Map.empty
     }
 
 depThree :: Dependency
@@ -64,7 +64,7 @@ depThree =
     , dependencyVersion = Just (CEq "3.0.0")
     , dependencyLocations = []
     , dependencyEnvironments = []
-    , dependencyTags = M.empty
+    , dependencyTags = Map.empty
     }
 
 depFour :: Dependency
@@ -75,7 +75,7 @@ depFour =
     , dependencyVersion = Just (CEq "4.0.0")
     , dependencyLocations = []
     , dependencyEnvironments = []
-    , dependencyTags = M.empty
+    , dependencyTags = Map.empty
     }
 
 spec :: T.Spec

--- a/test/Python/SetupPySpec.hs
+++ b/test/Python/SetupPySpec.hs
@@ -4,7 +4,7 @@ module Python.SetupPySpec (
   spec,
 ) where
 
-import Data.Map.Strict qualified as M
+import Data.Map.Strict qualified as Map
 import Text.URI.QQ (uri)
 
 import DepTypes
@@ -43,7 +43,7 @@ expected = run . evalGrapher $ do
             )
       , dependencyLocations = []
       , dependencyEnvironments = []
-      , dependencyTags = M.empty
+      , dependencyTags = Map.empty
       }
   direct $
     Dependency
@@ -52,7 +52,7 @@ expected = run . evalGrapher $ do
       , dependencyVersion = Nothing
       , dependencyLocations = []
       , dependencyEnvironments = []
-      , dependencyTags = M.empty
+      , dependencyTags = Map.empty
       }
   direct $
     Dependency
@@ -61,7 +61,7 @@ expected = run . evalGrapher $ do
       , dependencyVersion = Just (CURI "https://example.com")
       , dependencyLocations = []
       , dependencyEnvironments = []
-      , dependencyTags = M.empty
+      , dependencyTags = Map.empty
       }
 
 spec :: Spec

--- a/test/Ruby/BundleShowSpec.hs
+++ b/test/Ruby/BundleShowSpec.hs
@@ -2,7 +2,7 @@ module Ruby.BundleShowSpec (
   spec,
 ) where
 
-import Data.Map.Strict qualified as M
+import Data.Map.Strict qualified as Map
 import Data.Text.IO qualified as TIO
 import Text.Megaparsec
 
@@ -22,7 +22,7 @@ expected = run . evalGrapher $ do
       , dependencyVersion = Just (CEq "1.0.0")
       , dependencyLocations = []
       , dependencyEnvironments = []
-      , dependencyTags = M.empty
+      , dependencyTags = Map.empty
       }
   direct $
     Dependency
@@ -31,7 +31,7 @@ expected = run . evalGrapher $ do
       , dependencyVersion = Just (CEq "2.0.0")
       , dependencyLocations = []
       , dependencyEnvironments = []
-      , dependencyTags = M.empty
+      , dependencyTags = Map.empty
       }
 
 bundleShowOutput :: [BundleShowDep]

--- a/test/Ruby/GemfileLockSpec.hs
+++ b/test/Ruby/GemfileLockSpec.hs
@@ -2,7 +2,7 @@ module Ruby.GemfileLockSpec (
   spec,
 ) where
 
-import Data.Map.Strict qualified as M
+import Data.Map.Strict qualified as Map
 import Data.Text.IO qualified as TIO
 import DepTypes
 import GraphUtil
@@ -18,7 +18,7 @@ dependencyOne =
     , dependencyVersion = Just (CEq "1.0.0")
     , dependencyLocations = ["temp@12345"]
     , dependencyEnvironments = []
-    , dependencyTags = M.empty
+    , dependencyTags = Map.empty
     }
 
 dependencyTwo :: Dependency
@@ -29,7 +29,7 @@ dependencyTwo =
     , dependencyVersion = Just (CEq "2.0.0")
     , dependencyLocations = ["remote"]
     , dependencyEnvironments = []
-    , dependencyTags = M.empty
+    , dependencyTags = Map.empty
     }
 
 dependencyThree :: Dependency
@@ -40,7 +40,7 @@ dependencyThree =
     , dependencyVersion = Just (CEq "3.0.0")
     , dependencyLocations = ["remote"]
     , dependencyEnvironments = []
-    , dependencyTags = M.empty
+    , dependencyTags = Map.empty
     }
 
 gitSection :: Section

--- a/test/Yarn/V2/LockfileSpec.hs
+++ b/test/Yarn/V2/LockfileSpec.hs
@@ -5,7 +5,7 @@ module Yarn.V2.LockfileSpec (
 import Algebra.Graph.AdjacencyMap qualified as AM
 import Algebra.Graph.AdjacencyMap.Extra qualified as AME
 import Control.Carrier.Diagnostics
-import Data.Map.Strict qualified as M
+import Data.Map.Strict qualified as Map
 import Data.Yaml (decodeFileThrow)
 import DepTypes
 import GraphUtil
@@ -47,7 +47,7 @@ spec = do
 exampleLockfile :: YarnLockfile
 exampleLockfile =
   YarnLockfile $
-    M.fromList
+    Map.fromList
       [
         ( [Descriptor Nothing "toplevel" "workspace:."]
         , PackageDescription
@@ -182,7 +182,7 @@ underscoreFromGitDep =
     , dependencyVersion = Just (CEq "cbb48b79fc1205aa04feb03dbc055cdd28a12652")
     , dependencyEnvironments = []
     , dependencyLocations = []
-    , dependencyTags = M.empty
+    , dependencyTags = Map.empty
     }
 
 underscoreFromNpmDep :: Dependency
@@ -193,5 +193,5 @@ underscoreFromNpmDep =
     , dependencyVersion = Just (CEq "1.13.1")
     , dependencyEnvironments = []
     , dependencyLocations = []
-    , dependencyTags = M.empty
+    , dependencyTags = Map.empty
     }

--- a/test/Yarn/V2/ResolversSpec.hs
+++ b/test/Yarn/V2/ResolversSpec.hs
@@ -3,8 +3,8 @@ module Yarn.V2.ResolversSpec (
 ) where
 
 import Data.Foldable (for_)
+import Data.String.Conversion (toString)
 import Data.Text
-import Data.Text qualified as T
 import Strategy.Yarn.V2.Lockfile
 import Strategy.Yarn.V2.Resolvers
 import Test.Hspec
@@ -57,7 +57,7 @@ testResolver ::
   [(Locator, Package)] ->
   Spec
 testResolver resolver supported =
-  describe (T.unpack (resolverName resolver)) $ do
+  describe (toString (resolverName resolver)) $ do
     it "Should work for supported locators" $ do
       for_ supported $ \(locator, result) -> do
         resolverSupportsLocator resolver locator `shouldBe` True

--- a/test/Yarn/YarnLockV1Spec.hs
+++ b/test/Yarn/YarnLockV1Spec.hs
@@ -3,7 +3,7 @@ module Yarn.YarnLockV1Spec (
 ) where
 
 import Data.ByteString qualified as BS
-import Data.Map.Strict qualified as M
+import Data.Map.Strict qualified as Map
 import Data.Text.Encoding
 import DepTypes
 import GraphUtil
@@ -19,7 +19,7 @@ packageOne =
     , dependencyVersion = Just (CEq "1.0.0")
     , dependencyLocations = ["https://registry.npmjs.org/packageOne"]
     , dependencyEnvironments = []
-    , dependencyTags = M.empty
+    , dependencyTags = Map.empty
     }
 
 packageTwo :: Dependency
@@ -30,7 +30,7 @@ packageTwo =
     , dependencyVersion = Just (CEq "2.0.0")
     , dependencyLocations = ["https://registry.npmjs.org/packageTwo"]
     , dependencyEnvironments = []
-    , dependencyTags = M.empty
+    , dependencyTags = Map.empty
     }
 
 packageThree :: Dependency
@@ -41,7 +41,7 @@ packageThree =
     , dependencyVersion = Just (CEq "3.0.0")
     , dependencyLocations = ["https://registry.npmjs.org/packageThree"]
     , dependencyEnvironments = []
-    , dependencyTags = M.empty
+    , dependencyTags = Map.empty
     }
 
 spec :: Spec


### PR DESCRIPTION
# Overview

Received some great feedback on styling of haskell code over last week. I would like to embed those suggestions into linter. Leaving this as a draft before making changes to existing code for style corrections (per this pr)

## Acceptance criteria

- [x] Adds linting rules for `void` over `()`
- [x] Adds linting rules for preference of `pure` over `return`
- [x] Adds linting rules for preference of `(<|>)` over `asum`, when considering only two items
- [x] Adds linting rules for preference of `<$>` over `<&>`
- [x] Adds linting rules for preference of complete name for qualified import

## Testing plan

N/A

## Risks

N/A

## References

This responds to https://github.com/fossas/team-analysis/issues/671

## Checklist

- [x] I added tests for this PR's change (or confirmed tests are not viable).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] I linked this PR to any referenced GitHub issues, if they exist.
