### PR TITLE
Bump hackage index-state and dependency versions

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -2,17 +2,38 @@ packages: .
 tests: True
 optimization: False
 
-package yarn-lock
-  tests: False
+allow-newer:
+  -- git-config needs to relax its upper bound on megaparsec. PR submitted;
+  -- no action from maintainer yet
+  --
+  -- we can remove this if/when 0.1.3 is released on hackage
+  , git-config:megaparsec
+  -- tomland neesd a relaxed upper bound on megaparsec. PR open at
+  -- https://github.com/kowainik/tomland/pull/386
+  --
+  -- we can remove this if/when 1.3.3.1 is released on hackage
+  , tomland:megaparsec
+  -- codec-rpm needs a bump to its attoparsec bound. latest upload to hackage
+  -- was in 2018, so we may have to fork when breakage occurs
+  , codec-rpm:attoparsec
 
-source-repository-package
-  type: git
-  location: https://github.com/fossas/yarn-lock.git
-  tag: 1ac8875f73eaf76237d506e900f944a34ad3c0fb
-
+-- the semver package only exposes lens-style accessors for its Version type;
+-- normal accessors are in an un-exposed Internal module. on master, the
+-- Internal module is exposed, but a new release hasn't been cut to hackage yet
+--
+-- we can remove this if/when 0.4.0.2 is released on hackage
 source-repository-package
   type: git
   location: https://github.com/fossas/semver.git
   tag: 7bc42dd298e0d98e119486ceab4f74042d46b004
 
-index-state: hackage.haskell.org 2021-04-08T20:19:17Z
+-- cpio-conduit-0.7.2 on hackage has an incompatibility with newer versions of
+-- base16-bytestring. we submitted a PR to fix this, and the PR was merged, but
+-- a new release was never cut to hackage
+-- We can remove this if/when 0.7.3 is released on hackage
+source-repository-package
+  type: git
+  location: https://github.com/da-x/cpio-conduit
+  tag: 30d92919e82c5033fffac7b34288f5a7fd28e9be
+
+index-state: hackage.haskell.org 2021-08-02T13:16:20Z

--- a/cabal.project.ci.linux
+++ b/cabal.project.ci.linux
@@ -9,17 +9,38 @@ packages: .
 package spectrometer
   ghc-options: -Werror
 
-package yarn-lock
-  tests: False
+allow-newer:
+  -- git-config needs to relax its upper bound on megaparsec. PR submitted;
+  -- no action from maintainer yet
+  --
+  -- we can remove this if/when 0.1.3 is released on hackage
+  , git-config:megaparsec
+  -- tomland neesd a relaxed upper bound on megaparsec. PR open at
+  -- https://github.com/kowainik/tomland/pull/386
+  --
+  -- we can remove this if/when 1.3.3.1 is released on hackage
+  , tomland:megaparsec
+  -- codec-rpm needs a bump to its attoparsec bound. latest upload to hackage
+  -- was in 2018, so we may have to fork when breakage occurs
+  , codec-rpm:attoparsec
 
-source-repository-package
-  type: git
-  location: https://github.com/fossas/yarn-lock.git
-  tag: 1ac8875f73eaf76237d506e900f944a34ad3c0fb
-
+-- the semver package only exposes lens-style accessors for its Version type;
+-- normal accessors are in an un-exposed Internal module. on master, the
+-- Internal module is exposed, but a new release hasn't been cut to hackage yet
+--
+-- we can remove this if/when 0.4.0.2 is released on hackage
 source-repository-package
   type: git
   location: https://github.com/fossas/semver.git
   tag: 7bc42dd298e0d98e119486ceab4f74042d46b004
 
-index-state: hackage.haskell.org 2021-04-08T20:19:17Z
+-- cpio-conduit-0.7.2 on hackage has an incompatibility with newer versions of
+-- base16-bytestring. we submitted a PR to fix this, and the PR was merged, but
+-- a new release was never cut to hackage
+-- We can remove this if/when 0.7.3 is released on hackage
+source-repository-package
+  type: git
+  location: https://github.com/da-x/cpio-conduit
+  tag: 30d92919e82c5033fffac7b34288f5a7fd28e9be
+
+index-state: hackage.haskell.org 2021-08-02T13:16:20Z

--- a/cabal.project.ci.macos
+++ b/cabal.project.ci.macos
@@ -7,17 +7,38 @@ packages: .
 package spectrometer
   ghc-options: -Werror
 
