### PR TITLE
Retry API requests that time out

### DIFF
--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -100,6 +100,7 @@ common deps
     , prettyprinter-ansi-terminal  ^>=1.1.1
     , random                       ^>=1.2.0
     , req                          ^>=3.9.1
+    , retry                        ^>=0.9.0.0
     , semver                       ^>=0.4.0.1
     , split                        ^>=0.2.3.4
     , stm                          ^>=2.5.0
@@ -215,6 +216,7 @@ library
     Graphing
     Path.Extra
     Parse.XML
+    Network.HTTP.Req.Extra
     Srclib.Converter
     Srclib.Types
     Strategy.Bundler

--- a/src/App/Fossa/FossaAPIV1.hs
+++ b/src/App/Fossa/FossaAPIV1.hs
@@ -50,6 +50,7 @@ import Fossa.API.Types (ApiOpts, ArchiveComponents, Issues, SignedURL, signedURL
 import Network.HTTP.Client qualified as C
 import Network.HTTP.Client qualified as HTTP
 import Network.HTTP.Req
+import Network.HTTP.Req.Extra (httpConfigRetryTimeouts)
 import Network.HTTP.Types qualified as HTTP
 import Srclib.Types
 import Text.URI (URI)
@@ -63,6 +64,7 @@ instance Has (Lift IO) sig m => MonadIO (FossaReq m) where
   liftIO = sendIO
 
 instance (Has (Lift IO) sig m, Has Diagnostics sig m) => MonadHttp (FossaReq m) where
+  getHttpConfig = pure httpConfigRetryTimeouts
   handleHttpException = FossaReq . fatal . mangleError
 
 newtype FossaReqAllow401 m a = FossaReqAllow401 {unFossaReqAllow401 :: EmptyC m a}
@@ -72,6 +74,7 @@ instance Has (Lift IO) sig m => MonadIO (FossaReqAllow401 m) where
   liftIO = sendIO
 
 instance (Has (Lift IO) sig m, Has Diagnostics sig m) => MonadHttp (FossaReqAllow401 m) where
+  getHttpConfig = pure httpConfigRetryTimeouts
   handleHttpException = FossaReqAllow401 . allow401
     where
       allow401 :: HttpException -> EmptyC m a

--- a/src/App/Fossa/VPS/Types.hs
+++ b/src/App/Fossa/VPS/Types.hs
@@ -26,6 +26,7 @@ import Data.Text.Encoding (decodeUtf8)
 import Data.Text.Prettyprint.Doc (viaShow)
 import Fossa.API.Types (ApiOpts)
 import Network.HTTP.Req
+import Network.HTTP.Req.Extra (httpConfigRetryTimeouts)
 import Path
 
 newtype NinjaScanID = NinjaScanID {unNinjaScanID :: Text}
@@ -107,6 +108,7 @@ instance ToDiagnostic HTTPRequestFailed where
   renderDiagnostic (HTTPRequestFailed exc) = "An HTTP request failed: " <> viaShow exc
 
 instance (Has (Lift IO) sig m, Has Diagnostics sig m) => MonadHttp (HTTP m) where
+  getHttpConfig = pure httpConfigRetryTimeouts
   handleHttpException = HTTP . fatal . HTTPRequestFailed
 
 runHTTP :: HTTP m a -> m a

--- a/src/Network/HTTP/Req/Extra.hs
+++ b/src/Network/HTTP/Req/Extra.hs
@@ -1,0 +1,35 @@
+module Network.HTTP.Req.Extra (
+  httpConfigRetryTimeouts,
+) where
+
+import Control.Exception (SomeException, fromException)
+import Control.Retry (RetryPolicy, constantDelay, limitRetriesByCumulativeDelay)
+import Network.HTTP.Client (HttpException (HttpExceptionRequest), HttpExceptionContent (ResponseTimeout))
+import Network.HTTP.Req (HttpConfig, HttpException (VanillaHttpException), defaultHttpConfig, httpConfigRetryJudgeException, httpConfigRetryPolicy)
+
+-- | An HttpConfig that adds a retry handler for ResponseTimeout
+httpConfigRetryTimeouts :: HttpConfig
+httpConfigRetryTimeouts =
+  defaultHttpConfig
+    { httpConfigRetryJudgeException = const isResponseTimeout
+    , httpConfigRetryPolicy = retryPolicy
+    }
+
+-- | Retry every 5 seconds for up to 5 minutes
+retryPolicy :: RetryPolicy
+retryPolicy = limitRetriesByCumulativeDelay maxDelay (constantDelay retryDelay)
+  where
+    -- five minutes
+    maxDelay :: Int
+    maxDelay = 5 * 60 * 1_000_000
+
+    -- five seconds
+    retryDelay :: Int
+    retryDelay = 5 * 1_000_000
+
+-- | Is the Exception a ResponseTimeout?
+isResponseTimeout :: SomeException -> Bool
+isResponseTimeout exc =
+  case fromException exc of
+    Just (VanillaHttpException (HttpExceptionRequest _ ResponseTimeout)) -> True
+    _ -> False

--- a/src/Network/HTTP/Req/Extra.hs
+++ b/src/Network/HTTP/Req/Extra.hs
@@ -8,6 +8,18 @@ import Network.HTTP.Client (HttpException (HttpExceptionRequest), HttpExceptionC
 import Network.HTTP.Req (HttpConfig, HttpException (VanillaHttpException), defaultHttpConfig, httpConfigRetryJudgeException, httpConfigRetryPolicy)
 
 -- | An HttpConfig that adds a retry handler for ResponseTimeout
+--
+-- ResponseTimeout occurs when the backend is available (the edge server accepts
+-- our connection) but the pod is not responding to our request
+--
+-- Some examples of behavior to expect:
+--
+-- 408 - Request Timeout - Retried
+-- 504 - Gateway Timeout - Retried
+-- 500 - Internal Server Failure - Immediate failure
+-- 502 - Bad Gateway - Immediate failure
+-- 503 - Service Unavailable - Immediate failure
+-- No internet - Immedate failure
 httpConfigRetryTimeouts :: HttpConfig
 httpConfigRetryTimeouts =
   defaultHttpConfig

--- a/src/Network/HTTP/Req/Extra.hs
+++ b/src/Network/HTTP/Req/Extra.hs
@@ -17,15 +17,15 @@ httpConfigRetryTimeouts =
 
 -- | Retry every 5 seconds for up to 5 minutes
 retryPolicy :: RetryPolicy
-retryPolicy = limitRetriesByCumulativeDelay maxDelay (constantDelay retryDelay)
+retryPolicy = limitRetriesByCumulativeDelay fiveMinutes (constantDelay fiveSeconds)
   where
     -- five minutes
-    maxDelay :: Int
-    maxDelay = 5 * 60 * 1_000_000
+    fiveMinutes :: Int
+    fiveMinutes = 5 * 60 * 1_000_000
 
     -- five seconds
-    retryDelay :: Int
-    retryDelay = 5 * 1_000_000
+    fiveSeconds :: Int
+    fiveSeconds = 5 * 1_000_000
 
 -- | Is the Exception a ResponseTimeout?
 isResponseTimeout :: SomeException -> Bool


### PR DESCRIPTION
# Overview

We need to be more resilient to API connectivity issues. This adds a retry policy to http requests when requests fail with `ResponseTimeout`.

## Acceptance criteria

- API requests are retried when the backend is unresponsive, but available. In particular, inability to connect to the backend -- i.e. `ConnectionTimeout` and `ConnectionFailure` -- are not retried. The case we're catching here is "the backend is up, but temporarily unresponsive"

## Testing plan

- Host a dummy server with netcat: `while true; do nc -l 8080; done` -- preinstalled on macos, easily installed on linux (or used in `nix-shell` via `nix-shell -p netcat`
- Before these changes are applied, run `fossa test --fossa-api-key foobar`. Note that it times out after 30 seconds
- After these changes are applied, run `fossa test --fossa-api-key foobar`. Note that it retries several times (visible from `nc` terminal), and eventually times out after 5 minutes

## Risks

N/A

## References

Closes https://github.com/fossas/team-analysis/issues/704