### PR TITLE
Gradle: Fixes Broken Link in Userguide (728)

### DIFF
--- a/docs/userguide.md
+++ b/docs/userguide.md
@@ -112,7 +112,7 @@ fossa analyze --help
 ### java
 
 - [maven](quickreference/maven.md)
-- [gradle](quickreference/gradle.md)
+- [gradle](strategies/gradle.md)
 
 ### javascript/typescript
 


### PR DESCRIPTION
# Overview

Fixes broken link in user guide for Gradle. 

Since quick reference docs are going away in future (talked with Leo in regards to docs overhaul), linking to strategy docs instead. 

## Acceptance criteria

- Can click on gradle reference link

## Testing plan

N/A

## Risks

N/A

## References

Closes: https://github.com/fossas/team-analysis/issues/728

## Checklist

- [x] I added tests for this PR's change (or confirmed tests are not viable).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] I linked this PR to any referenced GitHub issues, if they exist.
