### PR TITLE
docs: Normalize Changelog style

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -65,7 +65,7 @@
 - Fixes an issue where stdout doesn't always flush to the console. ([#265](https://github.com/fossas/spectrometer/pull/265))
 - Fixes an issue when referenced-dependencies are not being uploaded. ([#262](https://github.com/fossas/spectrometer/pull/262))
 - Adds support for `fossa-deps.json`. ([#261](https://github.com/fossas/spectrometer/pull/261))
-- Adds support for `vendored-dependencies` to be licensed scanned. ([#257](https://github.com/fossas/spectrometer/pull/257))
+- Adds support for `vendored-dependencies` to be license scanned. ([#257](https://github.com/fossas/spectrometer/pull/257))
 
 ## v2.8.0
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,276 +2,258 @@
 
 ## v2.13.0
 
-- Adds support for elixir projects using `mix` command ([#287](https://github.com/fossas/spectrometer/pull/287))
+- Elixir: Adds support for Elixir projects using `mix`. ([#287](https://github.com/fossas/spectrometer/pull/287))
 
 ## v2.12.3
 
-- Fixes an issue where unresolvable Gradle configurations would cause Gradle analysis to show no dependencies ([#292](https://github.com/fossas/spectrometer/pull/292)).
+- Gradle: Fixes an issue where unresolvable Gradle configurations would cause Gradle analysis to show no dependencies ([#292](https://github.com/fossas/spectrometer/pull/292)).
 
 ## v2.12.2
 
-- Supports poetry build backend of `poetry.masonry.api` ([#309](https://github.com/fossas/spectrometer/pull/309))
-- Support for Graph Breadth Tagging ([#308](https://github.com/fossas/spectrometer/pull/308))
+- Python: Fixes an issue where older Poetry lockfiles were not correctly identified. ([#309](https://github.com/fossas/spectrometer/pull/309))
 
 ## v2.12.1
 
-- Add `--exclude-path` and `--only-path` to monorepo functionality in fossa analyze. ([#291](https://github.com/fossas/spectrometer/pull/291))
-- Support globs in exclude/only path flags. ([#291](https://github.com/fossas/spectrometer/pull/291))
+- VPS: Adds `--exclude-path` and `--only-path` to monorepo functionality in `fossa analyze`. ([#291](https://github.com/fossas/spectrometer/pull/291))
+- VPS: Support globs in `--{exclude,only}-path` flags. ([#291](https://github.com/fossas/spectrometer/pull/291))
 
 ## v2.12.0
 
-- Adds poetry support for python ([#300](https://github.com/fossas/spectrometer/pull/300))
+- Python: Adds support for the Poetry package manager. ([#300](https://github.com/fossas/spectrometer/pull/300))
 
 ## v2.11.1
 
-- Support CPAN deps in the fossa-deps file ([#296](https://github.com/fossas/spectrometer/pull/296))
+- Perl: Adds support for CPAN dependencies in `fossa-deps`. ([#296](https://github.com/fossas/spectrometer/pull/296))
 
 ## v2.11.0
 
-- Analysis target configuration ([#273](https://github.com/fossas/spectrometer/pull/273))
-- Support `fossa test` and `fossa report` for monorepo projects ([#290](https://github.com/fossas/spectrometer/pull/290))
-- Maven `pom.xml`: Adds `${property}` substitution for `<groupId>` and `<artifactId>` fields in dependencies ([#282](https://github.com/fossas/spectrometer/pull/282))
+- Adds support for selecting which folders analysis targets are discovered in. ([#273](https://github.com/fossas/spectrometer/pull/273))
+- VPS: Adds support for `fossa test` and `fossa report` for monorepo projects. ([#290](https://github.com/fossas/spectrometer/pull/290))
+- Maven: Adds support for `${property}` substitution for `<groupId>` and `<artifactId>` fields in dependencies. ([#282](https://github.com/fossas/spectrometer/pull/282))
 
 ## v2.10.3
 
-- Support ReleaseGroup configuration ([#283](https://github.com/fossas/spectrometer/pull/283))
-- Support HTTP endpoints for archive uploads ([#276](https://github.com/fossas/spectrometer/pull/276))
-- Support VCS branches for `fossa analyze --experimental-enable-monorepo` invocations ([#289](https://github.com/fossas/spectrometer/pull/289))
-- Add `--experimental-enable-monorepo` and other associated flags to `fossa analyze`, which enables experimental monorepo support ([#286](https://github.com/fossas/spectrometer/pull/286))
-  Monorepo flags are only used with support from FOSSA engineering, and are experimental while we build robust support for monorepo projects with FOSSA partners.
-- Deprecate `fossa vps` subcommands ([#286](https://github.com/fossas/spectrometer/pull/286))
+- Adds support for specifying a release group on project creation. ([#283](https://github.com/fossas/spectrometer/pull/283))
+- Adds support for non-HTTPS backends for archive uploads (e.g. for on-premises deployments). ([#276](https://github.com/fossas/spectrometer/pull/276))
+- Adds `--experimental-enable-monorepo` and other associated flags to `fossa analyze`, which enables experimental monorepo support. ([#286](https://github.com/fossas/spectrometer/pull/286))
+- Deprecates `fossa vps` subcommands. ([#286](https://github.com/fossas/spectrometer/pull/286))
 
 ## v2.10.2
 
-- Fixes an issue where some `fossa` commands (including `fossa test`) would exit non-zero on success ([#278](https://github.com/fossas/spectrometer/pull/278)).
+- Fixes an issue where some `fossa` commands (including `fossa test`) would exit non-zero on success. ([#278](https://github.com/fossas/spectrometer/pull/278)).
 
 ## v2.10.1
 
-- Fixes an issue where `fossa container analyze` returned 0 exit code on failure ([#275](https://github.com/fossas/spectrometer/pull/275))
+- Fixes an issue where `fossa container analyze` exited zero on failure. ([#275](https://github.com/fossas/spectrometer/pull/275))
 
 ## v2.10.0
 
-- Adds support for short flags to mirror CLI v1 commands ([#264](https://github.com/fossas/spectrometer/pull/264))
-- Added a `remote-dependencies` section in the `fossa-deps` file to support archives at remote locations ([#260](https://github.com/fossas/spectrometer/pull/260))
-- Modify the payload for `custom-dependencies` to include optional fields in a new `metadata` section ([#260](https://github.com/fossas/spectrometer/pull/260))
+- Adds support for short flags. ([#264](https://github.com/fossas/spectrometer/pull/264))
+- Adds a `remote-dependencies` section in the `fossa-deps` file to support archives at specific URLs. ([#260](https://github.com/fossas/spectrometer/pull/260))
+- Renames some fields for `custom-dependencies` to avoid confusion. ([#260](https://github.com/fossas/spectrometer/pull/260))
 
 ## v2.9.2
 
-- Adds JSON-formatted project information to the output of `fossa analyze` with `--json` ([#255](https://github.com/fossas/spectrometer/pull/255))
+- Adds JSON-formatted project information to the output of `fossa analyze` with `--json`. ([#255](https://github.com/fossas/spectrometer/pull/255))
 
 ## v2.9.1
 
-- Bump wiggins - Updated vps aosp-notice-file subcommand to upload ninja files & trigger async task. ([#272](https://github.com/fossas/spectrometer/pull/272))
+- VPS: Bump wiggins - Updated `vps aosp-notice-file` subcommand to upload ninja files & trigger async task. ([#272](https://github.com/fossas/spectrometer/pull/272))
 
 ## v2.9.0
 
-- Fix an issue where stdout doesn't always flush to the console ([#265](https://github.com/fossas/spectrometer/pull/265))
-- Fix an issue when referenced-dependencies are not being uploaded ([#262](https://github.com/fossas/spectrometer/pull/262))
-- Adds support for `fossa-deps.json` ([#261](https://github.com/fossas/spectrometer/pull/261))
-- Adds support for `vendored-dependencies` to be licensed scanned ([#257](https://github.com/fossas/spectrometer/pull/257))
+- Fixes an issue where stdout doesn't always flush to the console. ([#265](https://github.com/fossas/spectrometer/pull/265))
+- Fixes an issue when referenced-dependencies are not being uploaded. ([#262](https://github.com/fossas/spectrometer/pull/262))
+- Adds support for `fossa-deps.json`. ([#261](https://github.com/fossas/spectrometer/pull/261))
+- Adds support for `vendored-dependencies` to be licensed scanned. ([#257](https://github.com/fossas/spectrometer/pull/257))
 
 ## v2.8.0
 
-- Adds support for `--branch` flag on `fossa container analyze` command ([#253](https://github.com/fossas/spectrometer/pull/253))
-- Adds support and documentation for user-defined dependencies ([#245](https://github.com/fossas/spectrometer/pull/245))
-- Allows using `.yml` or `.yaml` extensions for `fossa-deps` file, but not both ([#245](https://github.com/fossas/spectrometer/pull/245))
-- `fossa-deps` file is checked before running discovery/analysis, and is no longer run in parallel with other analysis functions ([#245](https://github.com/fossas/spectrometer/pull/245))
+- Adds support for `--branch` flag on `fossa container analyze` command. ([#253](https://github.com/fossas/spectrometer/pull/253))
+- Adds support and documentation for user-defined dependencies. ([#245](https://github.com/fossas/spectrometer/pull/245))
+- Allows using `.yml` or `.yaml` extensions for `fossa-deps` file, but not both. ([#245](https://github.com/fossas/spectrometer/pull/245))
+- `fossa analyze` now checks `fossa-deps` before running analysis (instead of checking in parallel with other analyses). ([#245](https://github.com/fossas/spectrometer/pull/245))
 
 ## v2.7.2
 
-- Updates the VSI Plugin.
-- Adds support for VSI powered dependency discovery as a strategy.
+- VSI: Updates the VSI Plugin.
+- VSI: Adds support for VSI powered dependency discovery as a strategy.
 
 ## v2.7.1
 
-- Adds support for Yarn v2 lockfiles ([#244](https://github.com/fossas/spectrometer/pull/244))
-- Fixes the dependency version parser for `.csproj`, `.vbproj`, and similar .NET files ([#247](https://github.com/fossas/spectrometer/pull/247))
-- Re-enables status messages for commands like `fossa test` in CI environments ([#248](https://github.com/fossas/spectrometer/pull/248))
+- Re-enables status messages for commands like `fossa test` in non-ANSI environments. ([#248](https://github.com/fossas/spectrometer/pull/248))
+- Yarn: Adds support for Yarn v2 lockfiles. ([#244](https://github.com/fossas/spectrometer/pull/244))
+- NuGet: Fixes the dependency version parser for `.csproj`, `.vbproj`, and similar .NET files. ([#247](https://github.com/fossas/spectrometer/pull/247))
 
 ## v2.7.0
 
-- Adds support for the Conda package manager ([#226](https://github.com/fossas/spectrometer/pull/226))
+- Conda: Adds support for the Conda package manager. ([#226](https://github.com/fossas/spectrometer/pull/226))
 
 ## v2.6.1
 
-- Adds --follow to the vps analyze subcommand, which allows for following symbolic links during VPS scans. ([#243](https://github.com/fossas/spectrometer/pull/243))
+- VPS: Adds `--follow` to the `vps analyze` subcommand, which allows for following symbolic links during VPS scans. ([#243](https://github.com/fossas/spectrometer/pull/243))
 
 ## v2.6.0
 
-- Improves the output of `fossa analyze` by displaying the status of ongoing Project Discovery and Project Analysis tasks ([#239](https://github.com/fossas/spectrometer/pull/239))
+- Display the progress of `fossa analyze` while running. ([#239](https://github.com/fossas/spectrometer/pull/239))
 
 ## v2.5.18
 
-- Fixes issue where transitive dependencies could be missing in npm projects ([#240](https://github.com/fossas/spectrometer/pull/240))
+- NPM: Fixes issue where transitive dependencies could be missing in NPM projects. ([#240](https://github.com/fossas/spectrometer/pull/240))
 
 ## v2.5.17
 
-- Fix `fossa container analyze` `--project` and `--revision` flags ([#238](https://github.com/fossas/spectrometer/pull/238))
+- Containers: Fixes an issue where `--project` and `--revision` were not correctly handled in `fossa container analyze`. ([#238](https://github.com/fossas/spectrometer/pull/238))
 
 ## v2.5.16
 
-- Support for manually specified dependencies through `fossa-deps.yaml` ([#236](https://github.com/fossas/spectrometer/pull/236))
+- Adds support for `fossa-deps.yml`. ([#236](https://github.com/fossas/spectrometer/pull/236))
 
 ## v2.5.15
 
-- Requirements.txt: fix hang when parsing unsupported fields ([#235](https://github.com/fossas/spectrometer/pull/235))
+- Python: Fixes an issue where parsing unsupported fields in `requirements.txt` could prevent Python analyses from terminating. ([#235](https://github.com/fossas/spectrometer/pull/235))
 
 ## v2.5.14
 
-- Golang: map package imports to modules ([#234](https://github.com/fossas/spectrometer/pull/234))
+- Go: Upload module identifiers instead of package identifiers to the backend. ([#234](https://github.com/fossas/spectrometer/pull/234))
 
 ## v2.5.13
 
-Update VPS plugin to 2021-04-27-312bbe8 ([#233](https://github.com/fossas/spectrometer/pull/233))
-
-- Improve performance of scanning projects
-- Reduce memory pressure when scanning large projects
+- VPS: Update VPS plugin to `2021-04-27-312bbe8`. ([#233](https://github.com/fossas/spectrometer/pull/233))
+  - Improve performance of scanning projects
+  - Reduce memory pressure when scanning large projects
 
 ## v2.5.12
 
-Update VPS plugin to 2021-04-19-9162a26 ([#231](https://github.com/fossas/spectrometer/pull/231))
+- VPS: Update VPS plugin to `2021-04-19-9162a26`. ([#231](https://github.com/fossas/spectrometer/pull/231))
 
 ## v2.5.11
 
-- Update container scanning version ([#230](https://github.com/fossas/spectrometer/pull/230))
-- Change container scanning layer scope ([#228](https://github.com/fossas/spectrometer/pull/228))
-- Initial configuration file ([#220](https://github.com/fossas/spectrometer/pull/220))
-- Glide.lock: Parse versions as Text ([#221](https://github.com/fossas/spectrometer/pull/221))
-- Add container layers and artifact locations ([#225](https://github.com/fossas/spectrometer/pull/225))
-- Tiny hlint/ormolu fixes ([#224](https://github.com/fossas/spectrometer/pull/224))
+- Allow flags to be set via configuration file. ([#220](https://github.com/fossas/spectrometer/pull/220))
+- Containers: add support for layers. ([#228](https://github.com/fossas/spectrometer/pull/228))
 
 ## v2.5.10
 
-- Freeze dependencies to allow reproducible builds ([#222](https://github.com/fossas/spectrometer/pull/222))
-- Add documentation for replay logging ([#212](https://github.com/fossas/spectrometer/pull/212))
-- Only activate replay/record mode using --replay/--record (previously it was turned on in --debug mode) ([#212](https://github.com/fossas/spectrometer/pull/212))
-- Fixed a bug where container scanning failed when ignored artifacts aren't in the right shape ([#223](https://github.com/fossas/spectrometer/pull/223))
+- Only activate replay/record mode using `--replay`/`--record` (previously it was turned on in `--debug` mode). ([#212](https://github.com/fossas/spectrometer/pull/212))
+- Containers: Fixed a bug where container scanning failed when ignored artifacts aren't in the right shape. ([#223](https://github.com/fossas/spectrometer/pull/223))
 
 ## v2.5.9
 
-- Update the VPS scanning plugin:
+- VPS: Update the VPS scanning plugin:
   - Resolve issues reading IPR files with null byte content.
   - Workaround recursive variable declarations when parsing Android.mk files.
 
 ## v2.5.8
 
-- Support makefiles in `fossa vps aosp-notice-file` ([#216](https://github.com/fossas/spectrometer/pull/216))
-- Require paths to ninja files as arguments in `fossa vps aosp-notice-file` ([#217](https://github.com/fossas/spectrometer/pull/217))
+- VPS: Support makefiles in `fossa vps aosp-notice-file`. ([#216](https://github.com/fossas/spectrometer/pull/216))
+- VPS: Require paths to ninja files as arguments in `fossa vps aosp-notice-file`. ([#217](https://github.com/fossas/spectrometer/pull/217))
 
 ## v2.5.7
 
-- Print project URL after `fossa vps analyze` ([#215](https://github.com/fossas/spectrometer/pull/215))
+- VPS: Print project URL after `fossa vps analyze`. ([#215](https://github.com/fossas/spectrometer/pull/215))
 
 ## v2.5.6
 
-- Fixes an issue that could cause gradle project analysis to hang forever ([#211](https://github.com/fossas/spectrometer/pull/211))
+- Gradle: Fixes an issue that sometimes prevented Gradle project analyses from terminating. ([#211](https://github.com/fossas/spectrometer/pull/211))
 
 ## v2.5.5
 
-- Fixes an issue where Composer lockfiles could cause a crash when parsing ([#207](https://github.com/fossas/spectrometer/pull/207))
+- PHP: Fixes an issue where Composer lockfiles could cause a crash when parsing. ([#207](https://github.com/fossas/spectrometer/pull/207))
 
 ## v2.5.4
 
-- Fix an issue that could prevent scala analysis from terminating ([#206](https://github.com/fossas/spectrometer/pull/187))
+- Scala: Fixes an issue that sometimes prevented Scala analyses from terminating. ([#206](https://github.com/fossas/spectrometer/pull/187))
 
 ## v2.5.0
 
-- Add container analysis toolchain
+- Containers: Add container analysis toolchain. ([#173](https://github.com/fossas/spectrometer/pull/173))
 
 ## v2.4.11
 
-- Fixes for a couple of issues that caused analysis failures during upload ([#187](https://github.com/fossas/spectrometer/pull/187)/[#188](https://github.com/fossas/spectrometer/pull/188))
+- Fixes several issues that caused analysis failures during upload. ([#187](https://github.com/fossas/spectrometer/pull/187), [#188](https://github.com/fossas/spectrometer/pull/188))
 
 ## v2.4.9
 
-- Fix a bug with `requirements.txt` parsing line extensions ([#183](https://github.com/fossas/spectrometer/pull/183))
-- Fix a bug where we didn't read the cached fossa revision for projects without VCS ([#182](https://github.com/fossas/spectrometer/pull/182))
-- Fix a bug with project URL output when no branch is supplied in instances where VCS does not exist ([#181](https://github.com/fossas/spectrometer/pull/181))
+- Python: Fixes an issue with `requirements.txt` parsing line extensions. ([#183](https://github.com/fossas/spectrometer/pull/183))
+- Fixes an issue where we didn't read the cached revision when picking a revision for `fossa test` in projects without VCS. ([#182](https://github.com/fossas/spectrometer/pull/182))
+- Fixes an issue where invalid project URLs would be printed for projects without VCS when `--branch` was not specified. ([#181](https://github.com/fossas/spectrometer/pull/181))
 
 ## v2.4.8
 
-- Introduce a new hidden `fossa compatibility` command which runs fossa v1 `fossa analyze` and allows users to access the archive uploader([#179](https://github.com/fossas/spectrometer/pull/179))
+- Introduce a new hidden `fossa compatibility` command which runs fossa v1 `fossa analyze` and allows users to access the archive uploader. ([#179](https://github.com/fossas/spectrometer/pull/179))
 
 ## v2.4.7
 
-- Fixes an issue where `fossa test` would always succeed for push-only API keys ([#170](https://github.com/fossas/spectrometer/pull/170))
-- Fixes an issue with glide.lock parser ([#175](https://github.com/fossas/spectrometer/pull/175))
-- Fixes an issue where subdirectories were erroneously ignored ([#174](https://github.com/fossas/spectrometer/pull/174))
-- Fixes an issue where dependency graphs would be filtered out if they had no direct dependencies ([#172](https://github.com/fossas/spectrometer/pull/172))
-- Adds multi-module project support to gomodules static analysis ([#171](https://github.com/fossas/spectrometer/pull/171))
+- Fixes an issue where `fossa test` would always exit zero for push-only API keys. ([#170](https://github.com/fossas/spectrometer/pull/170))
+- Fixes an issue where dependency graphs would be filtered out if they had no direct dependencies (e.g. in strategies like Yarn where direct dependencies are unknown). ([#172](https://github.com/fossas/spectrometer/pull/172))
+- Go: Fixes an issue with `glide.lock` parser. ([#175](https://github.com/fossas/spectrometer/pull/175))
+- Go: Adds multi-module project support to `go.mod` static analysis. ([#171](https://github.com/fossas/spectrometer/pull/171))
+- NPM, Yarn: Fixes an issue where subdirectories were erroneously ignored. ([#174](https://github.com/fossas/spectrometer/pull/174))
 
 ## v2.4.6
 
-- Update Wiggins CLI plugin to version `2020-12-11-5d581ea`
+- VPS: Update Wiggins CLI plugin to version `2020-12-11-5d581ea`
 
 ## v2.4.5
 
-- Update `fossa vps analyze` to use a new VPS project scanning engine:
+- VPS: Update `fossa vps analyze` to use a new VPS project scanning engine:
   - Improve scan performance
   - Support "License Only" scans, where the project is scanned for licenses but is not inspected for vendored dependencies.
 
 ## v2.4.4
 
-- Improves maven pom `${property}` interpolation ([#158](https://github.com/fossas/spectrometer/pull/158))
+- Maven: Add limited support for POM `${property}` interpolation. ([#158](https://github.com/fossas/spectrometer/pull/158))
 
 ## v2.4.3
 
-- Adds `--version` flag ([#157](https://github.com/fossas/spectrometer/pull/157))
+- Adds `--version` flag. ([#157](https://github.com/fossas/spectrometer/pull/157))
 
 ## v2.4
 
-- Integrates `vpscli scan` as `fossa vps analyze` ([#148](https://github.com/fossas/spectrometer/pull/148))
-- Removes `vpscli` binary ([#148](https://github.com/fossas/spectrometer/pull/148))
-- Adds support for `--team` and other metadata flags to vps analysis ([#149](https://github.com/fossas/spectrometer/pull/149))
-- Adds `fossa vps test` command, analogous to `fossa test` for vps projects ([#150](https://github.com/fossas/spectrometer/pull/150))
-- Adds `fossa vps report` command, analogous to `fossa report` for vps projects ([#150](https://github.com/fossas/spectrometer/pull/150))
-- Adds support for unpacking of gzipped RPMs ([#154](https://github.com/fossas/spectrometer/pull/154))
+- RPM: Adds support for unpacking of gzipped RPMs. ([#154](https://github.com/fossas/spectrometer/pull/154))
+- VPS: Integrates `vpscli scan` as `fossa vps analyze`. ([#148](https://github.com/fossas/spectrometer/pull/148))
+- VPS: Removes `vpscli` binary. ([#148](https://github.com/fossas/spectrometer/pull/148))
+- VPS: Adds support for `--team` and other metadata flags to VPS analysis. ([#149](https://github.com/fossas/spectrometer/pull/149))
+- VPS: Adds `fossa vps test` command, analogous to `fossa test` for VPS projects. ([#150](https://github.com/fossas/spectrometer/pull/150))
+- VPS: Adds `fossa vps report` command, analogous to `fossa report` for VPS projects. ([#150](https://github.com/fossas/spectrometer/pull/150))
 
 ## v2.3.2
 
-- Adds `fossa list-targets` to list "analysis-targets" (projects and subprojects) available for analysis ([#140](https://github.com/fossas/spectrometer/pull/140))
-- Adds `--filter TARGET` option to `fossa analyze` ([#140](https://github.com/fossas/spectrometer/pull/140))
-- Merges the dependencies of `*req*.txt` and `setup.py` files we find ([#140](https://github.com/fossas/spectrometer/pull/140))
-- Improves maven project discovery ([#140](https://github.com/fossas/spectrometer/pull/140))
-- Fixes gradle wrapper integration ([#140](https://github.com/fossas/spectrometer/pull/140))
-- Adds support for "detached HEAD" state in git and svn ([#141](https://github.com/fossas/spectrometer/pull/141))
+- Adds `fossa list-targets` to list "analysis targets" (projects and subprojects) available for analysis. ([#140](https://github.com/fossas/spectrometer/pull/140))
+- Adds `--filter TARGET` option to `fossa analyze`. ([#140](https://github.com/fossas/spectrometer/pull/140))
+- Adds support for "detached HEAD" state in `git` and `svn`. ([#141](https://github.com/fossas/spectrometer/pull/141))
+- Python: Dependencies found via `*req*.txt` and `setup.py` are now merged. ([#140](https://github.com/fossas/spectrometer/pull/140))
+- Maven: Natively support multi-POM Maven projects. ([#140](https://github.com/fossas/spectrometer/pull/140))
+- Gradle: Fixes an issue where subprojects were not handled correctly. ([#140](https://github.com/fossas/spectrometer/pull/140))
 
 ## v2.3.1
 
-- RPM: Merge spec file results in the analyzer. ([#138](https://github.com/fossas/spectrometer/pull/138))
-- Erlang: Resolve rebar3 aliased packages to their true names. ([#139](https://github.com/fossas/spectrometer/pull/139))
-- Gradle: Accept and tag all build configuration names. ([#134](https://github.com/fossas/spectrometer/pull/134))
+- RPM: Dependencies from multiple `*.spec` files in the same directory are now merged. ([#138](https://github.com/fossas/spectrometer/pull/138))
+- Erlang: Aliased packages in `rebar3` are now resolved to their true names. ([#139](https://github.com/fossas/spectrometer/pull/139))
+- Gradle: Support all build configurations (instead of a hard-coded list of known configuration names). ([#134](https://github.com/fossas/spectrometer/pull/134))
 
 ## v2.3.0
 
-- Adds a user guide
-- Fixes bug where the rebar3 strategy would incorrectly find dependencies as top-level projects ([#119](https://github.com/fossas/spectrometer/pull/119))
-- Fixes various issues in the setup.py parser ([#119](https://github.com/fossas/spectrometer/pull/119))
-- Adds an analyzer for haskell projects using cabal-install ([#122](https://github.com/fossas/spectrometer/pull/122))
-- Adds an analyzer for PHP projects via composer ([#121](https://github.com/fossas/spectrometer/pull/121))
+- Erlang: Fixes an issue where the `rebar3` strategy would incorrectly identify dependencies as top-level projects. ([#119](https://github.com/fossas/spectrometer/pull/119))
+- Python: Fixes various issues in the `setup.py` parser. ([#119](https://github.com/fossas/spectrometer/pull/119))
+- Haskell: Adds support for Haskell projects using `cabal-install`. ([#122](https://github.com/fossas/spectrometer/pull/122))
+- PHP: Adds support for PHP projects using `composer`. ([#121](https://github.com/fossas/spectrometer/pull/121))
 
 ## v2.2.4
 
-- Adds analyzer for scala via `sbt` ([#54](https://github.com/fossas/spectrometer/pull/54))
+- Scala: Adds support for Scala projects using `sbt`. ([#54](https://github.com/fossas/spectrometer/pull/54))
 
 ## v2.2.1
 
-- Fixes bug where the req.txt strategy would run even when no relevant files were present ([#109](https://github.com/fossas/spectrometer/pull/109))
+- Python: Fixes an issue where the `req.txt` strategy would run even when no relevant files were present. ([#109](https://github.com/fossas/spectrometer/pull/109))
 
 ## v2.2.0
 
-- Fixes `fossa test` and project links for git projects with `https` remotes ([#92](https://github.com/fossas/spectrometer/pull/92))
-
-- Fixes strategy failures related to command-not-found errors ([#106](https://github.com/fossas/spectrometer/pull/106))
-
-- Merges the dependencies of `*req*.txt` files we find ([#102](https://github.com/fossas/spectrometer/pull/102))
-
-- Re-enables deep dependency gathering for golang projects ([#98](https://github.com/fossas/spectrometer/pull/98))
-
-- Fixes directory skipping (e.g., `node_modules`) ([#100](https://github.com/fossas/spectrometer/pull/100))
-
-- Adds CLI-side support for contributor counting ([#94](https://github.com/fossas/spectrometer/pull/94))
-
-- Enables paket.lock strategy ([#107](https://github.com/fossas/spectrometer/pull/107))
-
-- Improves parallelism of strategy discovery ([#93](https://github.com/fossas/spectrometer/pull/93))
+- Improves contributor counting accuracy using repository metadata. ([#94](https://github.com/fossas/spectrometer/pull/94))
+- Improves parallelism of strategy discovery. ([#93](https://github.com/fossas/spectrometer/pull/93))
+- Fixes an issue where URLs printed by `fossa test` and other commands were incorrect for `git` projects with `https` remotes. ([#92](https://github.com/fossas/spectrometer/pull/92))
+- Fixes an issue where `IOException`s (like "command not found") would cause strategies to crash. ([#106](https://github.com/fossas/spectrometer/pull/106))
+- Fixes an issue where with effect typechecking. ([#100](https://github.com/fossas/spectrometer/pull/100))
+- Python: Dependencies of multiple `*req*.txt` files in a single project are now merged. ([#102](https://github.com/fossas/spectrometer/pull/102))
+- Go: Re-enables deep dependency reporting (which was previously disabled for development purposes). ([#98](https://github.com/fossas/spectrometer/pull/98))
+- NuGet: Adds support for analyzing `paket.lock` files. ([#107](https://github.com/fossas/spectrometer/pull/107))


### PR DESCRIPTION
This PR normalizes the style conventions of the changelog:

1. Where reasonable, prefer sentences that read sensibly when the version is the first word of the sentence. For example, in a release for v1.2.3, you might write "Adds support for foo.", which would be read as "v1.2.3 adds support for foo.".
2. Only include changes that are user-visible. Users don't care about refactors, tech debt, style changes, etc.
3. Write entries as if they are being read by users, which usually means avoiding internal names and concepts. Users don't know what "analysis target configuration" is, but they do understand "we now support picking which subset of folders in CWD to analyze".
4. Some entries are "scoped" e.g. for languages or cross-team projects (e.g. containers, VPS).
5. The syntax for individual entries is is `- $SCOPE:? $DESCRIPTION_AS_A_SENTENCE. ($PR)`.

(Hmm, should I add these into `CONTRIBUTING.md`?)