### PR TITLE
Search upwards in a directory for gradlew and gradlew.bat

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Spectrometer Changelog
 
+## Unreleased
+
+- Gradle: Search parent directories for gradlew and gradlew.bat ([#336](https://github.com/fossas/spectrometer/pull/336)) 
+
 ## v2.15.3
 
 - Resolve a scan performance regression for `fossa vps` invocations. ([#335](https://github.com/fossas/spectrometer/pull/335))

--- a/docs/strategies/gradle.md
+++ b/docs/strategies/gradle.md
@@ -11,20 +11,24 @@ Gradle users generally specify their builds using a `build.gradle` file (written
 <!-- omit in toc -->
 ## Table of contents
 
-- [Concepts](#concepts)
-  - [Subprojects and configurations](#subprojects-and-configurations)
-  - [Gradle wrappers](#gradle-wrappers)
-- [Running Gradle](#running-gradle)
-- [Discovery](#discovery)
-- [Tactics](#tactics)
-  - [Tactic selection](#tactic-selection)
-  - [Gradle build plugin](#gradle-build-plugin)
-  - [Parsing `gradle :dependencies`](#parsing-gradle-dependencies)
-- [Debugging an integration](#debugging-an-integration)
-  - [Determining whether Gradle targets are detected](#determining-whether-gradle-targets-are-detected)
-  - [Manually checking Gradle dependency results](#manually-checking-gradle-dependency-results)
-  - [Debugging the "Gradle build plugin" tactic](#debugging-the-gradle-build-plugin-tactic)
-- [Manually specifying Gradle dependencies](#manually-specifying-gradle-dependencies)
+- [Gradle](#gradle)
+  - [Concepts](#concepts)
+    - [Subprojects and configurations](#subprojects-and-configurations)
+      - [Subprojects](#subprojects)
+      - [Configurations](#configurations)
+      - [Relationship to analysis targets](#relationship-to-analysis-targets)
+    - [Gradle wrappers](#gradle-wrappers)
+  - [Running Gradle](#running-gradle)
+  - [Discovery](#discovery)
+  - [Tactics](#tactics)
+    - [Tactic selection](#tactic-selection)
+    - [Gradle build plugin](#gradle-build-plugin)
+    - [Parsing `gradle :dependencies`](#parsing-gradle-dependencies)
+  - [Debugging an integration](#debugging-an-integration)
+    - [Determining whether Gradle targets are detected](#determining-whether-gradle-targets-are-detected)
+    - [Manually checking Gradle dependency results](#manually-checking-gradle-dependency-results)
+    - [Debugging the "Gradle build plugin" tactic](#debugging-the-gradle-build-plugin-tactic)
+  - [Manually specifying Gradle dependencies](#manually-specifying-gradle-dependencies)
 
 ## Concepts
 
@@ -70,9 +74,9 @@ This strategy requires dynamic analysis in its discovery phase (not just in the 
 
 When executing Gradle for an analysis target at directory `ANALYSIS_TARGET_DIR`, the CLI will prefer (in order):
 
-1. `$ANALYSIS_TARGET_DIR/gradlew`
-2. `$ANALYSIS_TARGET_DIR/gradlew.bat`
-3. `gradle` (from `$PATH`)
+1. `gradlew`. Search upwards in the directory `ANALYSIS_TARGET_DIR` for the nearest `gradlew` file.
+1. `gradlew.bat`. Search upwards in the directory `ANALYSIS_TARGET_DIR` for the nearest `gradlew.bat` file.
+1. `gradle` (from `$PATH`)
 
 For more details, see [Gradle wrappers](#gradle-wrappers).
 

--- a/docs/strategies/gradle.md
+++ b/docs/strategies/gradle.md
@@ -74,8 +74,8 @@ This strategy requires dynamic analysis in its discovery phase (not just in the 
 
 When executing Gradle for an analysis target at directory `ANALYSIS_TARGET_DIR`, the CLI will prefer (in order):
 
-1. `gradlew`. Search upwards in the directory `ANALYSIS_TARGET_DIR` for the nearest `gradlew` file.
-1. `gradlew.bat`. Search upwards in the directory `ANALYSIS_TARGET_DIR` for the nearest `gradlew.bat` file.
+1. `gradlew`. First looking in `ANALYSIS_TARGET_DIR` and then recursively searching parent directories until `gradlew` is found.
+1. `gradlew.bat`. First looking in `ANALYSIS_TARGET_DIR` and then recursively searching parent directories until `gradlew.bat` is found.
 1. `gradle` (from `$PATH`)
 
 For more details, see [Gradle wrappers](#gradle-wrappers).

--- a/src/Strategy/Gradle.hs
+++ b/src/Strategy/Gradle.hs
@@ -118,8 +118,8 @@ runGradle dir cmd =
 -- Search upwards in a directory for the existence of the supplied file.
 walkUpDir :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs Dir -> Text -> m (Path Abs File)
 walkUpDir dir filename = do
-  relFile <- case parseRelFile $ Data.String.Conversion.toString filename of
-    Nothing -> fatal $ toText $ "invalid file name: " <> filename
+  relFile <- case parseRelFile $ toString filename of
+    Nothing -> fatal $ "invalid file name: " <> filename
     Just path -> pure path
   let absFile = dir </> relFile
   exists <- doesFileExist absFile
@@ -129,7 +129,7 @@ walkUpDir dir filename = do
       let parentDir = parent dir
       if parentDir /= dir
         then walkUpDir parentDir filename
-        else fatal $ toText $ "invalid file name: " <> filename
+        else fatal $ "invalid file name: " <> filename
 
 -- Search for a `build.gradle`. Each `build.gradle` is its own analysis target.
 --

--- a/src/Strategy/Gradle.hs
+++ b/src/Strategy/Gradle.hs
@@ -46,7 +46,7 @@ import Data.Maybe (fromMaybe, mapMaybe)
 import Data.Set (Set)
 import Data.Set qualified as Set
 import Data.Set.NonEmpty (nonEmpty, toSet)
-import Data.String.Conversion (decodeUtf8, encodeUtf8, toText, toString)
+import Data.String.Conversion (decodeUtf8, encodeUtf8, toString, toText)
 import Data.Text (Text)
 import Data.Text qualified as Text
 import DepTypes (
@@ -109,10 +109,11 @@ discover dir = context "Gradle" $ do
 -- Run a Gradle command in a specific working directory, while correctly trying
 -- Gradle wrappers.
 runGradle :: (Has ReadFS sig m, Has Exec sig m, Has Diagnostics sig m) => Path Abs Dir -> (Text -> Command) -> m BL.ByteString
-runGradle dir cmd = do
-  walkUpDir dir "gradlew" >>= execThrow dir . cmd . toText
-  <||> (walkUpDir dir "gradlew.bat" >>= execThrow dir . cmd . toText)
-  <||> execThrow dir (cmd "gradle")
+runGradle dir cmd =
+  do
+    walkUpDir dir "gradlew" >>= execThrow dir . cmd . toText
+    <||> (walkUpDir dir "gradlew.bat" >>= execThrow dir . cmd . toText)
+    <||> execThrow dir (cmd "gradle")
 
 -- Search upwards in a directory for the existence of the supplied file.
 walkUpDir :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs Dir -> Text -> m (Path Abs File)
@@ -129,7 +130,6 @@ walkUpDir dir filename = do
       if parentDir /= dir
         then walkUpDir parentDir filename
         else fatal $ toText $ "invalid file name: " <> filename
-
 
 -- Search for a `build.gradle`. Each `build.gradle` is its own analysis target.
 --


### PR DESCRIPTION
# Overview

Gradle projects are not guaranteed to have the gradle wrapper binary located in the same directory as the `build.gradle` file we use for discovery. This PR ensures that if the analysis is being run in a directory where gradlew is not present, we will traverse upwards and search for it.

## Acceptance criteria

Directories that contain a `build.gradle` file but have `gradlew` located in a parent directory are properly analyzed.

## Testing plan

- Start with a gradle project that has a working build and has gradle subprojects (this is important for guaranteeing a `build.gradle` not alongside `gradlew`)
- Navigate to the sub projects directory.
- Run `fossa analyze --debug` and verify that the correct gradle script was run.

Concrete example:
- I clone https://github.com/grpc/grpc-java (This has been my example for 2 years so I may be on a weird commit and may have done something crazy to build it).
- Navigate to `grpclib` that has a `build.gradle` file.
- Run `fossa analyze --debug -o` and see the following line which shows gradlew from the parent being run successfully.
```[DEBUG] [TASK 35] Gradle > running gradle script > Running command '/Users/zachlavallee/Programming/BuildTools/gradle/grpc-java/gradlew'```

## Risks

There aren't many risks associated with this PR as traversing upwards is something we do in CLI v1.

## References

Closes https://github.com/fossas/team-analysis/issues/685 which has a lot of reference information as well.

## Checklist

- [x] I added tests for this PR's change (or confirmed tests are not viable).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [X] I linked this PR to any referenced GitHub issues, if they exist.
