### PR TITLE
Fixes yarn.lock runtime error when symlinked package is included

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Spectrometer Changelog
 
+## v2.15.16
+
+- Yarn: Analyzes yarn.lock without runtime error, when yarn.lock includes symlinked package. ([#363](https://github.com/fossas/spectrometer/pull/363))
+
 ## v2.15.15
 
 - Monorepo: Efficiently upload binary blobs for ninja & buildspec files ([#362](https://github.com/fossas/spectrometer/pull/362)).

--- a/cabal.project
+++ b/cabal.project
@@ -43,7 +43,7 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/fossas/yarn2nix
-  tag: 711ba824560d1adc0656e99616f67c99a278180f
+  tag: dfba681579e4303ab68f4a3ddb5eaedfe91a99ee
   subdir: yarn-lock
 
 index-state: hackage.haskell.org 2021-08-02T13:16:20Z

--- a/cabal.project.ci.linux
+++ b/cabal.project.ci.linux
@@ -50,7 +50,7 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/fossas/yarn2nix
-  tag: 711ba824560d1adc0656e99616f67c99a278180f
+  tag: dfba681579e4303ab68f4a3ddb5eaedfe91a99ee
   subdir: yarn-lock
 
 index-state: hackage.haskell.org 2021-08-02T13:16:20Z

--- a/cabal.project.ci.macos
+++ b/cabal.project.ci.macos
@@ -48,7 +48,7 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/fossas/yarn2nix
-  tag: 711ba824560d1adc0656e99616f67c99a278180f
+  tag: dfba681579e4303ab68f4a3ddb5eaedfe91a99ee
   subdir: yarn-lock
 
 index-state: hackage.haskell.org 2021-08-02T13:16:20Z

--- a/cabal.project.ci.windows
+++ b/cabal.project.ci.windows
@@ -50,7 +50,7 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/fossas/yarn2nix
-  tag: 711ba824560d1adc0656e99616f67c99a278180f
+  tag: dfba681579e4303ab68f4a3ddb5eaedfe91a99ee
   subdir: yarn-lock
 
 index-state: hackage.haskell.org 2021-08-02T13:16:20Z

--- a/src/Strategy/Yarn/V1/YarnLock.hs
+++ b/src/Strategy/Yarn/V1/YarnLock.hs
@@ -59,6 +59,7 @@ buildGraph lockfile =
               YL.FileRemoteNoIntegrity url -> [url]
               YL.GitRemote url rev -> [url <> "@" <> rev]
               YL.DirectoryLocal dirPath -> [dirPath]
+              YL.DirectoryLocalSymLinked dirPath -> [dirPath]
         , dependencyEnvironments = []
         , dependencyTags = Map.empty
         }


### PR DESCRIPTION
# Overview

Adds new remote type to support sym linked packages when parsing yarn.lock file of Yarn v1.

## Acceptance criteria

- Build completes and test passes for all platforms
- When Yarn.lock has symlinked type - CLI doesn't throw error

## Testing plan

Execute against following valid `yarn.lock` file:

```
# THIS IS AN AUTOGENERATED FILE. DO NOT EDIT THIS FILE DIRECTLY.
# yarn lockfile v1

"decamelize@link:/Users/megh/Work/decamelize":
  version "0.0.0"
  uid ""
```

**Before:**
```bash
[ WARN] ----------
  An error occurred:

      Error parsing file /Users/megh/Work/upstream/spectrometer/rapid/yarn.lock:
          Aeson exception:
          Error in $['decamelize@link:/Users/megh/Work/decamelize']: parsing PackageDescription failed, expected Object, but encountered String

      Traceback:
        - Parsing YAML file '/Users/megh/Work/upstream/spectrometer/rapid/yarn.lock'
        - Reading lockfile
        - Lockfile V2 analysis
        - Yarn

  >>>

    Relevant warnings include:

      Error parsing file /Users/megh/Work/upstream/spectrometer/rapid/yarn.lock:
          Some packages could not be made sense of:
            Package at /Users/megh/Work/upstream/spectrometer/rapid/yarn.lock:4:1:
              We don’t know this remote type.


      Traceback:
        - Lockfile V1 analysis
        - Yarn
[ INFO] [ 0 Waiting / 6 Running / 27 Completed ]
[ INFO] [ 0 Waiting / 4 Running / 29 Completed ]
[ INFO] [ 0 Waiting / 2 Running / 31 Completed ]
[ INFO] [ 0 Waiting / 1 Running / 32 Completed ]
[ERROR] ----------
  An error occurred:

      No analysis targets found in directory.

      Make sure your project is supported. See the user guide for details:
          https://github.com/fossas/spectrometer/blob/v2.15.12/docs/userguide.md


      Traceback:
```

**After With Fix:**
```bash
➜  spectrometer git:(fix/yarn-link-pkgs) ✗ ./fossa analyze ./rapid -o | jq
[ INFO] [ 0 Waiting / 4 Running / 0 Completed ]
[ INFO] [ 0 Waiting / 8 Running / 0 Completed ]
[ INFO] [ 0 Waiting / 9 Running / 0 Completed ]
[ INFO] [ 1 Waiting / 10 Running / 0 Completed ]
[ INFO] [ 4 Waiting / 10 Running / 0 Completed ]
[ INFO] [ 8 Waiting / 10 Running / 0 Completed ]
[ INFO] [ 12 Waiting / 10 Running / 0 Completed ]
[ INFO] [ 16 Waiting / 10 Running / 0 Completed ]
[ INFO] [ 20 Waiting / 10 Running / 0 Completed ]
[ INFO] [ 21 Waiting / 10 Running / 1 Completed ]
[ INFO] Analyzing yarn project at /Users/megh/Work/upstream/spectrometer/rapid/
[ INFO] [ 3 Waiting / 12 Running / 18 Completed ]
[ INFO] [ 1 Waiting / 12 Running / 20 Completed ]
[ INFO] [ 0 Waiting / 12 Running / 21 Completed ]
[ INFO] [ 0 Waiting / 3 Running / 30 Completed ]
[ INFO] [ 0 Waiting / 1 Running / 32 Completed ]
{
  "projects": [
    {
      "graph": {
....
```

## Risks

N/A

## References

- This closes: https://github.com/fossas/team-analysis/issues/727
- https://classic.yarnpkg.com/en/docs/cli/link/

## Checklist

- [x] I added tests for this PR's change (or confirmed tests are not viable).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] I linked this PR to any referenced GitHub issues, if they exist.
