### PR TITLE
WIP: Adds shard yml strategy for crystal lang

### DIFF
--- a/docs/strategies/crystal/shards.md
+++ b/docs/strategies/crystal/shards.md
@@ -1,0 +1,52 @@
+# Crystal - Shards
+
+Shards is crystal dependency manager, accompanied usual with language. It manages dependencies for crystal projects.
+
+## Project Discovery
+
+Find the first file named `shard.yml`
+
+## Analysis: shard.yml
+
+we parse `shard.yml` file for direct dependencies. When faced with version constraint (e.g. >= 2.3.0), we resolve to latest version matching constraint. 
+
+## Limitations
+
+- Only direct dependencies are reported. 
+- Path dependencies are not supported.
+
+## Example 
+
+1. Create shard.yml file for your project with `shard init`
+2. Update your shard file with relevant dependencies. Example shown below.
+
+```yaml
+name: appname
+version: 1.2.3
+crystal: '>= 0.35.0'
+
+authors:
+- user <user@example.com>
+
+description: |
+  example description
+
+dependencies:
+dependencies:
+  pg:
+    github: will/crystal-pg
+    version: "~> 0.5"
+  pkgC:
+    path: ./../local-path-c/
+
+development_dependencies:
+  webmock:
+    github: manastech/webmock.cr
+
+```
+3. Run `fossa analyze` on root of the project.
+
+## References
+
+- [Shards Code](https://github.com/crystal-lang/shards)
+- [Shard.yml Spec](https://github.com/crystal-lang/shards/blob/master/docs/shard.yml.adoc)

--- a/docs/strategies/crystal/shards.md
+++ b/docs/strategies/crystal/shards.md
@@ -4,7 +4,7 @@ Shards is crystal dependency manager, accompanied usual with language. It manage
 
 ## Project Discovery
 
-Find the first file named `shard.yml`
+Find the file named `shard.yml`
 
 ## Analysis: shard.yml
 

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -240,6 +240,7 @@ library
     Strategy.Dart.PubDeps
     Strategy.Dart.PubSpec
     Strategy.Dart.PubSpecLock
+    Strategy.Crystal.ShardYml
     Strategy.Elixir.MixTree
     Strategy.Erlang.ConfigParser
     Strategy.Erlang.Rebar3Tree
@@ -292,6 +293,7 @@ library
     Strategy.Ruby.BundleShow
     Strategy.Ruby.GemfileLock
     Strategy.Scala
+    Strategy.Shards
     Strategy.Yarn
     Strategy.Yarn.V1.YarnLock
     Strategy.Yarn.V2.Lockfile
@@ -340,6 +342,7 @@ test-suite unit-tests
     Composer.ComposerLockSpec
     Conda.CondaListSpec
     Conda.EnvironmentYmlSpec
+    Crystal.ShardYmlSpec
     Control.Carrier.DiagnosticsSpec
     Dart.PubDepsSpec
     Dart.PubSpecSpec

--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -95,6 +95,7 @@ import Strategy.Python.Setuptools qualified as Setuptools
 import Strategy.RPM qualified as RPM
 import Strategy.Rebar3 qualified as Rebar3
 import Strategy.Scala qualified as Scala
+import Strategy.Shards qualified as Shards
 import Strategy.Yarn qualified as Yarn
 import System.Exit (die)
 import Types (DiscoveredProject (..), FoundTargets)
@@ -202,6 +203,7 @@ discoverFuncs =
   , Rebar3.discover
   , RepoManifest.discover
   , Scala.discover
+  , Shards.discover
   , Setuptools.discover
   , Stack.discover
   , Yarn.discover

--- a/src/Strategy/Crystal/ShardYml.hs
+++ b/src/Strategy/Crystal/ShardYml.hs
@@ -30,7 +30,7 @@ import DepTypes (
 import Effect.ReadFS (Has, ReadFS, readContentsYaml)
 import Graphing (Graphing, fromList)
 import Path
-import Types (GraphBreadth (Partial))
+import Types ( GraphBreadth(Partial), DependencyResults(..) )
 
 newtype PackageName = PackageName {unPackageName :: Text} deriving (Show, Eq, Ord, FromJSONKey)
 
@@ -141,7 +141,12 @@ buildGraph ymlContent = fromList $ prodDeps ++ devDeps
       uncurry (toDependency [EnvDevelopment])
         <$> maybe [] (Map.toList . Map.filter isSupported) (devDependencies ymlContent)
 
-analyzeShardYmlFile :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs File -> m (Graphing Dependency, GraphBreadth)
+analyzeShardYmlFile :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs File -> m DependencyResults
 analyzeShardYmlFile shardFile = do
   shardContent <- context "Reading shard.yml" $ readContentsYaml shardFile
-  context "building graphing from shard.yml only" $ pure (buildGraph shardContent, Partial)
+  context "building graphing from shard.yml only" $ pure DependencyResults
+      { dependencyGraph = buildGraph shardContent
+      , dependencyGraphBreadth = Partial
+      , dependencyManifestFiles = [shardFile]
+      }
+ 

--- a/src/Strategy/Crystal/ShardYml.hs
+++ b/src/Strategy/Crystal/ShardYml.hs
@@ -1,0 +1,143 @@
+module Strategy.Crystal.ShardYml (
+  buildGraph,
+  analyzeShardYmlFile,
+
+  -- * for testing
+  ShardYmlContent (..),
+  ShardYmlDepSource (..),
+  GitSource (..),
+  PackageName (..),
+) where
+
+import Control.Applicative (Alternative ((<|>)))
+import Control.Effect.Diagnostics (Diagnostics, context)
+import Data.Aeson.Types (FromJSONKey)
+import Data.Aeson.Types qualified as AesonTypes
+import Data.Foldable (asum)
+import Data.Map (Map)
+import Data.Map.Strict qualified as Map
+import Data.Maybe (fromMaybe)
+import Data.Text (Text)
+import Data.Yaml (FromJSON (parseJSON), (.:), (.:?))
+import Data.Yaml qualified as Yaml
+import DepTypes (
+  DepEnvironment (EnvDevelopment, EnvProduction),
+  DepType (GitType),
+  Dependency (..),
+  VerConstraint (CEq),
+ )
+import Effect.ReadFS (Has, ReadFS, readContentsYaml)
+import Graphing (Graphing, fromList)
+import Path
+import Types (GraphBreadth (Partial))
+
+newtype PackageName = PackageName {unPackageName :: Text} deriving (Show, Eq, Ord, FromJSONKey)
+
+-- | Represents Shard.yml content
+-- Reference: https://github.com/crystal-lang/shards/blob/master/docs/shard.yml.adoc
+data ShardYmlContent = ShardYmlContent
+  { dependencies :: Maybe (Map PackageName ShardYmlDepSource)
+  , devDependencies :: Maybe (Map PackageName ShardYmlDepSource)
+  }
+  deriving (Show, Eq, Ord)
+
+instance FromJSON PackageName where
+  parseJSON (AesonTypes.String pkg) = pure $ PackageName pkg
+  parseJSON _ = fail "failed to parse package's name"
+
+data GitSource
+  = Github Text
+  | Gitlab Text
+  | BitBucket Text
+  | Git Text
+  deriving (Show, Eq, Ord)
+
+data ShardYmlDepSource
+  = ShardYamlDepGitSource
+      { gitSource :: GitSource
+      , gitBranch :: Maybe Text
+      , gitTag :: Maybe Text
+      , gitCommit :: Maybe Text
+      , version :: Maybe Text
+      }
+  | ShardYamlDepPathSource {hostPath :: Text}
+  deriving (Show, Eq, Ord)
+
+instance FromJSON ShardYmlContent where
+  parseJSON = Yaml.withObject "shard.yml content" $ \o -> do
+    dependencies <- o .:? "dependencies"
+    devDependencies <- o .:? "development_dependencies"
+    pure $ ShardYmlContent dependencies devDependencies
+
+instance FromJSON ShardYmlDepSource where
+  parseJSON (Yaml.Object o) =
+    ( ShardYamlDepGitSource <$> gitSource o
+        <*> o .:? "branch"
+        <*> o .:? "tag"
+        <*> o .:? "commit"
+        <*> o .:? "version"
+    )
+      <|> (ShardYamlDepPathSource <$> o .: "path")
+    where
+      gitSource :: Yaml.Object -> Yaml.Parser GitSource
+      gitSource gitO =
+        asum
+          [ Git <$> gitO .: "git"
+          , Github <$> gitO .: "github"
+          , Gitlab <$> gitO .: "gitlab"
+          , BitBucket <$> gitO .: "bitbucket"
+          ]
+  parseJSON _ = fail "failed parsing shard dependency's source!"
+
+isSupported :: ShardYmlDepSource -> Bool
+isSupported ShardYamlDepGitSource{} = True
+isSupported _ = False
+
+buildGraph :: ShardYmlContent -> Graphing Dependency
+buildGraph ymlContent = fromList $ prodDeps ++ devDeps
+  where
+    toDependency :: [DepEnvironment] -> PackageName -> ShardYmlDepSource -> Dependency
+    toDependency envs pkgName src =
+      Dependency
+        { dependencyType = GitType
+        , dependencyName = fromMaybe (unPackageName pkgName) $ depName src
+        , dependencyVersion = depVersion src
+        , dependencyLocations = []
+        , dependencyEnvironments = envs
+        , dependencyTags = Map.empty
+        }
+
+    depName :: ShardYmlDepSource -> Maybe Text
+    depName src = case src of
+      ShardYamlDepGitSource gitOrigin _ _ _ _ -> case gitOrigin of
+        Github repoPath -> Just $ "https://github.com/" <> repoPath <> ".git"
+        Gitlab repoPath -> Just $ "https://gitlab.com/" <> repoPath <> ".git"
+        BitBucket repoPath -> Just $ "https://bitbucket.com/" <> repoPath <> ".git"
+        Git repoUrl -> Just repoUrl
+      _ -> Nothing
+
+    depVersion :: ShardYmlDepSource -> Maybe VerConstraint
+    depVersion src = case src of
+      ShardYamlDepGitSource _ branch tag commit version ->
+        asum
+          [ CEq <$> version
+          , CEq <$> tag
+          , CEq <$> branch
+          , CEq <$> commit
+          ]
+      _ -> Nothing
+
+    prodDeps :: [Dependency]
+    prodDeps =
+      uncurry (toDependency [EnvProduction])
+        <$> maybe [] (Map.toList . Map.filter isSupported) (dependencies ymlContent)
+
+    devDeps :: [Dependency]
+    devDeps =
+      uncurry (toDependency [EnvDevelopment])
+        <$> maybe [] (Map.toList . Map.filter isSupported) (devDependencies ymlContent)
+
+analyzeShardYmlFile :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs File -> m (Graphing Dependency, GraphBreadth)
+analyzeShardYmlFile shardFile = do
+  shardContent <- context "Reading shard.yml" $ readContentsYaml shardFile
+  context "building graphing from shard.yml only" $ pure (buildGraph shardContent, Partial)

--- a/src/Strategy/Shards.hs
+++ b/src/Strategy/Shards.hs
@@ -16,7 +16,7 @@ import Types (DependencyResults (..), DiscoveredProject (..))
 discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has ReadFS rsig run, Has Exec rsig run, Has Diagnostics rsig run) => Path Abs Dir -> m [DiscoveredProject run]
 discover dir = context "shards" $ do
   projects <- context "Finding projects" $ findProjects dir
-  pure (map mkProject projects)
+  pure $ map mkProject projects
 
 findProjects :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs Dir -> m [ShardProject]
 findProjects = walk' $ \dir _ files -> do

--- a/src/Strategy/Shards.hs
+++ b/src/Strategy/Shards.hs
@@ -9,10 +9,9 @@ import Control.Effect.Diagnostics (Diagnostics, context)
 import Discovery.Walk (WalkStep (WalkContinue, WalkSkipAll), findFileNamed, walk')
 import Effect.Exec (Exec, Has)
 import Effect.ReadFS (ReadFS)
-import Graphing (Graphing)
 import Path
 import Strategy.Crystal.ShardYml (analyzeShardYmlFile)
-import Types (Dependency, DiscoveredProject (..), GraphBreadth)
+import Types (DiscoveredProject (..), DependencyResults (..))
 
 discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has ReadFS rsig run, Has Exec rsig run, Has Diagnostics rsig run) => Path Abs Dir -> m [DiscoveredProject run]
 discover dir = context "shards" $ do
@@ -36,10 +35,10 @@ mkProject project =
   DiscoveredProject
     { projectType = "shard"
     , projectBuildTargets = mempty
-    , projectDependencyGraph = const $ getDeps project
+    , projectDependencyResults = const $ getDeps project
     , projectPath = shardDir project
     , projectLicenses = pure []
     }
 
-getDeps :: (Has Exec sig m, Has ReadFS sig m, Has Diagnostics sig m) => ShardProject -> m (Graphing Dependency, GraphBreadth)
+getDeps :: (Has Exec sig m, Has ReadFS sig m, Has Diagnostics sig m) => ShardProject -> m DependencyResults
 getDeps project = analyzeShardYmlFile $ shardYml project

--- a/src/Strategy/Shards.hs
+++ b/src/Strategy/Shards.hs
@@ -1,0 +1,45 @@
+module Strategy.Shards (
+  discover,
+  findProjects,
+  getDeps,
+  mkProject,
+) where
+
+import Control.Effect.Diagnostics (Diagnostics, context)
+import Discovery.Walk (WalkStep (WalkContinue, WalkSkipAll), findFileNamed, walk')
+import Effect.Exec (Exec, Has)
+import Effect.ReadFS (ReadFS)
+import Graphing (Graphing)
+import Path
+import Strategy.Crystal.ShardYml (analyzeShardYmlFile)
+import Types (Dependency, DiscoveredProject (..), GraphBreadth)
+
+discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has ReadFS rsig run, Has Exec rsig run, Has Diagnostics rsig run) => Path Abs Dir -> m [DiscoveredProject run]
+discover dir = context "shards" $ do
+  projects <- context "Finding projects" $ findProjects dir
+  pure (map mkProject projects)
+
+findProjects :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs Dir -> m [ShardProject]
+findProjects = walk' $ \dir _ files -> do
+  case findFileNamed "shard.yml" files of
+    Nothing -> pure ([], WalkContinue)
+    Just shardYmlFile -> pure ([ShardProject shardYmlFile dir], WalkSkipAll)
+
+data ShardProject = ShardProject
+  { shardYml :: Path Abs File
+  , shardDir :: Path Abs Dir
+  }
+  deriving (Eq, Ord, Show)
+
+mkProject :: (Has Exec sig n, Has ReadFS sig n, Has Diagnostics sig n) => ShardProject -> DiscoveredProject n
+mkProject project =
+  DiscoveredProject
+    { projectType = "shard"
+    , projectBuildTargets = mempty
+    , projectDependencyGraph = const $ getDeps project
+    , projectPath = shardDir project
+    , projectLicenses = pure []
+    }
+
+getDeps :: (Has Exec sig m, Has ReadFS sig m, Has Diagnostics sig m) => ShardProject -> m (Graphing Dependency, GraphBreadth)
+getDeps project = analyzeShardYmlFile $ shardYml project

--- a/src/Strategy/Shards.hs
+++ b/src/Strategy/Shards.hs
@@ -11,7 +11,7 @@ import Effect.Exec (Exec, Has)
 import Effect.ReadFS (ReadFS)
 import Path
 import Strategy.Crystal.ShardYml (analyzeShardYmlFile)
-import Types (DiscoveredProject (..), DependencyResults (..))
+import Types (DependencyResults (..), DiscoveredProject (..))
 
 discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has ReadFS rsig run, Has Exec rsig run, Has Diagnostics rsig run) => Path Abs Dir -> m [DiscoveredProject run]
 discover dir = context "shards" $ do

--- a/test/Crystal/ShardYmlSpec.hs
+++ b/test/Crystal/ShardYmlSpec.hs
@@ -13,6 +13,7 @@ import Strategy.Crystal.ShardYml (
   PackageName (..),
   ShardYmlContent (..),
   ShardYmlDepSource (..),
+  ShardYamlDepGitSource(..),
   buildGraph,
  )
 import Test.Hspec
@@ -30,19 +31,19 @@ bitBucketOrigin :: GitSource
 bitBucketOrigin = BitBucket "bitbucket_username/repo"
 
 gitSourceOnly :: GitSource -> ShardYmlDepSource
-gitSourceOnly git = ShardYamlDepGitSource git Nothing Nothing Nothing Nothing
+gitSourceOnly git = ShardYamlGitSource $ ShardYamlDepGitSource git Nothing Nothing Nothing Nothing
 
 gitSourceWithBranch :: GitSource -> Text -> ShardYmlDepSource
-gitSourceWithBranch git branch = ShardYamlDepGitSource git (Just branch) Nothing Nothing Nothing
+gitSourceWithBranch git branch = ShardYamlGitSource $ ShardYamlDepGitSource git (Just branch) Nothing Nothing Nothing
 
 gitSourceWithCommit :: GitSource -> Text -> ShardYmlDepSource
-gitSourceWithCommit git commit = ShardYamlDepGitSource git Nothing Nothing (Just commit) Nothing
+gitSourceWithCommit git commit = ShardYamlGitSource $  ShardYamlDepGitSource git Nothing Nothing (Just commit) Nothing
 
 gitSourceWithTag :: GitSource -> Text -> ShardYmlDepSource
-gitSourceWithTag git tag = ShardYamlDepGitSource git Nothing (Just tag) Nothing Nothing
+gitSourceWithTag git tag = ShardYamlGitSource $ ShardYamlDepGitSource git Nothing (Just tag) Nothing Nothing
 
 gitSourceWithVersion :: GitSource -> Text -> ShardYmlDepSource
-gitSourceWithVersion git version = ShardYamlDepGitSource git Nothing Nothing Nothing (Just version)
+gitSourceWithVersion git version = ShardYamlGitSource $ ShardYamlDepGitSource git Nothing Nothing Nothing (Just version)
 
 pathSource :: Text -> ShardYmlDepSource
 pathSource = ShardYamlDepPathSource

--- a/test/Crystal/ShardYmlSpec.hs
+++ b/test/Crystal/ShardYmlSpec.hs
@@ -1,0 +1,201 @@
+module Crystal.ShardYmlSpec (
+  spec,
+) where
+
+import Data.ByteString qualified as BS
+import Data.Map.Strict qualified as Map
+import Data.Text (Text)
+import Data.Yaml (decodeEither')
+import DepTypes
+import GraphUtil (expectDeps, expectDirect, expectEdges)
+import Strategy.Crystal.ShardYml (
+  GitSource (..),
+  PackageName (..),
+  ShardYmlContent (..),
+  ShardYmlDepSource (..),
+  buildGraph,
+ )
+import Test.Hspec
+
+gitOrigin :: GitSource
+gitOrigin = Git "https://some.git"
+
+githubOrigin :: GitSource
+githubOrigin = Github "github_username/repo"
+
+gitlabOrigin :: GitSource
+gitlabOrigin = Gitlab "gitlab_username/repo"
+
+bitBucketOrigin :: GitSource
+bitBucketOrigin = BitBucket "bitbucket_username/repo"
+
+gitSourceOnly :: GitSource -> ShardYmlDepSource
+gitSourceOnly git = ShardYamlDepGitSource git Nothing Nothing Nothing Nothing
+
+gitSourceWithBranch :: GitSource -> Text -> ShardYmlDepSource
+gitSourceWithBranch git branch = ShardYamlDepGitSource git (Just branch) Nothing Nothing Nothing
+
+gitSourceWithCommit :: GitSource -> Text -> ShardYmlDepSource
+gitSourceWithCommit git commit = ShardYamlDepGitSource git Nothing Nothing (Just commit) Nothing
+
+gitSourceWithTag :: GitSource -> Text -> ShardYmlDepSource
+gitSourceWithTag git tag = ShardYamlDepGitSource git Nothing (Just tag) Nothing Nothing
+
+gitSourceWithVersion :: GitSource -> Text -> ShardYmlDepSource
+gitSourceWithVersion git version = ShardYamlDepGitSource git Nothing Nothing Nothing (Just version)
+
+pathSource :: Text -> ShardYmlDepSource
+pathSource = ShardYamlDepPathSource
+
+newGitOriginDep :: Maybe VerConstraint -> DepEnvironment -> Dependency
+newGitOriginDep version env =
+  Dependency
+    GitType
+    "https://some.git"
+    version
+    []
+    [env]
+    Map.empty
+
+spec :: Spec
+spec = do
+  specFile <- runIO (BS.readFile "test/Crystal/testdata/shard.yml")
+  describe "parse shard.yml" $
+    it "should parse dependencies" $ do
+      let expectedPubSpecContent =
+            ShardYmlContent
+              { dependencies =
+                  Just $
+                    Map.fromList
+                      [ (PackageName "a", gitSourceWithBranch gitOrigin "develop")
+                      , (PackageName "b", gitSourceWithCommit gitOrigin "005dc")
+                      , (PackageName "c", gitSourceWithTag gitOrigin "someTag")
+                      , (PackageName "d", gitSourceWithVersion gitOrigin "<= 2.3.1")
+                      , (PackageName "e", gitSourceOnly githubOrigin)
+                      , (PackageName "f", gitSourceOnly gitlabOrigin)
+                      , (PackageName "g", gitSourceOnly bitBucketOrigin)
+                      , (PackageName "h", gitSourceOnly gitOrigin)
+                      , (PackageName "i", gitSourceWithBranch githubOrigin "develop")
+                      , (PackageName "j", pathSource "./../local-path")
+                      ]
+              , devDependencies =
+                  Just $
+                    Map.fromList
+                      [ (PackageName "k", pathSource "./../local-path-dev")
+                      , (PackageName "l", gitSourceOnly gitOrigin)
+                      ]
+              }
+      case decodeEither' specFile of
+        Right res -> res `shouldBe` expectedPubSpecContent
+        Left err -> expectationFailure $ "failed to parse: " <> show err
+
+  describe "buildGraph" $ do
+    it "should resolve url for github source" $ do
+      let graph =
+            buildGraph $
+              ShardYmlContent
+                (Just $ Map.fromList [(PackageName "a", gitSourceWithBranch githubOrigin "develop")])
+                Nothing
+
+      let dep =
+            Dependency
+              GitType
+              "https://github.com/github_username/repo.git"
+              (Just $ CEq "develop")
+              []
+              [EnvProduction]
+              Map.empty
+
+      expectDirect [dep] graph
+      expectDeps [dep] graph
+      expectEdges [] graph
+
+    it "should resolve url for gitlab source" $ do
+      let graph =
+            buildGraph $
+              ShardYmlContent
+                (Just $ Map.fromList [(PackageName "a", gitSourceWithBranch gitlabOrigin "release")])
+                Nothing
+
+      let dep =
+            Dependency
+              GitType
+              "https://gitlab.com/gitlab_username/repo.git"
+              (Just $ CEq "release")
+              []
+              [EnvProduction]
+              Map.empty
+
+      expectDirect [dep] graph
+      expectDeps [dep] graph
+      expectEdges [] graph
+
+    it "should resolve url for bitbucket source" $ do
+      let graph =
+            buildGraph $
+              ShardYmlContent
+                (Just $ Map.fromList [(PackageName "a", gitSourceWithBranch bitBucketOrigin "hotfix")])
+                Nothing
+
+      let dep =
+            Dependency
+              GitType
+              "https://bitbucket.com/bitbucket_username/repo.git"
+              (Just $ CEq "hotfix")
+              []
+              [EnvProduction]
+              Map.empty
+
+      expectDirect [dep] graph
+      expectDeps [dep] graph
+      expectEdges [] graph
+
+    it "should not graph path dependency" $ do
+      let graph =
+            buildGraph $
+              ShardYmlContent
+                ( Just $
+                    Map.fromList
+                      [ (PackageName "g_path_a", pathSource "./../local-path")
+                      ]
+                )
+                ( Just $
+                    Map.fromList
+                      [ (PackageName "g_path_b", pathSource "./../local-path")
+                      ]
+                )
+      expectDirect [] graph
+      expectDeps [] graph
+      expectEdges [] graph
+
+    it "should build graph" $ do
+      let graph =
+            buildGraph $
+              ShardYmlContent
+                ( Just $
+                    Map.fromList
+                      [ (PackageName "g_a", gitSourceWithCommit gitOrigin "ccc")
+                      , (PackageName "g_b", gitSourceWithTag gitOrigin "v1.2.3")
+                      , (PackageName "g_c", gitSourceWithVersion gitOrigin ">= 2.3.1")
+                      , (PackageName "g_d", gitSourceOnly gitOrigin)
+                      , (PackageName "g_e", gitSourceWithBranch gitOrigin "hotfix")
+                      ]
+                )
+                ( Just $
+                    Map.fromList
+                      [ (PackageName "g_e", gitSourceWithBranch gitOrigin "automated-workflow")
+                      ]
+                )
+
+      let deps =
+            [ newGitOriginDep (Just $ CEq "ccc") EnvProduction
+            , newGitOriginDep (Just $ CEq "v1.2.3") EnvProduction
+            , newGitOriginDep (Just $ CEq ">= 2.3.1") EnvProduction
+            , newGitOriginDep Nothing EnvProduction
+            , newGitOriginDep (Just $ CEq "hotfix") EnvProduction
+            , newGitOriginDep (Just $ CEq "automated-workflow") EnvDevelopment
+            ]
+
+      expectDirect deps graph
+      expectDeps deps graph
+      expectEdges [] graph

--- a/test/Crystal/ShardYmlSpec.hs
+++ b/test/Crystal/ShardYmlSpec.hs
@@ -11,9 +11,9 @@ import GraphUtil (expectDeps, expectDirect, expectEdges)
 import Strategy.Crystal.ShardYml (
   GitSource (..),
   PackageName (..),
+  ShardYamlDepGitSource (..),
   ShardYmlContent (..),
   ShardYmlDepSource (..),
-  ShardYamlDepGitSource(..),
   buildGraph,
  )
 import Test.Hspec
@@ -37,7 +37,7 @@ gitSourceWithBranch :: GitSource -> Text -> ShardYmlDepSource
 gitSourceWithBranch git branch = ShardYamlGitSource $ ShardYamlDepGitSource git (Just branch) Nothing Nothing Nothing
 
 gitSourceWithCommit :: GitSource -> Text -> ShardYmlDepSource
-gitSourceWithCommit git commit = ShardYamlGitSource $  ShardYamlDepGitSource git Nothing Nothing (Just commit) Nothing
+gitSourceWithCommit git commit = ShardYamlGitSource $ ShardYamlDepGitSource git Nothing Nothing (Just commit) Nothing
 
 gitSourceWithTag :: GitSource -> Text -> ShardYmlDepSource
 gitSourceWithTag git tag = ShardYamlGitSource $ ShardYamlDepGitSource git Nothing (Just tag) Nothing Nothing

--- a/test/Crystal/testdata/shard.yml
+++ b/test/Crystal/testdata/shard.yml
@@ -1,0 +1,49 @@
+name: somename
+version: 1.2.3
+crystal: '>= 0.35.0'
+
+authors:
+- Some User <some@user.org>
+
+description: |
+  Some description
+
+dependencies:
+  a:
+    git: https://some.git
+    branch: develop
+  b:
+    git: https://some.git
+    commit: 005dc
+  c:
+    git: https://some.git
+    tag: someTag
+  d:
+    git: https://some.git
+    version: <= 2.3.1
+  e:
+    github: github_username/repo
+  f:
+    gitlab: gitlab_username/repo
+  g:
+    bitbucket: bitbucket_username/repo
+  h:
+    git: https://some.git
+  i:
+    github: github_username/repo
+    branch: develop
+  j:
+    path: ./../local-path
+
+development_dependencies:
+  k:
+    path: ./../local-path-dev
+  l:
+    git: https://some.git
+
+scripts:
+  postinstall: make ext
+
+targets:
+  shards:
+    main: src/shards.cr


### PR DESCRIPTION
# Overview

Adds support for crystal language's shards package manager. 

Shards package manager only supports two types of dependencies:
- Git dependency
- Path dependency

This PR adds a strategy to parse `shard.yml`, to report direct dependencies. It ignores path dependencies. 

## Acceptance criteria

* Direct dependencies from crystal project can be graphed and reported.
* Path dependencies from `shard.yml` are ignored. 

## Testing plan

* Clone any crystal project
* Run `fossa analyze -o` to get candidate results
* Compare candidate results and content of shard.yml for manual confirmation

I also performed e2e test against production. 

## Risks

N/A

## References

N/A

## Checklist

- [ ] I added tests for this PR's change (or confirmed tests are not viable).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] I linked this PR to any referenced GitHub issues, if they exist.
