### PR TITLE
Adds apple m1 installation workaround in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ more.
 curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/spectrometer/master/install.sh | bash
 ```
 
+### macOS with Apple M1 Silicon
+
+```bash
+arch -x86_64 /bin/bash -c "$(curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/spectrometer/master/install.sh)"
+```
+
 ### Windows with Powershell
 
 ```powershell


### PR DESCRIPTION
# Overview

Adds workaround for apple m1 silicon in the installation docs. 

## Acceptance criteria

- Provided install instruction works for m1 macbooks.

## Testing plan

- I tested on my personal device. This is the same workaround described and identified by kit and connor.

## Risks

N/A

## References

Works on https://github.com/fossas/team-analysis/issues/713

## Checklist

- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] I linked this PR to any referenced GitHub issues, if they exist.
