### PR TITLE
Add docs about unsupported v1 report commands

### DIFF
--- a/docs/differences-from-v1.md
+++ b/docs/differences-from-v1.md
@@ -3,19 +3,18 @@
 Upgrading from FOSSA CLI 1.x to 2.x is a major breaking change. For most users, this change should be seamless. For users who use less common flags, or who have heavily customized their CLI usage, you may need to update some scripts.
 
 ## Table of contents <!-- omit in toc -->
-- [Differences from FOSSA 1.x to 2.x](#differences-from-fossa-1x-to-2x)
-  - [What's new in FOSSA 2.x?](#whats-new-in-fossa-2x)
-    - ["Modules" are now "analysis targets"](#modules-are-now-analysis-targets)
-    - [Automatic analysis target discovery](#automatic-analysis-target-discovery)
-    - [Automatic analysis target strategy selection](#automatic-analysis-target-strategy-selection)
-    - [Improved correctness](#improved-correctness)
-    - [Improved debug logging](#improved-debug-logging)
-  - [How to upgrade to FOSSA 2.x](#how-to-upgrade-to-fossa-2x)
-    - [Remove calls to `fossa init`](#remove-calls-to-fossa-init)
-    - [Migrate your configuration file](#migrate-your-configuration-file)
-    - [Migrate "archive upload" targets](#migrate-archive-upload-targets)
-    - [Getting help with your migration](#getting-help-with-your-migration)
-    - [Migrate "fossa report" commands](#migrate-fossa-report-commands)
+
+- [What's new in FOSSA 2.x?](#whats-new-in-fossa-2x)
+  - ["Modules" are now "analysis targets"](#modules-are-now-analysis-targets)
+  - [Automatic analysis target discovery](#automatic-analysis-target-discovery)
+  - [Automatic analysis target strategy selection](#automatic-analysis-target-strategy-selection)
+  - [Improved correctness](#improved-correctness)
+  - [Improved debug logging](#improved-debug-logging)
+- [How to upgrade to FOSSA 2.x](#how-to-upgrade-to-fossa-2x)
+  - [Remove calls to `fossa init`](#remove-calls-to-fossa-init)
+  - [Migrate your configuration file](#migrate-your-configuration-file)
+  - [Migrate "archive upload" targets](#migrate-archive-upload-targets)
+  - [Getting help with your migration](#getting-help-with-your-migration)
 
 ## What's new in FOSSA 2.x?
 

--- a/docs/differences-from-v1.md
+++ b/docs/differences-from-v1.md
@@ -3,17 +3,19 @@
 Upgrading from FOSSA CLI 1.x to 2.x is a major breaking change. For most users, this change should be seamless. For users who use less common flags, or who have heavily customized their CLI usage, you may need to update some scripts.
 
 ## Table of contents <!-- omit in toc -->
-- [What's new in FOSSA 2.x?](#whats-new-in-fossa-2x)
-  - ["Modules" are now "analysis targets"](#modules-are-now-analysis-targets)
-  - [Automatic analysis target discovery](#automatic-analysis-target-discovery)
-  - [Automatic analysis target strategy selection](#automatic-analysis-target-strategy-selection)
-  - [Improved correctness](#improved-correctness)
-  - [Improved debug logging](#improved-debug-logging)
-- [How to upgrade to FOSSA 2.x](#how-to-upgrade-to-fossa-2x)
-  - [Remove calls to `fossa init`](#remove-calls-to-fossa-init)
-  - [Migrate your configuration file](#migrate-your-configuration-file)
-  - [Migrate "archive upload" targets](#migrate-archive-upload-targets)
-  - [Getting help with your migration](#getting-help-with-your-migration)
+- [Differences from FOSSA 1.x to 2.x](#differences-from-fossa-1x-to-2x)
+  - [What's new in FOSSA 2.x?](#whats-new-in-fossa-2x)
+    - ["Modules" are now "analysis targets"](#modules-are-now-analysis-targets)
+    - [Automatic analysis target discovery](#automatic-analysis-target-discovery)
+    - [Automatic analysis target strategy selection](#automatic-analysis-target-strategy-selection)
+    - [Improved correctness](#improved-correctness)
+    - [Improved debug logging](#improved-debug-logging)
+  - [How to upgrade to FOSSA 2.x](#how-to-upgrade-to-fossa-2x)
+    - [Remove calls to `fossa init`](#remove-calls-to-fossa-init)
+    - [Migrate your configuration file](#migrate-your-configuration-file)
+    - [Migrate "archive upload" targets](#migrate-archive-upload-targets)
+    - [Getting help with your migration](#getting-help-with-your-migration)
+    - [Migrate "fossa report" commands](#migrate-fossa-report-commands)
 
 ## What's new in FOSSA 2.x?
 
@@ -74,3 +76,9 @@ In 2.x, archive uploads are no longer a special analysis target type. Instead, y
 If you run into migration issues, you can get support by opening a ticket in this repository.
 
 If you are integrating a private project and want to share more details, or if you're a FOSSA customer with priority support, you can also email support@fossa.com or file a ticket at support.fossa.com for assistance.
+
+### Migrate "fossa report" commands
+
+In 1.x, `fossa report` supported `fossa report dependencies`, `fossa report licenses` and `fossa report attribution`.
+
+In 2.x, only `fossa report attribution --json` is reported. The information in the previously supported v1 commands is contained in the output from `attribution`.


### PR DESCRIPTION
# Overview

Closes https://github.com/fossas/spectrometer/issues/304

Adds a note that `fossa report` `dependencies` and `licenses` are no longer supported.
