### PR TITLE
Allow older poetry build backend identifier and minor refactor/fixes

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,8 +1,14 @@
 # Spectrometer Changelog
 
-## Unreleased
+## v2.12.2
 
+- Supports poetry build backend of `poetry.masonry.api` ([#309](https://github.com/fossas/spectrometer/pull/309))
 - Support for Graph Breadth Tagging ([#308](https://github.com/fossas/spectrometer/pull/308))
+
+## v2.12.1
+
+- Add `--exclude-path` and `--only-path` to monorepo functionality in fossa analyze. ([#291](https://github.com/fossas/spectrometer/pull/291))
+- Support globs in exclude/only path flags. ([#291](https://github.com/fossas/spectrometer/pull/291))
 
 ## v2.12.0
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,11 @@
 - Add `--exclude-path` and `--only-path` to monorepo functionality in fossa analyze. ([#291](https://github.com/fossas/spectrometer/pull/291))
 - Support globs in exclude/only path flags. ([#291](https://github.com/fossas/spectrometer/pull/291))
 
+## v2.12.1
+
+- Add `--exclude-path` and `--only-path` to monorepo functionality in fossa analyze. ([#291](https://github.com/fossas/spectrometer/pull/291))
+- Support globs in exclude/only path flags. ([#291](https://github.com/fossas/spectrometer/pull/291))
+
 ## v2.12.0
 
 - Adds poetry support for python ([#300](https://github.com/fossas/spectrometer/pull/300))

--- a/Changelog.md
+++ b/Changelog.md
@@ -10,11 +10,6 @@
 - Add `--exclude-path` and `--only-path` to monorepo functionality in fossa analyze. ([#291](https://github.com/fossas/spectrometer/pull/291))
 - Support globs in exclude/only path flags. ([#291](https://github.com/fossas/spectrometer/pull/291))
 
-## v2.12.1
-
-- Add `--exclude-path` and `--only-path` to monorepo functionality in fossa analyze. ([#291](https://github.com/fossas/spectrometer/pull/291))
-- Support globs in exclude/only path flags. ([#291](https://github.com/fossas/spectrometer/pull/291))
-
 ## v2.12.0
 
 - Adds poetry support for python ([#300](https://github.com/fossas/spectrometer/pull/300))

--- a/docs/strategies/python/poetry.md
+++ b/docs/strategies/python/poetry.md
@@ -35,7 +35,7 @@ Where,
 
 ### Limitations
 
-* For poetry project, build system's `build-backend` must be set to `poetry.core.masonry.api` in `pyproject.toml`. If not done so, it will not discover the project. Refer to [Poetry and PEP-517](https://python-poetry.org/docs/pyproject/#poetry-and-pep-517) for more details. 
+* For poetry project, build system's `build-backend` must be set to `poetry.core.masonry.api` or `poetry.masonry.api` in `pyproject.toml`. If not done so, it will not discover the project. Refer to [Poetry and PEP-517](https://python-poetry.org/docs/pyproject/#poetry-and-pep-517) for more details. 
 * All extras specified in `[tool.poetry.extras]` are currently not reported. 
 * Any [path dependencies](https://python-poetry.org/docs/dependency-specification/#path-dependencies) will not be reported.
 

--- a/src/Strategy/Python/Poetry.hs
+++ b/src/Strategy/Python/Poetry.hs
@@ -49,7 +49,7 @@ discover dir = context "Poetry" $ do
 usesPoetryBackend :: Text -> Bool
 usesPoetryBackend backend =
   backend == "poetry.core.masonry.api" -- For poetry versions >=1.1.0a1 (released 2020)
-    || backend == "poetry.masonry.api"
+    || backend == "poetry.masonry.api" -- Refer to https://github.com/python-poetry/poetry/pull/2212
 
 -- | Reference message text for poetry build backend setting value required in pyproject.toml.
 -- Users should configure poetry build backend in pyproject.toml for poetry project discovery.

--- a/src/Strategy/Python/Poetry.hs
+++ b/src/Strategy/Python/Poetry.hs
@@ -13,7 +13,7 @@ import Control.Effect.Diagnostics (Diagnostics, context)
 import Data.Map (Map)
 import Data.Map.Strict qualified as Map
 import Data.Maybe (fromMaybe)
-import Data.Text (Text, toLower)
+import Data.Text (Text)
 import DepTypes (DepType (..), Dependency (..))
 import Discovery.Walk (
   WalkStep (WalkContinue, WalkSkipAll),
@@ -24,7 +24,7 @@ import Effect.Logger (Logger (..), Pretty (pretty), logDebug)
 import Effect.ReadFS (ReadFS, readContentsToml)
 import Graphing (Graphing, deep, edge, empty, fromList, gmap, promoteToDirect)
 import Path (Abs, Dir, File, Path)
-import Strategy.Python.Poetry.Common (getPoetryBuildBackend, logIgnoredDeps, pyProjectDeps, toMap)
+import Strategy.Python.Poetry.Common (getPoetryBuildBackend, logIgnoredDeps, pyProjectDeps, toCanonicalName, toMap)
 import Strategy.Python.Poetry.PoetryLock (PackageName (..), PoetryLock (..), PoetryLockPackage (..), poetryLockCodec)
 import Strategy.Python.Poetry.PyProject (PyProject (..), pyProjectCodec)
 import Types (DiscoveredProject (..), GraphBreadth (..))
@@ -46,8 +46,10 @@ discover dir = context "Poetry" $ do
   pure (map mkProject projects)
 
 -- | Poetry build backend identifier required in [pyproject.toml](https://python-poetry.org/docs/pyproject/#poetry-and-pep-517).
-poetryBuildBackendIdentifier :: Text
-poetryBuildBackendIdentifier = "poetry.core.masonry.api"
+usesPoetryBackend :: Text -> Bool
+usesPoetryBackend backend =
+  backend == "poetry.core.masonry.api" -- For poetry versions >=1.1.0a1 (released 2020)
+    || backend == "poetry.masonry.api"
 
 -- | Reference message text for poetry build backend setting value required in pyproject.toml.
 -- Users should configure poetry build backend in pyproject.toml for poetry project discovery.
@@ -78,7 +80,7 @@ findProjects = walk' $ \dir _ files -> do
       case pyprojectBuildBackend of
         Nothing -> pure ([], WalkContinue)
         Just pbs ->
-          if pbs == poetryBuildBackendIdentifier
+          if usesPoetryBackend pbs
             then pure ([project], WalkSkipAll)
             else ([], WalkContinue) <$ warnIncorrectBuildBackend pbs
 
@@ -126,10 +128,11 @@ setGraphDirectsFromPyproject :: Graphing Dependency -> PyProject -> Graphing Dep
 setGraphDirectsFromPyproject graph pyproject = promoteToDirect isDirect graph
   where
     -- Dependencies in `poetry.lock` are direct if they're specified in `pyproject.toml`.
+    -- `pyproject.toml` may use non canonical naming, when naming dependencies.
     isDirect :: Dependency -> Bool
     isDirect dep = case pyprojectPoetry pyproject of
       Nothing -> False
-      Just _ -> any (\n -> dependencyName n == dependencyName dep) (pyProjectDeps pyproject)
+      Just _ -> any (\n -> toCanonicalName (dependencyName n) == toCanonicalName (dependencyName dep)) $ pyProjectDeps pyproject
 
 -- | Using a Poetry lockfile, build the graph of packages.
 -- The resulting graph contains edges, but does not distinguish between direct and deep dependencies,
@@ -155,29 +158,14 @@ graphFromLockFile poetryLock = gmap pkgNameToDependency (foldr deep edges pkgsNo
     edges :: Graphing PackageName
     edges = foldr (uncurry edge) empty (concatMap edgeOf depsWithEdges)
 
-    lowerCasedPkgName :: PackageName -> PackageName
-    lowerCasedPkgName name = PackageName . toLower $ unPackageName name
+    canonicalPkgName :: PackageName -> PackageName
+    canonicalPkgName name = PackageName . toCanonicalName $ unPackageName name
 
     mapOfDependency :: Map PackageName Dependency
     mapOfDependency = toMap pkgs
 
     -- Pip packages are [case insensitive](https://www.python.org/dev/peps/pep-0508/#id21), but poetry.lock may use
-    -- non-canonical name for reference. Try to lookup with provided casing, otherwise fallback to lower casing.
-    --
-    -- Poetry.lock when referencing deep dependencies uses non canonical names.
-    --
-    --  ```toml
-    --  [package.dependencies]
-    --  MarkupSafe = ">=2.0"
-    --  ....
-    --
-    -- [[package]]
-    -- name = "markupsafe"
-    -- version = "2.0.1"
-    -- ...
-    -- ```
-    --
-    -- TODO: Better approach to handle casing scenarios with poetry.lock file.
+    -- non-canonical name for reference. Try to lookup with provided name, otherwise fallback to canonical naming.
     pkgNameToDependency :: PackageName -> Dependency
     pkgNameToDependency name =
       fromMaybe
@@ -191,4 +179,4 @@ graphFromLockFile poetryLock = gmap pkgNameToDependency (foldr deep edges pkgsNo
             }
         )
         $ Map.lookup name mapOfDependency
-          <|> Map.lookup (lowerCasedPkgName name) mapOfDependency
+          <|> Map.lookup (canonicalPkgName name) mapOfDependency

--- a/test/Python/Poetry/CommonSpec.hs
+++ b/test/Python/Poetry/CommonSpec.hs
@@ -6,7 +6,7 @@ import Data.Map qualified as Map
 import Data.Text (Text)
 import Data.Text.IO qualified as TIO
 import DepTypes (DepEnvironment (..), DepType (..), Dependency (..), VerConstraint (..))
-import Strategy.Python.Poetry.Common (getPoetryBuildBackend, pyProjectDeps, supportedPoetryLockDep, supportedPyProjectDep, toMap)
+import Strategy.Python.Poetry.Common (getPoetryBuildBackend, pyProjectDeps, supportedPoetryLockDep, supportedPyProjectDep, toCanonicalName, toMap)
 import Strategy.Python.Poetry.PoetryLock (
   ObjectVersion (..),
   PackageName (..),
@@ -145,6 +145,12 @@ spec :: Spec
 spec = do
   nominalContents <- runIO (TIO.readFile "test/Python/Poetry/testdata/pyproject1.toml")
   emptyContents <- runIO (TIO.readFile "test/Python/Poetry/testdata/pyproject2.toml")
+
+  describe "toCanonicalName" $ do
+    it "should convert text to lowercase" $
+      toCanonicalName "GreatScore" `shouldBe` "greatscore"
+    it "should replace underscore (_) to hyphens (-)" $
+      toCanonicalName "my_oh_so_great_pkg" `shouldBe` "my-oh-so-great-pkg"
 
   describe "getDependencies" $
     it "should get all dependencies" $


### PR DESCRIPTION
# Overview

* This fix addresses orphan poetry projects using older versions (any before 1.1.0a1).
* It also refactors package name matching to be as close to poetry implementation. 

## Acceptance criteria

* Poetry projects using build-backend of `poetry.masonry.api` can be discovered.

## Testing plan

* I ran against example lock file, and pyproject.toml. 

## Risks

N/A

## References

N/A

## Checklist

- [x] I added tests for this PR's change (or confirmed tests are not viable).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] I linked this PR to any referenced GitHub issues, if they exist.
