### PR TITLE
Add docs for .NET

### DIFF
--- a/docs/quickreference/nuget.md
+++ b/docs/quickreference/nuget.md
@@ -1,4 +1,4 @@
-# Quick reference: nuget
+# Quick reference: NuGet
 
 ## Requirements
 
@@ -11,8 +11,7 @@ One more more of the following:
 - `project.assets.json`
 - `packages.config`
 - `project.json`
-- `paket.lock`
 
 ## Project discovery
 
-Directories containing any of the files listed above are considered Nuget projects.
+Directories containing any of the files listed above are considered NuGet projects.

--- a/docs/quickreference/paket.md
+++ b/docs/quickreference/paket.md
@@ -1,0 +1,11 @@
+# Quick reference: Paket
+
+## Requirements
+
+**Ideal/Minimum**
+
+- `paket.lock` file
+
+## Project discovery
+
+Directories containing any of the files listed above are considered Paket projects

--- a/docs/strategies.md
+++ b/docs/strategies.md
@@ -84,3 +84,4 @@ The CLI supports the following strategies:
 - [ruby](strategies/ruby.md) (bundler)
 - [rust](strategies/rust.md) (cargo)
 - [sbt](strategies/sbt.md) (sbt)
+- [.NET](strategies/dotnet.md) (NuGet, Paket)

--- a/docs/strategies/dotnet.md
+++ b/docs/strategies/dotnet.md
@@ -1,0 +1,19 @@
+# .NET Analysis
+
+There are several different methods of .NET analysis, that use both the `NuGet` (`nuspec`, `PackageReference`, `packages.config`, `project.json`, `project.assets.json`) and `Paket` package managers.
+
+| Strategy                             | Direct Deps | Deep Deps | Edges |
+| ---                                  | ---         | ---       | ---   |
+| [nuspec][nuspec] | ✅          | ❌        | ❌    |
+| [PackageReference][packagereference]  | ✅          | ❌        | ❌    |
+| [packages.config][packagesconfig]             | ✅          | ❌        | ❌    |
+| [paket][paket]             | ✅          | ✅        | ✅    |
+| [project.assets.json][projectassetsjson]                       | ✅          | ✅        | ✅    |
+| [project.json][project]                       | ✅          | ❌        | ❌    |
+
+[nuspec]: dotnet/nuspec.md
+[packagereference]: dotnet/packagereference.md
+[packagesconfig]: dotnet/packagesconfig.md
+[paket]: dotnet/paket.md
+[projectassetsjson]: dotnet/projectassetsjson.md
+[projectjson]: dotnet/projectjson.md

--- a/docs/strategies/dotnet.md
+++ b/docs/strategies/dotnet.md
@@ -2,14 +2,14 @@
 
 There are several different methods of .NET analysis, that use both the `NuGet` (`nuspec`, `PackageReference`, `packages.config`, `project.json`, `project.assets.json`) and `Paket` package managers.
 
-| Strategy                             | Direct Deps | Deep Deps | Edges |
-| ---                                  | ---         | ---       | ---   |
-| [nuspec][nuspec] | ✅          | ❌        | ❌    |
-| [PackageReference][packagereference]  | ✅          | ❌        | ❌    |
-| [packages.config][packagesconfig]             | ✅          | ❌        | ❌    |
-| [paket][paket]             | ✅          | ✅        | ✅    |
-| [project.assets.json][projectassetsjson]                       | ✅          | ✅        | ✅    |
-| [project.json][project]                       | ✅          | ❌        | ❌    |
+| Strategy                                 | Direct Deps | Deep Deps | Edges |
+| ---------------------------------------- | ----------- | --------- | ----- |
+| [nuspec][nuspec]                         | ✅          | ❌        | ❌    |
+| [PackageReference][packagereference]     | ✅          | ❌        | ❌    |
+| [packages.config][packagesconfig]        | ✅          | ❌        | ❌    |
+| [paket][paket]                           | ✅          | ✅        | ✅    |
+| [project.assets.json][projectassetsjson] | ✅          | ✅        | ✅    |
+| [project.json][projectjson]              | ✅          | ❌        | ❌    |
 
 [nuspec]: dotnet/nuspec.md
 [packagereference]: dotnet/packagereference.md

