### PR TITLE
Fix only.paths and exclude.paths in fossa_yml.md

### DIFF
--- a/docs/reference/fossa_yml.md
+++ b/docs/reference/fossa_yml.md
@@ -168,11 +168,11 @@ The list of paths to exclude from scanning in your directory.
 This section is intended to be used as the inverse to `paths.only`. If you have a certain directory such as `development` you wish to exclude, `paths.exclude` enables you to do this.
 
 ### Analysis target configuration
-Analysis target configuration allows you to select a very specific subset of your directory for scanning. The `target` and `path` sections allow users to configure which targets and directories should be scanned. This is useful if you have a custom test directory or development projects within the root project. 
+Analysis target configuration allows you to select a very specific subset of your directory for scanning. The `target` and `path` sections allow users to configure which targets and directories should be scanned. This is useful if you have a custom test directory or development projects within the root project.
 
 Analysis target configuration determines which targets should be scanned with the following logic:
-1. Targets that match the `only.targets` and `only.paths` sections are unioned to create a list of targets to be scanned.
-2. Targets remaining after the `only` step that match the `exclude.targets` and `exclude.paths` sections are removed from the list of targets to be scanned.
+1. Targets that match the `targets.only` and `paths.only` sections are unioned to create a list of targets to be scanned.
+2. Targets remaining after the `only` step that match the `targets.exclude` and `paths.exclude` sections are removed from the list of targets to be scanned.
     -  If no targets were listed in the `only` sections, `exclude` will remove targets from the list of all available targets.
 3. Analysis is run on the remaining targets.
 


### PR DESCRIPTION

# Overview

This is a documentation only change. There was a paragraph that looked like this:

```
1. Targets that match the `only.targets` and `only.paths` sections are unioned to create a list of targets to be scanned.
2. Targets remaining after the `only` step that match the `exclude.targets` and `exclude.paths` sections are removed from the list of targets to be scanned.
```

Here it is on master: https://github.com/fossas/spectrometer/blob/master/docs/reference/fossa_yml.md#analysis-target-configuration

I'm pretty sure that that should be `paths.only` instead of `only.paths`, so I switched that and a few other similar errors around.

## Acceptance criteria

My changes to the docs are correct.

## Testing plan

## Risks

## References

## Checklist

- [ ] I added tests for this PR's change (or confirmed tests are not viable).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] I linked this PR to any referenced GitHub issues, if they exist.
