### PR TITLE
Analyses-725: Uses safe lookup for yarn.lock

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Spectrometer Changelog
 
+## v2.15.20
+
+- Yarn: Fixes potential runtime errors, when yarn.lock contains deep dependency without specification at root level in yarn.lock. ([#369](https://github.com/fossas/spectrometer/pull/369))
+
 ## v2.15.19
 
 - Fixes an issue with `fossa-deps.yml` `vendored-dependencies` entries where uploads would fail if the dependency was in a subdirectory. ([#373](https://github.com/fossas/spectrometer/pull/373))

--- a/cabal.project
+++ b/cabal.project
@@ -43,7 +43,7 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/fossas/yarn2nix
-  tag: dfba681579e4303ab68f4a3ddb5eaedfe91a99ee
+  tag: 276fb494a22bbc50634a8ff8911d6b53782ab1ed
   subdir: yarn-lock
 
 index-state: hackage.haskell.org 2021-08-02T13:16:20Z

--- a/cabal.project.ci.linux
+++ b/cabal.project.ci.linux
@@ -50,7 +50,7 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/fossas/yarn2nix
-  tag: dfba681579e4303ab68f4a3ddb5eaedfe91a99ee
+  tag: 276fb494a22bbc50634a8ff8911d6b53782ab1ed
   subdir: yarn-lock
 
 index-state: hackage.haskell.org 2021-08-02T13:16:20Z

--- a/cabal.project.ci.macos
+++ b/cabal.project.ci.macos
@@ -48,7 +48,7 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/fossas/yarn2nix
-  tag: dfba681579e4303ab68f4a3ddb5eaedfe91a99ee
+  tag: 276fb494a22bbc50634a8ff8911d6b53782ab1ed
   subdir: yarn-lock
 
 index-state: hackage.haskell.org 2021-08-02T13:16:20Z

--- a/cabal.project.ci.windows
+++ b/cabal.project.ci.windows
@@ -50,7 +50,7 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/fossas/yarn2nix
-  tag: dfba681579e4303ab68f4a3ddb5eaedfe91a99ee
+  tag: 276fb494a22bbc50634a8ff8911d6b53782ab1ed
   subdir: yarn-lock
 
 index-state: hackage.haskell.org 2021-08-02T13:16:20Z

--- a/test/Yarn/YarnLockV1Spec.hs
+++ b/test/Yarn/YarnLockV1Spec.hs
@@ -55,6 +55,17 @@ packageFour =
     , dependencyTags = Map.empty
     }
 
+packageFive :: Dependency
+packageFive =
+  Dependency
+    { dependencyType = NodeJSType
+    , dependencyName = "packageFive"
+    , dependencyVersion = Just (CEq "5.0.0")
+    , dependencyLocations = ["https://someurl.io/somefile.gz"]
+    , dependencyEnvironments = []
+    , dependencyTags = Map.empty
+    }
+
 spec :: Spec
 spec = do
   testFile <- runIO (BS.readFile "test/Yarn/testdata/yarn.lock")
@@ -64,7 +75,7 @@ spec = do
         Left _ -> expectationFailure "failed to parse"
         Right lockfile -> do
           let graph = buildGraph lockfile
-          expectDeps [packageOne, packageTwo, packageThree, packageFour] graph
+          expectDeps [packageOne, packageTwo, packageThree, packageFour, packageFive] graph
           expectDirect [] graph
           expectEdges
             [ (packageOne, packageTwo)

--- a/test/Yarn/testdata/yarn.lock
+++ b/test/Yarn/testdata/yarn.lock
@@ -16,3 +16,8 @@ packageThree@^3.0.0:
 packageFour@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/packageFour"
+packageFive@5.0.0:
+  version "5.0.0"
+  resolved "https://someurl.io/somefile.gz#somehash"
+  dependencies:
+    unSeenDep "0.0.0"


### PR DESCRIPTION
# Overview

Uses safe lookup, to address scenarios when, yarn v1 has deep dependencies (ex: @f/sub-dep, e.g.) from resolved dependency (eg: @f/a@0.0.1, typically file or remote sourced) which are not specified at root level:

```
"@f/a@0.0.1":
  version "0.0.1"
  resolved "some-file-url.gz"
  integrity sha1-somehash
  dependencies:
    "@f/sub-dep" "0.0.0"
    jsdom "^16.6.0"
    tslib "^2.2.0"
``` 

## Acceptance criteria

- CLI does not produce runtime error, when parsing valid yarn.lock with unspecified deep dependency.

## Testing plan

Test against yarn lock file provided in: fossas/team-analysis#725

**Before**

```
➜  spectrometer git:(analyses-725/safe-lookup) ✗ fossa analyze ./rapid -o | jq
[ INFO] [ 0 Waiting / 8 Running / 0 Completed ]
[ INFO] [ 20 Waiting / 11 Running / 1 Completed ]
[ INFO] Analyzing yarn project at /Users/megh/Work/upstream/spectrometer/rapid/
[ INFO] [ 0 Waiting / 10 Running / 23 Completed ]
[ INFO] [ 0 Waiting / 8 Running / 25 Completed ]
[ INFO] [ 0 Waiting / 2 Running / 31 Completed ]
[ INFO] [ 0 Waiting / 1 Running / 32 Completed ]
[ERROR] ----------
  An error occurred:

      An exception occurred: Map.!: given key is not an element in the map
      CallStack (from HasCallStack):
        error, called at libraries/containers/containers/src/Data/Map/Internal.hs:627:17 in containers-0.6.2.1:Data.Map.Internal

      Traceback:
        

➜  spectrometer git:(analyses-725/safe-lookup) ✗ 
```

**After**

```
➜  spectrometer git:(analyses-725/safe-lookup) ✗ ./fossa analyze ./rapid -o | jq > graph.json
[ INFO] [ 0 Waiting / 8 Running / 0 Completed ]
[ INFO] [ 11 Waiting / 9 Running / 0 Completed ]
[ INFO] [ 15 Waiting / 9 Running / 0 Completed ]
[ INFO] [ 19 Waiting / 9 Running / 0 Completed ]
[ INFO] [ 23 Waiting / 9 Running / 0 Completed ]
[ INFO] [ 21 Waiting / 10 Running / 1 Completed ]
[ INFO] Analyzing yarn project at /Users/megh/Work/upstream/spectrometer/rapid/
[ INFO] [ 0 Waiting / 4 Running / 29 Completed ]
[ INFO] [ 0 Waiting / 3 Running / 30 Completed ]
[ INFO] [ 0 Waiting / 2 Running / 31 Completed ]
[ INFO] [ 0 Waiting / 1 Running / 32 Completed ]
➜  spectrometer git:(analyses-725/safe-lookup) ✗ head graph.json
{
  "projects": [
    {
      "graph": {
        "assocs": [
          [
            0,
            [
              31
            ]
➜  spectrometer git:(analyses-725/safe-lookup) ✗ 
```

## Risks

N/A

## References

Closes fossas/team-analysis#725

## Checklist

- [x] I added tests for this PR's change (or confirmed tests are not viable).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] I linked this PR to any referenced GitHub issues, if they exist.