--- a/docs/strategies/dotnet/nuspec.md
+++ b/docs/strategies/dotnet/nuspec.md
@@ -1,0 +1,61 @@
+# nuspec
+
+A `.nuspec` file is an XML manifest that contains package metadata for Nuget packages. This manifest is used both to build the package and to provide information to consumers.
+
+## Project Discovery
+
+Walk the directory and find all files with a  `.nuspec` suffix
+
+## Analysis
+
+Depending on the version of Nuget in use, dependencies can be specified in two ways
+
+TODO: do we ONLY look at dependency groups????
+### Dependencies element
+
+The <dependencies> element within <metadata> contains any number of <dependency> elements that identify other packages upon which the top-level package depends. Example:
+
+```
+<?xml version="1.0"?>
+<package >
+  <metadata>
+    <id>GenericServices</id>
+    <version>1.0.10</version>
+    <title>GenericServices</title>
+    <authors>Jon Smith</authors>
+    <owners>Jon Smith</owners>
+    <dependencies>
+      <dependency id="GenericLibsBase" version="1.0.1" />
+      <dependency id="EntityFramework" version="6.1.3" />
+      <dependency id="AutoMapper" version="4.2.1" />
+      <dependency id="DelegateDecompiler.EntityFramework" version="0.18" />
+    </dependencies>
+  </metadata>
+</package>
+```
+
+### Dependency groups
+
+As an alternative to a single flat list, dependencies can be specified according to the framework profile of the target project using <group> elements within <dependencies>.
+
+```
+<?xml version="1.0"?>
+<package >
+  <metadata>
+    <id>GenericServices</id>
+    <version>1.0.10</version>
+    <title>GenericServices</title>
+    <authors>Jon Smith</authors>
+    <owners>Jon Smith</owners>
+    <dependencies>
+      <group>
+        <dependency id="RouteMagic" version="1.1.0" />
+      </group>
+      <group targetFramework=".NETFramework4.7.2">
+        <dependency id="jQuery" version="1.6.2" />
+        <dependency id="WebActivator" version="1.4.4" />
+      </group>
+    </dependencies>
+  </metadata>
+</package>
+```

--- a/docs/strategies/dotnet/packagereference.md
+++ b/docs/strategies/dotnet/packagereference.md
@@ -1,0 +1,19 @@
+# PackageReference
+
+Package references, using the `PackageReference` node, manage NuGet dependencies directly within project files (as opposed to a separate `packages.config` file)
+
+## Project Discovery
+
+Walk the directory and find all NuGet project files, i.e. files with the suffix of `.csproj`, `.xproj`, `.vbproj`, `.dbproj`, or `.fsproj`.
+
+## Analysis
+
+Parse the XML project files, and collect dependency data from all `PackageReference` tags:
+
+```
+<ItemGroup>
+    <!-- ... -->
+    <PackageReference Include="Sitecore.Kernel" Version="12.0.0" />
+    <!-- ... -->
+</ItemGroup>
+```

--- a/docs/strategies/dotnet/packagesconfig.md
+++ b/docs/strategies/dotnet/packagesconfig.md
@@ -1,0 +1,21 @@
+# packages.config
+
+The `packages.config` XML file is used in some project types to maintain the list of packages referenced by the project.
+
+Note: projects that use `PackageReference` do not use `packages.config`.
+
+## Project Discovery
+
+Walk the directory and find all files names `packages.config`
+
+## Analysis
+
+Parse the XML file, and collect dependency data from all `package` tags within the `packages` section:
+
+```
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="jQuery" version="3.1.1" targetFramework="net46" />
+  <package id="NLog" version="4.3.10" targetFramework="net46" />
+</packages>
+```

