### PR TITLE
Minor: Includes lonely dependency in yarn v1 lock graphing

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Spectrometer Changelog
 
+## v2.15.14
+
+- Yarn: Fixes missing dependency from the analyses, when dependency has zero deep dependencies, and is not a deep dependency of any other dependency. ([#359](https://github.com/fossas/spectrometer/pull/359))
+
 ## v2.15.13
 
 Adds another closed beta feature around FOSSA C/C++ support.

--- a/test/Yarn/YarnLockV1Spec.hs
+++ b/test/Yarn/YarnLockV1Spec.hs
@@ -44,6 +44,17 @@ packageThree =
     , dependencyTags = Map.empty
     }
 
+packageFour :: Dependency
+packageFour =
+  Dependency
+    { dependencyType = NodeJSType
+    , dependencyName = "packageFour"
+    , dependencyVersion = Just (CEq "4.0.0")
+    , dependencyLocations = ["https://registry.npmjs.org/packageFour"]
+    , dependencyEnvironments = []
+    , dependencyTags = Map.empty
+    }
+
 spec :: Spec
 spec = do
   testFile <- runIO (BS.readFile "test/Yarn/testdata/yarn.lock")
@@ -53,7 +64,7 @@ spec = do
         Left _ -> expectationFailure "failed to parse"
         Right lockfile -> do
           let graph = buildGraph lockfile
-          expectDeps [packageOne, packageTwo, packageThree] graph
+          expectDeps [packageOne, packageTwo, packageThree, packageFour] graph
           expectDirect [] graph
           expectEdges
             [ (packageOne, packageTwo)

--- a/test/Yarn/testdata/yarn.lock
+++ b/test/Yarn/testdata/yarn.lock
@@ -13,3 +13,6 @@ packageTwo@^2.0.0:
 packageThree@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/packageThree"
+packageFour@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/packageFour"


### PR DESCRIPTION
# Overview

Yarn V1 lock analyses excluded dependency which had no outgoing, or incoming edges. This PR ensures, we include those dependencies in graphing analyses. 

This is prereq for: https://github.com/fossas/team-analysis/issues/723

## Acceptance criteria

- Test passes
- Dependency without any edges are included in the graphing

## Testing plan

- You will have to rely on unit tests. 
- Create yarn project, add a dependency which has no direct dependencies (e.g. https://github.com/sindresorhus/decamelize). Perform analyses. 

## Risks

N/A

## References

Works on https://github.com/fossas/team-analysis/issues/723

## Checklist

- [x] I added tests for this PR's change (or confirmed tests are not viable).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] I linked this PR to any referenced GitHub issues, if they exist.
