### PR TITLE
Add better logging and diffing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -148,7 +148,7 @@ jobs:
     # If git has changes, then the formatter check fails.
     - name: check git status
       run: |
-        git diff --name-only --exit-code
+        git diff --exit-code
 
   create-release:
     name: create-release

--- a/Makefile
+++ b/Makefile
@@ -26,11 +26,16 @@ fmt:
 
 # Confirm everything is formatted without changing anything
 check-fmt:
+	@echo "Running fourmolu"
+	@fourmolu --version
 	@fourmolu --mode check ${FMT_OPTS} $(shell find ${FIND_OPTS})
 	@echo "No formatting errors found"
 
 # Lint everything (If this fails, update .hlint.yaml or report the failure)
 lint:
-	hlint src test
+	@echo "Running hlint"
+	@hlint --version
+	@hlint src test
+	@echo "No linter errors found"
 
 .PHONY: build test analyze install-local fmt check check-fmt lint


### PR DESCRIPTION
This should be a transparent change, only adding logs to the CI lint and fmt jobs.  Also, when the formatter fails, a git diff is shown between the expected and current states.