--- a/docs/strategies/dotnet/paket.md
+++ b/docs/strategies/dotnet/paket.md
@@ -1,0 +1,30 @@
+# Paket
+
+Paket is a dependency manager for .NET projects. Paket enables precise and predictable control over your dependencies
+
+Paket manages your dependencies with three core file types:
+
+`paket.dependencies`, where you specify your dependencies and their versions for your entire codebase.
+`paket.references`, a file that specifies a subset of your dependencies for every project in a solution.
+`paket.lock`, a lock file that Paket generates when it runs. When you check it into source control, you get reproducible builds.
+
+## Project Discovery
+
+Walk the directory and find all lock files (`paket.lock`)
+
+## Analysis
+Parse the lock file, and construct a dependency graph:
+
+```
+NUGET
+  remote: nuget.com
+    one (1.0.0)
+      two (>1.0.0)
+    two (2.0.0)
+
+HTTP
+  remote: custom-site.com
+    three (3.0.0)
+```
+
+dependencies can come from either NuGet, Github, or a specified remote URL.

--- a/docs/strategies/dotnet/projectassetsjson.md
+++ b/docs/strategies/dotnet/projectassetsjson.md
@@ -1,0 +1,11 @@
+# project.assets.json
+
+The `project.assets.json` file is used in `.NET Core` projects to manage dependencies and other resources
+
+## Project Discovery
+
+Walk the directory and find all files names `project.assets.json`
+
+## Analysis
+
+Parse the JSON file, and construct a full dependency graph (direct and transitive dependencies).

--- a/docs/strategies/dotnet/projectjson.md
+++ b/docs/strategies/dotnet/projectjson.md
@@ -1,0 +1,18 @@
+# project.json
+
+The `project.json` file maintains a list of packages used in a project, known as a package management format. It supersedes `packages.config` but is in turn superseded by `PackageReference` with NuGet 4.0+.
+
+## Project Discovery
+
+Walk the directory and find all files names `project.json`
+
+## Analysis
+
+Parse the JSON file and search for the `dependencies` section:
+
+```
+"dependencies": {
+    "Microsoft.NETCore": "5.0.0",
+    "System.Runtime.Serialization.Primitives": "4.0.10"
+}
+``` 

--- a/docs/userguide.md
+++ b/docs/userguide.md
@@ -121,7 +121,8 @@ fossa analyze --help
 
 ### .NET
 
-- [nuget](quickreference/nuget.md)
+- [NuGet](quickreference/nuget.md)
+- [Paket](quickreference/paket.md)
 
 ### objective-c
 
@@ -254,6 +255,7 @@ Supported dependency types:
 - `maven` - Maven dependencies that can be found at many different sources. Specified as `name: javax.xml.bind:jaxb-api` where the convention is `groupId:artifactId`.
 - `npm` - Javascript dependencies found at [npmjs.com](https://www.npmjs.com/).
 - `nuget` - .NET dependencies found at [NuGet.org](https://www.nuget.org/).
+- `paket` - .NET dependencies found at [fsprojects.github.io/Paket/](https://fsprojects.github.io/Paket/).
 - `pub` - Dart dependencies found at [pub.dev](https://www.pub.dev/).
 - `pypi` - Python dependencies that are typically found at [Pypi.org](https://pypi.org/).
 - `cocoapods` - Swift and Objective-C dependencies found at [Cocoapods.org](https://cocoapods.org/).


### PR DESCRIPTION
# Overview

Add documentation for our `.NET` analysis strategies

## Testing plan

Are the assertions that I've made 100% accurate with how our analyzers work?

## Risks

- I'm unsure of a few of the strategies, specifically:
  - The chart in `docs/strategies/dotnet.md`
  - TODO in `docs/strategies/dotnet/nuspec.md`

## References

partially closes: https://github.com/fossas/team-analysis/issues/683

## Checklist

~- [ ] I added tests for this PR's change (or confirmed tests are not viable).~
~- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.~
~- [ ] I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.~
~- [ ] I linked this PR to any referenced GitHub issues, if they exist.~
