### PR TITLE
Use new `shrink` function to filter sourceunit dependencies

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Spectrometer Changelog
 
+## v2.14.4
+
+- Gradle: Fixes an issue where all dependencies would appear as direct ([#319](https://github.com/fossas/spectrometer/pull/319))
+
 ## v2.14.3
 
 - Monorepo: archive expansion now respects `--exclude-path` and `--only-path`. ([#320](https://github.com/fossas/spectrometer/pull/320))

--- a/src/Algebra/Graph/AdjacencyMap/Extra.hs
+++ b/src/Algebra/Graph/AdjacencyMap/Extra.hs
@@ -1,5 +1,7 @@
 module Algebra.Graph.AdjacencyMap.Extra (
   gtraverse,
+  shrink,
+  shrinkSingle,
 ) where
 
 import Algebra.Graph.AdjacencyMap qualified as AM
@@ -17,3 +19,27 @@ gtraverse f = fmap mkAdjacencyMap . traverse (\(a, xs) -> (,) <$> f a <*> traver
   where
     mkAdjacencyMap :: Ord c => [(c, [c])] -> AM.AdjacencyMap c
     mkAdjacencyMap = AM.fromAdjacencySets . fmap (fmap Set.fromList)
+
+-- | Filter vertices in an AdjacencyMap, preserving the overall structure by rewiring edges through deleted vertices.
+--
+-- For example, given the graph @1 -> 2 -> 3 -> 4@ and applying @filterRewire (/= 3)@, we return the graph
+-- @1 -> 2 -> 4@
+shrink :: Ord a => (a -> Bool) -> AM.AdjacencyMap a -> AM.AdjacencyMap a
+shrink f gr = foldr shrinkSingle gr filteredOutVertices
+  where
+    filteredOutVertices = filter (not . f) (AM.vertexList gr)
+
+-- | Delete a vertex in an AdjacencyMap, preserving the overall structure by rewiring edges through the delted vertex.
+--
+-- For example, given the graph @1 -> 2 -> 3 -> 4@ and applying @deleteRewire 3@, we return the graph
+-- @1 -> 2 -> 4@
+shrinkSingle :: forall a. Ord a => a -> AM.AdjacencyMap a -> AM.AdjacencyMap a
+shrinkSingle vert gr = AM.overlay (AM.removeVertex vert gr) inducedEdges
+  where
+    inducedEdges :: AM.AdjacencyMap a
+    inducedEdges =
+      AM.edges
+        [ (pre, post)
+        | pre <- Set.toList (AM.preSet vert gr)
+        , post <- Set.toList (AM.postSet vert gr)
+        ]

--- a/src/Algebra/Graph/AdjacencyMap/Extra.hs
+++ b/src/Algebra/Graph/AdjacencyMap/Extra.hs
@@ -22,7 +22,7 @@ gtraverse f = fmap mkAdjacencyMap . traverse (\(a, xs) -> (,) <$> f a <*> traver
 
 -- | Filter vertices in an AdjacencyMap, preserving the overall structure by rewiring edges through deleted vertices.
 --
--- For example, given the graph @1 -> 2 -> 3 -> 4@ and applying @filterRewire (/= 3)@, we return the graph
+-- For example, given the graph @1 -> 2 -> 3 -> 4@ and applying @shrink (/= 3)@, we return the graph
 -- @1 -> 2 -> 4@
 shrink :: Ord a => (a -> Bool) -> AM.AdjacencyMap a -> AM.AdjacencyMap a
 shrink f gr = foldr shrinkSingle gr filteredOutVertices
@@ -31,7 +31,7 @@ shrink f gr = foldr shrinkSingle gr filteredOutVertices
 
 -- | Delete a vertex in an AdjacencyMap, preserving the overall structure by rewiring edges through the delted vertex.
 --
--- For example, given the graph @1 -> 2 -> 3 -> 4@ and applying @deleteRewire 3@, we return the graph
+-- For example, given the graph @1 -> 2 -> 3 -> 4@ and applying @shrinkSingle 3@, we return the graph
 -- @1 -> 2 -> 4@
 shrinkSingle :: forall a. Ord a => a -> AM.AdjacencyMap a -> AM.AdjacencyMap a
 shrinkSingle vert gr = AM.overlay (AM.removeVertex vert gr) inducedEdges

--- a/src/App/Fossa/Analyze/GraphMangler.hs
+++ b/src/App/Fossa/Analyze/GraphMangler.hs
@@ -14,12 +14,13 @@ import Data.Set qualified as Set
 import App.Fossa.Analyze.Graph qualified as G
 import App.Fossa.Analyze.GraphBuilder
 import DepTypes
-import Graphing (Graphing (..))
+import Graphing (Graphing)
+import Graphing qualified
 
 graphingToGraph :: Graphing Dependency -> G.Graph
 graphingToGraph graphing = run . evalGraphBuilder G.empty $ do
-  let depAmap = graphingAdjacent graphing
-      depDirect = Set.toList (graphingDirect graphing)
+  let depAmap = Graphing.toAdjacencyMap graphing
+      depDirect = Graphing.directList graphing
 
       nodes = dfs depDirect depAmap
 

--- a/src/App/Fossa/Analyze/Project.hs
+++ b/src/App/Fossa/Analyze/Project.hs
@@ -3,7 +3,6 @@ module App.Fossa.Analyze.Project (
   mkResult,
 ) where
 
-import Data.Set qualified as Set
 import Data.Text (Text)
 import DepTypes
 import Graphing (Graphing)
@@ -22,7 +21,7 @@ mkResult project graphResults =
         -- their dependencies would be filtered out. The real fix to this is to
         -- have a separate designation for "reachable" vs "direct" on nodes in a
         -- Graphing, where direct deps are inherently reachable.
-        if Set.null (Graphing.graphingDirect graph)
+        if null (Graphing.directList graph)
           then graph
           else Graphing.pruneUnreachable graph
     , projectResultGraphBreadth = graphBreadth

--- a/src/Graphing.hs
+++ b/src/Graphing.hs
@@ -63,7 +63,7 @@ import Prelude qualified
 -- automatically deduplicated using the 'Ord' instance of @ty@.
 --
 -- Typically, when consuming a Graphing, we only care about nodes in the graph
--- reachable from 'graphingDirect'
+-- reachable from 'directList'
 newtype Graphing ty = Graphing {unGraphing :: AdjacencyMap (Node ty)}
   deriving (Eq, Ord, Show)
 

--- a/src/Graphing.hs
+++ b/src/Graphing.hs
@@ -14,7 +14,7 @@
 module Graphing (
   -- * Graphing type
   Graphing (..),
-  Node(..),
+  Node (..),
   empty,
   size,
   direct,
@@ -52,10 +52,10 @@ import Algebra.Graph.AdjacencyMap (AdjacencyMap)
 import Algebra.Graph.AdjacencyMap qualified as AM
 import Algebra.Graph.AdjacencyMap.Algorithm qualified as AMA
 import Algebra.Graph.AdjacencyMap.Extra qualified as AME
-import Data.Set qualified as Set
 import Data.Bifunctor (bimap)
+import Data.Set qualified as Set
 import Prelude hiding (filter)
-import qualified Prelude
+import Prelude qualified
 
 -- | A @Graphing ty@ is a graph of nodes with type @ty@.
 --
@@ -197,7 +197,7 @@ edge :: Ord ty => ty -> ty -> Graphing ty
 edge parent child = Graphing (AM.edge (Node parent) (Node child))
 
 -- | Build a Graphing containing several edges
-edges :: Ord ty => [(ty,ty)] -> Graphing ty
+edges :: Ord ty => [(ty, ty)] -> Graphing ty
 edges = Graphing . AM.edges . map (bimap Node Node)
 
 -- | Add a single deep node to the graphing
@@ -207,7 +207,6 @@ deep = Graphing . AM.vertex . Node
 -- | Add several deep nodes to the graphing.
 deeps :: Ord ty => [ty] -> Graphing ty
 deeps = Graphing . AM.vertices . map Node
-
 
 -- | @unfold direct getDeps toDependency@ unfolds a graph, given:
 --

--- a/src/Graphing.hs
+++ b/src/Graphing.hs
@@ -1,24 +1,42 @@
--- | A graph augmented with a set of "direct" vertices
+-- | A graph (Algebra.Graph.AdjacencyMap) augmented with the notion of "direct" vertices.
 --
--- Graphings can be built with the 'direct' and 'edge' primitives.
+-- Graphings can be built with the 'direct', 'edge', 'deep', 'directs', ... primitives.
 --
 -- For simple (non-cyclic) graphs, try 'unfold'. For graphs with only direct dependencies, try 'fromList'
+--
+-- Most commonly, Graphings are built by combining sub-graphs with (<>), e.g.,
+--
+-- @
+--     myCoolGraph = directs myListOfDirectNodes <> edges myListOfEdges
+-- @
 --
 -- For describing complex graphs, see the 'Effect.Grapher' effect.
 module Graphing (
   -- * Graphing type
   Graphing (..),
+  Node(..),
   empty,
   size,
   direct,
+  directs,
   edge,
+  edges,
   deep,
+  deeps,
+
+  -- * Accessing graph elements
+  directList,
+  vertexList,
+  toAdjacencyMap,
 
   -- * Manipulating a Graphing
   gmap,
   gtraverse,
+  induce,
   induceJust,
-  Graphing.filter,
+  filter,
+  shrink,
+  shrinkSingle,
   pruneUnreachable,
   stripRoot,
   promoteToDirect,
@@ -34,10 +52,10 @@ import Algebra.Graph.AdjacencyMap (AdjacencyMap)
 import Algebra.Graph.AdjacencyMap qualified as AM
 import Algebra.Graph.AdjacencyMap.Algorithm qualified as AMA
 import Algebra.Graph.AdjacencyMap.Extra qualified as AME
-import Data.List qualified as List
-import Data.Maybe (catMaybes)
-import Data.Set (Set)
 import Data.Set qualified as Set
+import Data.Bifunctor (bimap)
+import Prelude hiding (filter)
+import qualified Prelude
 
 -- | A @Graphing ty@ is a graph of nodes with type @ty@.
 --
@@ -46,99 +64,150 @@ import Data.Set qualified as Set
 --
 -- Typically, when consuming a Graphing, we only care about nodes in the graph
 -- reachable from 'graphingDirect'
-data Graphing ty = Graphing
-  { graphingDirect :: Set ty
-  , graphingAdjacent :: AdjacencyMap ty
-  }
+newtype Graphing ty = Graphing {unGraphing :: AdjacencyMap (Node ty)}
   deriving (Eq, Ord, Show)
 
+data Node a = Root | Node a
+  deriving (Eq, Ord, Show)
+
+instance Functor Node where
+  fmap _ Root = Root
+  fmap f (Node a) = Node (f a)
+
+instance Foldable Node where
+  foldMap _ Root = mempty
+  foldMap f (Node a) = f a
+
+instance Traversable Node where
+  traverse _ Root = pure Root
+  traverse f (Node a) = Node <$> f a
+
 instance Ord ty => Semigroup (Graphing ty) where
-  graphing <> graphing' =
-    Graphing
-      (graphingDirect graphing `Set.union` graphingDirect graphing')
-      (graphingAdjacent graphing `AM.overlay` graphingAdjacent graphing')
+  Graphing graphing <> Graphing graphing' = Graphing (AM.overlay graphing graphing')
 
 instance Ord ty => Monoid (Graphing ty) where
-  mempty = Graphing Set.empty AM.empty
+  mempty = Graphing AM.empty
 
 -- | Transform a Graphing by applying a function to each of its vertices.
 --
 -- Graphing isn't a lawful 'Functor', so we don't provide an instance.
 gmap :: (Ord ty, Ord ty') => (ty -> ty') -> Graphing ty -> Graphing ty'
-gmap f gr = gr{graphingDirect = direct', graphingAdjacent = adjacent'}
-  where
-    direct' = Set.map f (graphingDirect gr)
-    adjacent' = AM.gmap f (graphingAdjacent gr)
+gmap f = Graphing . AM.gmap (fmap f) . unGraphing
 
 -- | Map each element of the Graphing to an action, evaluate the actions, and
 -- collect the results.
 --
 -- Graphing isn't a lawful 'Traversable', so we don't provide an instance.
 gtraverse :: (Ord b, Applicative f) => (a -> f b) -> Graphing a -> f (Graphing b)
-gtraverse f Graphing{graphingDirect, graphingAdjacent} = Graphing <$> newSet <*> newAdjacent
-  where
-    -- newSet :: f (Set b)
-    newSet = fmap Set.fromList . traverse f . Set.toList $ graphingDirect
+gtraverse f = fmap Graphing . AME.gtraverse (traverse f) . unGraphing
 
-    -- newAdjacent :: f (AM.AdjacencyMap b)
-    newAdjacent = AME.gtraverse f graphingAdjacent
+-- | Filter Graphing elements. Alias for 'filter' to match the AdjacencyMap naming
+induce :: (ty -> Bool) -> Graphing ty -> Graphing ty
+induce = filter
 
 -- | Like 'AM.induceJust', but for Graphings
 induceJust :: Ord a => Graphing (Maybe a) -> Graphing a
-induceJust gr = gr{graphingDirect = direct', graphingAdjacent = adjacent'}
-  where
-    direct' = Set.fromList . catMaybes . Set.toList $ graphingDirect gr
-    adjacent' = AM.induceJust (graphingAdjacent gr)
+induceJust = Graphing . AM.induceJust . AM.gmap sequenceA . unGraphing
 
 -- | Filter Graphing elements
-filter :: (ty -> Bool) -> Graphing ty -> Graphing ty
-filter f gr = gr{graphingDirect = direct', graphingAdjacent = adjacent'}
+filter :: forall ty. (ty -> Bool) -> Graphing ty -> Graphing ty
+filter f = Graphing . AM.induce f' . unGraphing
   where
-    direct' = Set.filter f (graphingDirect gr)
-    adjacent' = AM.induce f (graphingAdjacent gr)
+    f' :: Node ty -> Bool
+    f' Root = True
+    f' (Node a) = f a
+
+-- | Filter vertices in a Graphing, preserving the overall structure by rewiring edges through deleted vertices.
+--
+-- For example, given the graph @1 -> 2 -> 3 -> 4@ and applying @shrink (/= 3)@, we return the graph
+-- @1 -> 2 -> 4@
+shrink :: forall a. Ord a => (a -> Bool) -> Graphing a -> Graphing a
+shrink f = Graphing . AME.shrink f' . unGraphing
+  where
+    f' :: Node a -> Bool
+    f' Root = True
+    f' (Node a) = f a
+
+-- | Delete a vertex in a Grahing, preserving the overall structure by rewiring edges through the delted vertex.
+--
+-- For example, given the graph @1 -> 2 -> 3 -> 4@ and applying @shrinkSingle 3@, we return the graph
+-- @1 -> 2 -> 4@
+shrinkSingle :: Ord a => a -> Graphing a -> Graphing a
+shrinkSingle vert = Graphing . AME.shrinkSingle (Node vert) . unGraphing
 
 -- | The empty Graphing
 empty :: Graphing ty
-empty = Graphing Set.empty AM.empty
+empty = Graphing AM.empty
 
 -- | Determines the number of nodes in the graph ("reachable" or not)
 size :: Graphing ty -> Int
-size = AM.vertexCount . graphingAdjacent
+size = length . Set.filter ignoreRoot . AM.vertexSet . unGraphing
+  where
+    ignoreRoot :: Node a -> Bool
+    ignoreRoot Root = False
+    ignoreRoot _ = True
 
 -- | Strip all items from the direct set, promote their immediate children to direct items
-stripRoot :: Ord ty => Graphing ty -> Graphing ty
-stripRoot gr = gr{graphingDirect = direct'}
+stripRoot :: forall ty. Ord ty => Graphing ty -> Graphing ty
+stripRoot (Graphing gr) = Graphing $ AM.overlay newDirectEdges (AM.removeVertex Root gr)
   where
-    roots = Set.toList $ graphingDirect gr
-    edgeSet root = AM.postSet root $ graphingAdjacent gr
-    direct' = Set.unions $ map edgeSet roots
+    currentDirect :: [Node ty]
+    currentDirect = Set.toList $ AM.postSet Root gr
 
--- | Add a direct dependency to this Graphing
-direct :: Ord ty => ty -> Graphing ty -> Graphing ty
-direct dep gr = gr{graphingDirect = direct', graphingAdjacent = adjacent'}
-  where
-    direct' = Set.insert dep (graphingDirect gr)
-    adjacent' = AM.overlay (AM.vertex dep) (graphingAdjacent gr)
+    newDirect :: [Node ty]
+    newDirect = Set.toList . Set.unions $ map (`AM.postSet` gr) currentDirect
+
+    newDirectEdges :: AM.AdjacencyMap (Node ty)
+    newDirectEdges = AM.edges $ map (Root,) newDirect
+
+-- | Add a direct node to this Graphing
+direct :: Ord ty => ty -> Graphing ty
+direct node = Graphing (AM.edge Root (Node node))
+
+-- | Add several direct nodes to this Graphing
+directs :: Ord ty => [ty] -> Graphing ty
+directs nodes = Graphing (AM.edges [(Root, Node node) | node <- nodes])
 
 -- | Mark dependencies that pass a predicate as direct dependencies.
 -- Dependencies that are already marked as "direct" are unaffected.
-promoteToDirect :: Ord ty => (ty -> Bool) -> Graphing ty -> Graphing ty
-promoteToDirect f gr = gr{graphingDirect = direct'}
+promoteToDirect :: forall ty. Ord ty => (ty -> Bool) -> Graphing ty -> Graphing ty
+promoteToDirect f gr = gr <> directs matchingVertices
   where
-    direct' = foldr Set.insert (graphingDirect gr) vertices
-    vertices = List.filter f $ AM.vertexList (graphingAdjacent gr)
+    matchingVertices :: [ty]
+    matchingVertices = Prelude.filter f (vertexList gr)
 
--- | Add an edge between two nodes in this Graphing
-edge :: Ord ty => ty -> ty -> Graphing ty -> Graphing ty
-edge parent child gr = gr{graphingAdjacent = adjacent'}
-  where
-    adjacent' = AM.overlay (AM.edge parent child) (graphingAdjacent gr)
+-- | Get a list of direct vertices in the Graphing
+directList :: Ord ty => Graphing ty -> [ty]
+directList (Graphing gr) = [node | Node node <- Set.toList (AM.postSet Root gr)]
 
--- | Adds a node to this graph as a deep dependency.
-deep :: Ord ty => ty -> Graphing ty -> Graphing ty
-deep dep gr = gr{graphingAdjacent = adjacent'}
+-- | Get a list of vertices in the Graphing
+vertexList :: Graphing ty -> [ty]
+vertexList gr = [node | Node node <- AM.vertexList (unGraphing gr)]
+
+-- | Convert to the underlying AdjacencyMap (without the Root element)
+toAdjacencyMap :: Ord ty => Graphing ty -> AM.AdjacencyMap ty
+toAdjacencyMap = AM.induceJust . AM.gmap convert . unGraphing
   where
-    adjacent' = AM.overlay (AM.vertex dep) (graphingAdjacent gr)
+    convert :: Node ty -> Maybe ty
+    convert Root = Nothing
+    convert (Node a) = Just a
+
+-- | Build a Graphing containing a single edge between two nodes
+edge :: Ord ty => ty -> ty -> Graphing ty
+edge parent child = Graphing (AM.edge (Node parent) (Node child))
+
+-- | Build a Graphing containing several edges
+edges :: Ord ty => [(ty,ty)] -> Graphing ty
+edges = Graphing . AM.edges . map (bimap Node Node)
+
+-- | Add a single deep node to the graphing
+deep :: ty -> Graphing ty
+deep = Graphing . AM.vertex . Node
+
+-- | Add several deep nodes to the graphing.
+deeps :: Ord ty => [ty] -> Graphing ty
+deeps = Graphing . AM.vertices . map Node
+
 
 -- | @unfold direct getDeps toDependency@ unfolds a graph, given:
 --
@@ -150,12 +219,14 @@ deep dep gr = gr{graphingAdjacent = adjacent'}
 --
 -- __Unfold does not work for recursive inputs__
 unfold :: forall dep res. Ord res => [dep] -> (dep -> [dep]) -> (dep -> res) -> Graphing res
-unfold seed getDeps toDependency =
-  Graphing
-    { graphingDirect = Set.fromList (map toDependency seed)
-    , graphingAdjacent = AM.vertices (map toDependency seed) `AM.overlay` AM.edges [(toDependency parentDep, toDependency childDep) | (parentDep, childDep) <- edgesFrom seed]
-    }
+unfold seed getDeps toDependency = directs directNodes <> edges builtEdges
   where
+    directNodes :: [res]
+    directNodes = map toDependency seed
+
+    builtEdges :: [(res, res)]
+    builtEdges = map (bimap toDependency toDependency) (edgesFrom seed)
+
     edgesFrom :: [dep] -> [(dep, dep)]
     edgesFrom nodes = do
       node <- nodes
@@ -165,20 +236,34 @@ unfold seed getDeps toDependency =
 -- | Remove unreachable vertices from the graph
 --
 -- A vertex is reachable if there's a path from the "direct" vertices to that vertex
-pruneUnreachable :: Ord ty => Graphing ty -> Graphing ty
-pruneUnreachable gr = gr{graphingAdjacent = AM.induce (`Set.member` reachable) (graphingAdjacent gr)}
+pruneUnreachable :: forall ty. Ord ty => Graphing ty -> Graphing ty
+pruneUnreachable (Graphing gr) = Graphing (AM.induce keepPredicate gr)
   where
-    reachable = Set.fromList $ AMA.dfs (Set.toList (graphingDirect gr)) (graphingAdjacent gr)
+    directNodes :: [Node ty]
+    directNodes = Set.toList $ AM.postSet Root gr
+
+    reachableNodes :: Set.Set (Node ty)
+    reachableNodes = Set.fromList $ AMA.dfs directNodes gr
+
+    keepPredicate :: Node ty -> Bool
+    keepPredicate Root = True
+    keepPredicate (Node ty) = Set.member (Node ty) reachableNodes
 
 -- | Build a graphing from a list, where all list elements are treated as direct
 -- dependencies
+--
+-- Alias for 'directs'
 fromList :: Ord ty => [ty] -> Graphing ty
-fromList nodes = Graphing (Set.fromList nodes) (AM.vertices nodes)
+fromList = directs
 
 -- | Wrap an AdjacencyMap as a Graphing
-fromAdjacencyMap :: AM.AdjacencyMap ty -> Graphing ty
-fromAdjacencyMap = Graphing Set.empty
+--
+-- All nodes in the resulting Graphing are considered indirect/"deep"
+fromAdjacencyMap :: Ord ty => AM.AdjacencyMap ty -> Graphing ty
+fromAdjacencyMap = Graphing . AM.gmap Node
 
 -- | Get the list of nodes in the Graphing.
+--
+-- Alias for 'vertexList'
 toList :: Graphing ty -> [ty]
-toList Graphing{graphingAdjacent} = AM.vertexList graphingAdjacent
+toList = vertexList

--- a/src/Srclib/Converter.hs
+++ b/src/Srclib/Converter.hs
@@ -40,7 +40,7 @@ toSourceUnit ProjectResult{..} =
     renderedPath = toText (toFilePath projectResultPath)
 
     filteredGraph :: Graphing Dependency
-    filteredGraph = Graphing.filter (\d -> shouldPublishDep d && isSupportedType d) projectResultGraph
+    filteredGraph = Graphing.shrink (\d -> shouldPublishDep d && isSupportedType d) projectResultGraph
 
     locatorGraph :: Graphing Locator
     locatorGraph = Graphing.gmap toLocator filteredGraph

--- a/src/Srclib/Converter.hs
+++ b/src/Srclib/Converter.hs
@@ -46,13 +46,13 @@ toSourceUnit ProjectResult{..} =
     locatorGraph = Graphing.gmap toLocator filteredGraph
 
     locatorAdjacent :: AM.AdjacencyMap Locator
-    locatorAdjacent = Graphing.graphingAdjacent locatorGraph
+    locatorAdjacent = Graphing.toAdjacencyMap locatorGraph
 
     deps :: [SourceUnitDependency]
     deps = map (mkSourceUnitDependency locatorAdjacent) (AM.vertexList locatorAdjacent)
 
     imports :: [Locator]
-    imports = Set.toList $ Graphing.graphingDirect locatorGraph
+    imports = Graphing.directList locatorGraph
 
 mkSourceUnitDependency :: AM.AdjacencyMap Locator -> Locator -> SourceUnitDependency
 mkSourceUnitDependency gr locator =

--- a/test/Go/GoListSpec.hs
+++ b/test/Go/GoListSpec.hs
@@ -15,7 +15,8 @@ import Data.Map.Strict qualified as Map
 import DepTypes
 import Effect.Exec
 import Effect.Grapher
-import Graphing (Graphing (..))
+import Graphing (Graphing)
+import Graphing qualified
 import Path.IO (getCurrentDir)
 import Strategy.Go.GoList
 import Test.Hspec
@@ -80,4 +81,4 @@ spec = do
 
       case result of
         Left err -> fail $ "failed to build graph" <> show (renderFailureBundle err)
-        Right (graph, _) -> length (graphingDirect graph) `shouldBe` 12
+        Right (graph, _) -> length (Graphing.directList graph) `shouldBe` 12

--- a/test/GraphUtil.hs
+++ b/test/GraphUtil.hs
@@ -6,9 +6,9 @@ module GraphUtil (
 ) where
 
 import Algebra.Graph.AdjacencyMap qualified as AM
-import Algebra.Graph.ToGraph (vertexSet)
-import Data.Foldable (toList, traverse_)
-import Graphing (Graphing (..))
+import Data.Foldable (traverse_)
+import Graphing (Graphing)
+import Graphing qualified
 import Test.Hspec (
   Expectation,
   shouldBe,
@@ -21,20 +21,20 @@ import Test.Hspec (
 
 -- | Expect the given dependencies to be the deps in the graph
 expectDeps :: (Ord a, Show a) => [a] -> Graphing a -> Expectation
-expectDeps deps graph = toList (vertexSet (graphingAdjacent graph)) `shouldMatchList` deps
+expectDeps deps graph = Graphing.vertexList graph `shouldMatchList` deps
 
 -- | Expects the given `a` to exist in the `Graphing`
 expectDep :: (Ord a, Show a) => a -> Graphing a -> Expectation
-expectDep dep graph = toList (vertexSet (graphingAdjacent graph)) `shouldContain` [dep]
+expectDep dep graph = Graphing.vertexList graph `shouldContain` [dep]
 
 -- TODO: I expect the shouldSatisfy will produce poor test failure messages
 
 -- | Expect only the given edges between @[(parent,child)]@ dependencies to be present in the graph
 expectEdges :: (Ord a, Show a) => [(a, a)] -> Graphing a -> Expectation
 expectEdges edges graph =
-  (length edges `shouldBe` AM.edgeCount (graphingAdjacent graph))
-    *> traverse_ (`shouldSatisfy` \(from, to) -> AM.hasEdge from to (graphingAdjacent graph)) edges
+  (length edges `shouldBe` AM.edgeCount (Graphing.toAdjacencyMap graph))
+    *> traverse_ (`shouldSatisfy` \(from, to) -> AM.hasEdge from to (Graphing.toAdjacencyMap graph)) edges
 
 -- | Expect the given dependencies to be the direct deps in the graph
-expectDirect :: (Eq a, Show a) => [a] -> Graphing a -> Expectation
-expectDirect expected graph = toList (graphingDirect graph) `shouldMatchList` expected
+expectDirect :: (Ord a, Show a) => [a] -> Graphing a -> Expectation
+expectDirect expected graph = Graphing.directList graph `shouldMatchList` expected

--- a/test/GraphingSpec.hs
+++ b/test/GraphingSpec.hs
@@ -6,7 +6,6 @@ import GraphUtil
 import Graphing
 import Test.Hspec
 import Prelude
-import Debug.Trace
 
 spec :: Spec
 spec = do
@@ -23,7 +22,6 @@ spec = do
     it "should add deep node to graphing" $ do
       let graph :: Graphing Int
           graph = Graphing.deep 5 <> Graphing.edge 2 3
-      traceM (show graph)
       expectDirect [] graph
       expectDeps [5, 2, 3] graph
       expectEdges [(2, 3)] graph
@@ -44,14 +42,14 @@ spec = do
       --
       -- 1 -> 3 -> 4 with 1 and 3 as direct
       let graph :: Graphing Int
-          graph = Graphing.directs [1,2] <> Graphing.edges (zip [1..3] [2..4])
+          graph = Graphing.directs [1, 2] <> Graphing.edges (zip [1 .. 3] [2 .. 4])
 
           graph' :: Graphing Int
           graph' = Graphing.shrinkSingle 2 graph
 
-      expectDirect [1,3] graph'
-      expectDeps [1,3,4] graph'
-      expectEdges [(1,3),(3,4)] graph'
+      expectDirect [1, 3] graph'
+      expectDeps [1, 3, 4] graph'
+      expectEdges [(1, 3), (3, 4)] graph'
 
     it "should preserve multiple outgoing edges" $ do
       -- 1 -> 2 -> 3 --> 4
@@ -62,23 +60,23 @@ spec = do
       -- 1 -> 2 --> 4
       --        \-> 5
       let graph :: Graphing Int
-          graph = Graphing.edges [(1,2), (2,3), (3,4), (3,5)]
+          graph = Graphing.edges [(1, 2), (2, 3), (3, 4), (3, 5)]
 
           graph' :: Graphing Int
           graph' = Graphing.shrinkSingle 3 graph
 
       expectDirect [] graph'
-      expectDeps [1,2,4,5] graph'
-      expectEdges [(1,2),(2,4), (2,5)] graph'
+      expectDeps [1, 2, 4, 5] graph'
+      expectEdges [(1, 2), (2, 4), (2, 5)] graph'
 
   describe "shrink" $ do
     it "should collapse edges through several nodes" $ do
       let graph :: Graphing Int
-          graph = Graphing.edges (zip [1..4] [2..5])
+          graph = Graphing.edges (zip [1 .. 4] [2 .. 5])
 
           graph' :: Graphing Int
           graph' = Graphing.shrink (\x -> x /= 2 && x /= 3) graph
 
       expectDirect [] graph'
-      expectDeps [1,4,5] graph'
-      expectEdges [(1,4),(4,5)] graph'
+      expectDeps [1, 4, 5] graph'
+      expectEdges [(1, 4), (4, 5)] graph'

--- a/test/GraphingSpec.hs
+++ b/test/GraphingSpec.hs
@@ -6,6 +6,7 @@ import GraphUtil
 import Graphing
 import Test.Hspec
 import Prelude
+import Debug.Trace
 
 spec :: Spec
 spec = do
@@ -21,7 +22,8 @@ spec = do
   describe "deep" $ do
     it "should add deep node to graphing" $ do
       let graph :: Graphing Int
-          graph = Graphing.deep 5 $ Graphing.edge 2 3 (Graphing.empty)
+          graph = Graphing.deep 5 <> Graphing.edge 2 3
+      traceM (show graph)
       expectDirect [] graph
       expectDeps [5, 2, 3] graph
       expectEdges [(2, 3)] graph

--- a/test/GraphingSpec.hs
+++ b/test/GraphingSpec.hs
@@ -35,3 +35,50 @@ spec = do
       expectDirect [0, 2, 4, 10] graph
       expectDeps [10, 8, 6, 4, 2, 0] graph
       expectEdges [(10, 8), (8, 6), (6, 4), (4, 2), (2, 0)] graph
+
+  describe "shrinkSingle" $ do
+    it "should preserve root node relationships" $ do
+      -- 1 -> 2 -> 3 -> 4 with 1 and 2 as direct
+      --
+      -- -> shrinkSingle 2
+      --
+      -- 1 -> 3 -> 4 with 1 and 3 as direct
+      let graph :: Graphing Int
+          graph = Graphing.directs [1,2] <> Graphing.edges (zip [1..3] [2..4])
+
+          graph' :: Graphing Int
+          graph' = Graphing.shrinkSingle 2 graph
+
+      expectDirect [1,3] graph'
+      expectDeps [1,3,4] graph'
+      expectEdges [(1,3),(3,4)] graph'
+
+    it "should preserve multiple outgoing edges" $ do
+      -- 1 -> 2 -> 3 --> 4
+      --             \-> 5
+      --
+      -- -> shrinkSingle 3
+      --
+      -- 1 -> 2 --> 4
+      --        \-> 5
+      let graph :: Graphing Int
+          graph = Graphing.edges [(1,2), (2,3), (3,4), (3,5)]
+
+          graph' :: Graphing Int
+          graph' = Graphing.shrinkSingle 3 graph
+
+      expectDirect [] graph'
+      expectDeps [1,2,4,5] graph'
+      expectEdges [(1,2),(2,4), (2,5)] graph'
+
+  describe "shrink" $ do
+    it "should collapse edges through several nodes" $ do
+      let graph :: Graphing Int
+          graph = Graphing.edges (zip [1..4] [2..5])
+
+          graph' :: Graphing Int
+          graph' = Graphing.shrink (\x -> x /= 2 && x /= 3) graph
+
+      expectDirect [] graph'
+      expectDeps [1,4,5] graph'
+      expectEdges [(1,4),(4,5)] graph'

--- a/test/Python/PoetrySpec.hs
+++ b/test/Python/PoetrySpec.hs
@@ -4,8 +4,8 @@ module Python.PoetrySpec (
 
 import Data.Map qualified as Map
 import DepTypes (DepEnvironment (..), DepType (..), Dependency (..), VerConstraint (..))
-import Effect.Grapher (addNode, direct, edge, evalGrapher, run)
 import Graphing (Graphing)
+import Graphing qualified
 import Strategy.Python.Poetry (graphFromLockFile, setGraphDirectsFromPyproject)
 import Strategy.Python.Poetry.PoetryLock (
   PackageName (..),
@@ -51,19 +51,18 @@ candidatePoetryLock =
     ]
 
 expectedGraph :: Graphing Dependency
-expectedGraph = run . evalGrapher $ do
-  edge
+expectedGraph =
+  Graphing.edge
     (Dependency PipType "flow_pipes" (Just $ CEq "1.21.0") [] [EnvProduction] Map.empty)
     (Dependency PipType "flow_pipes_gravity" (Just $ CEq "1.1.1") [] [EnvProduction] Map.empty)
-  direct (Dependency PipType "flow_pipes" (Just $ CEq "1.21.0") [] [EnvProduction] Map.empty)
+    <> Graphing.direct (Dependency PipType "flow_pipes" (Just $ CEq "1.21.0") [] [EnvProduction] Map.empty)
 
 expectedGraphWithNoDeps :: Graphing Dependency
-expectedGraphWithNoDeps = run . evalGrapher $ do
-  addNode (Dependency PipType "somePkg" (Just $ CEq "1.21.0") [] [EnvProduction] Map.empty)
+expectedGraphWithNoDeps = Graphing.deep (Dependency PipType "somePkg" (Just $ CEq "1.21.0") [] [EnvProduction] Map.empty)
 
 expectedGraphWithDeps :: Graphing Dependency
-expectedGraphWithDeps = run . evalGrapher $ do
-  edge
+expectedGraphWithDeps =
+  Graphing.edge
     (Dependency PipType "somePkg" (Just $ CEq "1.21.0") [] [EnvProduction] Map.empty)
     (Dependency PipType "pkgOneChildOne" (Just $ CEq "1.22.0") [] [EnvProduction] Map.empty)
 


### PR DESCRIPTION
# Overview

When converting our internal graph representation to a `SourceUnit` we, among other things, [filter out unsupported dependency types](https://github.com/fossas/spectrometer/blob/546826367d9041a5e68e787ef5152014d584ab6c/src/Srclib/Converter.hs#L43)

This is problematic, because some analyzers (looking at you, `Gradle`) produce graphs containing only `SubprojectType` dependencies as direct. When we filter out those dependencies, we're left with a graph without any direct dependencies -- only deep dependencies and edges between them.

`shrink` is a new operation like `filter` that removes vertices, but incoming and outgoing edges from removed vertices are rewritten to preserve the overall graph structure. This means that, e.g., direct deps that are filtered out will have their successors marked as direct after a `shrink`

Unrelatedly, this refactors `Graphing` into its isomorphic representation, `AdjacencyMap (Node a)`, where `data Node a = Root | Node a`. This gains us much more code reuse in general, and reduces the surface area for incorrectly implementing `Graphing` operations. In particular, it was non-trivial to correctly implement `shrink` otherwise. I also refactor the operations of `Graphing` to more-closely mirror those of `AdjacencyMap`

## Acceptance criteria

- SourceUnits generated from Gradle projects contain direct dependencies as appropriate
- `shrink` is semantically sound for multi-node removal, rewiring several incoming/outgoing edges, and rewriting "direct" relationships

## Testing plan

1. Manual testing
  - scan a Gradle project (with at least one dependency) prior to these changes; notice that the resulting `SourceUnit.Build.Imports` array is empty
  - scan a Gradle project (with at least one dependency) after these changes; notice that the resulting `SourceUnit.Build.Imports` array is non-empty
2. Unit tests to validate the properties of `shrink`/`shrinkSingle`

## Risks

`shrink` needs to be semantically sound, because we run it on every SourceUnit we generate in the CLI.

## References

ZD3001 / ZD3006

- [x] I added tests for this PR's change (or confirmed tests are not viable).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] I linked this PR to any referenced GitHub issues, if they exist.
