### PR TITLE
Don't attempt to upload analysis results to monorepo projects

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,8 +2,8 @@
 
 ## v2.15.7
 
-- Resolve an issue where errors running `fossa report` and `fossa test` would be made more confusing when the project isn't a monorepo project ([#321](https://github.com/fossas/spectrometer/pull/321))
-- Prevent uploading standard analysis results to monorepo projects, where they'd be silently ignored ([#341](https://github.com/fossas/spectrometer/pull/341))
+- Resolves an issue where errors running `fossa report` and `fossa test` would be made more confusing when the project isn't a monorepo project ([#321](https://github.com/fossas/spectrometer/pull/321))
+- Prevents uploading standard analysis results to monorepo projects, where they'd be silently ignored ([#341](https://github.com/fossas/spectrometer/pull/341))
 
 ## v2.15.6 
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,10 @@
 # Spectrometer Changelog
 
+## v2.15.7
+
+- Resolve an issue where errors running `fossa report` and `fossa test` would be made more confusing when the project isn't a monorepo project ([#321](https://github.com/fossas/spectrometer/pull/321))
+- Prevent uploading standard analysis results to monorepo projects, where they'd be silently ignored ([#341](https://github.com/fossas/spectrometer/pull/341))
+
 ## v2.15.6 
 
 - CocoaPods: Fixes `Podfile.lock` parsing. It safely parses when Pod and Dependencies entries are enclosed with quotations. ([#337](https://github.com/fossas/spectrometer/pull/337))

--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -16,7 +16,7 @@ import App.Fossa.API.BuildLink (getFossaBuildUrl)
 import App.Fossa.Analyze.GraphMangler (graphingToGraph)
 import App.Fossa.Analyze.Project (ProjectResult (..), mkResult)
 import App.Fossa.Analyze.Record (AnalyzeEffects (..), AnalyzeJournal (..), loadReplayLog, saveReplayLog)
-import App.Fossa.FossaAPIV1 (UploadResponse (..), uploadAnalysis, uploadContributors)
+import App.Fossa.FossaAPIV1 (UploadResponse (..), getProject, projectIsMonorepo, uploadAnalysis, uploadContributors)
 import App.Fossa.ManualDeps (analyzeFossaDepsFile)
 import App.Fossa.ProjectInference (inferProjectDefault, inferProjectFromVCS, mergeOverride, saveRevision)
 import App.Fossa.VSI.IAT.AssertRevisionBinaries (assertRevisionBinaries)
@@ -36,7 +36,7 @@ import Control.Carrier.Output.IO
 import Control.Carrier.StickyLogger (StickyLogger, logSticky', runStickyLogger)
 import Control.Carrier.TaskPool
 import Control.Concurrent
-import Control.Effect.Diagnostics (fromMaybeText, (<||>))
+import Control.Effect.Diagnostics (fatalText, fromMaybeText, recover, (<||>))
 import Control.Effect.Exception (Lift, SomeException, throwIO, try)
 import Control.Effect.Lift (sendIO)
 import Control.Effect.Record (runRecord)
@@ -290,6 +290,13 @@ doAssertRevisionBinaries :: (Has Diag.Diagnostics sig m, Has ReadFS sig m, Has (
 doAssertRevisionBinaries (IATAssertionEnabled dir) apiOpts locator = assertRevisionBinaries dir apiOpts locator
 doAssertRevisionBinaries _ _ _ = pure ()
 
+dieOnMonorepoUpload :: (Has Diag.Diagnostics sig m, Has (Lift IO) sig m) => ApiOpts -> ProjectRevision -> m ()
+dieOnMonorepoUpload apiOpts revision = do
+  project <- recover $ getProject apiOpts revision
+  if maybe False projectIsMonorepo project
+    then fatalText "This project already exists as a monorepo project. Perhaps you meant to supply `--experimental-enable-monorepo`, or run `fossa vps analyze`?"
+    else pure ()
+
 data AnalyzeError
   = ErrNoProjectsDiscovered
   | ErrFilteredAllProjects Int [ProjectResult]
@@ -330,6 +337,7 @@ uploadSuccessfulAnalysis ::
 uploadSuccessfulAnalysis (BaseDir basedir) apiOpts metadata jsonOutput override units = do
   revision <- mergeOverride override <$> (inferProjectFromVCS basedir <||> inferProjectDefault basedir)
   saveRevision revision
+  dieOnMonorepoUpload apiOpts revision
 
   logInfo ""
   logInfo ("Using project name: `" <> pretty (projectName revision) <> "`")

--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -294,7 +294,7 @@ dieOnMonorepoUpload :: (Has Diag.Diagnostics sig m, Has (Lift IO) sig m) => ApiO
 dieOnMonorepoUpload apiOpts revision = do
   project <- recover $ getProject apiOpts revision
   if maybe False projectIsMonorepo project
-    then fatalText "This project already exists as a monorepo project. Perhaps you meant to supply `--experimental-enable-monorepo`, or run `fossa vps analyze`?"
+    then fatalText "This project already exists as a monorepo project. Perhaps you meant to supply '--experimental-enable-monorepo', or meant to run 'fossa vps analyze' instead?"
     else pure ()
 
 data AnalyzeError

--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -336,8 +336,8 @@ uploadSuccessfulAnalysis ::
   m Locator
 uploadSuccessfulAnalysis (BaseDir basedir) apiOpts metadata jsonOutput override units = do
   revision <- mergeOverride override <$> (inferProjectFromVCS basedir <||> inferProjectDefault basedir)
-  saveRevision revision
   dieOnMonorepoUpload apiOpts revision
+  saveRevision revision
 
   logInfo ""
   logInfo ("Using project name: `" <> pretty (projectName revision) <> "`")


### PR DESCRIPTION
# Overview

Monorepo scans are not valid scans for `fossa analyze` (without `--experimental-enable-monorepo`), but currently there is no way for users to know this- their scans run and claim to be successful, but when they open the project in the UI nothing looks different and the new revision is nowhere to be found.

## Acceptance criteria

* Fail the standard analysis flow for projects that are marked monorepo, providing a helpful error message.
* Do not fail standard analysis for new projects.
* Do not fail standard analysis for existing non-monorepo projects.

## Testing plan

1. Scan a monorepo project using `fossa vps analyze` or `fossa analyze --enable-experimental-monorepo aosp` (both of these create a monorepo project, so they are equivalent for the purpose of this test).
2. Immediately try to use `fossa analyze` on the same project. Observe that the error message appears and nothing changes in the UI.
3. Scan a new project that doesn't exist. Observe that it works and the new project appears in the UI.
4. Scan a new revision of the project in step 3. Observe that it works and the new revision appears in the UI.

_Aside:_ Also tested the changes in #321 at the same time against these projects, which works great!

## Risks

No major risk here. Worst case scenario if the `getProject` API hasn't been updated on the server to return monorepo status we assume all projects are _not_ monorepo, so we get the same functionality as before (ignored analysis runs).

## Checklist

- [x] I added tests for this PR's change (or confirmed tests are not viable).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] I linked this PR to any referenced GitHub issues, if they exist.