-package yarn-lock
-  tests: False
+allow-newer:
+  -- git-config needs to relax its upper bound on megaparsec. PR submitted;
+  -- no action from maintainer yet
+  --
+  -- we can remove this if/when 0.1.3 is released on hackage
+  , git-config:megaparsec
+  -- tomland neesd a relaxed upper bound on megaparsec. PR open at
+  -- https://github.com/kowainik/tomland/pull/386
+  --
+  -- we can remove this if/when 1.3.3.1 is released on hackage
+  , tomland:megaparsec
+  -- codec-rpm needs a bump to its attoparsec bound. latest upload to hackage
+  -- was in 2018, so we may have to fork when breakage occurs
+  , codec-rpm:attoparsec
 
-source-repository-package
-  type: git
-  location: https://github.com/fossas/yarn-lock.git
-  tag: 1ac8875f73eaf76237d506e900f944a34ad3c0fb
-
+-- the semver package only exposes lens-style accessors for its Version type;
+-- normal accessors are in an un-exposed Internal module. on master, the
+-- Internal module is exposed, but a new release hasn't been cut to hackage yet
+--
+-- we can remove this if/when 0.4.0.2 is released on hackage
 source-repository-package
   type: git
   location: https://github.com/fossas/semver.git
   tag: 7bc42dd298e0d98e119486ceab4f74042d46b004
 
-index-state: hackage.haskell.org 2021-04-08T20:19:17Z
+-- cpio-conduit-0.7.2 on hackage has an incompatibility with newer versions of
+-- base16-bytestring. we submitted a PR to fix this, and the PR was merged, but
+-- a new release was never cut to hackage
+-- We can remove this if/when 0.7.3 is released on hackage
+source-repository-package
+  type: git
+  location: https://github.com/da-x/cpio-conduit
+  tag: 30d92919e82c5033fffac7b34288f5a7fd28e9be
+
+index-state: hackage.haskell.org 2021-08-02T13:16:20Z

--- a/cabal.project.ci.windows
+++ b/cabal.project.ci.windows
@@ -9,17 +9,38 @@ packages: .
 package spectrometer
   ghc-options: -Werror
 
-package yarn-lock
-  tests: False
+allow-newer:
+  -- git-config needs to relax its upper bound on megaparsec. PR submitted;
+  -- no action from maintainer yet
+  --
+  -- we can remove this if/when 0.1.3 is released on hackage
+  , git-config:megaparsec
+  -- tomland neesd a relaxed upper bound on megaparsec. PR open at
+  -- https://github.com/kowainik/tomland/pull/386
+  --
+  -- we can remove this if/when 1.3.3.1 is released on hackage
+  , tomland:megaparsec
+  -- codec-rpm needs a bump to its attoparsec bound. latest upload to hackage
+  -- was in 2018, so we may have to fork when breakage occurs
+  , codec-rpm:attoparsec
 
-source-repository-package
-  type: git
-  location: https://github.com/fossas/yarn-lock.git
-  tag: 1ac8875f73eaf76237d506e900f944a34ad3c0fb
-
+-- the semver package only exposes lens-style accessors for its Version type;
+-- normal accessors are in an un-exposed Internal module. on master, the
+-- Internal module is exposed, but a new release hasn't been cut to hackage yet
+--
+-- we can remove this if/when 0.4.0.2 is released on hackage
 source-repository-package
   type: git
   location: https://github.com/fossas/semver.git
   tag: 7bc42dd298e0d98e119486ceab4f74042d46b004
 
-index-state: hackage.haskell.org 2021-04-08T20:19:17Z
+-- cpio-conduit-0.7.2 on hackage has an incompatibility with newer versions of
+-- base16-bytestring. we submitted a PR to fix this, and the PR was merged, but
+-- a new release was never cut to hackage
+-- We can remove this if/when 0.7.3 is released on hackage
+source-repository-package
+  type: git
+  location: https://github.com/da-x/cpio-conduit
+  tag: 30d92919e82c5033fffac7b34288f5a7fd28e9be
+
+index-state: hackage.haskell.org 2021-08-02T13:16:20Z

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -67,8 +67,8 @@ common deps
     , algebraic-graphs             ^>=0.5
     , ansi-terminal                ^>=0.11
     , async                        ^>=2.2.2
-    , attoparsec                   ^>=0.13.2.3
-    , base16-bytestring            ^>=0.1.1.7
+    , attoparsec                   ^>=0.14.1
+    , base16-bytestring            ^>=1.0.1.0
     , bytestring                   ^>=0.10.8
     , codec-rpm                    ^>=0.2.2
     , concurrent-output            ^>=1.10.12
@@ -76,7 +76,7 @@ common deps
     , conduit-extra                ^>=1.3.5
     , containers                   ^>=0.6.0
     , cpio-conduit                 ^>=0.7.0
