### PR TITLE
Also apply to `fmt` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,8 @@ check: check-fmt lint
 # Format everything (if this fails, update FMT_OPTS or use your IDE to format)
 # `@command` does not echo the command before running
 fmt:
+	@echo "Running fourmolu"
+	@fourmolu --version
 	@fourmolu --mode inplace ${FMT_OPTS} $(shell find ${FIND_OPTS})
 
 # Confirm everything is formatted without changing anything


### PR DESCRIPTION
Follow-up to #349, also apply the `fourmolu` logging to the `fmt` target in the makefile.