### PR TITLE
Display all dependencies in `projects` --output

### DIFF
--- a/src/App/Fossa/Analyze/GraphMangler.hs
+++ b/src/App/Fossa/Analyze/GraphMangler.hs
@@ -4,7 +4,6 @@ module App.Fossa.Analyze.GraphMangler (
 
 import Algebra.Graph.AdjacencyMap (AdjacencyMap)
 import Algebra.Graph.AdjacencyMap qualified as AM
-import Algebra.Graph.ToGraph (dfs)
 import Control.Algebra
 import Data.Foldable (traverse_)
 import Data.Map.Strict (Map)
@@ -22,7 +21,7 @@ graphingToGraph graphing = run . evalGraphBuilder G.empty $ do
   let depAmap = Graphing.toAdjacencyMap graphing
       depDirect = Graphing.directList graphing
 
-      nodes = dfs depDirect depAmap
+      nodes = Graphing.vertexList graphing
 
   refs <- Map.fromList <$> traverse addingNode nodes
 


### PR DESCRIPTION
# Overview

We have two forms of graph output in `--output` mode; `projects`, which contains our special `Graph` type, and `sourceUnits`, which contains the dependency graphs that get uploaded to core during normal analysis.

In an attempt to match the implicit filtering behavior of unreachable dependencies in `SourceUnit`s, `GraphMangler` (the thing that turns `Graphing` into the `projects` `Graph`) only includes dependencies reachable from direct dependencies.

This presents a problem: any graphs without direct dependencies appear as empty in `projects`.

Instead, these changes add the entire `vertexList` to the `Graph`s produced by `GraphMangler`

## Testing plan

- Scan a yarn project in `--output` mode before these changes; notice empty graphs in the `projects` key
- Scan a yarn project in `--output` mode after these changes

## Risks

- This output is used only for debugging purposes. If we have any internal tooling that relies on unreachable dependencies being filtered from `projects` dependency graphs, we'll need to update that tooling