### PR TITLE
fix: Pass settings file path as separate exec arg

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,8 +1,12 @@
 # Spectrometer Changelog
 
+## v2.14.5
+
+- Maven: Fixes an issue where projects with `settings.xml` files would not be analyzed correctly using the `dependency:tree` tactic. ([#327](https://github.com/fossas/spectrometer/pull/327))
+
 ## v2.14.4
 
-- Gradle: Fixes an issue where all dependencies would appear as direct ([#319](https://github.com/fossas/spectrometer/pull/319))
+- Gradle: Fixes an issue where all dependencies would appear as direct. ([#319](https://github.com/fossas/spectrometer/pull/319))
 
 ## v2.14.3
 

--- a/src/Strategy/Maven/DepTree.hs
+++ b/src/Strategy/Maven/DepTree.hs
@@ -80,7 +80,7 @@ deptreeCmd settingsFile outputFile =
           -- the failing module.)
           "--fail-at-end"
         ]
-          <> maybe [] (\p -> ["--settings " <> toText (fromAbsFile p)]) settingsFile
+          <> maybe [] (\file -> ["--settings", toText file]) settingsFile
     , -- `mvn dependency:tree` will exit non-zero when the build of any module
       -- in a multi-module build fails. However, this should not cause an Exec
       -- failure, since we can still get partial results.


### PR DESCRIPTION
# Overview

This breaks otherwise since we're exec'ing instead of shelling out.

I'm not sure how best to test this except with integration tests - I'll come back to this once https://github.com/fossas/team-analysis/issues/676 is done.

## Acceptance criteria

Using the Maven `dependency:tree` tactic in a project with a `settings.xml` now works correctly.

## Testing plan

1. Comment out the other tactics in the Maven strategy.
2. Clone `biojava/biojava`.
3. Rename `travis-settings.xml` to `settings.xml`.
4. Run the analyzer, and see that versions are populated correctly.

## References

Resolves ongoing [ZD-2896](https://fossa.zendesk.com/agent/tickets/2896).

## Checklist

- [x] I added tests for this PR's change (or confirmed tests are not viable).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] I linked this PR to any referenced GitHub issues, if they exist.
