### PR TITLE
Feature flag support

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Spectrometer Changelog
 
+## Unreleased
+
+- Adds support for querying FOSSA for enabled feature flags ([#352]https://github.com/fossas/spectrometer/pull/352)
+
 ## v2.15.9
 
 - CocoaPods: Supports git sources in `Podfile.lock` analysis. ([#345](https://github.com/fossas/spectrometer/pull/345))

--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -16,13 +16,14 @@ import App.Fossa.API.BuildLink (getFossaBuildUrl)
 import App.Fossa.Analyze.GraphMangler (graphingToGraph)
 import App.Fossa.Analyze.Project (ProjectResult (..), mkResult)
 import App.Fossa.Analyze.Record (AnalyzeEffects (..), AnalyzeJournal (..), loadReplayLog, saveReplayLog)
-import App.Fossa.FossaAPIV1 (UploadResponse (..), getProject, projectIsMonorepo, uploadAnalysis, uploadContributors)
+import App.Fossa.FossaAPIV1 (UploadResponse (..), featureFlagEnabled, getProject, projectIsMonorepo, uploadAnalysis, uploadContributors)
 import App.Fossa.ManualDeps (analyzeFossaDepsFile)
 import App.Fossa.ProjectInference (inferProjectDefault, inferProjectFromVCS, mergeOverride, saveRevision)
 import App.Fossa.VSI.IAT.AssertRevisionBinaries (assertRevisionBinaries)
 import App.Fossa.VSIDeps (analyzeVSIDeps)
 import App.Types (
   BaseDir (..),
+  FeatureFlag (..),
   OverrideProject,
   ProjectMetadata,
   ProjectRevision (projectBranch, projectName, projectRevision),
@@ -281,6 +282,14 @@ analyze (BaseDir basedir) destination override unpackArchives jsonOutput enableV
 
 analyzeVSI :: (MonadIO m, Has Diag.Diagnostics sig m, Has Exec sig m, Has (Lift IO) sig m, Has Logger sig m) => VSIAnalysisMode -> Maybe ApiOpts -> Path Abs Dir -> AllFilters -> m (Maybe SourceUnit)
 analyzeVSI VSIAnalysisEnabled (Just apiOpts) dir filters = do
+  -- The endpoint to disable this function if VSI analysis is disabled server-side is new.
+  -- For most feature flags, we'd want to default to the flag *not* enabled.
+  -- However in the case of VSI, we want to default to the flag being enabled if we fail to check it in Core to maintain existing functionality.
+  enabled <- recover $ featureFlagEnabled apiOpts FeatureFlagVSIMonorepo
+  if enabled == Just False
+    then fatalText "VSI analysis is not enabled in FOSSA. Please contact FOSSA for assistance."
+    else pure ()
+
   logInfo "Running VSI analysis"
   results <- analyzeVSIDeps dir apiOpts filters
   pure $ Just results

--- a/src/App/Fossa/FossaAPIV1.hs
+++ b/src/App/Fossa/FossaAPIV1.hs
@@ -590,7 +590,7 @@ instance FromJSON FeatureFlagEnabledBody where
     FeatureFlagEnabledBody <$> obj .: "enabled"
 
 featureFlagEnabledEndpoint :: Url scheme -> FeatureFlag -> Url scheme
-featureFlagEnabledEndpoint baseurl featureFlag = baseurl /: "api" /: "feature_flag" /: "org" /: coreFlagName featureFlag
+featureFlagEnabledEndpoint baseurl featureFlag = baseurl /: "api" /: "feature_flags" /: "org" /: coreFlagName featureFlag
 
 featureFlagEnabled :: (Has (Lift IO) sig m, Has Diagnostics sig m) => ApiOpts -> FeatureFlag -> m Bool
 featureFlagEnabled apiOpts featureFlag = fossaReq $ do

--- a/src/App/Types.hs
+++ b/src/App/Types.hs
@@ -65,6 +65,9 @@ data NinjaGraphCLIOptions = NinjaGraphCLIOptions
 
 -- | Feature flags are set in the FOSSA API.
 -- Not all feature flags are relevant to Spectrometer, but those that are can be found here.
+--
+-- Since this is client side, the intent is to use the feature flag state to provide better errors to users,
+-- or for FOSSA to selectively enable experimental or optional features in CLI on an organization's behalf org-wide.
 data FeatureFlag
   = -- | Enable VSI and Monorepo functionality
     FeatureFlagVSIMonorepo

--- a/src/App/Types.hs
+++ b/src/App/Types.hs
@@ -6,6 +6,8 @@ module App.Types (
   ReleaseGroupMetadata (..),
   ProjectRevision (..),
   MonorepoAnalysisOpts (..),
+  FeatureFlag (..),
+  coreFlagName,
 ) where
 
 import Data.Aeson (FromJSON (parseJSON), withObject, (.:))
@@ -60,3 +62,13 @@ data NinjaGraphCLIOptions = NinjaGraphCLIOptions
   , ninjaScanId :: Text
   , ninjaBuildName :: Text
   }
+
+-- | Feature flags are set in the FOSSA API.
+-- Not all feature flags are relevant to Spectrometer, but those that are can be found here.
+data FeatureFlag
+  = -- | Enable VSI and Monorepo functionality
+    FeatureFlagVSIMonorepo
+
+-- | Translate the flag to its name in the FOSSA API.
+coreFlagName :: FeatureFlag -> Text
+coreFlagName FeatureFlagVSIMonorepo = "vendoredPackageScanning"


### PR DESCRIPTION
# Overview

Add support for feature flags.

Some features, notably VSI and Monorepo, fail with what appears to be an API error if the flag isn't enabled.
Supporting feature flags client side allows us to preflight check a flag for better error messages.

This also unlocks the ability for us to add experimental features to the FOSSA CLI without users being forced to add to an ever-growing list of `--experimental-...` flags. Since this logic is client side this isn't suitable for paywalled features, but I think it's definitely suitable for features which are intended to be generally available once a beta is complete. If a user recompiles Spectrometer with the feature flag force-enabled, they shouldn't be surprised if the feature it was guarding was in a beta state. 

## Acceptance criteria

* You think this is a good idea
* You can run monorepo and VSI scans against the staging instance with the feature flag enabled.
* You get a better error message when the feature flag is disabled.

Example commands:

```shell
# Run a VSI command
# Assuming https://github.com/fossas/cpp-vsi-demo is at ~/projects/cpp-demo
cabal run fossa -- analyze ~/projects/cpp-demo/example-internal-project --endpoint '<endpoint>' --fossa-api-key <key> --project cpp-example-internal-project --revision $(date +%s) --enable-vsi

# Run a monorepo command
# todo: fill in were to get the example project
cabal run fossa -- analyze ~/projects/aosp-mini --endpoint '<endpoint>' --fossa-api-key <key> --project aosp-mini --revision $(date +%s) --experimental-enable-monorepo aosp
```

## Testing plan

I ran the commands specified in the `Example commands` section.

## Risks

I don't think this is super risky, as feature flag usage is opt-in.

## Checklist

- [x] I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
