### PR TITLE
fix(maven): Locators should include group ID

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Spectrometer Changelog
 
+## v2.15.2
+
+- Maven: Fixes an issue where dependencies parsed from `dependency:tree` would fail to resolve when uploaded. ([#332](https://github.com/fossas/spectrometer/pull/332))
+
 ## v2.15.1
 
 - Maven: Fixes an issue where dependencies with a platform specifier were not correctly parsed. ([#329](https://github.com/fossas/spectrometer/pull/329))

--- a/src/Strategy/Maven/DepTree.hs
+++ b/src/Strategy/Maven/DepTree.hs
@@ -5,6 +5,7 @@ module Strategy.Maven.DepTree (
   -- * Exported for testing
   DotGraph (..),
   PackageId (..),
+  toDependency,
 ) where
 
 import Control.Algebra (Has, run)
@@ -144,10 +145,10 @@ buildGraph :: [DotGraph] -> Graphing Dependency
 buildGraph = gmap toDependency . foldMap toGraph
 
 toDependency :: PackageId -> Dependency
-toDependency PackageId{artifactName, artifactVersion, buildTag} =
+toDependency PackageId{groupName, artifactName, artifactVersion, buildTag} =
   Dependency
     { dependencyType = MavenType
-    , dependencyName = artifactName
+    , dependencyName = groupName <> ":" <> artifactName
     , dependencyVersion = Just $ CEq artifactVersion
     , dependencyLocations = []
     , dependencyEnvironments = maybe [EnvProduction] ((: []) . toBuildTag) buildTag

--- a/test/Maven/DepTreeSpec.hs
+++ b/test/Maven/DepTreeSpec.hs
@@ -2,8 +2,19 @@ module Maven.DepTreeSpec (spec) where
 
 import Data.Text (Text)
 import Data.Text.IO qualified as TextIO
-import Strategy.Maven.DepTree (DotGraph (..), PackageId (..), parseDotGraphs)
-import Test.Hspec (Spec, describe, it, runIO)
+import DepTypes (
+  DepEnvironment (..),
+  DepType (MavenType),
+  Dependency (..),
+  VerConstraint (..),
+ )
+import Strategy.Maven.DepTree (
+  DotGraph (..),
+  PackageId (..),
+  parseDotGraphs,
+  toDependency,
+ )
+import Test.Hspec (Spec, describe, it, runIO, shouldBe)
 import Test.Hspec.Megaparsec (shouldParse, shouldSucceedOn)
 import Text.Megaparsec (parse)
 
@@ -29,6 +40,27 @@ spec =
     it "parses package IDs with platforms" $
       parse parseDotGraphs "" fixturePackageIDWithPlatformContents
         `shouldParse` fixturePackageIDWithPlatformGraph
+
+    it "renders parsed dependencies" $ do
+      let p =
+            PackageId
+              { groupName = "org.apache.commons"
+              , artifactName = "commons-rng-parent"
+              , artifactType = "pom"
+              , artifactVersion = "1.4-SNAPSHOT"
+              , artifactPlatform = Nothing
+              , buildTag = Nothing
+              }
+      let d =
+            Dependency
+              { dependencyType = MavenType
+              , dependencyName = "org.apache.commons:commons-rng-parent"
+              , dependencyVersion = Just (CEq "1.4-SNAPSHOT")
+              , dependencyLocations = []
+              , dependencyEnvironments = [EnvProduction]
+              , dependencyTags = mempty
+              }
+      toDependency p `shouldBe` d
 
 fixtureSingleFile :: FilePath
 fixtureSingleFile = "test/Maven/testdata/fossa-deptree.dot"


### PR DESCRIPTION
# Overview

Maven dependency locators are of the format `groupID:artifactID`. Today, we incorrectly only upload `artifactID`, which makes the dependencies fail to resolve.

## Acceptance criteria

Maven locators should now be correctly formed.

## Testing plan

Comment out other Maven tactics, then run `fossa analyze --output` on `biojava/biojava` with this fix and see that group IDs are correctly added.

## References

- [ZD-2896](https://fossa.zendesk.com/agent/tickets/2896)

## Checklist

- [x] I added tests for this PR's change (or confirmed tests are not viable).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] I linked this PR to any referenced GitHub issues, if they exist.
