### PR TITLE
Gradle: Considers configs `testCompileClasspath` and `testRuntimeClasspath` to be test configs

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Spectrometer Changelog
 
+## v2.15.17
+
+- Gradle: Classifies dependency from `testCompileClasspath` and `testRuntimeClasspath` configurations as test dependencies. ([#366](https://github.com/fossas/spectrometer/pull/366))
+
 ## v2.15.16
 
 - Yarn: Analyzes yarn.lock without runtime error, when yarn.lock includes symlinked package. ([#363](https://github.com/fossas/spectrometer/pull/363))

--- a/docs/strategies/gradle.md
+++ b/docs/strategies/gradle.md
@@ -29,6 +29,7 @@ Gradle users generally specify their builds using a `build.gradle` file (written
     - [Manually checking Gradle dependency results](#manually-checking-gradle-dependency-results)
     - [Debugging the "Gradle build plugin" tactic](#debugging-the-gradle-build-plugin-tactic)
   - [Manually specifying Gradle dependencies](#manually-specifying-gradle-dependencies)
+  - [Configurations For Development and Testing](#configurations-for-development-and-testing)
   - [Android Gradle Configurations For Development and Testing](#android-gradle-configurations-for-development-and-testing)
 
 ## Concepts
@@ -192,6 +193,23 @@ Notice that the `name` field follows Maven conventions: `groupId:artifactId`.
 
 For more details, see the [manual dependencies](../userguide.md#manually-specifying-dependencies) documentation.
 
+## Configurations For Development and Testing
+
+We classify following configurations are for development:
+
+```
+- compileOnly
+```
+
+and following are for testing: 
+
+```
+- testImplementation
+- testCompileOnly
+- testRuntimeOnly
+- testCompileClasspath
+- testRuntimeClasspath
+```
 ## Android Gradle Configurations For Development and Testing
 
 We classify following configurations, and any dependencies originating from it as a test environment dependency:

--- a/src/Strategy/Gradle.hs
+++ b/src/Strategy/Gradle.hs
@@ -312,10 +312,12 @@ buildGraph projectsAndDeps = run . withLabeling toDependency $ Map.traverseWithK
         edge projAsDep dep
         mkRecursiveEdges dep envLabel
 
+    -- | Infers environment label based on the name of configuration.
+    -- Ref: https://docs.gradle.org/current/userguide/java_library_plugin.html#sec:java_library_configurations_graph
     configNameToLabel :: ConfigName -> GradleLabel
     configNameToLabel conf = case unConfigName conf of
       "compileOnly" -> Env EnvDevelopment
-      x | x `elem` ["testImplementation", "testCompileOnly", "testRuntimeOnly"] -> Env EnvTesting
+      x | x `elem` ["testImplementation", "testCompileOnly", "testRuntimeOnly", "testCompileClasspath", "testRuntimeClasspath"] -> Env EnvTesting
       x | isDefaultAndroidDevConfig x -> Env EnvDevelopment
       x | isDefaultAndroidTestConfig x -> Env EnvTesting
       x -> Env $ EnvOther x

--- a/src/Strategy/Gradle.hs
+++ b/src/Strategy/Gradle.hs
@@ -312,7 +312,7 @@ buildGraph projectsAndDeps = run . withLabeling toDependency $ Map.traverseWithK
         edge projAsDep dep
         mkRecursiveEdges dep envLabel
 
-    -- | Infers environment label based on the name of configuration.
+    -- Infers environment label based on the name of configuration.
     -- Ref: https://docs.gradle.org/current/userguide/java_library_plugin.html#sec:java_library_configurations_graph
     configNameToLabel :: ConfigName -> GradleLabel
     configNameToLabel conf = case unConfigName conf of


### PR DESCRIPTION
# Overview

Considers configs named, `testCompileClasspath` and `testRuntimeClasspath` to be test configurations and subsequently dependencies with them. 

## Acceptance criteria

- Dependencies from `testCompileClasspath` are classified as test dependency
- Dependencies from `testRuntimeClasspath` are classified as test dependency

## Testing plan

Replay logs from: https://fossa.zendesk.com/agent/tickets/3139. It should not include dependencies from aforementioned configurations in the build graph. 

## Risks

N/A

## References

Closes: https://github.com/fossas/team-analysis/issues/730

## Checklist

- [x] I added tests for this PR's change (or confirmed tests are not viable).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] I linked this PR to any referenced GitHub issues, if they exist.
