### PR TITLE
Ensure `fossa.debug.json` is written even when exceptions are thrown

### DIFF
--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -210,7 +210,6 @@ runDependencyAnalysis (BaseDir basedir) filters project =
   case applyFiltersToProject basedir filters project of
     Nothing -> logInfo $ "Skipping " <> pretty (projectType project) <> " project at " <> viaShow (projectPath project) <> ": no filters matched"
     Just targets -> do
-      logInfo $ pretty $ show targets
       logInfo $ "Analyzing " <> pretty (projectType project) <> " project at " <> pretty (toFilePath (projectPath project))
       graphResult <- Diag.runDiagnosticsIO . stickyDiag $ projectDependencyGraph project targets
       Diag.withResult SevWarn graphResult (output . mkResult project)


### PR DESCRIPTION
# Overview

Previously, when we didn't find any projects to scan, or when all of the projects were filtered out by our "production path" name filter, we'd log a message and exit with `exitFailure`.

In `--record` mode, this is an issue, because the uncaught exception would prevent `saveReplayLog` from running.

This PR does two things:

1. Catches and rethrows exceptions in `analyzeMain`, so `fossa.debug.json` is written even when an exception occurs.

2. Removes the use of `exitFailure` from `analyze`, as `logWithExit` already does that for us when a `Diagnostics` error is thrown. We convert the messages previously output with `logError` into `Diagnostics` errors, which leads to better presentation, e.g.,:

```
[ERROR] ----------
  An error occurred:

      No analysis targets found in directory

      Traceback:
```

..rather than displaying `ExitFailure` as an error

## Acceptance criteria

1. Analyzing a directory with no analysis targets, while in `--record` mode, still produces a `fossa.debug.json`
2. `fossa.debug.json` should be emitted even when exceptions are thrown

## Testing plan

- for (1), run `fossa analyze --output --record ~/path/to/some/empty/directory/`
- for (2), run `fossa analyze --output --record ~/path/to/some/big/project/directory/`, and press ctrl-c before it completes (this throws an async exception that would previously prevent `fossa.debug.json` from being written)

in both scenarios, a `fossa.debug.json` file should be created

## Risks

This intentionally prevents exiting before `fossa.debug.json` is written. In the worst case, when running in `--record` mode, `fossa` will become unresponsive to `ctrl-c` until `fossa.debug.json` is written