### PR TITLE
Output the real project ID and revision with `--json`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,8 +1,12 @@
 # Spectrometer Changelog
 
+## v2.15.5
+
+- Fixes an issue where `--json` would output the raw project ID, instead of a normalized ID ([#339](https://github.com/fossas/spectrometer/pull/339))
+
 ## v2.15.4
 
-- Gradle: Search parent directories for gradlew and gradlew.bat ([#336](https://github.com/fossas/spectrometer/pull/336)) 
+- Gradle: Search parent directories for gradlew and gradlew.bat ([#336](https://github.com/fossas/spectrometer/pull/336))
 
 This release also adds a number of closed beta features around FOSSA C/C++ support.
 For now this functionality is considered publicly undocumented, and is only used with support from FOSSA engineering.

--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -36,7 +36,7 @@ import Control.Carrier.Output.IO
 import Control.Carrier.StickyLogger (StickyLogger, logSticky', runStickyLogger)
 import Control.Carrier.TaskPool
 import Control.Concurrent
-import Control.Effect.Diagnostics ((<||>))
+import Control.Effect.Diagnostics ((<||>), fromMaybeText)
 import Control.Effect.Exception (Lift, SomeException, throwIO, try)
 import Control.Effect.Lift (sendIO)
 import Control.Effect.Record (runRecord)
@@ -64,7 +64,7 @@ import Path (Abs, Dir, Path, fromAbsDir, toFilePath)
 import Path.IO (makeRelative)
 import Path.IO qualified as P
 import Srclib.Converter qualified as Srclib
-import Srclib.Types (Locator, SourceUnit, parseLocator)
+import Srclib.Types (Locator (locatorProject, locatorRevision), SourceUnit, parseLocator)
 import Strategy.Bundler qualified as Bundler
 import Strategy.Cargo qualified as Cargo
 import Strategy.Carthage qualified as Carthage
@@ -354,7 +354,10 @@ uploadSuccessfulAnalysis (BaseDir basedir) apiOpts metadata jsonOutput override 
   void . Diag.recover . runExecIO $ tryUploadContributors basedir apiOpts (uploadLocator uploadResult)
 
   if fromFlag JsonOutput jsonOutput
-    then logStdout . decodeUtf8 . Aeson.encode $ buildProjectSummary revision (uploadLocator uploadResult) buildUrl
+    then do
+      summary <- Diag.context "Analysis ran successfully, but the server returned invalid metadata" $
+        buildProjectSummary revision (uploadLocator uploadResult) buildUrl
+      logStdout . decodeUtf8 $ Aeson.encode summary
     else pure ()
 
   pure locator
@@ -438,11 +441,13 @@ tryUploadContributors baseDir apiOpts locator = do
   uploadContributors apiOpts locator contributors
 
 -- | Build project summary JSON to be output to stdout
-buildProjectSummary :: ProjectRevision -> Text -> Text -> Aeson.Value
-buildProjectSummary project projectLocator projectUrl =
-  Aeson.object
-    [ "project" .= projectName project
-    , "revision" .= projectRevision project
+buildProjectSummary :: Has Diag.Diagnostics sig m => ProjectRevision -> Text -> Text -> m Aeson.Value
+buildProjectSummary project projectLocator projectUrl = do
+  let locator = parseLocator projectLocator
+  revision <- fromMaybeText "Server returned an invalid project revision" $ locatorRevision locator
+  pure $ Aeson.object
+    [ "project" .= locatorProject locator
+    , "revision" .= revision
     , "branch" .= projectBranch project
     , "url" .= projectUrl
     , "id" .= projectLocator

--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -36,7 +36,7 @@ import Control.Carrier.Output.IO
 import Control.Carrier.StickyLogger (StickyLogger, logSticky', runStickyLogger)
 import Control.Carrier.TaskPool
 import Control.Concurrent
-import Control.Effect.Diagnostics ((<||>), fromMaybeText)
+import Control.Effect.Diagnostics (fromMaybeText, (<||>))
 import Control.Effect.Exception (Lift, SomeException, throwIO, try)
 import Control.Effect.Lift (sendIO)
 import Control.Effect.Record (runRecord)
@@ -355,8 +355,9 @@ uploadSuccessfulAnalysis (BaseDir basedir) apiOpts metadata jsonOutput override 
 
   if fromFlag JsonOutput jsonOutput
     then do
-      summary <- Diag.context "Analysis ran successfully, but the server returned invalid metadata" $
-        buildProjectSummary revision (uploadLocator uploadResult) buildUrl
+      summary <-
+        Diag.context "Analysis ran successfully, but the server returned invalid metadata" $
+          buildProjectSummary revision (uploadLocator uploadResult) buildUrl
       logStdout . decodeUtf8 $ Aeson.encode summary
     else pure ()
 
@@ -445,13 +446,14 @@ buildProjectSummary :: Has Diag.Diagnostics sig m => ProjectRevision -> Text -> 
 buildProjectSummary project projectLocator projectUrl = do
   let locator = parseLocator projectLocator
   revision <- fromMaybeText "Server returned an invalid project revision" $ locatorRevision locator
-  pure $ Aeson.object
-    [ "project" .= locatorProject locator
-    , "revision" .= revision
-    , "branch" .= projectBranch project
-    , "url" .= projectUrl
-    , "id" .= projectLocator
-    ]
+  pure $
+    Aeson.object
+      [ "project" .= locatorProject locator
+      , "revision" .= revision
+      , "branch" .= projectBranch project
+      , "url" .= projectUrl
+      , "id" .= projectLocator
+      ]
 
 buildResult :: Maybe SourceUnit -> [ProjectResult] -> Aeson.Value
 buildResult maybeSrcUnit projects =


### PR DESCRIPTION
# Overview

FOSSA strips protocols (and .git suffixes) from project ID's in locators.  When this happens, the project ID we return under the `--json` flag does not match the project component of the actual locator.  This PR uses the return value of the build upload call to determine the correct locator.  This way, even though FOSSA may not be consistent with the _requested_ project ID, the CLI will be correctly determine the _true_ project ID.

## Acceptance criteria

* Without `--json`, no change.
* With `--json`:
  * fail if no revision was sent (with good error message).
  * use the API return value instead of the supplied project name

## Testing plan

Run with ` --json --project https://foo.bar/baz.git`, check the following (using psuedo-`jq` syntax):
- `$.project` is an exact infix of `$.id`
- `$.project` is NOT equal to `https://foo.bar/baz.git` (only true when original starts with `https?:`)

## Risks

No known risks.

## References

https://teamfossa.slack.com/archives/CJBPV3Z0E/p1629392377095100
https://fossa.zendesk.com/agent/tickets/3114

## Checklist

- [x] I added tests for this PR's change (or confirmed tests are not viable).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] I linked this PR to any referenced GitHub issues, if they exist.
