### PR TITLE
Parses entry in pod and dependency section correctly when it is enclosed with quotation

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Spectrometer Changelog
 
+## v2.15.6 
+
+- CocoaPods: Fixes `Podfile.lock` parsing. It safely parses when Pod and Dependencies entries are enclosed with quotations. ([#337](https://github.com/fossas/spectrometer/pull/337))
+
 ## v2.15.5
 
 - Fixes an issue where `--json` would output the raw project ID, instead of a normalized ID ([#339](https://github.com/fossas/spectrometer/pull/339))

--- a/docs/strategies/ios/cocoapods.md
+++ b/docs/strategies/ios/cocoapods.md
@@ -20,8 +20,8 @@ We scan the `Podfile.lock` for two particular sections: `PODS` and
 dependencies, and `DEPENDENCIES` tells us which of the dependencies the project
 depends on directly.
 
-In the following example, we have four dependencies, `one`, `two`, `three`, and
-`four`.  `one`, and `three` are direct dependencies, `one` depends on both
+In the following example, we have five dependencies, `one`, `two`, `three`,
+`four` and `five/+zlib`. `one`, `three` and `five/+zlib` are direct dependencies, `one` depends on both
 `two` and `three`, and `three` depends on `four`.
 
 ```
@@ -33,8 +33,10 @@ PODS:
   - three (3.0.0)
     - four (= 2.3.3)
   - four (4.0.0):
+  - "five/+zlib (7.0.0)"
 
 DEPENDENCIES:
   - one (> 4.4)
   - three (from `Submodules/subproject/.podspec`)
+  - "five/+zlib (7.0.0)"
 ```

--- a/test/Cocoapods/PodfileLockSpec.hs
+++ b/test/Cocoapods/PodfileLockSpec.hs
@@ -3,81 +3,143 @@ module Cocoapods.PodfileLockSpec (
 ) where
 
 import Data.Map.Strict qualified as Map
+import Data.Text (Text)
 import Data.Text.IO qualified as TIO
+import Data.Void (Void)
 import DepTypes
 import GraphUtil
 import Strategy.Cocoapods.PodfileLock
 import Test.Hspec qualified as T
-import Text.Megaparsec
+import Test.Hspec.Megaparsec (shouldParse)
+import Text.Megaparsec (Parsec, errorBundlePretty, parse, runParser)
+
+parseMatch :: (Show a, Eq a) => Parsec Void Text a -> Text -> a -> T.Expectation
+parseMatch parser input expected = parse parser "" input `shouldParse` expected
+
+depOf :: Text -> Maybe Text -> Dependency
+depOf name version =
+  Dependency
+    { dependencyType = PodType
+    , dependencyName = name
+    , dependencyVersion = CEq <$> version
+    , dependencyLocations = []
+    , dependencyEnvironments = []
+    , dependencyTags = Map.empty
+    }
 
 dependencyOne :: Dependency
-dependencyOne =
-  Dependency
-    { dependencyType = PodType
-    , dependencyName = "one"
-    , dependencyVersion = Just (CEq "1.0.0")
-    , dependencyLocations = []
-    , dependencyEnvironments = []
-    , dependencyTags = Map.empty
-    }
+dependencyOne = depOf "one" (Just "1.0.0")
 
 dependencyTwo :: Dependency
-dependencyTwo =
-  Dependency
-    { dependencyType = PodType
-    , dependencyName = "two"
-    , dependencyVersion = Just (CEq "2.0.0")
-    , dependencyLocations = []
-    , dependencyEnvironments = []
-    , dependencyTags = Map.empty
-    }
+dependencyTwo = depOf "two" (Just "2.0.0")
 
 dependencyThree :: Dependency
-dependencyThree =
-  Dependency
-    { dependencyType = PodType
-    , dependencyName = "three"
-    , dependencyVersion = Just (CEq "3.0.0")
-    , dependencyLocations = []
-    , dependencyEnvironments = []
-    , dependencyTags = Map.empty
-    }
+dependencyThree = depOf "three" (Just "3.0.0")
 
 dependencyFour :: Dependency
-dependencyFour =
-  Dependency
-    { dependencyType = PodType
-    , dependencyName = "four"
-    , dependencyVersion = Just (CEq "4.0.0")
-    , dependencyLocations = []
-    , dependencyEnvironments = []
-    , dependencyTags = Map.empty
-    }
+dependencyFour = depOf "four" (Just "4.0.0")
+
+dependencyAbnormalName :: Dependency
+dependencyAbnormalName = depOf "ab-normal/+name" (Just "2.0.0")
+
+dependencyNotSoSafeName :: Dependency
+dependencyNotSoSafeName = depOf "not-so-safe-name" (Just "2.0.0")
+
+dependencyGitSourced :: Dependency
+dependencyGitSourced = depOf "some-dep-sourced-from-git" (Just "2.0.0")
+
+dependencyGitTagged :: Dependency
+dependencyGitTagged = depOf "depWithTag" (Just "2.0.0")
+
+dependencyTwoDepA :: Dependency
+dependencyTwoDepA = depOf "two_dep_A" Nothing
+
+dependencyTwoDepB :: Dependency
+dependencyTwoDepB = depOf "two-dep-B" Nothing
 
 podSection :: Section
-podSection = PodSection [Pod "one" "1.0.0" [Dep "two", Dep "three"], Pod "two" "2.0.0" [], Pod "three" "3.0.0" [Dep "four"], Pod "four" "4.0.0" []]
+podSection =
+  PodSection
+    [ Pod "one" "1.0.0" [Dep "two" Nothing, Dep "three" Nothing, Dep "ab-normal/+name" Nothing]
+    , Pod "two" "2.0.0" [Dep "two_dep_A" Nothing, Dep "two-dep-B" Nothing]
+    , Pod "three" "3.0.0" [Dep "four" Nothing]
+    , Pod "ab-normal/+name" "2.0.0" []
+    , Pod "four" "4.0.0" []
+    , Pod "not-so-safe-name" "2.0.0" []
+    , Pod "some-dep-sourced-from-git" "2.0.0" []
+    , Pod "depWithTag" "2.0.0" []
+    ]
 
 dependencySection :: Section
-dependencySection = DependencySection [Dep "one", Dep "three"]
+dependencySection =
+  DependencySection
+    [ Dep "one" Nothing
+    , Dep "three" Nothing
+    , Dep "not-so-safe-name" Nothing
+    , Dep "some-dep-sourced-from-git" (Just $ PodGitSrc "git@github.example.com:ab/ios.git" $ Just "559e6a")
+    , Dep "depWithTag" (Just $ PodGitSrc "git@github.example.com:ab/cap.git" $ Just "v1.2.3")
+    ]
 
 spec :: T.Spec
 spec = do
   T.describe "podfile lock analyzer" $
     T.it "produces the expected output" $ do
       let graph = buildGraph [podSection, dependencySection]
-
-      expectDeps [dependencyOne, dependencyTwo, dependencyThree, dependencyFour] graph
-      expectDirect [dependencyOne, dependencyThree] graph
+      expectDeps
+        [ dependencyOne
+        , dependencyTwo
+        , dependencyThree
+        , dependencyAbnormalName
+        , dependencyFour
+        , dependencyNotSoSafeName
+        , dependencyGitSourced
+        , dependencyGitTagged
+        , dependencyTwoDepA
+        , dependencyTwoDepB
+        ]
+        graph
+      expectDirect
+        [ dependencyOne
+        , dependencyThree
+        , dependencyNotSoSafeName
+        , dependencyGitSourced
+        , dependencyGitTagged
+        ]
+        graph
       expectEdges
-        [ (dependencyOne, dependencyTwo)
+        [ (dependencyOne, dependencyAbnormalName)
+        , (dependencyOne, dependencyTwo)
         , (dependencyOne, dependencyThree)
+        , (dependencyTwo, dependencyTwoDepA)
+        , (dependencyTwo, dependencyTwoDepB)
         , (dependencyThree, dependencyFour)
         ]
         graph
 
   podLockFile <- T.runIO (TIO.readFile "test/Cocoapods/testdata/Podfile.lock")
-  T.describe "podfile lock parser" $
-    T.it "parses error messages into an empty list" $
+  T.describe "podfile lock parser" $ do
+    T.describe "dep parser" $ do
+      let shouldParseInto input = parseMatch depParser input
+      T.it "parses names" $ do
+        "- atomFire (1.0.0)" `shouldParseInto` Dep "atomFire" Nothing
+        "- \"at/+om (1.0.0)\"" `shouldParseInto` Dep "at/+om" Nothing
+        "- \"not-so-safe-name (2.0.0)\"" `shouldParseInto` Dep "not-so-safe-name" Nothing
+
+    T.describe "pod parser" $ do
+      let shouldParseInto input = parseMatch podParser input
+      T.it "parses names" $ do
+        "- atomFire (1.0.0)" `shouldParseInto` Pod "atomFire" "1.0.0" ([])
+        "- \"atomFire (1.0.0)\"" `shouldParseInto` Pod "atomFire" "1.0.0" ([])
+
+    T.describe "pod dependency" $ do
+      let shouldParseInto input = parseMatch depGitSrcParser input
+      T.it "parses git dependency" $ do
+        "from `gitUrl`, commit `c`" `shouldParseInto` PodGitSrc "gitUrl" (Just "c")
+        "from `gitUrl`, tag `t`" `shouldParseInto` PodGitSrc "gitUrl" (Just "t")
+        "from `gitUrl`, branch `b`" `shouldParseInto` PodGitSrc "gitUrl" (Just "b")
+        "from `gitUrl`" `shouldParseInto` PodGitSrc "gitUrl" Nothing
+
+    T.it "parses pod and dependency sections" $
       case runParser findSections "" podLockFile of
         Left err -> T.expectationFailure ("failed to parse: " <> errorBundlePretty err)
         Right result -> do

--- a/test/Cocoapods/PodfileLockSpec.hs
+++ b/test/Cocoapods/PodfileLockSpec.hs
@@ -60,9 +60,9 @@ dependencyTwoDepB = depOf "two-dep-B" Nothing
 podSection :: Section
 podSection =
   PodSection
-    [ Pod "one" "1.0.0" [Dep "two" Nothing, Dep "three" Nothing, Dep "ab-normal/+name" Nothing]
-    , Pod "two" "2.0.0" [Dep "two_dep_A" Nothing, Dep "two-dep-B" Nothing]
-    , Pod "three" "3.0.0" [Dep "four" Nothing]
+    [ Pod "one" "1.0.0" [Dep "two", Dep "three", Dep "ab-normal/+name"]
+    , Pod "two" "2.0.0" [Dep "two_dep_A", Dep "two-dep-B"]
+    , Pod "three" "3.0.0" [Dep "four"]
     , Pod "ab-normal/+name" "2.0.0" []
     , Pod "four" "4.0.0" []
     , Pod "not-so-safe-name" "2.0.0" []
@@ -73,11 +73,11 @@ podSection =
 dependencySection :: Section
 dependencySection =
   DependencySection
-    [ Dep "one" Nothing
-    , Dep "three" Nothing
-    , Dep "not-so-safe-name" Nothing
-    , Dep "some-dep-sourced-from-git" (Just $ PodGitSrc "git@github.example.com:ab/ios.git" $ Just "559e6a")
-    , Dep "depWithTag" (Just $ PodGitSrc "git@github.example.com:ab/cap.git" $ Just "v1.2.3")
+    [ Dep "one"
+    , Dep "three"
+    , Dep "not-so-safe-name"
+    , Dep "some-dep-sourced-from-git"
+    , Dep "depWithTag"
     ]
 
 spec :: T.Spec
@@ -121,23 +121,15 @@ spec = do
     T.describe "dep parser" $ do
       let shouldParseInto input = parseMatch depParser input
       T.it "parses names" $ do
-        "- atomFire (1.0.0)" `shouldParseInto` Dep "atomFire" Nothing
-        "- \"at/+om (1.0.0)\"" `shouldParseInto` Dep "at/+om" Nothing
-        "- \"not-so-safe-name (2.0.0)\"" `shouldParseInto` Dep "not-so-safe-name" Nothing
+        "- atomFire (1.0.0)" `shouldParseInto` Dep "atomFire"
+        "- \"at/+om (1.0.0)\"" `shouldParseInto` Dep "at/+om"
+        "- \"not-so-safe-name (2.0.0)\"" `shouldParseInto` Dep "not-so-safe-name"
 
     T.describe "pod parser" $ do
       let shouldParseInto input = parseMatch podParser input
       T.it "parses names" $ do
         "- atomFire (1.0.0)" `shouldParseInto` Pod "atomFire" "1.0.0" ([])
         "- \"atomFire (1.0.0)\"" `shouldParseInto` Pod "atomFire" "1.0.0" ([])
-
-    T.describe "pod dependency" $ do
-      let shouldParseInto input = parseMatch depGitSrcParser input
-      T.it "parses git dependency" $ do
-        "from `gitUrl`, commit `c`" `shouldParseInto` PodGitSrc "gitUrl" (Just "c")
-        "from `gitUrl`, tag `t`" `shouldParseInto` PodGitSrc "gitUrl" (Just "t")
-        "from `gitUrl`, branch `b`" `shouldParseInto` PodGitSrc "gitUrl" (Just "b")
-        "from `gitUrl`" `shouldParseInto` PodGitSrc "gitUrl" Nothing
 
     T.it "parses pod and dependency sections" $
       case runParser findSections "" podLockFile of

--- a/test/Cocoapods/testdata/Podfile.lock
+++ b/test/Cocoapods/testdata/Podfile.lock
@@ -2,14 +2,24 @@ PODS:
   - one (1.0.0):
     - two (= 3.2.1)
     - three (= 3.2.1)
+    - "ab-normal/+name (2.0.0)"
   - two (2.0.0)
+    - two_dep_A
+    - "two-dep-B"
   - three (3.0.0)
     - four (= 2.3.3)
+  - "ab-normal/+name (2.0.0)"
   - four (4.0.0):
+  - "not-so-safe-name (2.0.0)"
+  - some-dep-sourced-from-git (2.0.0)
+  - depWithTag (2.0.0)
 
 DEPENDENCIES:
   - one (> 4.4)
   - three (from `Submodules/subproject/.podspec`)
+  - "not-so-safe-name (2.0.0)"
+  - "some-dep-sourced-from-git (from `git@github.example.com:ab/ios.git`, commit `559e6a`)"
+  - depWithTag (from `git@github.example.com:ab/cap.git`, tag `v1.2.3`)
 
 SPEC REPOS:
   https://github.com/cocoapods/specs.git:


### PR DESCRIPTION
# Overview

It correctly parses when Podlock file has quotations in entry for dependency and pod section.  

## Acceptance criteria

- Parse Entry in Pod correctly when enclosed with quotation
- Parse Entry in Dependency correctly when enclosed with quotation

## Testing plan

- I've included unit tests to of those effect

For reproducible example, 

- Setup simple pod project
- Add `pod 'GoogleUtilities' ` in `Podfile`
- Execute `pod install`
- Analyze Pod project with applied fixes
- Analyze Pod project without applied fixes

## Risks

N/A

## References

Works on https://github.com/fossas/team-analysis/issues/716

## Checklist

- [x] I added tests for this PR's change (or confirmed tests are not viable).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] I linked this PR to any referenced GitHub issues, if they exist.