-    , cryptonite                   ^>=0.28
+    , cryptonite                   ^>=0.29
     , directory                    ^>=1.3.6.1
     , exceptions                   ^>=0.10.4
     , file-embed                   ^>=0.0.11
@@ -89,17 +89,17 @@ common deps
     , http-client                  ^>=0.7.1
     , http-types                   ^>=0.12.3
     , lzma-conduit                 ^>=1.2.1
-    , megaparsec                   ^>=8.0
+    , megaparsec                   ^>=9.1.0
     , modern-uri                   ^>=0.3.4
     , mtl                          ^>=2.2.2
     , optparse-applicative         >=0.15     && <0.17
     , parser-combinators           ^>=1.3
-    , path                         ^>=0.8
+    , path                         ^>=0.9.0
     , path-io                      ^>=1.6.0
     , prettyprinter                >=1.6      && <1.8
     , prettyprinter-ansi-terminal  ^>=1.1.1
     , random                       ^>=1.2.0
-    , req                          ^>=3.7
+    , req                          ^>=3.9.1
     , semver                       ^>=0.4.0.1
     , split                        ^>=0.2.3.4
     , stm                          ^>=2.5.0
@@ -109,16 +109,16 @@ common deps
     , text                         ^>=1.2.3
     , th-lift-instances            ^>=0.1.17
     , time                         >=1.9      && <1.11
-    , tomland                      ^>=1.3.0.0
+    , tomland                      ^>=1.3.3.0
     , transformers
     , typed-process                ^>=0.2.6
     , unordered-containers         ^>=0.2.10
     , vector                       ^>=0.12.0.3
-    , versions                     ^>=4.0.1
+    , versions                     ^>=5.0.0
     , xml                          ^>=1.3.14
     , yaml                         ^>=0.11.1
-    , yarn-lock                    ^>=0.6.2
-    , zip                          ^>=1.5.0
+    , yarn-lock                    ^>=0.6.5
+    , zip                          ^>=1.7.1
     , zlib                         ^>=0.6.2.1
 
 library
@@ -371,12 +371,12 @@ test-suite unit-tests
     Yarn.V2.ResolversSpec
     Yarn.YarnLockV1Spec
 
-  build-tool-depends: hspec-discover:hspec-discover ^>=2.7.1
+  build-tool-depends: hspec-discover:hspec-discover ^>=2.8.2
   build-depends:
     , hedgehog                        ^>=1.0.2
-    , hspec                           ^>=2.7.1
-    , hspec-core                      ^>=2.7.9
+    , hspec                           ^>=2.8.2
+    , hspec-core                      ^>=2.8.2
     , hspec-expectations-pretty-diff  ^>=0.7.2.5
     , hspec-hedgehog                  ^>=0.0.1.2
-    , hspec-megaparsec                ^>=2.1
+    , hspec-megaparsec                ^>=2.2
     , spectrometer

--- a/src/App/Fossa/Container.hs
+++ b/src/App/Fossa/Container.hs
@@ -41,7 +41,7 @@ import Effect.Exec (AllowErr (Never), Command (..), Exec, execJson, execThrow, r
 import Effect.Logger
 import Effect.ReadFS (ReadFS, readContentsJson, resolveFile, runReadFSIO)
 import Options.Applicative (Parser, argument, help, metavar, str)
-import Path (Dir, Rel, reldir, toFilePath)
+import Path (reldir, toFilePath)
 import Path.IO (getCurrentDir)
 
 newtype ImageText = ImageText {unImageText :: Text} deriving (Show, Eq, Ord)

--- a/src/App/Version/TH.hs
+++ b/src/App/Version/TH.hs
@@ -24,7 +24,7 @@ import GitHash (giHash, tGitInfoCwd)
 import Instances.TH.Lift ()
 import Language.Haskell.TH (TExpQ)
 import Language.Haskell.TH.Syntax (reportWarning, runIO)
-import Path (Dir, Rel, mkRelDir)
+import Path (mkRelDir)
 
 gitTagPointCommand :: Text -> Command
 gitTagPointCommand commit =


### PR DESCRIPTION
# Overview

Our hackage index-state is four months out of date.

In addition to bumping our dependencies to the latest versions, this PR allows us to build with ghc 9 (with `--allow-newer`) other than some breakage in `App.Version.TH`. I'll hold off on submitting a ghc 9 PR until we can build without `--allow-newer`.

## Acceptance criteria

It compiles and tests pass; critical commands continue to work

## Testing plan

- Unit tests
- Manual testing of critical commands (`fossa analyze` / `fossa test` / `fossa report`)

## Risks

Our dependencies were over four months out of date. I've done my best to look through dependency changelogs to make sure we weren't affected by any major changes, but there's always the risk that I missed something