### PR TITLE
Debug bundles (part 1)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,7 @@
 
 ## v2.17.0
 
-- When running `fossa analyze` with the `--debug` flag, we now create a `fossa.debug.json` file containing detailed runtime traces for project discovery and dependency analysis
+- When running `fossa analyze` with the `--debug` flag, we now create a `fossa.debug.json.gz` file containing detailed runtime traces for project discovery and dependency analysis
 
 ## v2.16.6
 - Monorepo: Adds automatic retries to failed API calls. ([#392](https://github.com/fossas/spectrometer/pull/392))

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,20 +1,24 @@
 # Spectrometer Changelog
 
+## v2.17.0
+
+- When running `fossa analyze` with the `--debug` flag, we now create a `fossa.debug.json` file containing detailed runtime traces for project discovery and dependency analysis
+
 ## v2.16.6
-- Monorepo: Add automatic retries to failed API calls. ([#392](https://github.com/fossas/spectrometer/pull/392))
+- Monorepo: Adds automatic retries to failed API calls. ([#392](https://github.com/fossas/spectrometer/pull/392))
 
 ## v2.16.5
-- JSON Output for `fossa test --json` when there are no issues. ([#387](https://github.com/fossas/spectrometer/pull/387))
+- Adds JSON Output for `fossa test --json` when there are no issues. ([#387](https://github.com/fossas/spectrometer/pull/387))
 
 ## v2.16.4
-- Monorepo: Fix bug with symlink logic mismatch between walker and buildspec uploader. ([#388](https://github.com/fossas/spectrometer/pull/388))
+- Monorepo: Fixes bug with symlink logic mismatch between walker and buildspec uploader. ([#388](https://github.com/fossas/spectrometer/pull/388))
 
 ## v2.16.3
-- Monorepo: Fix bug with non-glob exclusions. ([#386](https://github.com/fossas/spectrometer/pull/386))
+- Monorepo: Fixes bug with non-glob exclusions. ([#386](https://github.com/fossas/spectrometer/pull/386))
 
 ## v2.16.2
-- Monorepo: Don't crash if there are no ninja/buildspec files to upload. ([#385](https://github.com/fossas/spectrometer/pull/385))
-- Monorepo: Fix issue with only-path/exclude-path globs.
+- Monorepo: Fixes crash when there are no ninja/buildspec files to upload. ([#385](https://github.com/fossas/spectrometer/pull/385))
+- Monorepo: Fixes issue with only-path/exclude-path globs.
 
 ## v2.16.1
 - Gradle: Supports analysis of projects using gralde v3.3 or below. ([#370](https://github.com/fossas/spectrometer/pull/370))

--- a/devdocs/replay-logging.md
+++ b/devdocs/replay-logging.md
@@ -8,16 +8,16 @@ It leverages some unique properties of haskell that allow us to "record" an end-
 
 ## Recording
 
-The `--record` flag is used to run `fossa analyze` in record mode. The analysis will run normally (if a bit slower), and create a file called `fossa.debug.json`.
+The `--debug` flag is used to run `fossa analyze` in record mode. The analysis will run normally (if a bit slower), and create a file called `fossa.debug.json`.
 
-In addition to some basic metadata, `fossa.debug.json` contains the arguments and results of each method invocation from our `ReadFS` and `Exec` effects:
+In addition to some basic metadata, `fossa.debug.json` contains the arguments and results of each method invocation from our `ReadFS` and `Exec` effects within the `journals` key:
 
 ```json
 {
-  "commit": "0abcdef",
+  "system": {...},
   "workdir": "/foo",
   "args": ["analyze", "--record"],
-  "effects": {
+  "journals": {
     "ReadFS": [...]
     "Exec": [...]
   }
@@ -25,6 +25,8 @@ In addition to some basic metadata, `fossa.debug.json` contains the arguments an
 ```
 
 ## Replaying
+
+**Replay mode is temporarily unavailable.**
 
 The `--replay <file>` flag is used to run `fossa analyze` in replay mode. Rather than reading from real files with our `ReadFS` effect or running real commands with our `Exec` effect, we stub in the recorded effect calls from `fossa.debug.json`.
 

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -178,6 +178,7 @@ library
     App.OptionExtensions
     App.Pathfinder.Main
     App.Pathfinder.Scan
+    App.Pathfinder.Types
     App.Types
     App.Util
     App.Version

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -134,6 +134,7 @@ library
     App.Fossa.API.BuildLink
     App.Fossa.API.BuildWait
     App.Fossa.Analyze
+    App.Fossa.Analyze.Debug
     App.Fossa.Analyze.Graph
     App.Fossa.Analyze.GraphBuilder
     App.Fossa.Analyze.GraphMangler

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -140,6 +140,7 @@ library
     App.Fossa.Analyze.GraphMangler
     App.Fossa.Analyze.Project
     App.Fossa.Analyze.Record
+    App.Fossa.Analyze.Types
     App.Fossa.ArchiveUploader
     App.Fossa.BinaryDeps
     App.Fossa.BinaryDeps.Jar

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -33,7 +33,6 @@ common lang
     GADTSyntax
     GeneralizedNewtypeDeriving
     HexFloatLiterals
-    ImportQualifiedPost
     InstanceSigs
     KindSignatures
     LambdaCase
@@ -47,12 +46,13 @@ common lang
     RankNTypes
     ScopedTypeVariables
     StandaloneDeriving
-    StandaloneKindSignatures
     StrictData
     TupleSections
     TypeApplications
     TypeOperators
     TypeSynonymInstances
+    ImportQualifiedPost
+    StandaloneKindSignatures
 
   ghc-options:
     -Wall -Wincomplete-uni-patterns -Wcompat
@@ -131,14 +131,14 @@ library
   exposed-modules:
     Algebra.Graph.AdjacencyMap.Extra
     App.Docs
+    App.Fossa.API.BuildLink
+    App.Fossa.API.BuildWait
     App.Fossa.Analyze
     App.Fossa.Analyze.Graph
     App.Fossa.Analyze.GraphBuilder
     App.Fossa.Analyze.GraphMangler
     App.Fossa.Analyze.Project
     App.Fossa.Analyze.Record
-    App.Fossa.API.BuildLink
-    App.Fossa.API.BuildWait
     App.Fossa.ArchiveUploader
     App.Fossa.BinaryDeps
     App.Fossa.BinaryDeps.Jar
@@ -183,6 +183,7 @@ library
     Console.Sticky
     Control.Carrier.AtomicCounter
     Control.Carrier.AtomicState
+    Control.Carrier.Debug
     Control.Carrier.Diagnostics
     Control.Carrier.Diagnostics.StickyContext
     Control.Carrier.Finally
@@ -194,6 +195,7 @@ library
     Control.Effect.AtomicCounter
     Control.Effect.AtomicState
     Control.Effect.ConsoleRegion
+    Control.Effect.Debug
     Control.Effect.Diagnostics
     Control.Effect.Finally
     Control.Effect.Output
@@ -225,9 +227,9 @@ library
     Effect.ReadFS
     Fossa.API.Types
     Graphing
-    Path.Extra
-    Parse.XML
     Network.HTTP.Req.Extra
+    Parse.XML
+    Path.Extra
     Srclib.Converter
     Srclib.Types
     Strategy.Android.Util
@@ -291,8 +293,8 @@ library
     Strategy.Python.SetupPy
     Strategy.Python.Setuptools
     Strategy.Python.Util
-    Strategy.Rebar3
     Strategy.RPM
+    Strategy.Rebar3
     Strategy.Ruby.BundleShow
     Strategy.Ruby.GemfileLock
     Strategy.Scala
@@ -353,9 +355,9 @@ test-suite unit-tests
     Conda.EnvironmentYmlSpec
     Control.Carrier.DiagnosticsSpec
     Dart.PubDepsSpec
-    Dart.PubSpecSpec
     Dart.PubSpecLockSpec
     Discovery.ArchiveSpec
+    Dart.PubSpecSpec
     Discovery.FiltersSpec
     Effect.ExecSpec
     Elixir.MixTreeSpec
@@ -371,8 +373,8 @@ test-suite unit-tests
     Go.TransitiveSpec
     Googlesource.RepoManifestSpec
     Gradle.GradleSpec
-    GraphingSpec
     GraphUtil
+    GraphingSpec
     Haskell.CabalSpec
     Haskell.StackSpec
     Maven.DepTreeSpec

--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -32,7 +32,7 @@ import App.Types (
  )
 import App.Util (validateDir)
 import Control.Carrier.AtomicCounter (AtomicCounter, runAtomicCounter)
-import Control.Carrier.Debug
+import Control.Carrier.Debug (Debug, DiagDebugC, debugEverything, diagToDebug, ignoreDebug, runDebug)
 import Control.Carrier.Diagnostics qualified as Diag
 import Control.Carrier.Diagnostics.StickyContext
 import Control.Carrier.Finally
@@ -171,8 +171,8 @@ analyzeMain workdir recordMode logSeverity destination project unpackArchives js
     $ case recordMode of
       RecordModeNone -> do
         basedir <- sendIO $ validateDir workdir
-        (scope, res) <- runDebug $ readFSToDebug $ execToDebug $ diagToDebug $ doAnalyze basedir
-        logStdout $ ("\n" <>) $ decodeUtf8 $ Aeson.encode scope
+        (scope, res) <- runDebug $ debugEverything $ doAnalyze basedir
+        sendIO $ Aeson.encodeFile "fossa.debug.json" scope
         pure res
       RecordModeRecord -> do
         basedir <- sendIO $ validateDir workdir

--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -15,7 +15,7 @@ module App.Fossa.Analyze (
 
 import App.Docs (userGuideUrl)
 import App.Fossa.API.BuildLink (getFossaBuildUrl)
-import App.Fossa.Analyze.Debug (debugEverything, diagToDebug)
+import App.Fossa.Analyze.Debug (diagToDebug, collectDebugBundle)
 import App.Fossa.Analyze.GraphMangler (graphingToGraph)
 import App.Fossa.Analyze.Project (ProjectResult (..), mkResult)
 import App.Fossa.Analyze.Record (AnalyzeEffects (..), AnalyzeJournal (..), loadReplayLog, saveReplayLog)
@@ -34,7 +34,7 @@ import App.Types (
  )
 import App.Util (validateDir)
 import Control.Carrier.AtomicCounter (AtomicCounter, runAtomicCounter)
-import Control.Carrier.Debug (Debug, ignoreDebug, runDebug, debugMetadata)
+import Control.Carrier.Debug (Debug, ignoreDebug, debugMetadata)
 import Control.Carrier.Diagnostics qualified as Diag
 import Control.Carrier.Diagnostics.StickyContext
 import Control.Carrier.Finally
@@ -166,7 +166,7 @@ analyzeMain workdir recordMode logSeverity destination project unpackArchives js
     $ case recordMode of
       RecordModeNone -> do
         basedir <- sendIO $ validateDir workdir
-        (scope, res) <- runDebug $ debugEverything $ doAnalyze basedir
+        (scope, res) <- collectDebugBundle $ doAnalyze basedir
         sendIO $ Aeson.encodeFile "fossa.debug.json" scope
         pure res
       RecordModeRecord -> do

--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -32,6 +32,7 @@ import App.Types (
  )
 import App.Util (validateDir)
 import Control.Carrier.AtomicCounter (AtomicCounter, runAtomicCounter)
+import Control.Carrier.Debug
 import Control.Carrier.Diagnostics qualified as Diag
 import Control.Carrier.Diagnostics.StickyContext
 import Control.Carrier.Finally
@@ -103,7 +104,6 @@ import Strategy.Yarn qualified as Yarn
 import System.Exit (die)
 import Types (DiscoveredProject (..), FoundTargets)
 import VCS.Git (fetchGitContributors)
-import Control.Carrier.Debug
 
 type TaskEffs sig m =
   ( Has (Lift IO) sig m
@@ -171,7 +171,7 @@ analyzeMain workdir recordMode logSeverity destination project unpackArchives js
     $ case recordMode of
       RecordModeNone -> do
         basedir <- sendIO $ validateDir workdir
-        (scope, res) <- runDebug $ readFSToDebug $ diagToDebug $ doAnalyze basedir
+        (scope, res) <- runDebug $ readFSToDebug $ execToDebug $ diagToDebug $ doAnalyze basedir
         logStdout $ ("\n" <>) $ decodeUtf8 $ Aeson.encode scope
         pure res
       RecordModeRecord -> do

--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -197,6 +197,8 @@ applyFiltersToProject basedir filters DiscoveredProject{..} =
     Just rel -> do
       applyFilters filters projectType rel projectBuildTargets
 
+-- NOTE: When adding analyzers, make sure to also add them to
+-- App.Fossa.ListTargets
 runAnalyzers ::
   ( Has (Output ProjectResult) sig m
   , Has ReadFS sig m

--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -15,6 +15,7 @@ module App.Fossa.Analyze (
 
 import App.Docs (userGuideUrl)
 import App.Fossa.API.BuildLink (getFossaBuildUrl)
+import App.Fossa.Analyze.Debug (DiagDebugC, diagToDebug, debugEverything)
 import App.Fossa.Analyze.GraphMangler (graphingToGraph)
 import App.Fossa.Analyze.Project (ProjectResult (..), mkResult)
 import App.Fossa.Analyze.Record (AnalyzeEffects (..), AnalyzeJournal (..), loadReplayLog, saveReplayLog)
@@ -32,7 +33,7 @@ import App.Types (
  )
 import App.Util (validateDir)
 import Control.Carrier.AtomicCounter (AtomicCounter, runAtomicCounter)
-import Control.Carrier.Debug (Debug, DiagDebugC, debugEverything, diagToDebug, ignoreDebug, runDebug)
+import Control.Carrier.Debug (Debug, ignoreDebug, runDebug)
 import Control.Carrier.Diagnostics qualified as Diag
 import Control.Carrier.Diagnostics.StickyContext
 import Control.Carrier.Finally

--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -285,10 +285,10 @@ runAnalyzers basedir filters = do
   -- single Gomodules.discover
   -- single Gradle.discover
   -- single Leiningen.discover
-  -- single Maven.discover
+  single Maven.discover
   -- single Mix.discover
   -- single Npm.discover
-  -- single Nuspec.discover
+  single Nuspec.discover
   -- single PackageReference.discover
   -- single PackagesConfig.discover
   -- single Paket.discover

--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -103,6 +103,7 @@ import Strategy.Python.Setuptools qualified as Setuptools
 import Strategy.RPM qualified as RPM
 import Strategy.Rebar3 qualified as Rebar3
 import Strategy.Scala qualified as Scala
+import Strategy.SwiftPM qualified as SwiftPM
 import Strategy.Yarn qualified as Yarn
 import System.Exit (die)
 import Types (DiscoveredProject (..), FoundTargets)
@@ -188,42 +189,6 @@ analyzeMain workdir recordMode logSeverity destination project unpackArchives js
   where
     doAnalyze basedir = analyze basedir destination project unpackArchives jsonOutput modeOptions filters
 
---discoverFuncs :: (TaskEffs sig m, TaskEffs rsig run) => [Path Abs Dir -> m [DiscoveredProject run]]
---discoverFuncs =
--- [ Bundler.discover
--- , Cabal.discover
--- , Cargo.discover
--- , Carthage.discover
--- , Cocoapods.discover
--- , Composer.discover
--- , Conda.discover
--- , Glide.discover
--- , Godep.discover
--- , Gomodules.discover
--- , Gradle.discover
--- , Leiningen.discover
--- , Maven.discover
--- , Mix.discover
--- , Npm.discover
--- , Nuspec.discover
--- , PackageReference.discover
--- , PackagesConfig.discover
--- , Paket.discover
--- , Pipenv.discover
--- , Poetry.discover
--- , ProjectAssetsJson.discover
--- , ProjectJson.discover
--- , Pub.discover
--- , RPM.discover
--- , Rebar3.discover
--- , RepoManifest.discover
--- , Scala.discover
--- , Setuptools.discover
--- , Stack.discover
--- , SwiftPM.discover
--- , Yarn.discover
--- ]
-
 runDependencyAnalysis ::
   ( AnalyzeProject a
   , Has (Lift IO) sig m
@@ -273,36 +238,37 @@ runAnalyzers ::
   AllFilters ->
   m ()
 runAnalyzers basedir filters = do
-  -- single Bundler.discover
-  -- single Cabal.discover
-  -- single Cargo.discover
-  -- single Carthage.discover
-  -- single Cocoapods.discover
-  -- single Composer.discover
-  -- single Conda.discover
-  -- single Glide.discover
-  -- single Godep.discover
-  -- single Gomodules.discover
-  -- single Gradle.discover
-  -- single Leiningen.discover
+  single Bundler.discover
+  single Cabal.discover
+  single Cargo.discover
+  single Carthage.discover
+  single Cocoapods.discover
+  single Composer.discover
+  single Conda.discover
+  single Glide.discover
+  single Godep.discover
+  single Gomodules.discover
+  single Gradle.discover
+  single Leiningen.discover
   single Maven.discover
-  -- single Mix.discover
-  -- single Npm.discover
+  single Mix.discover
+  single Npm.discover
   single Nuspec.discover
-  -- single PackageReference.discover
-  -- single PackagesConfig.discover
-  -- single Paket.discover
-  -- single Pipenv.discover
-  -- single Poetry.discover
-  -- single ProjectAssetsJson.discover
-  -- single ProjectJson.discover
-  -- single Pub.discover
-  -- single RPM.discover
-  -- single Rebar3.discover
-  -- single RepoManifest.discover
-  -- single Scala.discover
-  -- single Setuptools.discover
-  -- single Stack.discover
+  single PackageReference.discover
+  single PackagesConfig.discover
+  single Paket.discover
+  single Pipenv.discover
+  single Poetry.discover
+  single ProjectAssetsJson.discover
+  single ProjectJson.discover
+  single Pub.discover
+  single RPM.discover
+  single Rebar3.discover
+  single RepoManifest.discover
+  single Scala.discover
+  single Setuptools.discover
+  single Stack.discover
+  single SwiftPM.discover
   single Yarn.discover
   where
     single f = withDiscoveredProjects f basedir (runDependencyAnalysis basedir filters)
@@ -346,12 +312,10 @@ analyze (BaseDir basedir) destination override unpackArchives jsonOutput ModeOpt
       . runFinally
       . withTaskPool capabilities updateProgress
       . runAtomicCounter
-      -- withDiscoveredProjects discoverFuncs (fromFlag UnpackArchives unpackArchives) basedir (runDependencyAnalysis (BaseDir basedir) filters)
       $ do
         runAnalyzers basedir filters
         when (fromFlag UnpackArchives unpackArchives) $
           forkTask $ do
-            -- FIXME: cleanup?
             res <- Diag.runDiagnosticsIO . diagToDebug . stickyDiag $ Archive.discover (`runAnalyzers` filters) basedir
             Diag.withResult SevError res (const (pure ()))
 

--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -10,12 +10,12 @@ module App.Fossa.Analyze (
   BinaryDiscoveryMode (..),
   RecordMode (..),
   ModeOptions (..),
-  discoverFuncs,
+  -- discoverFuncs,
 ) where
 
 import App.Docs (userGuideUrl)
 import App.Fossa.API.BuildLink (getFossaBuildUrl)
-import App.Fossa.Analyze.Debug (DiagDebugC, diagToDebug, debugEverything)
+import App.Fossa.Analyze.Debug (debugEverything, diagToDebug)
 import App.Fossa.Analyze.GraphMangler (graphingToGraph)
 import App.Fossa.Analyze.Project (ProjectResult (..), mkResult)
 import App.Fossa.Analyze.Record (AnalyzeEffects (..), AnalyzeJournal (..), loadReplayLog, saveReplayLog)
@@ -69,51 +69,46 @@ import Path (Abs, Dir, Path, fromAbsDir, toFilePath)
 import Path.IO (makeRelative)
 import Path.IO qualified as P
 import Srclib.Converter qualified as Srclib
-import Srclib.Types (Locator (locatorProject, locatorRevision), SourceUnit (..), parseLocator)
-import Strategy.Bundler qualified as Bundler
-import Strategy.Cargo qualified as Cargo
-import Strategy.Carthage qualified as Carthage
-import Strategy.Cocoapods qualified as Cocoapods
-import Strategy.Composer qualified as Composer
-import Strategy.Conda qualified as Conda
-import Strategy.Glide qualified as Glide
-import Strategy.Godep qualified as Godep
-import Strategy.Gomodules qualified as Gomodules
-import Strategy.Googlesource.RepoManifest qualified as RepoManifest
-import Strategy.Gradle qualified as Gradle
-import Strategy.Haskell.Cabal qualified as Cabal
-import Strategy.Haskell.Stack qualified as Stack
-import Strategy.Leiningen qualified as Leiningen
-import Strategy.Maven qualified as Maven
-import Strategy.Mix qualified as Mix
-import Strategy.Npm qualified as Npm
-import Strategy.NuGet.Nuspec qualified as Nuspec
-import Strategy.NuGet.PackageReference qualified as PackageReference
-import Strategy.NuGet.PackagesConfig qualified as PackagesConfig
-import Strategy.NuGet.Paket qualified as Paket
-import Strategy.NuGet.ProjectAssetsJson qualified as ProjectAssetsJson
-import Strategy.NuGet.ProjectJson qualified as ProjectJson
-import Strategy.Pub qualified as Pub
-import Strategy.Python.Pipenv qualified as Pipenv
-import Strategy.Python.Poetry qualified as Poetry
-import Strategy.Python.Setuptools qualified as Setuptools
-import Strategy.RPM qualified as RPM
-import Strategy.Rebar3 qualified as Rebar3
-import Strategy.Scala qualified as Scala
-import Strategy.SwiftPM qualified as SwiftPM
+import Srclib.Types (Locator (locatorProject, locatorRevision), SourceUnit, parseLocator)
+
+--import Strategy.Bundler qualified as Bundler
+--import Strategy.Cargo qualified as Cargo
+--import Strategy.Carthage qualified as Carthage
+--import Strategy.Cocoapods qualified as Cocoapods
+--import Strategy.Composer qualified as Composer
+--import Strategy.Conda qualified as Conda
+--import Strategy.Glide qualified as Glide
+--import Strategy.Godep qualified as Godep
+--import Strategy.Gomodules qualified as Gomodules
+--import Strategy.Googlesource.RepoManifest qualified as RepoManifest
+--import Strategy.Gradle qualified as Gradle
+--import Strategy.Haskell.Cabal qualified as Cabal
+--import Strategy.Haskell.Stack qualified as Stack
+--import Strategy.Leiningen qualified as Leiningen
+--import Strategy.Maven qualified as Maven
+--import Strategy.Mix qualified as Mix
+--import Strategy.Npm qualified as Npm
+--import Strategy.NuGet.Nuspec qualified as Nuspec
+--import Strategy.NuGet.PackageReference qualified as PackageReference
+--import Strategy.NuGet.PackagesConfig qualified as PackagesConfig
+--import Strategy.NuGet.Paket qualified as Paket
+--import Strategy.NuGet.ProjectAssetsJson qualified as ProjectAssetsJson
+--import Strategy.NuGet.ProjectJson qualified as ProjectJson
+--import Strategy.Pub qualified as Pub
+--import Strategy.Python.Pipenv qualified as Pipenv
+--import Strategy.Python.Poetry qualified as Poetry
+--import Strategy.Python.Setuptools qualified as Setuptools
+--import Strategy.RPM qualified as RPM
+--import Strategy.Rebar3 qualified as Rebar3
+--import Strategy.Scala qualified as Scala
+
+import App.Fossa.Analyze.Types
 import Strategy.Yarn qualified as Yarn
 import System.Exit (die)
 import Types (DiscoveredProject (..), FoundTargets)
 import VCS.Git (fetchGitContributors)
-
-type TaskEffs sig m =
-  ( Has (Lift IO) sig m
-  , MonadIO m
-  , Has ReadFS sig m
-  , Has Exec sig m
-  , Has Logger sig m
-  , Has Diag.Diagnostics sig m
-  )
+import Control.Monad (when)
+import qualified Discovery.Archive as Archive
 
 data ScanDestination
   = -- | upload to fossa with provided api key and base url
@@ -195,55 +190,64 @@ analyzeMain workdir recordMode logSeverity destination project unpackArchives js
   where
     doAnalyze basedir = analyze basedir destination project unpackArchives jsonOutput modeOptions filters
 
-discoverFuncs :: (TaskEffs sig m, TaskEffs rsig run) => [Path Abs Dir -> m [DiscoveredProject run]]
-discoverFuncs =
-  [ Bundler.discover
-  , Cabal.discover
-  , Cargo.discover
-  , Carthage.discover
-  , Cocoapods.discover
-  , Composer.discover
-  , Conda.discover
-  , Glide.discover
-  , Godep.discover
-  , Gomodules.discover
-  , Gradle.discover
-  , Leiningen.discover
-  , Maven.discover
-  , Mix.discover
-  , Npm.discover
-  , Nuspec.discover
-  , PackageReference.discover
-  , PackagesConfig.discover
-  , Paket.discover
-  , Pipenv.discover
-  , Poetry.discover
-  , ProjectAssetsJson.discover
-  , ProjectJson.discover
-  , Pub.discover
-  , RPM.discover
-  , Rebar3.discover
-  , RepoManifest.discover
-  , Scala.discover
-  , Setuptools.discover
-  , Stack.discover
-  , SwiftPM.discover
-  , Yarn.discover
-  ]
+--discoverFuncs :: (TaskEffs sig m, TaskEffs rsig run) => [Path Abs Dir -> m [DiscoveredProject run]]
+--discoverFuncs =
+-- [ Bundler.discover
+-- , Cabal.discover
+-- , Cargo.discover
+-- , Carthage.discover
+-- , Cocoapods.discover
+-- , Composer.discover
+-- , Conda.discover
+-- , Glide.discover
+-- , Godep.discover
+-- , Gomodules.discover
+-- , Gradle.discover
+-- , Leiningen.discover
+-- , Maven.discover
+-- , Mix.discover
+-- , Npm.discover
+-- , Nuspec.discover
+-- , PackageReference.discover
+-- , PackagesConfig.discover
+-- , Paket.discover
+-- , Pipenv.discover
+-- , Poetry.discover
+-- , ProjectAssetsJson.discover
+-- , ProjectJson.discover
+-- , Pub.discover
+-- , RPM.discover
+-- , Rebar3.discover
+-- , RepoManifest.discover
+-- , Scala.discover
+-- , Setuptools.discover
+-- , Stack.discover
+-- , SwiftPM.discover
+-- , Yarn.discover
+-- ]
 
 runDependencyAnalysis ::
-  (Has (Lift IO) sig m, Has AtomicCounter sig m, Has Debug sig m, Has Logger sig m, Has (Output ProjectResult) sig m) =>
+  ( AnalyzeProject a
+  , Has (Lift IO) sig m
+  , Has AtomicCounter sig m
+  , Has Debug sig m
+  , Has Logger sig m
+  , Has ReadFS sig m
+  , Has Exec sig m
+  , Has (Output ProjectResult) sig m
+  , MonadIO m
+  ) =>
   -- | Analysis base directory
-  BaseDir ->
+  Path Abs Dir ->
   AllFilters ->
-  DiscoveredProject (StickyDiagC (DiagDebugC (Diag.DiagnosticsC m))) ->
+  DiscoveredProject a ->
   m ()
-runDependencyAnalysis (BaseDir basedir) filters project =
+runDependencyAnalysis basedir filters project =
   case applyFiltersToProject basedir filters project of
     Nothing -> logInfo $ "Skipping " <> pretty (projectType project) <> " project at " <> viaShow (projectPath project) <> ": no filters matched"
     Just targets -> do
       logInfo $ "Analyzing " <> pretty (projectType project) <> " project at " <> pretty (toFilePath (projectPath project))
-      graphResult <- Diag.runDiagnosticsIO . diagToDebug . stickyDiag $ projectDependencyResults project targets
+      graphResult <- Diag.runDiagnosticsIO . diagToDebug . stickyDiag $ analyzeProject targets (projectData project)
       Diag.withResult SevWarn graphResult (output . mkResult basedir project)
 
 applyFiltersToProject :: Path Abs Dir -> AllFilters -> DiscoveredProject n -> Maybe FoundTargets
@@ -255,6 +259,25 @@ applyFiltersToProject basedir filters DiscoveredProject{..} =
     Nothing -> Just projectBuildTargets
     Just rel -> do
       applyFilters filters projectType rel projectBuildTargets
+
+runAnalyzers ::
+  ( Has (Output ProjectResult) sig m
+  , Has ReadFS sig m
+  , Has Exec sig m
+  , Has Logger sig m
+  , Has TaskPool sig m
+  , Has AtomicCounter sig m
+  , Has (Lift IO) sig m
+  , Has Debug sig m
+  , MonadIO m
+  ) =>
+  Path Abs Dir ->
+  AllFilters ->
+  m ()
+runAnalyzers basedir filters = do
+  single Yarn.discover
+  where
+    single f = withDiscoveredProjects f basedir (runDependencyAnalysis basedir filters)
 
 analyze ::
   ( Has (Lift IO) sig m
@@ -295,7 +318,12 @@ analyze (BaseDir basedir) destination override unpackArchives jsonOutput ModeOpt
       . runFinally
       . withTaskPool capabilities updateProgress
       . runAtomicCounter
-      $ withDiscoveredProjects discoverFuncs (fromFlag UnpackArchives unpackArchives) basedir (runDependencyAnalysis (BaseDir basedir) filters)
+      -- withDiscoveredProjects discoverFuncs (fromFlag UnpackArchives unpackArchives) basedir (runDependencyAnalysis (BaseDir basedir) filters)
+      $ do
+          runAnalyzers basedir filters
+          when (fromFlag UnpackArchives unpackArchives) $ forkTask $ do -- FIXME: cleanup?
+            res <- Diag.runDiagnosticsIO . diagToDebug . stickyDiag $ Archive.discover (`runAnalyzers` filters) basedir
+            Diag.withResult SevError res (const (pure ()))
 
   let filteredProjects = filterProjects (BaseDir basedir) projectResults
 

--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -32,6 +32,7 @@ import App.Types (
   ProjectRevision (projectBranch, projectName, projectRevision),
  )
 import App.Util (validateDir)
+import Codec.Compression.GZip qualified as GZip
 import Control.Carrier.AtomicCounter (AtomicCounter, runAtomicCounter)
 import Control.Carrier.Debug (Debug, debugMetadata, debugScope, ignoreDebug)
 import Control.Carrier.Diagnostics qualified as Diag
@@ -48,6 +49,7 @@ import Control.Monad (when)
 import Control.Monad.IO.Class (MonadIO)
 import Data.Aeson ((.=))
 import Data.Aeson qualified as Aeson
+import Data.ByteString.Lazy qualified as BL
 import Data.Flag (Flag, fromFlag)
 import Data.Foldable (traverse_)
 import Data.Functor (void)
@@ -154,7 +156,7 @@ analyzeMain workdir logSeverity destination project unpackArchives jsonOutput mo
       SevDebug -> do
         basedir <- sendIO $ validateDir workdir
         (scope, res) <- collectDebugBundle . Diag.errorBoundaryIO $ doAnalyze basedir
-        sendIO $ Aeson.encodeFile "fossa.debug.json" scope
+        sendIO . BL.writeFile "fossa.debug.json.gz" . GZip.compress $ Aeson.encode scope
         either Diag.rethrow pure res
       _ -> do
         basedir <- sendIO $ validateDir workdir

--- a/src/App/Fossa/Analyze/Debug.hs
+++ b/src/App/Fossa/Analyze/Debug.hs
@@ -39,6 +39,7 @@ import System.Info qualified as Info
 collectDebugBundle ::
   ( Has Exec sig m
   , Has ReadFS sig m
+  , Has Diagnostics sig m
   , Has (Lift IO) sig m
   ) =>
   DebugEverythingC (DebugC m) a ->

--- a/src/App/Fossa/Analyze/Debug.hs
+++ b/src/App/Fossa/Analyze/Debug.hs
@@ -78,7 +78,7 @@ logToDebug = interpret $ \case
 -----------------------------------------------
 
 -- | Combine all of our debug wrappers into a mega-wrapper
-type DebugEverythingC m = DiagDebugC (ReadFSDebugC (ExecDebugC (LogDebugC m)))
+type DebugEverythingC m = DiagDebugC (ReadFSDebugC (ExecDebugC m))
 
 debugEverything :: (Has Debug sig m, Has Exec sig m, Has ReadFS sig m, Has Logger sig m) => DebugEverythingC m a -> m a
-debugEverything = logToDebug . execToDebug . readFSToDebug . diagToDebug
+debugEverything = execToDebug . readFSToDebug . diagToDebug

--- a/src/App/Fossa/Analyze/Debug.hs
+++ b/src/App/Fossa/Analyze/Debug.hs
@@ -1,0 +1,84 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module App.Fossa.Analyze.Debug (
+  -- * Debug individual effects
+  DiagDebugC,
+  diagToDebug,
+  ReadFSDebugC,
+  readFSToDebug,
+  ExecDebugC,
+  execToDebug,
+  LogDebugC,
+  logToDebug,
+
+  -- * Debug all effects
+  debugEverything,
+) where
+
+import Control.Carrier.Debug
+import Control.Carrier.Diagnostics (Diagnostics (Context, Fatal))
+import Control.Carrier.Simple (SimpleC, interpret)
+import Control.Effect.Sum (Member, inj)
+import Control.Monad.IO.Class (MonadIO)
+import Effect.Exec (Exec, ExecF (..))
+import Effect.Logger (Logger, LoggerF (..))
+import Effect.ReadFS (ReadFS, ReadFSF (..))
+
+newtype DiagDebugC m a = DiagDebugC {runDiagDebugC :: m a}
+  deriving (Functor, Applicative, Monad, MonadIO)
+
+-- | Transcribe 'context' as 'debugScope', and 'fatal' as 'debugError'
+instance (Member Diagnostics sig, Member Debug sig, Algebra sig m) => Algebra (Diagnostics :+: sig) (DiagDebugC m) where
+  alg hdl sig ctx = DiagDebugC $
+    case sig of
+      L thing@(Context nm _) -> debugScope nm $ alg (runDiagDebugC . hdl) (inj thing) ctx
+      L thing@(Fatal err) -> do
+        debugError err
+        alg (runDiagDebugC . hdl) (inj thing) ctx
+      L ours -> alg (runDiagDebugC . hdl) (inj ours) ctx
+      R other -> alg (runDiagDebugC . hdl) other ctx
+
+diagToDebug :: DiagDebugC m a -> m a
+diagToDebug = runDiagDebugC
+
+-----------------------------------------------
+
+type ReadFSDebugC = SimpleC ReadFSF
+
+-- | Record most ReadFS constructors, ignoring ListDir because it explodes the
+-- size of the debug bundle
+readFSToDebug :: (Has ReadFS sig m, Has Debug sig m) => ReadFSDebugC m a -> m a
+readFSToDebug = interpret $ \case
+  cons@ReadContentsBS'{} -> recording cons
+  cons@ReadContentsText'{} -> recording cons
+  cons@DoesFileExist{} -> recording cons
+  cons@DoesDirExist{} -> recording cons
+  cons@ResolveFile'{} -> recording cons
+  cons@ResolveDir'{} -> recording cons
+  cons@ListDir{} -> ignoring cons
+
+-----------------------------------------------
+
+type ExecDebugC = SimpleC ExecF
+
+execToDebug :: (Has Exec sig m, Has Debug sig m) => ExecDebugC m a -> m a
+execToDebug = interpret $ \case
+  cons@Exec{} -> recording cons
+
+-----------------------------------------------
+
+type LogDebugC = SimpleC LoggerF
+
+logToDebug :: (Has Logger sig m, Has Debug sig m) => LogDebugC m a -> m a
+logToDebug = interpret $ \case
+  cons@Log{} -> recording cons
+  cons@LogStdout{} -> ignoring cons
+
+-----------------------------------------------
+
+-- | Combine all of our debug wrappers into a mega-wrapper
+type DebugEverythingC m = DiagDebugC (ReadFSDebugC (ExecDebugC (LogDebugC m)))
+
+debugEverything :: (Has Debug sig m, Has Exec sig m, Has ReadFS sig m, Has Logger sig m) => DebugEverythingC m a -> m a
+debugEverything = logToDebug . execToDebug . readFSToDebug . diagToDebug

--- a/src/App/Fossa/Analyze/Debug.hs
+++ b/src/App/Fossa/Analyze/Debug.hs
@@ -26,7 +26,7 @@ import Control.Effect.Lift (Lift)
 import Control.Effect.Record (Journal, RecordC, runRecord)
 import Control.Effect.Sum (Member, inj)
 import Control.Monad.IO.Class (MonadIO)
-import Data.Aeson (ToJSON)
+import Data.Aeson (ToJSON (toEncoding), defaultOptions, genericToEncoding)
 import Data.String.Conversion (toText)
 import Data.Word (Word64)
 import Effect.Exec (Exec, ExecF (..))
@@ -91,7 +91,8 @@ data DebugBundle = DebugBundle
   }
   deriving (Show, Generic)
 
-instance ToJSON DebugBundle
+instance ToJSON DebugBundle where
+  toEncoding = genericToEncoding defaultOptions
 
 data SystemInfo = SystemInfo
   { systemInfoOs :: String
@@ -102,7 +103,8 @@ data SystemInfo = SystemInfo
   }
   deriving (Eq, Ord, Show, Generic)
 
-instance ToJSON SystemInfo
+instance ToJSON SystemInfo where
+  toEncoding = genericToEncoding defaultOptions
 
 data SystemMemory = SystemMemory
   { systemMemoryLiveBytes :: Word64
@@ -110,7 +112,8 @@ data SystemMemory = SystemMemory
   }
   deriving (Eq, Ord, Show, Generic)
 
-instance ToJSON SystemMemory
+instance ToJSON SystemMemory where
+  toEncoding = genericToEncoding defaultOptions
 
 data BundleJournals = BundleJournals
   { bundleJournalReadFS :: Journal ReadFSF
@@ -118,7 +121,8 @@ data BundleJournals = BundleJournals
   }
   deriving (Show, Generic)
 
-instance ToJSON BundleJournals
+instance ToJSON BundleJournals where
+  toEncoding = genericToEncoding defaultOptions
 
 -----------------------------------------------
 

--- a/src/App/Fossa/Analyze/Debug.hs
+++ b/src/App/Fossa/Analyze/Debug.hs
@@ -152,6 +152,7 @@ type ReadFSDebugC = SimpleC ReadFSF
 readFSToDebug :: (Has ReadFS sig m, Has Debug sig m) => ReadFSDebugC m a -> m a
 readFSToDebug = interpret $ \case
   cons@ReadContentsBS'{} -> recording cons
+  cons@ReadContentsBSLimit'{} -> ignoring cons
   cons@ReadContentsText'{} -> recording cons
   cons@DoesFileExist{} -> recording cons
   cons@DoesDirExist{} -> recording cons

--- a/src/App/Fossa/Analyze/Debug.hs
+++ b/src/App/Fossa/Analyze/Debug.hs
@@ -80,5 +80,5 @@ logToDebug = interpret $ \case
 -- | Combine all of our debug wrappers into a mega-wrapper
 type DebugEverythingC m = DiagDebugC (ReadFSDebugC (ExecDebugC m))
 
-debugEverything :: (Has Debug sig m, Has Exec sig m, Has ReadFS sig m, Has Logger sig m) => DebugEverythingC m a -> m a
+debugEverything :: (Has Debug sig m, Has Exec sig m, Has ReadFS sig m) => DebugEverythingC m a -> m a
 debugEverything = execToDebug . readFSToDebug . diagToDebug

--- a/src/App/Fossa/Analyze/Types.hs
+++ b/src/App/Fossa/Analyze/Types.hs
@@ -1,0 +1,23 @@
+module App.Fossa.Analyze.Types (
+  AnalyzeProject (..),
+) where
+
+import Control.Carrier.Diagnostics
+import Control.Effect.Lift
+import Control.Monad.IO.Class (MonadIO)
+import Effect.Exec
+import Effect.Logger
+import Effect.ReadFS
+import Types
+
+type TaskEffs sig m =
+  ( Has (Lift IO) sig m
+  , MonadIO m
+  , Has ReadFS sig m
+  , Has Exec sig m
+  , Has Logger sig m
+  , Has Diagnostics sig m
+  )
+
+class AnalyzeProject a where
+  analyzeProject :: TaskEffs sig m => FoundTargets -> a -> m DependencyResults

--- a/src/App/Fossa/Analyze/Types.hs
+++ b/src/App/Fossa/Analyze/Types.hs
@@ -3,11 +3,12 @@ module App.Fossa.Analyze.Types (
 ) where
 
 import Control.Carrier.Diagnostics
+import Control.Effect.Debug (Debug)
 import Control.Effect.Lift
 import Control.Monad.IO.Class (MonadIO)
-import Effect.Exec
-import Effect.Logger
-import Effect.ReadFS
+import Effect.Exec (Exec)
+import Effect.Logger (Logger)
+import Effect.ReadFS (ReadFS)
 import Types
 
 type TaskEffs sig m =
@@ -17,6 +18,7 @@ type TaskEffs sig m =
   , Has Exec sig m
   , Has Logger sig m
   , Has Diagnostics sig m
+  , Has Debug sig m
   )
 
 class AnalyzeProject a where

--- a/src/App/Fossa/Analyze/Types.hs
+++ b/src/App/Fossa/Analyze/Types.hs
@@ -1,5 +1,6 @@
 module App.Fossa.Analyze.Types (
   AnalyzeProject (..),
+  AnalyzeTaskEffs,
 ) where
 
 import Control.Carrier.Diagnostics
@@ -11,7 +12,7 @@ import Effect.Logger (Logger)
 import Effect.ReadFS (ReadFS)
 import Types
 
-type TaskEffs sig m =
+type AnalyzeTaskEffs sig m =
   ( Has (Lift IO) sig m
   , MonadIO m
   , Has ReadFS sig m
@@ -22,4 +23,4 @@ type TaskEffs sig m =
   )
 
 class AnalyzeProject a where
-  analyzeProject :: TaskEffs sig m => FoundTargets -> a -> m DependencyResults
+  analyzeProject :: AnalyzeTaskEffs sig m => FoundTargets -> a -> m DependencyResults

--- a/src/App/Fossa/ListTargets.hs
+++ b/src/App/Fossa/ListTargets.hs
@@ -7,6 +7,7 @@ module App.Fossa.ListTargets (
 import App.Fossa.Analyze (discoverFuncs)
 import App.Types (BaseDir (..))
 import Control.Carrier.AtomicCounter
+import Control.Carrier.Debug (ignoreDebug)
 import Control.Carrier.Diagnostics qualified as Diag
 import Control.Carrier.Finally
 import Control.Carrier.StickyLogger (StickyLogger, logSticky', runStickyLogger)
@@ -29,7 +30,8 @@ listTargetsMain :: BaseDir -> IO ()
 listTargetsMain (BaseDir basedir) = do
   capabilities <- getNumCapabilities
 
-  withDefaultLogger SevInfo
+  ignoreDebug
+    . withDefaultLogger SevInfo
     . runStickyLogger SevInfo
     . runFinally
     . withTaskPool capabilities updateProgress

--- a/src/App/Fossa/ListTargets.hs
+++ b/src/App/Fossa/ListTargets.hs
@@ -13,6 +13,8 @@ import Control.Carrier.Finally
 import Control.Carrier.StickyLogger (StickyLogger, logSticky', runStickyLogger)
 import Control.Carrier.TaskPool
 import Control.Concurrent (getNumCapabilities)
+import Control.Effect.Debug (Debug)
+import Control.Effect.Lift (Lift)
 import Data.Foldable (for_)
 import Data.Set qualified as Set
 import Data.Set.NonEmpty
@@ -20,15 +22,41 @@ import Discovery.Projects (withDiscoveredProjects)
 import Effect.Exec
 import Effect.Logger
 import Effect.ReadFS
-import Path (toFilePath)
+import Path
 import Path.IO (makeRelative)
+import Strategy.Bundler qualified as Bundler
+import Strategy.Cargo qualified as Cargo
+import Strategy.Carthage qualified as Carthage
+import Strategy.Cocoapods qualified as Cocoapods
+import Strategy.Composer qualified as Composer
+import Strategy.Conda qualified as Conda
+import Strategy.Glide qualified as Glide
+import Strategy.Godep qualified as Godep
+import Strategy.Gomodules qualified as Gomodules
+import Strategy.Googlesource.RepoManifest qualified as RepoManifest
+import Strategy.Gradle qualified as Gradle
+import Strategy.Haskell.Cabal qualified as Cabal
+import Strategy.Haskell.Stack qualified as Stack
+import Strategy.Leiningen qualified as Leiningen
+import Strategy.Maven qualified as Maven
+import Strategy.Mix qualified as Mix
+import Strategy.Npm qualified as Npm
+import Strategy.NuGet.Nuspec qualified as Nuspec
+import Strategy.NuGet.PackageReference qualified as PackageReference
+import Strategy.NuGet.PackagesConfig qualified as PackagesConfig
+import Strategy.NuGet.Paket qualified as Paket
+import Strategy.NuGet.ProjectAssetsJson qualified as ProjectAssetsJson
+import Strategy.NuGet.ProjectJson qualified as ProjectJson
+import Strategy.Pub qualified as Pub
+import Strategy.Python.Pipenv qualified as Pipenv
+import Strategy.Python.Poetry qualified as Poetry
+import Strategy.Python.Setuptools qualified as Setuptools
+import Strategy.RPM qualified as RPM
+import Strategy.Rebar3 qualified as Rebar3
+import Strategy.Scala qualified as Scala
+import Strategy.Yarn qualified as Yarn
 import Types (BuildTarget (..), DiscoveredProject (..), FoundTargets (..))
 
-type DummyM = ReadFSIOC (ExecIOC (Diag.DiagnosticsC (LoggerC IO)))
-
-listTargetsMain = undefined
-
-{-
 listTargetsMain :: BaseDir -> IO ()
 listTargetsMain (BaseDir basedir) = do
   capabilities <- getNumCapabilities
@@ -41,34 +69,82 @@ listTargetsMain (BaseDir basedir) = do
     . runReadFSIO
     . runExecIO
     . runAtomicCounter
-    $ do
-      withDiscoveredProjects discoverFuncs False basedir $ \(project :: DiscoveredProject DummyM) -> do
-        let maybeRel = makeRelative basedir (projectPath project)
+    $ runAll basedir
 
-        case maybeRel of
-          Nothing -> pure ()
-          Just rel -> do
-            logInfo $
-              "Found project: "
-                <> pretty (projectType project)
-                <> "@"
-                <> pretty (toFilePath rel)
+runAll ::
+  ( Has ReadFS sig m
+  , Has Exec sig m
+  , Has Logger sig m
+  , Has TaskPool sig m
+  , Has (Lift IO) sig m
+  , Has AtomicCounter sig m
+  , Has Debug sig m
+  ) =>
+  Path Abs Dir ->
+  m ()
+runAll basedir = do
+  single Bundler.discover
+  single Cabal.discover
+  single Cargo.discover
+  single Carthage.discover
+  single Cocoapods.discover
+  single Composer.discover
+  single Conda.discover
+  single Glide.discover
+  single Godep.discover
+  single Gomodules.discover
+  single Gradle.discover
+  single Leiningen.discover
+  single Maven.discover
+  single Mix.discover
+  single Npm.discover
+  single Nuspec.discover
+  single PackageReference.discover
+  single PackagesConfig.discover
+  single Paket.discover
+  single Pipenv.discover
+  single Poetry.discover
+  single ProjectAssetsJson.discover
+  single ProjectJson.discover
+  single Pub.discover
+  single RPM.discover
+  single Rebar3.discover
+  single RepoManifest.discover
+  single Scala.discover
+  single Setuptools.discover
+  single Stack.discover
+  single Yarn.discover
+  where
+    single f = withDiscoveredProjects f basedir (printSingle basedir)
 
-            case projectBuildTargets project of
-              ProjectWithoutTargets -> do
-                logInfo $
-                  "Found target: "
-                    <> pretty (projectType project)
-                    <> "@"
-                    <> pretty (toFilePath rel)
-              FoundTargets targets -> for_ (Set.toList $ toSet targets) $ \target -> do
-                logInfo $
-                  "Found target: "
-                    <> pretty (projectType project)
-                    <> "@"
-                    <> pretty (toFilePath rel)
-                    <> ":"
-                    <> pretty (unBuildTarget target)
+printSingle :: Has Logger sig m => Path Abs Dir -> DiscoveredProject a -> m ()
+printSingle basedir project = do
+  let maybeRel = makeRelative basedir (projectPath project)
+
+  case maybeRel of
+    Nothing -> pure ()
+    Just rel -> do
+      logInfo $
+        "Found project: "
+          <> pretty (projectType project)
+          <> "@"
+          <> pretty (toFilePath rel)
+
+      case projectBuildTargets project of
+        ProjectWithoutTargets -> do
+          logInfo $
+            "Found target: "
+              <> pretty (projectType project)
+              <> "@"
+              <> pretty (toFilePath rel)
+        FoundTargets targets -> for_ (Set.toList $ toSet targets) $ \target -> do
+          logInfo $
+            "Found target: "
+              <> pretty (projectType project)
+              <> "@"
+              <> pretty (toFilePath rel)
+              <> ":"
+              <> pretty (unBuildTarget target)
 
 updateProgress :: Has StickyLogger sig m => Progress -> m ()
 updateProgress Progress{..} =
@@ -82,5 +158,3 @@ updateProgress Progress{..} =
         <> " Completed"
         <> " ]"
     )
-
--}

--- a/src/App/Fossa/ListTargets.hs
+++ b/src/App/Fossa/ListTargets.hs
@@ -4,7 +4,7 @@ module App.Fossa.ListTargets (
   listTargetsMain,
 ) where
 
-import App.Fossa.Analyze (discoverFuncs)
+--import App.Fossa.Analyze (discoverFuncs)
 import App.Types (BaseDir (..))
 import Control.Carrier.AtomicCounter
 import Control.Carrier.Debug (ignoreDebug)
@@ -26,6 +26,9 @@ import Types (BuildTarget (..), DiscoveredProject (..), FoundTargets (..))
 
 type DummyM = ReadFSIOC (ExecIOC (Diag.DiagnosticsC (LoggerC IO)))
 
+listTargetsMain = undefined
+
+{-
 listTargetsMain :: BaseDir -> IO ()
 listTargetsMain (BaseDir basedir) = do
   capabilities <- getNumCapabilities
@@ -79,3 +82,5 @@ updateProgress Progress{..} =
         <> " Completed"
         <> " ]"
     )
+
+-}

--- a/src/App/Fossa/ListTargets.hs
+++ b/src/App/Fossa/ListTargets.hs
@@ -8,7 +8,6 @@ module App.Fossa.ListTargets (
 import App.Types (BaseDir (..))
 import Control.Carrier.AtomicCounter
 import Control.Carrier.Debug (ignoreDebug)
-import Control.Carrier.Diagnostics qualified as Diag
 import Control.Carrier.Finally
 import Control.Carrier.StickyLogger (StickyLogger, logSticky', runStickyLogger)
 import Control.Carrier.TaskPool
@@ -55,6 +54,7 @@ import Strategy.Python.Setuptools qualified as Setuptools
 import Strategy.RPM qualified as RPM
 import Strategy.Rebar3 qualified as Rebar3
 import Strategy.Scala qualified as Scala
+import Strategy.SwiftPM qualified as SwiftPM
 import Strategy.Yarn qualified as Yarn
 import Types (BuildTarget (..), DiscoveredProject (..), FoundTargets (..))
 
@@ -115,6 +115,7 @@ runAll basedir = do
   single Scala.discover
   single Setuptools.discover
   single Stack.discover
+  single SwiftPM.discover
   single Yarn.discover
   where
     single f = withDiscoveredProjects f basedir (printSingle basedir)

--- a/src/App/Fossa/ListTargets.hs
+++ b/src/App/Fossa/ListTargets.hs
@@ -15,6 +15,7 @@ import Control.Carrier.TaskPool
 import Control.Concurrent (getNumCapabilities)
 import Control.Effect.Debug (Debug)
 import Control.Effect.Lift (Lift)
+import Control.Monad.IO.Class (MonadIO)
 import Data.Foldable (for_)
 import Data.Set qualified as Set
 import Data.Set.NonEmpty
@@ -77,6 +78,7 @@ runAll ::
   , Has Logger sig m
   , Has TaskPool sig m
   , Has (Lift IO) sig m
+  , MonadIO m
   , Has AtomicCounter sig m
   , Has Debug sig m
   ) =>

--- a/src/App/Fossa/Main.hs
+++ b/src/App/Fossa/Main.hs
@@ -4,7 +4,7 @@ module App.Fossa.Main (
   appMain,
 ) where
 
-import App.Fossa.Analyze (BinaryDiscoveryMode (..), IATAssertionMode (..), JsonOutput (..), ModeOptions (ModeOptions), RecordMode (..), ScanDestination (..), UnpackArchives (..), VSIAnalysisMode (..), analyzeMain)
+import App.Fossa.Analyze (BinaryDiscoveryMode (..), IATAssertionMode (..), JsonOutput (..), ModeOptions (ModeOptions), ScanDestination (..), UnpackArchives (..), VSIAnalysisMode (..), analyzeMain)
 import App.Fossa.Compatibility (Argument, argumentParser, compatibilityMain)
 import App.Fossa.Configuration (
   ConfigFile (
@@ -192,7 +192,7 @@ appMain = do
       let analyzeOverride = override{overrideBranch = analyzeBranch <|> ((fileConfig >>= configRevision) >>= configBranch)}
           combinedFilters = normalizedFilters fileConfig analyzeOptions
           modeOptions = ModeOptions analyzeVSIMode assertionMode analyzeBinaryDiscoveryMode
-          doAnalyze destination = analyzeMain analyzeBaseDir analyzeRecordMode logSeverity destination analyzeOverride analyzeUnpackArchives analyzeJsonOutput modeOptions combinedFilters
+          doAnalyze destination = analyzeMain analyzeBaseDir logSeverity destination analyzeOverride analyzeUnpackArchives analyzeJsonOutput modeOptions combinedFilters
 
       if analyzeOutput
         then doAnalyze OutputStdout
@@ -418,7 +418,6 @@ analyzeOpts =
     <*> binaryDiscoveryOpt
     <*> iatAssertionOpt
     <*> monorepoOpts
-    <*> analyzeReplayOpt
     <*> baseDirArg
 
 vsiAnalyzeOpt :: Parser VSIAnalysisMode
@@ -435,12 +434,6 @@ iatAssertionOpt :: Parser AnalyzeVSIAssertionMode
 iatAssertionOpt =
   (AnalyzeVSIAssertionEnabled <$> strOption (long "experimental-link-project-binary" <> hidden))
     <|> pure AnalyzeVSIAssertionDisabled
-
-analyzeReplayOpt :: Parser RecordMode
-analyzeReplayOpt =
-  flag' RecordModeRecord (long "record" <> hidden)
-    <|> (RecordModeReplay <$> strOption (long "replay" <> hidden))
-    <|> pure RecordModeNone
 
 filterOpt :: Parser TargetFilter
 filterOpt = option (eitherReader parseFilter) (long "filter" <> help "(deprecated) Analysis-Target filters (default: none)" <> metavar "ANALYSIS-TARGET")
@@ -713,7 +706,6 @@ data AnalyzeOptions = AnalyzeOptions
   , analyzeBinaryDiscoveryMode :: BinaryDiscoveryMode
   , analyzeAssertMode :: AnalyzeVSIAssertionMode
   , monorepoAnalysisOpts :: MonorepoAnalysisOpts
-  , analyzeRecordMode :: RecordMode
   , analyzeBaseDir :: FilePath
   }
 

--- a/src/App/Fossa/Main.hs
+++ b/src/App/Fossa/Main.hs
@@ -322,7 +322,7 @@ baseDirArg = argument str (metavar "DIR" <> help "Set the base directory for sca
 opts :: Parser CmdOptions
 opts =
   CmdOptions
-    <$> switch (long "debug" <> help "Enable debug logging")
+    <$> switch (long "debug" <> help "Enable debug logging, and write detailed debug information to `fossa.debug.json`")
     <*> optional (uriOption (long "endpoint" <> short 'e' <> metavar "URL" <> help "The FOSSA API server base URL (default: https://app.fossa.com)"))
     <*> optional (strOption (long "project" <> short 'p' <> help "this repository's URL or VCS endpoint (default: VCS remote 'origin')"))
     <*> optional (strOption (long "revision" <> short 'r' <> help "this repository's current revision hash (default: VCS hash HEAD)"))

--- a/src/App/Fossa/Main.hs
+++ b/src/App/Fossa/Main.hs
@@ -222,7 +222,7 @@ appMain = do
     --
     ListTargetsCommand dir -> do
       baseDir <- validateDir dir
-      listTargetsMain baseDir
+      listTargetsMain logSeverity baseDir
     --
     VPSCommand VPSOptions{..} -> do
       apikey <- requireKey maybeApiKey

--- a/src/App/Fossa/Monorepo.hs
+++ b/src/App/Fossa/Monorepo.hs
@@ -16,15 +16,31 @@ import App.Types
 import Control.Carrier.Diagnostics
 import Control.Effect.Lift (Lift)
 import Data.Text
-import Effect.Exec
+import Effect.Exec (Exec, runExecIO)
 import Effect.Logger
+import Effect.ReadFS (ReadFS, runReadFSIO)
 import Fossa.API.Types
 
 monorepoMain :: BaseDir -> MonorepoAnalysisOpts -> Severity -> ApiOpts -> ProjectMetadata -> OverrideProject -> PathFilters -> IO ()
 monorepoMain basedir monoRepoAnalysisOpts logSeverity apiOpts projectMeta overrideProject filters = withDefaultLogger logSeverity $ do
-  logWithExit_ $ withWigginsBinary $ monorepoScan basedir monoRepoAnalysisOpts filters logSeverity apiOpts projectMeta overrideProject
+  logWithExit_ $ runReadFSIO $ runExecIO $ withWigginsBinary $ monorepoScan basedir monoRepoAnalysisOpts filters logSeverity apiOpts projectMeta overrideProject
 
-monorepoScan :: (Has Diagnostics sig m, Has (Lift IO) sig m, Has Logger sig m) => BaseDir -> MonorepoAnalysisOpts -> PathFilters -> Severity -> ApiOpts -> ProjectMetadata -> OverrideProject -> BinaryPaths -> m ()
+monorepoScan ::
+  ( Has Diagnostics sig m
+  , Has (Lift IO) sig m
+  , Has ReadFS sig m
+  , Has Exec sig m
+  , Has Logger sig m
+  ) =>
+  BaseDir ->
+  MonorepoAnalysisOpts ->
+  PathFilters ->
+  Severity ->
+  ApiOpts ->
+  ProjectMetadata ->
+  OverrideProject ->
+  BinaryPaths ->
+  m ()
 monorepoScan (BaseDir basedir) monorepoAnalysisOpts filters logSeverity apiOpts projectMeta projectOverride binaryPaths = do
   projectRevision <- mergeOverride projectOverride <$> (inferProjectFromVCS basedir <||> inferProjectDefault basedir)
   saveRevision projectRevision

--- a/src/App/Fossa/ProjectInference.hs
+++ b/src/App/Fossa/ProjectInference.hs
@@ -47,8 +47,8 @@ mergeOverride OverrideProject{..} InferredProject{..} = ProjectRevision name rev
     branch = overrideBranch <|> inferredBranch
 
 -- TODO: pass ReadFS and Exec constraints upward
-inferProjectFromVCS :: (Has Diagnostics sig m, Has (Lift IO) sig m) => Path Abs Dir -> m InferredProject
-inferProjectFromVCS current = runReadFSIO $ runExecIO (inferGit current <||> inferSVN current)
+inferProjectFromVCS :: (Has ReadFS sig m, Has Exec sig m, Has Diagnostics sig m) => Path Abs Dir -> m InferredProject
+inferProjectFromVCS current = inferGit current <||> inferSVN current
 
 -- | Similar to 'inferProjectDefault', but uses a saved revision
 inferProjectCached :: (Has (Lift IO) sig m, Has ReadFS sig m, Has Diagnostics sig m) => Path b Dir -> m InferredProject

--- a/src/App/Fossa/ProjectInference.hs
+++ b/src/App/Fossa/ProjectInference.hs
@@ -60,8 +60,8 @@ inferProjectCached dir = do
 -- | Infer a default project name from the directory, and a default
 -- revision from the current time. Writes `.fossa.revision` to the system
 -- temp directory for use by `fossa test`
-inferProjectDefault :: Has (Lift IO) sig m => Path b Dir -> m InferredProject
-inferProjectDefault dir = sendIO $ do
+inferProjectDefault :: (Has (Lift IO) sig m, Has Diagnostics sig m) => Path b Dir -> m InferredProject
+inferProjectDefault dir = context "Inferring project from directory name / timestamp" . sendIO $ do
   let name = FP.dropTrailingPathSeparator (fromRelDir (dirname dir))
   time <- floor <$> getPOSIXTime :: IO Int
 
@@ -76,7 +76,7 @@ svnCommand =
     }
 
 inferSVN :: (Has Exec sig m, Has Diagnostics sig m) => Path Abs Dir -> m InferredProject
-inferSVN dir = do
+inferSVN dir = context "Inferring project from SVN" $ do
   output <- execThrow dir svnCommand
   let props = toProps output
 
@@ -143,7 +143,7 @@ inferGit ::
   ) =>
   Path Abs Dir ->
   m InferredProject
-inferGit dir = do
+inferGit dir = context "Inferring project from git" $ do
   foundGitDir <- findGitDir dir
 
   case foundGitDir of

--- a/src/App/Fossa/Report.hs
+++ b/src/App/Fossa/Report.hs
@@ -27,6 +27,7 @@ import Data.Functor (void)
 import Data.String.Conversion (decodeUtf8)
 import Data.Text (Text)
 import Data.Text.IO (hPutStrLn)
+import Effect.Exec (runExecIO)
 import Effect.Logger (
   Pretty (pretty),
   Severity (SevInfo),
@@ -69,7 +70,7 @@ reportMain (BaseDir basedir) apiOpts logSeverity timeoutSeconds reportType overr
   * CLI command refactoring as laid out in https://github.com/fossas/issues/issues/129
   -}
   void . timeout timeoutSeconds . withDefaultLogger logSeverity . runStickyLogger SevInfo $
-    logWithExit_ . runReadFSIO $ do
+    logWithExit_ . runReadFSIO . runExecIO $ do
       revision <- mergeOverride override <$> (inferProjectFromVCS basedir <||> inferProjectCached basedir <||> inferProjectDefault basedir)
 
       logInfo ""

--- a/src/App/Fossa/Test.hs
+++ b/src/App/Fossa/Test.hs
@@ -26,6 +26,7 @@ import Data.Aeson qualified as Aeson
 import Data.Functor (void)
 import Data.String.Conversion (decodeUtf8)
 import Data.Text.IO (hPutStrLn)
+import Effect.Exec (runExecIO)
 import Effect.Logger (
   Severity (SevInfo),
   logError,
@@ -56,7 +57,7 @@ testMain ::
   IO ()
 testMain (BaseDir basedir) apiOpts logSeverity timeoutSeconds outputType override = do
   void . timeout timeoutSeconds . withDefaultLogger logSeverity . runStickyLogger SevInfo $
-    logWithExit_ . runReadFSIO $ do
+    logWithExit_ . runReadFSIO . runExecIO $ do
       revision <- mergeOverride override <$> (inferProjectFromVCS basedir <||> inferProjectCached basedir <||> inferProjectDefault basedir)
 
       logInfo ""

--- a/src/App/Fossa/VPS/AOSPNotice.hs
+++ b/src/App/Fossa/VPS/AOSPNotice.hs
@@ -2,23 +2,23 @@ module App.Fossa.VPS.AOSPNotice (
   aospNoticeMain,
 ) where
 
-import Control.Carrier.Diagnostics
-import Control.Effect.Lift (Lift)
-import Effect.Exec
-
 import App.Fossa.EmbeddedBinary
 import App.Fossa.ProjectInference
 import App.Fossa.VPS.Scan.RunWiggins
 import App.Fossa.VPS.Types
 import App.Types (BaseDir (..), OverrideProject)
+import Control.Carrier.Diagnostics
+import Control.Effect.Lift (Lift)
 import Data.Text (Text)
+import Effect.Exec (Exec, runExecIO)
 import Effect.Logger
+import Effect.ReadFS (ReadFS, runReadFSIO)
 import Fossa.API.Types (ApiOpts (..))
 import Path (Abs, Dir, Path)
 
 aospNoticeMain :: BaseDir -> Severity -> OverrideProject -> NinjaScanID -> NinjaFilePaths -> ApiOpts -> IO ()
 aospNoticeMain (BaseDir basedir) logSeverity overrideProject ninjaScanId ninjaFilePaths apiOpts = withDefaultLogger logSeverity $ do
-  logWithExit_ $ withWigginsBinary $ aospNoticeGenerate basedir logSeverity overrideProject ninjaScanId ninjaFilePaths apiOpts
+  logWithExit_ $ runExecIO $ runReadFSIO $ withWigginsBinary $ aospNoticeGenerate basedir logSeverity overrideProject ninjaScanId ninjaFilePaths apiOpts
 
 ----- main logic
 
@@ -26,6 +26,8 @@ aospNoticeGenerate ::
   ( Has Diagnostics sig m
   , Has Logger sig m
   , Has (Lift IO) sig m
+  , Has Exec sig m
+  , Has ReadFS sig m
   ) =>
   Path Abs Dir ->
   Severity ->

--- a/src/App/Fossa/VPS/NinjaGraph.hs
+++ b/src/App/Fossa/VPS/NinjaGraph.hs
@@ -55,7 +55,7 @@ ninjaGraphMain :: ApiOpts -> Severity -> OverrideProject -> NinjaGraphCLIOptions
 ninjaGraphMain apiOpts logSeverity overrideProject NinjaGraphCLIOptions{..} = do
   BaseDir basedir <- validateDir ninjaBaseDir
 
-  withDefaultLogger logSeverity . logWithExit_ $ do
+  withDefaultLogger logSeverity . logWithExit_ . runReadFSIO . runExecIO $ do
     ProjectRevision{..} <- mergeOverride overrideProject <$> (inferProjectFromVCS basedir <||> inferProjectDefault basedir)
     let ninjaGraphOpts = NinjaGraphOpts apiOpts ninjaDepsFile ninjaLunchTarget ninjaScanId projectName ninjaBuildName
 

--- a/src/App/Fossa/VPS/Report.hs
+++ b/src/App/Fossa/VPS/Report.hs
@@ -16,6 +16,7 @@ import Data.Functor (void)
 import Data.String.Conversion (decodeUtf8)
 import Data.Text (Text)
 import Data.Text.IO (hPutStrLn)
+import Effect.Exec (runExecIO)
 import Effect.Logger
 import Effect.ReadFS
 import Fossa.API.Types (ApiOpts)
@@ -52,7 +53,7 @@ reportMain (BaseDir basedir) apiOpts logSeverity timeoutSeconds reportType overr
   * CLI command refactoring as laid out in https://github.com/fossas/issues/issues/129
   -}
   void . timeout timeoutSeconds . withDefaultLogger logSeverity . runStickyLogger SevInfo $
-    logWithExit_ . runReadFSIO $ do
+    logWithExit_ . runReadFSIO . runExecIO $ do
       revision <- mergeOverride override <$> (inferProjectFromVCS basedir <||> inferProjectCached basedir <||> inferProjectDefault basedir)
 
       logSticky "[ Getting latest scan ID ]"

--- a/src/App/Fossa/VPS/Test.hs
+++ b/src/App/Fossa/VPS/Test.hs
@@ -15,6 +15,7 @@ import Control.Effect.Lift (sendIO)
 import Data.Aeson qualified as Aeson
 import Data.String.Conversion
 import Data.Text.IO (hPutStrLn)
+import Effect.Exec (runExecIO)
 import Effect.Logger
 import Effect.ReadFS
 import Fossa.API.Types (ApiOpts, Issues (..))
@@ -38,7 +39,7 @@ testMain ::
   IO ()
 testMain (BaseDir basedir) apiOpts logSeverity timeoutSeconds outputType override = do
   _ <- timeout timeoutSeconds . withDefaultLogger logSeverity . runStickyLogger SevInfo $
-    logWithExit_ . runReadFSIO $ do
+    logWithExit_ . runReadFSIO . runExecIO $ do
       revision <- mergeOverride override <$> (inferProjectFromVCS basedir <||> inferProjectCached basedir <||> inferProjectDefault basedir)
 
       logInfo ""

--- a/src/App/Pathfinder/Scan.hs
+++ b/src/App/Pathfinder/Scan.hs
@@ -45,13 +45,14 @@ scanMain basedir debug = do
 
   withDefaultLogger (bool SevInfo SevDebug debug) $ scan basedir
 
-runLicenseAnalysis ::
-  (Has (Lift IO) sig m, Has Logger sig m, Has (Output ProjectLicenseScan) sig m) =>
-  DiscoveredProject (ReadFSIOC (ExecIOC (Diag.DiagnosticsC IO))) ->
-  m ()
-runLicenseAnalysis project = do
-  licenseResult <- sendIO . Diag.runDiagnosticsIO . runExecIO . runReadFSIO $ projectLicenses project
-  Diag.withResult SevWarn licenseResult (output . mkLicenseScan project)
+runLicenseAnalysis = undefined
+-- runLicenseAnalysis ::
+--   (Has (Lift IO) sig m, Has Logger sig m, Has (Output ProjectLicenseScan) sig m) =>
+--   DiscoveredProject (ReadFSIOC (ExecIOC (Diag.DiagnosticsC IO))) ->
+--   m ()
+-- runLicenseAnalysis project = do
+--   licenseResult <- sendIO . Diag.runDiagnosticsIO . runExecIO . runReadFSIO $ projectLicenses project
+--   Diag.withResult SevWarn licenseResult (output . mkLicenseScan project)
 
 scan ::
   ( Has (Lift IO) sig m
@@ -72,23 +73,24 @@ scan basedir = runFinally $ do
       . runFinally
       . withTaskPool capabilities updateProgress
       . runAtomicCounter
-      $ withDiscoveredProjects discoverFuncs False basedir runLicenseAnalysis
+      $ undefined
+      -- $ withDiscoveredProjects discoverFuncs False basedir runLicenseAnalysis
 
   sendIO (BL.putStr (encode projectResults))
 
-discoverFuncs ::
-  ( Has Diag.Diagnostics sig m
-  , Has (Lift IO) sig m
-  , MonadIO m
-  , Has ReadFS sig m
-  , Has ReadFS rsig run
-  , Has Exec rsig run
-  , Has Diag.Diagnostics rsig run
-  , Has (Lift IO) rsig run
-  ) =>
-  -- | Discover functions
-  [Path Abs Dir -> m [DiscoveredProject run]]
-discoverFuncs = [Maven.discover, Nuspec.discover]
+--discoverFuncs ::
+  --( Has Diag.Diagnostics sig m
+  --, Has (Lift IO) sig m
+  --, MonadIO m
+  --, Has ReadFS sig m
+  --, Has ReadFS rsig run
+  --, Has Exec rsig run
+  --, Has Diag.Diagnostics rsig run
+  --, Has (Lift IO) rsig run
+  --) =>
+  ---- | Discover functions
+  --[Path Abs Dir -> m [DiscoveredProject run]]
+--discoverFuncs = [Maven.discover, Nuspec.discover]
 
 data ProjectLicenseScan = ProjectLicenseScan
   { licenseStrategyType :: Text

--- a/src/App/Pathfinder/Scan.hs
+++ b/src/App/Pathfinder/Scan.hs
@@ -48,8 +48,8 @@ scanMain basedir debug = do
 
 runAll ::
   ( Has ReadFS sig m
-  , Has (Output ProjectLicenseScan) sig m
   , Has Exec sig m
+  , Has (Output ProjectLicenseScan) sig m
   , Has Logger sig m
   , Has TaskPool sig m
   , Has (Lift IO) sig m
@@ -67,6 +67,8 @@ runAll basedir = do
 
 runSingle ::
   ( LicenseAnalyzeProject a
+  , Has ReadFS sig m
+  , Has Exec sig m
   , Has (Output ProjectLicenseScan) sig m
   , Has Logger sig m
   , Has (Lift IO) sig m
@@ -75,7 +77,7 @@ runSingle ::
   DiscoveredProject a ->
   m ()
 runSingle project = do
-  licenseResult <- Diag.runDiagnosticsIO . runExecIO . runReadFSIO $ licenseAnalyzeProject (projectData project)
+  licenseResult <- Diag.runDiagnosticsIO $ licenseAnalyzeProject (projectData project)
   Diag.withResult SevWarn licenseResult (output . mkLicenseScan project)
 
 scan ::

--- a/src/App/Pathfinder/Scan.hs
+++ b/src/App/Pathfinder/Scan.hs
@@ -5,8 +5,9 @@ module App.Pathfinder.Scan (
   scanMain,
 ) where
 
-import Control.Carrier.AtomicCounter (runAtomicCounter)
-import Control.Carrier.Debug (ignoreDebug)
+import App.Pathfinder.Types (LicenseAnalyzeProject (licenseAnalyzeProject))
+import Control.Carrier.AtomicCounter (AtomicCounter, runAtomicCounter)
+import Control.Carrier.Debug (Debug, ignoreDebug)
 import Control.Carrier.Diagnostics qualified as Diag
 import Control.Carrier.Error.Either
 import Control.Carrier.Finally
@@ -45,14 +46,37 @@ scanMain basedir debug = do
 
   withDefaultLogger (bool SevInfo SevDebug debug) $ scan basedir
 
-runLicenseAnalysis = undefined
--- runLicenseAnalysis ::
---   (Has (Lift IO) sig m, Has Logger sig m, Has (Output ProjectLicenseScan) sig m) =>
---   DiscoveredProject (ReadFSIOC (ExecIOC (Diag.DiagnosticsC IO))) ->
---   m ()
--- runLicenseAnalysis project = do
---   licenseResult <- sendIO . Diag.runDiagnosticsIO . runExecIO . runReadFSIO $ projectLicenses project
---   Diag.withResult SevWarn licenseResult (output . mkLicenseScan project)
+runAll ::
+  ( Has ReadFS sig m
+  , Has (Output ProjectLicenseScan) sig m
+  , Has Exec sig m
+  , Has Logger sig m
+  , Has TaskPool sig m
+  , Has (Lift IO) sig m
+  , Has AtomicCounter sig m
+  , Has Debug sig m
+  , MonadIO m
+  ) =>
+  Path Abs Dir ->
+  m ()
+runAll basedir = do
+  single Maven.discover
+  single Nuspec.discover
+  where
+    single f = withDiscoveredProjects f basedir runSingle
+
+runSingle ::
+  ( LicenseAnalyzeProject a
+  , Has (Output ProjectLicenseScan) sig m
+  , Has Logger sig m
+  , Has (Lift IO) sig m
+  , MonadIO m
+  ) =>
+  DiscoveredProject a ->
+  m ()
+runSingle project = do
+  licenseResult <- Diag.runDiagnosticsIO . runExecIO . runReadFSIO $ licenseAnalyzeProject (projectData project)
+  Diag.withResult SevWarn licenseResult (output . mkLicenseScan project)
 
 scan ::
   ( Has (Lift IO) sig m
@@ -70,27 +94,13 @@ scan basedir = runFinally $ do
       . runOutput @ProjectLicenseScan
       . runStickyLogger SevInfo
       . runReadFSIO
+      . runExecIO
       . runFinally
       . withTaskPool capabilities updateProgress
       . runAtomicCounter
-      $ undefined
-      -- $ withDiscoveredProjects discoverFuncs False basedir runLicenseAnalysis
+      $ runAll basedir
 
   sendIO (BL.putStr (encode projectResults))
-
---discoverFuncs ::
-  --( Has Diag.Diagnostics sig m
-  --, Has (Lift IO) sig m
-  --, MonadIO m
-  --, Has ReadFS sig m
-  --, Has ReadFS rsig run
-  --, Has Exec rsig run
-  --, Has Diag.Diagnostics rsig run
-  --, Has (Lift IO) rsig run
-  --) =>
-  ---- | Discover functions
-  --[Path Abs Dir -> m [DiscoveredProject run]]
---discoverFuncs = [Maven.discover, Nuspec.discover]
 
 data ProjectLicenseScan = ProjectLicenseScan
   { licenseStrategyType :: Text

--- a/src/App/Pathfinder/Scan.hs
+++ b/src/App/Pathfinder/Scan.hs
@@ -6,6 +6,7 @@ module App.Pathfinder.Scan (
 ) where
 
 import Control.Carrier.AtomicCounter (runAtomicCounter)
+import Control.Carrier.Debug (ignoreDebug)
 import Control.Carrier.Diagnostics qualified as Diag
 import Control.Carrier.Error.Either
 import Control.Carrier.Finally
@@ -64,7 +65,8 @@ scan basedir = runFinally $ do
   capabilities <- sendIO getNumCapabilities
 
   (projectResults, ()) <-
-    runOutput @ProjectLicenseScan
+    ignoreDebug
+      . runOutput @ProjectLicenseScan
       . runStickyLogger SevInfo
       . runReadFSIO
       . runFinally

--- a/src/App/Pathfinder/Types.hs
+++ b/src/App/Pathfinder/Types.hs
@@ -1,0 +1,24 @@
+module App.Pathfinder.Types (
+  LicenseAnalyzeProject (..),
+) where
+
+import Types
+import Control.Effect.Diagnostics (Diagnostics)
+import Effect.Logger (Logger)
+import Effect.Exec (Exec)
+import Effect.ReadFS (ReadFS)
+import Control.Monad.IO.Class (MonadIO)
+import Control.Effect.Lift (Lift)
+import Control.Algebra (Has)
+
+type TaskEffs sig m =
+  ( Has (Lift IO) sig m
+  , MonadIO m
+  , Has ReadFS sig m
+  , Has Exec sig m
+  , Has Logger sig m
+  , Has Diagnostics sig m
+  )
+
+class LicenseAnalyzeProject a where
+  licenseAnalyzeProject :: TaskEffs sig m => a -> m [LicenseResult]

--- a/src/App/Pathfinder/Types.hs
+++ b/src/App/Pathfinder/Types.hs
@@ -2,14 +2,14 @@ module App.Pathfinder.Types (
   LicenseAnalyzeProject (..),
 ) where
 
-import Types
-import Control.Effect.Diagnostics (Diagnostics)
-import Effect.Logger (Logger)
-import Effect.Exec (Exec)
-import Effect.ReadFS (ReadFS)
-import Control.Monad.IO.Class (MonadIO)
-import Control.Effect.Lift (Lift)
 import Control.Algebra (Has)
+import Control.Effect.Diagnostics (Diagnostics)
+import Control.Effect.Lift (Lift)
+import Control.Monad.IO.Class (MonadIO)
+import Effect.Exec (Exec)
+import Effect.Logger (Logger)
+import Effect.ReadFS (ReadFS)
+import Types
 
 type TaskEffs sig m =
   ( Has (Lift IO) sig m

--- a/src/Control/Carrier/Debug.hs
+++ b/src/Control/Carrier/Debug.hs
@@ -20,7 +20,7 @@ import Control.Effect.Debug as X
 import Control.Effect.Lift
 import Control.Effect.Record (Recordable, SomeEffectResult (SomeEffectResult), recordEff)
 import Control.Monad.IO.Class (MonadIO)
-import Control.Monad.Trans (lift)
+import Control.Monad.Trans (MonadTrans, lift)
 import Data.Aeson
 import Data.Aeson.Types (Pair)
 import Data.Fixed
@@ -29,7 +29,10 @@ import Data.Text (Text)
 import Data.Time.Clock.System (SystemTime (MkSystemTime), getSystemTime)
 
 newtype DebugC m a = DebugC {runDebugC :: OutputC ScopeEvent (AtomicStateC (Map.Map Text Value) m) a}
-  deriving (Functor, Applicative, Monad, MonadIO) -- TODO: MonadTrans
+  deriving (Functor, Applicative, Monad, MonadIO)
+
+instance MonadTrans DebugC where
+  lift = DebugC . lift . lift
 
 newtype Duration = Duration {unDuration :: Nano}
   deriving (Show)

--- a/src/Control/Carrier/Debug.hs
+++ b/src/Control/Carrier/Debug.hs
@@ -1,0 +1,165 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Control.Carrier.Debug (
+  DebugC,
+  DiagDebugC,
+  runDebug,
+  ignoreDebug,
+  diagToDebug,
+  readFSToDebug,
+  Scope (..),
+  module X,
+) where
+
+import Control.Carrier.Diagnostics
+import Control.Carrier.Output.IO
+import Control.Carrier.Simple (Simple, SimpleC, interpret, sendSimple)
+import Control.Effect.Debug as X
+import Control.Effect.Lift
+import Control.Effect.Record (Recordable, SomeEffectResult (SomeEffectResult), recordEff)
+import Control.Effect.Sum
+import Control.Monad.IO.Class (MonadIO)
+import Control.Monad.Trans (lift)
+import Data.Aeson
+import Data.Fixed
+import Data.Text (Text)
+import Data.Time.Clock.System (SystemTime (MkSystemTime), getSystemTime)
+import Effect.ReadFS
+import Path
+
+newtype DebugC m a = DebugC {runDebugC :: OutputC ScopeEvent m a}
+  deriving (Functor, Applicative, Monad, MonadIO) -- TODO: MonadTrans
+
+newtype Duration = Duration {unDuration :: Nano}
+  deriving (Show)
+
+data Scope = Scope
+  { scopeTiming :: Duration
+  , scopeEvents :: [ScopeEvent]
+  , scopeFiles :: [ScopeFile]
+  }
+  deriving (Show)
+
+instance ToJSON Scope where
+  toJSON Scope{..} =
+    object
+      [ "duration" .= show (unDuration scopeTiming)
+      , "events" .= scopeEvents
+      , "files" .= scopeFiles
+      ]
+
+data ScopeEvent
+  = EventEffect SomeEffectResult
+  | EventScope Text Scope
+  | EventError SomeDiagnostic
+
+instance ToJSON ScopeEvent where
+  toJSON (EventEffect (SomeEffectResult k v)) =
+    object
+      [ "effect" .= encodedK
+      , "result" .= encodedV
+      ]
+    where
+      (encodedK, encodedV) = recordEff k v
+  toJSON (EventError (SomeDiagnostic _ err)) = object
+    [ "error" .= show (renderDiagnostic err)
+    ]
+  toJSON (EventScope nm scope) =
+    object
+      [ ("scope: " <> nm) .= scope
+      ]
+
+instance Show ScopeEvent where -- FIXME
+  show (EventEffect (SomeEffectResult k v)) = "SomeEffectResult " <> show (recordEff k v)
+  show (EventScope txt sc) = "EventScope " <> show txt <> " " <> show sc
+  show (EventError (SomeDiagnostic _ err)) = "EventError " <> show (renderDiagnostic err)
+
+data ScopeFile = ScopeFile (Path Abs Dir) Text
+  deriving (Show)
+
+instance ToJSON ScopeFile where
+  toJSON _ = toJSON @Text "TODO"
+
+timeBetween :: SystemTime -> SystemTime -> Duration
+timeBetween (MkSystemTime sec ns) (MkSystemTime sec' ns') =
+  Duration (realToFrac (sec' - sec) + MkFixed (fromIntegral ns' - fromIntegral ns))
+
+runDebug :: Has (Lift IO) sig m => DebugC m a -> m (Scope, a)
+runDebug act = do
+  before <- sendIO getSystemTime
+  (evs, res) <- runOutput @ScopeEvent $ runDebugC act
+  after <- sendIO getSystemTime
+  let duration = timeBetween before after
+  pure (Scope duration evs [], res)
+
+instance Has (Lift IO) sig m => Algebra (Debug :+: sig) (DebugC m) where
+  alg hdl sig ctx = DebugC $
+    case sig of
+      L (DebugScope nm act) -> do
+        let act' = hdl (act <$ ctx)
+        (inner, res) <- lift $ runDebug act'
+        output (EventScope nm inner)
+        pure res
+      L (DebugEffect k v) -> do
+        output (EventEffect (SomeEffectResult k v))
+        pure ctx
+      L (DebugError err) -> do
+        output (EventError (SomeDiagnostic [] err)) -- FIXME: empty path?
+        pure ctx
+      L (DebugFile _) -> pure ctx -- FIXME
+      R other -> alg (runDebugC . hdl) (R other) ctx
+
+newtype IgnoreDebugC m a = IgnoreDebugC { runIgnoreDebugC :: m a }
+  deriving (Functor, Applicative, Monad, MonadIO)
+
+instance Algebra sig m => Algebra (Debug :+: sig) (IgnoreDebugC m) where
+  alg hdl sig ctx = IgnoreDebugC $
+    case sig of
+      L (DebugScope _ act) -> runIgnoreDebugC (hdl (act <$ ctx))
+      L DebugError{} -> pure ctx
+      L DebugEffect{} -> pure ctx
+      L DebugFile{} -> pure ctx
+      R other -> alg (runIgnoreDebugC . hdl) other ctx
+
+ignoreDebug :: IgnoreDebugC m a -> m a
+ignoreDebug = runIgnoreDebugC
+
+-----------------------------------------------
+
+newtype DiagDebugC m a = DiagDebugC {runDiagDebugC :: m a}
+  deriving (Functor, Applicative, Monad, MonadIO)
+
+instance (Member Diagnostics sig, Member Debug sig, Algebra sig m) => Algebra (Diagnostics :+: sig) (DiagDebugC m) where
+  alg hdl sig ctx = DiagDebugC $
+    case sig of
+      L thing@(Context nm _) -> debugScope nm $ alg (runDiagDebugC . hdl) (inj thing) ctx
+      L thing@(Fatal err) -> do
+        debugError err
+        alg (runDiagDebugC . hdl) (inj thing) ctx
+      L ours -> alg (runDiagDebugC . hdl) (inj ours) ctx
+      R other -> alg (runDiagDebugC . hdl) other ctx
+
+diagToDebug :: DiagDebugC m a -> m a
+diagToDebug = runDiagDebugC
+
+-----------------------------------------------
+
+type ReadFSDebugC = SimpleC ReadFSF
+
+recording :: (Recordable r, Has Debug sig m, Has (Simple r) sig m) => r a -> m a
+recording r = do
+  res <- sendSimple r
+  debugEffect r res
+  pure res
+
+readFSToDebug :: (Has ReadFS sig m, Has Debug sig m) => ReadFSDebugC m a -> m a
+readFSToDebug = interpret $ \case
+  cons@ReadContentsBS'{} -> recording cons
+  cons@ReadContentsText'{} -> recording cons
+  cons@DoesFileExist{} -> recording cons
+  cons@DoesDirExist{} -> recording cons
+  cons@ResolveFile'{} -> recording cons
+  cons@ResolveDir'{} -> recording cons
+  cons -> sendSimple cons

--- a/src/Control/Carrier/Debug.hs
+++ b/src/Control/Carrier/Debug.hs
@@ -118,8 +118,6 @@ instance Has (Lift IO) sig m => Algebra (Debug :+: sig) (DebugC m) where
       L (DebugError err) -> do
         output (EventError (SomeDiagnostic [] err)) -- FIXME: empty path?
         pure ctx
-      L (DebugBuildtool _) -> pure ctx -- FIXME
-      L (DebugFile _) -> pure ctx -- FIXME
       R other -> alg (runDebugC . hdl) (R (R other)) ctx
 
 -----------------------------------------------
@@ -134,8 +132,6 @@ instance Algebra sig m => Algebra (Debug :+: sig) (IgnoreDebugC m) where
       L DebugMetadata{} -> pure ctx
       L DebugError{} -> pure ctx
       L DebugEffect{} -> pure ctx
-      L DebugBuildtool{} -> pure ctx
-      L DebugFile{} -> pure ctx
       R other -> alg (runIgnoreDebugC . hdl) other ctx
 
 ignoreDebug :: IgnoreDebugC m a -> m a

--- a/src/Control/Carrier/Diagnostics.hs
+++ b/src/Control/Carrier/Diagnostics.hs
@@ -12,6 +12,7 @@ module Control.Carrier.Diagnostics (
   logErrorBundle,
   logWithExit_,
   runDiagnosticsIO,
+  errorBoundaryIO,
   withResult,
 
   -- * Re-exports
@@ -30,6 +31,7 @@ import Data.Monoid (Endo (..))
 import Data.Text (Text)
 import Effect.Logger
 import System.Exit (exitFailure, exitSuccess)
+import Data.Foldable (traverse_)
 
 newtype DiagnosticsC m a = DiagnosticsC {runDiagnosticsC :: ReaderC [Text] (ErrorC SomeDiagnostic (WriterC (Endo [SomeDiagnostic]) m)) a}
   deriving (Functor, Applicative, Monad, MonadIO)
@@ -91,11 +93,18 @@ instance Algebra sig m => Algebra (Diagnostics :+: sig) (DiagnosticsC m) where
       case res' of
         Left e -> pure (Left e <$ ctx)
         Right a -> pure (Right <$> a)
+    L (Rethrow bundle) -> do
+      traverse_ (\diag -> tell (Endo (diag :))) (failureWarnings bundle)
+      throwError (failureCause bundle)
     R other -> alg (runDiagnosticsC . hdl) (R (R (R other))) ctx
 
 -- | Run the DiagnosticsC carrier, also catching IO exceptions
 runDiagnosticsIO :: Has (Lift IO) sig m => DiagnosticsC m a -> m (Either FailureBundle a)
 runDiagnosticsIO act = runDiagnostics $ act `safeCatch` (\(e :: SomeException) -> fatal e)
+
+-- | Like 'errorBoundary', but also catches IO exceptions
+errorBoundaryIO :: (Has (Lift IO) sig m, Has Diagnostics sig m) => m a -> m (Either FailureBundle a)
+errorBoundaryIO act = errorBoundary $ act `safeCatch` (\(e :: SomeException) -> fatal e)
 
 -- | Use the result of a Diagnostics computation, logging an error on failure
 withResult :: Has Logger sig m => Severity -> Either FailureBundle a -> (a -> m ()) -> m ()

--- a/src/Control/Carrier/Diagnostics.hs
+++ b/src/Control/Carrier/Diagnostics.hs
@@ -27,11 +27,11 @@ import Control.Effect.Lift (Lift, sendIO)
 import Control.Exception (SomeException)
 import Control.Exception.Extra (safeCatch)
 import Control.Monad.Trans
+import Data.Foldable (traverse_)
 import Data.Monoid (Endo (..))
 import Data.Text (Text)
 import Effect.Logger
 import System.Exit (exitFailure, exitSuccess)
-import Data.Foldable (traverse_)
 
 newtype DiagnosticsC m a = DiagnosticsC {runDiagnosticsC :: ReaderC [Text] (ErrorC SomeDiagnostic (WriterC (Endo [SomeDiagnostic]) m)) a}
   deriving (Functor, Applicative, Monad, MonadIO)

--- a/src/Control/Carrier/Output/IO.hs
+++ b/src/Control/Carrier/Output/IO.hs
@@ -20,7 +20,7 @@ runOutput act = do
   ref <- sendIO $ newIORef []
   res <- runOutputRef ref act
   outputs <- sendIO $ readIORef ref
-  pure (outputs, res)
+  pure (reverse outputs, res)
 
 runOutputRef :: Has (Lift IO) sig m => IORef [o] -> OutputC o m a -> m a
 runOutputRef ref = interpret $ \case

--- a/src/Control/Effect/Debug.hs
+++ b/src/Control/Effect/Debug.hs
@@ -4,6 +4,7 @@ module Control.Effect.Debug (
   debugError,
   debugEffect,
   debugFile,
+  debugBuildtool,
   module X,
 ) where
 
@@ -11,6 +12,7 @@ import Control.Algebra as X
 import Control.Effect.Diagnostics (ToDiagnostic)
 import Control.Effect.Record (Recordable)
 import Data.Text (Text)
+import Effect.Exec (Command)
 import Path
 
 data Debug m a where
@@ -18,8 +20,7 @@ data Debug m a where
   DebugError :: ToDiagnostic err => err -> Debug m ()
   DebugEffect :: Recordable r => r a -> a -> Debug m ()
   DebugFile :: Path Abs File -> Debug m ()
-
---DebugKV :: ToJSON a => Text -> a -> Debug m ()
+  DebugBuildtool :: Command -> Debug m ()
 
 debugScope :: Has Debug sig m => Text -> m a -> m a
 debugScope nm act = send (DebugScope nm act)
@@ -33,5 +34,5 @@ debugEffect k v = send (DebugEffect k v)
 debugFile :: Has Debug sig m => Path Abs File -> m ()
 debugFile = send . DebugFile
 
---debugKV :: (ToJSON a, Has Debug sig m) => Text -> a -> m ()
---debugKV k v = send (DebugKV k v)
+debugBuildtool :: Has Debug sig m => Command -> m ()
+debugBuildtool = send . DebugBuildtool

--- a/src/Control/Effect/Debug.hs
+++ b/src/Control/Effect/Debug.hs
@@ -4,8 +4,6 @@ module Control.Effect.Debug (
   debugMetadata,
   debugError,
   debugEffect,
-  debugFile,
-  debugBuildtool,
   module X,
 ) where
 
@@ -13,8 +11,6 @@ import Control.Algebra as X
 import Control.Effect.Diagnostics (ToDiagnostic)
 import Control.Effect.Record (Recordable)
 import Data.Text (Text)
-import Effect.Exec (Command)
-import Path
 import Data.Aeson (ToJSON)
 
 data Debug m a where
@@ -22,8 +18,6 @@ data Debug m a where
   DebugMetadata :: ToJSON a => Text -> a -> Debug m ()
   DebugError :: ToDiagnostic err => err -> Debug m ()
   DebugEffect :: Recordable r => r a -> a -> Debug m ()
-  DebugFile :: Path Abs File -> Debug m ()
-  DebugBuildtool :: Command -> Debug m ()
 
 debugScope :: Has Debug sig m => Text -> m a -> m a
 debugScope nm act = send (DebugScope nm act)
@@ -38,9 +32,3 @@ debugError = send . DebugError
 
 debugEffect :: (Recordable r, Has Debug sig m) => r a -> a -> m ()
 debugEffect k v = send (DebugEffect k v)
-
-debugFile :: Has Debug sig m => Path Abs File -> m ()
-debugFile = send . DebugFile
-
-debugBuildtool :: Has Debug sig m => Command -> m ()
-debugBuildtool = send . DebugBuildtool

--- a/src/Control/Effect/Debug.hs
+++ b/src/Control/Effect/Debug.hs
@@ -1,0 +1,37 @@
+module Control.Effect.Debug (
+  Debug (..),
+  debugScope,
+  debugError,
+  debugEffect,
+  debugFile,
+  module X,
+) where
+
+import Control.Algebra as X
+import Control.Effect.Diagnostics (ToDiagnostic)
+import Control.Effect.Record (Recordable)
+import Data.Text (Text)
+import Path
+
+data Debug m a where
+  DebugScope :: Text -> m a -> Debug m a
+  DebugError :: ToDiagnostic err => err -> Debug m ()
+  DebugEffect :: Recordable r => r a -> a -> Debug m ()
+  DebugFile :: Path Abs File -> Debug m ()
+
+--DebugKV :: ToJSON a => Text -> a -> Debug m ()
+
+debugScope :: Has Debug sig m => Text -> m a -> m a
+debugScope nm act = send (DebugScope nm act)
+
+debugError :: (ToDiagnostic err, Has Debug sig m) => err -> m ()
+debugError = send . DebugError
+
+debugEffect :: (Recordable r, Has Debug sig m) => r a -> a -> m ()
+debugEffect k v = send (DebugEffect k v)
+
+debugFile :: Has Debug sig m => Path Abs File -> m ()
+debugFile = send . DebugFile
+
+--debugKV :: (ToJSON a, Has Debug sig m) => Text -> a -> m ()
+--debugKV k v = send (DebugKV k v)

--- a/src/Control/Effect/Debug.hs
+++ b/src/Control/Effect/Debug.hs
@@ -4,6 +4,7 @@ module Control.Effect.Debug (
   debugMetadata,
   debugError,
   debugEffect,
+  debugLog,
   module X,
 ) where
 
@@ -18,6 +19,7 @@ data Debug m a where
   DebugMetadata :: ToJSON a => Text -> a -> Debug m ()
   DebugError :: ToDiagnostic err => err -> Debug m ()
   DebugEffect :: Recordable r => r a -> a -> Debug m ()
+  DebugLog :: Text -> Debug m ()
 
 debugScope :: Has Debug sig m => Text -> m a -> m a
 debugScope nm act = send (DebugScope nm act)
@@ -32,3 +34,6 @@ debugError = send . DebugError
 
 debugEffect :: (Recordable r, Has Debug sig m) => r a -> a -> m ()
 debugEffect k v = send (DebugEffect k v)
+
+debugLog :: Has Debug sig m => Text -> m ()
+debugLog = send . DebugLog

--- a/src/Control/Effect/Debug.hs
+++ b/src/Control/Effect/Debug.hs
@@ -11,8 +11,8 @@ module Control.Effect.Debug (
 import Control.Algebra as X
 import Control.Effect.Diagnostics (ToDiagnostic)
 import Control.Effect.Record (Recordable)
-import Data.Text (Text)
 import Data.Aeson (ToJSON)
+import Data.Text (Text)
 
 data Debug m a where
   DebugScope :: Text -> m a -> Debug m a
@@ -21,6 +21,7 @@ data Debug m a where
   DebugEffect :: Recordable r => r a -> a -> Debug m ()
   DebugLog :: Text -> Debug m ()
 
+-- | Wrap an action into a new scope. This is analagous to Diagnostics' 'context'
 debugScope :: Has Debug sig m => Text -> m a -> m a
 debugScope nm act = send (DebugScope nm act)
 
@@ -29,11 +30,14 @@ debugScope nm act = send (DebugScope nm act)
 debugMetadata :: (ToJSON a, Has Debug sig m) => Text -> a -> m ()
 debugMetadata key val = send (DebugMetadata key val)
 
+-- | Add an error event to this scope
 debugError :: (ToDiagnostic err, Has Debug sig m) => err -> m ()
 debugError = send . DebugError
 
+-- | Add an effect event -- an effect constructor and its result value -- to this scope
 debugEffect :: (Recordable r, Has Debug sig m) => r a -> a -> m ()
 debugEffect k v = send (DebugEffect k v)
 
+-- | Add a log event to this scope
 debugLog :: Has Debug sig m => Text -> m ()
 debugLog = send . DebugLog

--- a/src/Control/Effect/Diagnostics.hs
+++ b/src/Control/Effect/Diagnostics.hs
@@ -14,6 +14,7 @@ module Control.Effect.Diagnostics (
   recover,
   recover',
   errorBoundary,
+  rethrow,
 
   -- * Diagnostic result types
   FailureBundle (..),
@@ -54,6 +55,7 @@ data Diagnostics m k where
   Recover' :: m a -> Diagnostics m (Either SomeDiagnostic a)
   Context :: Text -> m a -> Diagnostics m a
   ErrorBoundary :: m a -> Diagnostics m (Either FailureBundle a)
+  Rethrow :: FailureBundle -> Diagnostics m a
 
 -- | A class of diagnostic types that can be rendered in a user-friendly way
 class ToDiagnostic a where
@@ -100,6 +102,10 @@ recover' = send . Recover'
 -- This returns a FailureBundle if the action failed; otherwise returns the result of the action
 errorBoundary :: Has Diagnostics sig m => m a -> m (Either FailureBundle a)
 errorBoundary = send . ErrorBoundary
+
+-- | Rethrow a FailureBundle from an 'errorBoundary'
+rethrow :: Has Diagnostics sig m => FailureBundle -> m a
+rethrow = send . Rethrow
 
 -- | Push context onto the stack for "stack traces"/"tracebacks" in diagnostics.
 --

--- a/src/Control/Effect/Diagnostics.hs
+++ b/src/Control/Effect/Diagnostics.hs
@@ -38,6 +38,7 @@ module Control.Effect.Diagnostics (
 
 import Control.Algebra as X
 import Control.Exception (SomeException (..))
+import Data.Aeson (ToJSON, object, toJSON, (.=))
 import Data.List (intersperse)
 import Data.List.NonEmpty qualified as NE
 import Data.Maybe (catMaybes)
@@ -68,6 +69,13 @@ instance ToDiagnostic SomeException where
 -- | An error with a ToDiagnostic instance and an associated stack trace
 data SomeDiagnostic where
   SomeDiagnostic :: ToDiagnostic a => [Text] -> a -> SomeDiagnostic
+
+instance ToJSON SomeDiagnostic where
+  toJSON (SomeDiagnostic path cause) =
+    object
+      [ "errorPath" .= path
+      , "errorCause" .= show (renderDiagnostic cause)
+      ]
 
 -- | Analagous to @throwError@ from the error effect
 fatal :: (Has Diagnostics sig m, ToDiagnostic diag) => diag -> m a

--- a/src/Control/Effect/Record.hs
+++ b/src/Control/Effect/Record.hs
@@ -11,6 +11,7 @@ module Control.Effect.Record (
   runRecord,
   Journal (..),
   EffectResult (..),
+  SomeEffectResult (..),
 ) where
 
 import Control.Algebra
@@ -49,6 +50,10 @@ newtype Journal eff = Journal {unJournal :: Map Value Value}
 -- | The result of an effectful action
 data EffectResult r where
   EffectResult :: r a -> a -> EffectResult r
+
+-- | The result of an effectful action, but we don't know the effect
+data SomeEffectResult where
+  SomeEffectResult :: Recordable r => r a -> a -> SomeEffectResult
 
 instance FromJSON (Journal eff) where
   parseJSON = fmap (Journal . Map.fromList) . parseJSON

--- a/src/Control/Effect/Record.hs
+++ b/src/Control/Effect/Record.hs
@@ -59,6 +59,7 @@ instance FromJSON (Journal eff) where
 
 instance ToJSON (Journal eff) where
   toJSON = toJSON . Map.toList . unJournal
+  toEncoding = toEncoding . Map.toList . unJournal
 
 -- | Wrap and record an effect; generally used with @-XTypeApplications@, e.g.,
 --

--- a/src/Control/Effect/Record.hs
+++ b/src/Control/Effect/Record.hs
@@ -32,9 +32,9 @@ import Data.Text.Lazy qualified as LText
 import Data.Void (Void)
 import Path
 import Prettyprinter (Doc, defaultLayoutOptions, layoutPretty)
+import Prettyprinter.Render.Text (renderStrict)
 import System.Exit
 import Unsafe.Coerce (unsafeCoerce)
-import Prettyprinter.Render.Text (renderStrict)
 
 -- | A class of "recordable" effects -- i.e. an effect whose data constructors
 -- and "result values" (the @a@ in @e a@) can be serialized to JSON values

--- a/src/Control/Effect/Record/TH.hs
+++ b/src/Control/Effect/Record/TH.hs
@@ -37,7 +37,12 @@ recordEffClause con = do
     []
 
 toJsonTuple :: Con -> [Name] -> ExpQ
-toJsonTuple con nms = tupE ([e|constructor :: String|] : map varE nms)
+toJsonTuple con nms =
+  case nms of
+    -- When a constructor has no arguments, don't form a tuple over it. It will
+    -- otherwise build a "Unit tuple"(?!) over it with one element
+    [] -> [e|constructor :: String|]
+    _ -> tupE ([e|constructor :: String|] : map varE nms)
   where
     constructor = show $ conNm con
 

--- a/src/Control/Effect/Replay.hs
+++ b/src/Control/Effect/Replay.hs
@@ -31,9 +31,12 @@ import System.Exit
 import Unsafe.Coerce
 
 -- | A class of "replayable" effects -- i.e. an effect whose "result values"
--- (the @a@ in @e m a@) can be deserialized from JSON values produced by
+-- (the @a@ in @e a@) can be deserialized from JSON values produced by
 -- 'recordValue' from 'Recordable'
-class Recordable r => Replayable (r :: Type -> Type) where
+--
+-- We require that all types @e a@ have an 'Ord' instance so they can be used
+-- as keys in a 'Map'
+class (forall x. (Ord (r x)), Recordable r) => Replayable (r :: Type -> Type) where
   -- | Deserialize an effect data constructor and "return value" from JSON values
   replayDecode :: Value -> Value -> Parser (EffectResult r)
 

--- a/src/Data/Aeson/Extra.hs
+++ b/src/Data/Aeson/Extra.hs
@@ -1,13 +1,16 @@
 module Data.Aeson.Extra (
   forbidMembers,
   TextLike (..),
+  encodeJSONToText,
 ) where
 
 import Control.Applicative ((<|>))
+import Data.Aeson (ToJSON)
+import Data.Aeson qualified as Aeson
 import Data.Aeson.Types (FromJSON (parseJSON), Object, Parser)
 import Data.Foldable (traverse_)
 import Data.HashMap.Strict (member)
-import Data.String.Conversion (toString, toText)
+import Data.String.Conversion (decodeUtf8, toString, toText)
 import Data.Text (Text)
 
 -- | A Text-like field
@@ -47,3 +50,7 @@ forbidMembers typename names obj = traverse_ (badMember obj) names
       if member name hashmap
         then fail . toString $ "Invalid field name for " <> typename <> ": " <> name
         else pure ()
+
+-- | Like 'Data.Aeson.encode', but produces @Text@ instead of @ByteString@
+encodeJSONToText :: ToJSON a => a -> Text
+encodeJSONToText = decodeUtf8 . Aeson.encode

--- a/src/Data/Set/NonEmpty.hs
+++ b/src/Data/Set/NonEmpty.hs
@@ -4,6 +4,7 @@ module Data.Set.NonEmpty (
   toSet,
 ) where
 
+import Data.Aeson (ToJSON)
 import Data.Set qualified as Set
 
 -- | A non empty set. Inspired by non empty list.
@@ -21,4 +22,5 @@ nonEmpty s
 toSet :: NonEmptySet a -> Set.Set a
 toSet = unEmptySet
 
-newtype NonEmptySet a = NonEmptySet {unEmptySet :: Set.Set a} deriving (Eq, Ord, Show, Semigroup)
+newtype NonEmptySet a = NonEmptySet {unEmptySet :: Set.Set a}
+  deriving (Eq, Ord, Show, Semigroup, ToJSON)

--- a/src/Discovery/Projects.hs
+++ b/src/Discovery/Projects.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Discovery.Projects (
@@ -8,36 +9,31 @@ import App.Fossa.Analyze.Debug (DiagDebugC, diagToDebug)
 import Control.Carrier.Debug (Debug)
 import Control.Carrier.Diagnostics qualified as Diag
 import Control.Carrier.Diagnostics.StickyContext
+import Control.Carrier.Output.IO
 import Control.Effect.AtomicCounter (AtomicCounter)
-import Control.Effect.Finally
 import Control.Effect.Lift
 import Control.Effect.TaskPool
-import Control.Monad (when)
-import Control.Monad.Trans.Class (MonadTrans (..))
-import Data.Foldable (for_, traverse_)
-import Discovery.Archive qualified as Archive
+import Data.Foldable (traverse_)
 import Effect.Logger
-import Effect.ReadFS (ReadFS)
 import Path
-import Types (DiscoveredProject)
+import Types
 
 -- | Run a list of discover functions in parallel, running the provided function
 -- on each discovered project. Note that the provided function is also run in
 -- parallel.
 withDiscoveredProjects ::
-  (Has AtomicCounter sig m, Has ReadFS sig m, Has (Lift IO) sig m, Has Debug sig m, Has TaskPool sig m, Has Logger sig m, Has Finally sig m) =>
-  -- | Discover functions
-  [Path Abs Dir -> StickyDiagC (DiagDebugC (Diag.DiagnosticsC m)) [DiscoveredProject run]] ->
+  ( Has AtomicCounter sig m
+  , Has (Lift IO) sig m
+  , Has Debug sig m
+  , Has TaskPool sig m
+  , Has Logger sig m
+  ) =>
+  -- | Discover function
+  (Path Abs Dir -> StickyDiagC (DiagDebugC (Diag.DiagnosticsC m)) [DiscoveredProject run]) ->
   -- | whether to unpack archives
-  Bool ->
   Path Abs Dir ->
   (DiscoveredProject run -> m ()) ->
   m ()
-withDiscoveredProjects discoverFuncs unpackArchives basedir f = do
-  for_ discoverFuncs $ \discover -> forkTask $ do
-    projectsResult <- Diag.runDiagnosticsIO . diagToDebug . stickyDiag $ discover basedir
-    Diag.withResult SevError projectsResult (traverse_ (forkTask . f))
-
-  when unpackArchives $ do
-    res <- Diag.runDiagnosticsIO $ Archive.discover (\dir -> lift $ withDiscoveredProjects discoverFuncs unpackArchives dir f) basedir
-    Diag.withResult SevError res (const (pure ()))
+withDiscoveredProjects discover basedir f = forkTask $ do
+  projectsResult <- Diag.runDiagnosticsIO . diagToDebug . stickyDiag $ discover basedir
+  Diag.withResult SevError projectsResult (traverse_ (forkTask . f))

--- a/src/Discovery/Projects.hs
+++ b/src/Discovery/Projects.hs
@@ -1,6 +1,3 @@
-{-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE UndecidableInstances #-}
-
 module Discovery.Projects (
   withDiscoveredProjects,
 ) where

--- a/src/Discovery/Projects.hs
+++ b/src/Discovery/Projects.hs
@@ -18,9 +18,8 @@ import Effect.Logger
 import Path
 import Types
 
--- | Run a list of discover functions in parallel, running the provided function
--- on each discovered project. Note that the provided function is also run in
--- parallel.
+-- | Fork a task to run a discover function, forking a task with the provided
+-- continuation applied to each discovered project
 withDiscoveredProjects ::
   ( Has AtomicCounter sig m
   , Has (Lift IO) sig m

--- a/src/Discovery/Projects.hs
+++ b/src/Discovery/Projects.hs
@@ -4,7 +4,8 @@ module Discovery.Projects (
   withDiscoveredProjects,
 ) where
 
-import Control.Carrier.Debug (Debug, DiagDebugC, diagToDebug)
+import App.Fossa.Analyze.Debug (DiagDebugC, diagToDebug)
+import Control.Carrier.Debug (Debug)
 import Control.Carrier.Diagnostics qualified as Diag
 import Control.Carrier.Diagnostics.StickyContext
 import Control.Effect.AtomicCounter (AtomicCounter)

--- a/src/Effect/Logger.hs
+++ b/src/Effect/Logger.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Effect.Logger (
@@ -25,14 +26,18 @@ import Control.Carrier.Simple
 import Control.Effect.ConsoleRegion
 import Control.Effect.Exception
 import Control.Effect.Lift (sendIO)
+import Control.Effect.Record.TH (deriveRecordable)
 import Control.Monad (when)
+import Data.Aeson (ToJSON)
 import Data.Text (Text)
 import Data.Text.Prettyprint.Doc as X
 import Data.Text.Prettyprint.Doc.Render.Terminal as X
+import GHC.Generics (Generic)
 import System.Console.ANSI (hSupportsANSI)
 import System.Console.Concurrent (errorConcurrent, outputConcurrent)
 import System.IO (stderr)
 import Prelude hiding (log)
+import Control.Effect.Record (RecordableValue)
 
 data LogCtx m = LogCtx
   { logCtxSeverity :: Severity
@@ -42,11 +47,23 @@ data LogCtx m = LogCtx
 
 type LogFormatter = Severity -> Doc AnsiStyle -> Text
 
+data Severity
+  = SevDebug
+  | SevInfo
+  | SevWarn
+  | SevError
+  deriving (Eq, Ord, Show, Generic)
+
+instance ToJSON Severity
+instance RecordableValue Severity
+
 data LoggerF a where
   Log :: Severity -> Doc AnsiStyle -> LoggerF ()
   -- | A dummy effect constructor that ensures stdout logging happens within the
   -- context of a Logger carrier that can ensure output gets flushed
   LogStdout :: LoggerF ()
+
+$(deriveRecordable ''LoggerF)
 
 type Logger = Simple LoggerF
 
@@ -59,13 +76,6 @@ logStdout :: (Has Logger sig m, Has (Lift IO) sig m) => Text -> m ()
 logStdout txt = do
   sendSimple LogStdout
   sendIO $ outputConcurrent txt
-
-data Severity
-  = SevDebug
-  | SevInfo
-  | SevWarn
-  | SevError
-  deriving (Eq, Ord, Show)
 
 logDebug :: Has Logger sig m => Doc AnsiStyle -> m ()
 logDebug = log SevDebug

--- a/src/Effect/Logger.hs
+++ b/src/Effect/Logger.hs
@@ -26,6 +26,7 @@ import Control.Carrier.Simple
 import Control.Effect.ConsoleRegion
 import Control.Effect.Exception
 import Control.Effect.Lift (sendIO)
+import Control.Effect.Record (RecordableValue)
 import Control.Effect.Record.TH (deriveRecordable)
 import Control.Monad (when)
 import Data.Aeson (ToJSON)
@@ -37,7 +38,6 @@ import System.Console.ANSI (hSupportsANSI)
 import System.Console.Concurrent (errorConcurrent, outputConcurrent)
 import System.IO (stderr)
 import Prelude hiding (log)
-import Control.Effect.Record (RecordableValue)
 
 data LogCtx m = LogCtx
   { logCtxSeverity :: Severity

--- a/src/Strategy/Bundler.hs
+++ b/src/Strategy/Bundler.hs
@@ -15,10 +15,12 @@ import Strategy.Ruby.BundleShow qualified as BundleShow
 import Strategy.Ruby.GemfileLock qualified as GemfileLock
 import Types
 
-discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has ReadFS rsig run, Has Exec rsig run, Has Diagnostics rsig run) => Path Abs Dir -> m [DiscoveredProject run]
-discover dir = context "Bundler" $ do
-  projects <- context "Finding projects" $ findProjects dir
-  pure (map mkProject projects)
+-- discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has ReadFS rsig run, Has Exec rsig run, Has Diagnostics rsig run) => Path Abs Dir -> m [DiscoveredProject run]
+-- discover dir = context "Bundler" $ do
+--   projects <- context "Finding projects" $ findProjects dir
+--   pure (map mkProject projects)
+discover = undefined
+mkProject = undefined
 
 findProjects :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs Dir -> m [BundlerProject]
 findProjects = walk' $ \dir _ files -> do
@@ -44,15 +46,15 @@ data BundlerProject = BundlerProject
   }
   deriving (Eq, Ord, Show)
 
-mkProject :: (Has ReadFS sig n, Has Exec sig n, Has Diagnostics sig n) => BundlerProject -> DiscoveredProject n
-mkProject project =
-  DiscoveredProject
-    { projectType = "bundler"
-    , projectBuildTargets = mempty
-    , projectDependencyResults = const $ getDeps project
-    , projectPath = bundlerDir project
-    , projectLicenses = pure []
-    }
+-- mkProject :: (Has ReadFS sig n, Has Exec sig n, Has Diagnostics sig n) => BundlerProject -> DiscoveredProject n
+-- mkProject project =
+--   DiscoveredProject
+--     { projectType = "bundler"
+--     , projectBuildTargets = mempty
+--     , projectDependencyResults = const $ getDeps project
+--     , projectPath = bundlerDir project
+--     , projectLicenses = pure []
+--     }
 
 getDeps :: (Has Exec sig m, Has ReadFS sig m, Has Diagnostics sig m) => BundlerProject -> m DependencyResults
 getDeps project = context "Bundler" $ analyzeBundleShow project <||> analyzeGemfileLock project

--- a/src/Strategy/Bundler.hs
+++ b/src/Strategy/Bundler.hs
@@ -8,9 +8,11 @@ module Strategy.Bundler (
 import App.Fossa.Analyze.Types (AnalyzeProject, analyzeProject)
 import Control.Effect.Diagnostics (Diagnostics, context, (<||>))
 import Control.Effect.Diagnostics qualified as Diag
+import Data.Aeson (ToJSON)
 import Discovery.Walk
 import Effect.Exec
 import Effect.ReadFS
+import GHC.Generics (Generic)
 import Path
 import Strategy.Ruby.BundleShow qualified as BundleShow
 import Strategy.Ruby.GemfileLock qualified as GemfileLock
@@ -43,7 +45,9 @@ data BundlerProject = BundlerProject
   , bundlerGemfileLock :: Maybe (Path Abs File)
   , bundlerDir :: Path Abs Dir
   }
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Ord, Show, Generic)
+
+instance ToJSON BundlerProject
 
 instance AnalyzeProject BundlerProject where
   analyzeProject _ = getDeps

--- a/src/Strategy/Bundler.hs
+++ b/src/Strategy/Bundler.hs
@@ -5,6 +5,7 @@ module Strategy.Bundler (
   getDeps,
 ) where
 
+import App.Fossa.Analyze.Types (AnalyzeProject, analyzeProject)
 import Control.Effect.Diagnostics (Diagnostics, context, (<||>))
 import Control.Effect.Diagnostics qualified as Diag
 import Discovery.Walk
@@ -15,12 +16,10 @@ import Strategy.Ruby.BundleShow qualified as BundleShow
 import Strategy.Ruby.GemfileLock qualified as GemfileLock
 import Types
 
--- discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has ReadFS rsig run, Has Exec rsig run, Has Diagnostics rsig run) => Path Abs Dir -> m [DiscoveredProject run]
--- discover dir = context "Bundler" $ do
---   projects <- context "Finding projects" $ findProjects dir
---   pure (map mkProject projects)
-discover = undefined
-mkProject = undefined
+discover :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs Dir -> m [DiscoveredProject BundlerProject]
+discover dir = context "Bundler" $ do
+  projects <- context "Finding projects" $ findProjects dir
+  pure (map mkProject projects)
 
 findProjects :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs Dir -> m [BundlerProject]
 findProjects = walk' $ \dir _ files -> do
@@ -46,15 +45,17 @@ data BundlerProject = BundlerProject
   }
   deriving (Eq, Ord, Show)
 
--- mkProject :: (Has ReadFS sig n, Has Exec sig n, Has Diagnostics sig n) => BundlerProject -> DiscoveredProject n
--- mkProject project =
---   DiscoveredProject
---     { projectType = "bundler"
---     , projectBuildTargets = mempty
---     , projectDependencyResults = const $ getDeps project
---     , projectPath = bundlerDir project
---     , projectLicenses = pure []
---     }
+instance AnalyzeProject BundlerProject where
+  analyzeProject _ = getDeps
+
+mkProject :: BundlerProject -> DiscoveredProject BundlerProject
+mkProject project =
+  DiscoveredProject
+    { projectType = "bundler"
+    , projectBuildTargets = mempty
+    , projectPath = bundlerDir project
+    , projectData = project
+    }
 
 getDeps :: (Has Exec sig m, Has ReadFS sig m, Has Diagnostics sig m) => BundlerProject -> m DependencyResults
 getDeps project = context "Bundler" $ analyzeBundleShow project <||> analyzeGemfileLock project

--- a/src/Strategy/Cargo.hs
+++ b/src/Strategy/Cargo.hs
@@ -23,6 +23,7 @@ import Discovery.Walk
 import Effect.Exec
 import Effect.Grapher
 import Effect.ReadFS (ReadFS)
+import GHC.Generics (Generic)
 import Graphing (Graphing, stripRoot)
 import Path
 import Types
@@ -147,7 +148,9 @@ data CargoProject = CargoProject
   { cargoDir :: Path Abs Dir
   , cargoToml :: Path Abs File
   }
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Ord, Show, Generic)
+
+instance ToJSON CargoProject
 
 instance AnalyzeProject CargoProject where
   analyzeProject _ = getDeps

--- a/src/Strategy/Cargo.hs
+++ b/src/Strategy/Cargo.hs
@@ -124,10 +124,12 @@ instance FromJSON CargoMetadata where
       <*> (obj .: "workspace_members" >>= traverse parsePkgId)
       <*> obj .: "resolve"
 
-discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has Exec rsig run, Has Diagnostics rsig run) => Path Abs Dir -> m [DiscoveredProject run]
-discover dir = context "Cargo" $ do
-  projects <- context "Finding projects" $ findProjects dir
-  pure (map mkProject projects)
+-- discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has Exec rsig run, Has Diagnostics rsig run) => Path Abs Dir -> m [DiscoveredProject run]
+-- discover dir = context "Cargo" $ do
+--   projects <- context "Finding projects" $ findProjects dir
+--   pure (map mkProject projects)
+discover = undefined
+mkProject = undefined
 
 findProjects :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs Dir -> m [CargoProject]
 findProjects = walk' $ \dir _ files -> do
@@ -148,15 +150,15 @@ data CargoProject = CargoProject
   }
   deriving (Eq, Ord, Show)
 
-mkProject :: (Has Exec sig n, Has Diagnostics sig n) => CargoProject -> DiscoveredProject n
-mkProject project =
-  DiscoveredProject
-    { projectType = "cargo"
-    , projectBuildTargets = mempty
-    , projectDependencyResults = const $ getDeps project
-    , projectPath = cargoDir project
-    , projectLicenses = pure []
-    }
+-- mkProject :: (Has Exec sig n, Has Diagnostics sig n) => CargoProject -> DiscoveredProject n
+-- mkProject project =
+--   DiscoveredProject
+--     { projectType = "cargo"
+--     , projectBuildTargets = mempty
+--     , projectDependencyResults = const $ getDeps project
+--     , projectPath = cargoDir project
+--     , projectLicenses = pure []
+--     }
 
 getDeps :: (Has Exec sig m, Has Diagnostics sig m) => CargoProject -> m DependencyResults
 getDeps project = do

--- a/src/Strategy/Carthage.hs
+++ b/src/Strategy/Carthage.hs
@@ -12,6 +12,7 @@ module Strategy.Carthage (
 
 import App.Fossa.Analyze.Types (AnalyzeProject, analyzeProject)
 import Control.Effect.Diagnostics
+import Data.Aeson (ToJSON)
 import Data.Char (isSpace)
 import Data.Foldable (for_, traverse_)
 import Data.Functor (void)
@@ -24,6 +25,7 @@ import DepTypes
 import Discovery.Walk
 import Effect.Grapher
 import Effect.ReadFS
+import GHC.Generics (Generic)
 import Graphing qualified as G
 import Path
 import Text.Megaparsec
@@ -53,7 +55,9 @@ data CarthageProject = CarthageProject
   { carthageDir :: Path Abs Dir
   , carthageLock :: Path Abs File
   }
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Ord, Show, Generic)
+
+instance ToJSON CarthageProject
 
 instance AnalyzeProject CarthageProject where
   analyzeProject _ = getDeps

--- a/src/Strategy/Carthage.hs
+++ b/src/Strategy/Carthage.hs
@@ -30,10 +30,12 @@ import Text.Megaparsec.Char
 import Text.Megaparsec.Char.Lexer qualified as L
 import Types
 
-discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has ReadFS rsig run, Has Diagnostics rsig run) => Path Abs Dir -> m [DiscoveredProject run]
-discover dir = context "Carthage" $ do
-  projects <- context "Finding projects" $ findProjects dir
-  pure (map mkProject projects)
+-- discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has ReadFS rsig run, Has Diagnostics rsig run) => Path Abs Dir -> m [DiscoveredProject run]
+-- discover dir = context "Carthage" $ do
+--   projects <- context "Finding projects" $ findProjects dir
+--   pure (map mkProject projects)
+discover = undefined
+mkProject = undefined
 
 findProjects :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs Dir -> m [CarthageProject]
 findProjects = walk' $ \dir _ files -> do
@@ -54,15 +56,15 @@ data CarthageProject = CarthageProject
   }
   deriving (Eq, Ord, Show)
 
-mkProject :: (Has ReadFS sig n, Has Diagnostics sig n) => CarthageProject -> DiscoveredProject n
-mkProject project =
-  DiscoveredProject
-    { projectType = "carthage"
-    , projectBuildTargets = mempty
-    , projectDependencyResults = const $ getDeps project
-    , projectPath = carthageDir project
-    , projectLicenses = pure []
-    }
+-- mkProject :: (Has ReadFS sig n, Has Diagnostics sig n) => CarthageProject -> DiscoveredProject n
+-- mkProject project =
+--   DiscoveredProject
+--     { projectType = "carthage"
+--     , projectBuildTargets = mempty
+--     , projectDependencyResults = const $ getDeps project
+--     , projectPath = carthageDir project
+--     , projectLicenses = pure []
+--     }
 
 getDeps :: (Has ReadFS sig m, Has Diagnostics sig m) => CarthageProject -> m DependencyResults
 getDeps project = do

--- a/src/Strategy/Cocoapods.hs
+++ b/src/Strategy/Cocoapods.hs
@@ -15,10 +15,12 @@ import Strategy.Cocoapods.Podfile qualified as Podfile
 import Strategy.Cocoapods.PodfileLock qualified as PodfileLock
 import Types
 
-discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has ReadFS rsig run, Has Diagnostics rsig run) => Path Abs Dir -> m [DiscoveredProject run]
-discover dir = context "Cocoapods" $ do
-  projects <- context "Finding projects" $ findProjects dir
-  pure (map mkProject projects)
+-- discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has ReadFS rsig run, Has Diagnostics rsig run) => Path Abs Dir -> m [DiscoveredProject run]
+-- discover dir = context "Cocoapods" $ do
+--   projects <- context "Finding projects" $ findProjects dir
+--   pure (map mkProject projects)
+discover = undefined
+mkProject = undefined
 
 findProjects :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs Dir -> m [CocoapodsProject]
 findProjects = walk' $ \dir _ files -> do
@@ -43,15 +45,15 @@ data CocoapodsProject = CocoapodsProject
   }
   deriving (Eq, Ord, Show)
 
-mkProject :: (Has ReadFS sig n, Has Diagnostics sig n) => CocoapodsProject -> DiscoveredProject n
-mkProject project =
-  DiscoveredProject
-    { projectType = "cocoapods"
-    , projectBuildTargets = mempty
-    , projectDependencyResults = const $ getDeps project
-    , projectPath = cocoapodsDir project
-    , projectLicenses = pure []
-    }
+-- mkProject :: (Has ReadFS sig n, Has Diagnostics sig n) => CocoapodsProject -> DiscoveredProject n
+-- mkProject project =
+--   DiscoveredProject
+--     { projectType = "cocoapods"
+--     , projectBuildTargets = mempty
+--     , projectDependencyResults = const $ getDeps project
+--     , projectPath = cocoapodsDir project
+--     , projectLicenses = pure []
+--     }
 
 getDeps :: (Has ReadFS sig m, Has Diagnostics sig m) => CocoapodsProject -> m DependencyResults
 getDeps project =

--- a/src/Strategy/Cocoapods.hs
+++ b/src/Strategy/Cocoapods.hs
@@ -5,16 +5,18 @@ module Strategy.Cocoapods (
   mkProject,
 ) where
 
+import App.Fossa.Analyze.Types (AnalyzeProject, analyzeProject)
 import Control.Applicative ((<|>))
 import Control.Effect.Diagnostics (Diagnostics, context, (<||>))
 import Control.Effect.Diagnostics qualified as Diag
+import Data.Aeson (ToJSON)
 import Discovery.Walk
 import Effect.ReadFS
+import GHC.Generics (Generic)
 import Path
 import Strategy.Cocoapods.Podfile qualified as Podfile
 import Strategy.Cocoapods.PodfileLock qualified as PodfileLock
 import Types
-import App.Fossa.Analyze.Types (AnalyzeProject, analyzeProject)
 
 discover :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs Dir -> m [DiscoveredProject CocoapodsProject]
 discover dir = context "Cocoapods" $ do
@@ -42,7 +44,9 @@ data CocoapodsProject = CocoapodsProject
   , cocoapodsPodfileLock :: Maybe (Path Abs File)
   , cocoapodsDir :: Path Abs Dir
   }
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Ord, Show, Generic)
+
+instance ToJSON CocoapodsProject
 
 instance AnalyzeProject CocoapodsProject where
   analyzeProject _ = getDeps

--- a/src/Strategy/Composer.hs
+++ b/src/Strategy/Composer.hs
@@ -18,6 +18,7 @@ import DepTypes
 import Discovery.Walk
 import Effect.Grapher
 import Effect.ReadFS
+import GHC.Generics (Generic)
 import Graphing (Graphing)
 import Path
 import Types
@@ -64,7 +65,9 @@ data ComposerProject = ComposerProject
   { composerDir :: Path Abs Dir
   , composerLock :: Path Abs File
   }
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Ord, Show, Generic)
+
+instance ToJSON ComposerProject
 
 instance AnalyzeProject ComposerProject where
   analyzeProject _ = getDeps

--- a/src/Strategy/Composer.hs
+++ b/src/Strategy/Composer.hs
@@ -21,10 +21,12 @@ import Graphing (Graphing)
 import Path
 import Types
 
-discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has ReadFS rsig run, Has Diagnostics rsig run) => Path Abs Dir -> m [DiscoveredProject run]
-discover dir = context "Composer" $ do
-  projects <- context "Finding projects" $ findProjects dir
-  pure (map mkProject projects)
+-- discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has ReadFS rsig run, Has Diagnostics rsig run) => Path Abs Dir -> m [DiscoveredProject run]
+-- discover dir = context "Composer" $ do
+--   projects <- context "Finding projects" $ findProjects dir
+--   pure (map mkProject projects)
+discover = undefined
+mkProject = undefined
 
 findProjects :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs Dir -> m [ComposerProject]
 findProjects = walk' $ \dir _ files -> do
@@ -39,15 +41,15 @@ findProjects = walk' $ \dir _ files -> do
 
       pure ([project], WalkContinue)
 
-mkProject :: (Has ReadFS sig n, Has Diagnostics sig n) => ComposerProject -> DiscoveredProject n
-mkProject project =
-  DiscoveredProject
-    { projectType = "composer"
-    , projectBuildTargets = mempty
-    , projectDependencyResults = const $ getDeps project
-    , projectPath = composerDir project
-    , projectLicenses = pure []
-    }
+-- mkProject :: (Has ReadFS sig n, Has Diagnostics sig n) => ComposerProject -> DiscoveredProject n
+-- mkProject project =
+--   DiscoveredProject
+--     { projectType = "composer"
+--     , projectBuildTargets = mempty
+--     , projectDependencyResults = const $ getDeps project
+--     , projectPath = composerDir project
+--     , projectLicenses = pure []
+--     }
 
 getDeps :: (Has ReadFS sig m, Has Diagnostics sig m) => ComposerProject -> m DependencyResults
 getDeps project = context "Composer" $ do

--- a/src/Strategy/Conda.hs
+++ b/src/Strategy/Conda.hs
@@ -2,15 +2,17 @@ module Strategy.Conda (
   discover,
 ) where
 
+import App.Fossa.Analyze.Types (AnalyzeProject, analyzeProject)
 import Control.Carrier.Diagnostics hiding (fromMaybe)
+import Data.Aeson (ToJSON)
 import Discovery.Walk
 import Effect.Exec
 import Effect.ReadFS
+import GHC.Generics (Generic)
 import Path
 import Strategy.Conda.CondaList qualified as CondaList
 import Strategy.Conda.EnvironmentYml qualified as EnvironmentYml
 import Types
-import App.Fossa.Analyze.Types (AnalyzeProject, analyzeProject)
 
 discover :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs Dir -> m [DiscoveredProject CondaProject]
 discover dir = map mkProject <$> findProjects dir
@@ -31,7 +33,9 @@ data CondaProject = CondaProject
   { condaDir :: Path Abs Dir
   , condaEnvironmentYml :: Path Abs File
   }
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Ord, Show, Generic)
+
+instance ToJSON CondaProject
 
 instance AnalyzeProject CondaProject where
   analyzeProject _ = getDeps

--- a/src/Strategy/Conda.hs
+++ b/src/Strategy/Conda.hs
@@ -11,8 +11,10 @@ import Strategy.Conda.CondaList qualified as CondaList
 import Strategy.Conda.EnvironmentYml qualified as EnvironmentYml
 import Types
 
-discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has ReadFS rsig run, Has Exec rsig run, Has Diagnostics rsig run) => Path Abs Dir -> m [DiscoveredProject run]
-discover dir = map mkProject <$> findProjects dir
+-- discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has ReadFS rsig run, Has Exec rsig run, Has Diagnostics rsig run) => Path Abs Dir -> m [DiscoveredProject run]
+-- discover dir = map mkProject <$> findProjects dir
+discover = undefined
+mkProject = undefined
 
 findProjects :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs Dir -> m [CondaProject]
 findProjects = walk' $ \dir _ files -> do
@@ -32,15 +34,15 @@ data CondaProject = CondaProject
   }
   deriving (Eq, Ord, Show)
 
-mkProject :: (Has ReadFS sig m, Has Exec sig m, Has Diagnostics sig m) => CondaProject -> DiscoveredProject m
-mkProject project =
-  DiscoveredProject
-    { projectType = "conda"
-    , projectBuildTargets = mempty
-    , projectDependencyResults = const $ getDeps project
-    , projectPath = condaDir project
-    , projectLicenses = pure []
-    }
+-- mkProject :: (Has ReadFS sig m, Has Exec sig m, Has Diagnostics sig m) => CondaProject -> DiscoveredProject m
+-- mkProject project =
+--   DiscoveredProject
+--     { projectType = "conda"
+--     , projectBuildTargets = mempty
+--     , projectDependencyResults = const $ getDeps project
+--     , projectPath = condaDir project
+--     , projectLicenses = pure []
+--     }
 
 -- Prefer analyzeCondaList over analyzeEnvironmentYml, results shoudln't be combined, it's either/or.
 -- There might be a dep with a version spec in an environment.yml file: i.e. conda+foo$1.2.*, and perhaps

--- a/src/Strategy/Elixir/MixTree.hs
+++ b/src/Strategy/Elixir/MixTree.hs
@@ -17,6 +17,7 @@ module Strategy.Elixir.MixTree (
   analyze,
 ) where
 
+import App.Fossa.Analyze.Types (AnalyzeProject, analyzeProject)
 import Control.Effect.Diagnostics (Diagnostics, Has, context)
 import Control.Monad (void)
 import Control.Monad.Combinators.Expr (Operator (..), makeExprParser)
@@ -99,6 +100,9 @@ data MixProject = MixProject
   , mixFile :: Path Abs File
   }
   deriving (Eq, Ord, Show)
+
+instance AnalyzeProject MixProject where
+  analyzeProject _ = analyze
 
 -- | Name of the Package.
 newtype PackageName = PackageName {unPackageName :: Text} deriving (Show, Eq, Ord)

--- a/src/Strategy/Elixir/MixTree.hs
+++ b/src/Strategy/Elixir/MixTree.hs
@@ -21,6 +21,7 @@ import App.Fossa.Analyze.Types (AnalyzeProject, analyzeProject)
 import Control.Effect.Diagnostics (Diagnostics, Has, context)
 import Control.Monad (void)
 import Control.Monad.Combinators.Expr (Operator (..), makeExprParser)
+import Data.Aeson (ToJSON)
 import Data.Foldable (asum)
 import Data.Functor (($>))
 import Data.Map (Map)
@@ -46,6 +47,7 @@ import DepTypes (
  )
 import Effect.Exec (AllowErr (Never), Command (..), Exec, execParser)
 import Effect.Logger (Logger, logWarn)
+import GHC.Generics (Generic)
 import Graphing (Graphing, unfold)
 import Path
 import Prettyprinter (pretty)
@@ -99,7 +101,9 @@ data MixProject = MixProject
   { mixDir :: Path Abs Dir
   , mixFile :: Path Abs File
   }
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Ord, Show, Generic)
+
+instance ToJSON MixProject
 
 instance AnalyzeProject MixProject where
   analyzeProject _ = analyze

--- a/src/Strategy/Glide.hs
+++ b/src/Strategy/Glide.hs
@@ -9,10 +9,12 @@ import Path
 import Strategy.Go.GlideLock qualified as GlideLock
 import Types
 
-discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has ReadFS rsig run, Has Diagnostics rsig run) => Path Abs Dir -> m [DiscoveredProject run]
-discover dir = context "Glide" $ do
-  projects <- context "Finding projects" $ findProjects dir
-  pure (map mkProject projects)
+-- discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has ReadFS rsig run, Has Diagnostics rsig run) => Path Abs Dir -> m [DiscoveredProject run]
+-- discover dir = context "Glide" $ do
+--   projects <- context "Finding projects" $ findProjects dir
+--   pure (map mkProject projects)
+discover = undefined
+mkProject = undefined
 
 findProjects :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs Dir -> m [GlideProject]
 findProjects = walk' $ \dir _ files -> do
@@ -25,15 +27,15 @@ data GlideProject = GlideProject
   , glideDir :: Path Abs Dir
   }
 
-mkProject :: (Has ReadFS sig n, Has Diagnostics sig n) => GlideProject -> DiscoveredProject n
-mkProject project =
-  DiscoveredProject
-    { projectType = "glide"
-    , projectBuildTargets = mempty
-    , projectDependencyResults = const $ getDeps project
-    , projectPath = glideDir project
-    , projectLicenses = pure []
-    }
+-- mkProject :: (Has ReadFS sig n, Has Diagnostics sig n) => GlideProject -> DiscoveredProject n
+-- mkProject project =
+--   DiscoveredProject
+--     { projectType = "glide"
+--     , projectBuildTargets = mempty
+--     , projectDependencyResults = const $ getDeps project
+--     , projectPath = glideDir project
+--     , projectLicenses = pure []
+--     }
 
 getDeps :: (Has ReadFS sig m, Has Diagnostics sig m) => GlideProject -> m DependencyResults
 getDeps project = context "Glide" (GlideLock.analyze' (glideLock project))

--- a/src/Strategy/Glide.hs
+++ b/src/Strategy/Glide.hs
@@ -4,8 +4,10 @@ module Strategy.Glide (
 
 import App.Fossa.Analyze.Types (AnalyzeProject, analyzeProject)
 import Control.Effect.Diagnostics (Diagnostics, context)
+import Data.Aeson (ToJSON)
 import Discovery.Walk
 import Effect.ReadFS
+import GHC.Generics (Generic)
 import Path
 import Strategy.Go.GlideLock qualified as GlideLock
 import Types
@@ -25,6 +27,9 @@ data GlideProject = GlideProject
   { glideLock :: Path Abs File
   , glideDir :: Path Abs Dir
   }
+  deriving (Eq, Ord, Show, Generic)
+
+instance ToJSON GlideProject
 
 instance AnalyzeProject GlideProject where
   analyzeProject _ = getDeps

--- a/src/Strategy/Godep.hs
+++ b/src/Strategy/Godep.hs
@@ -6,9 +6,11 @@ import App.Fossa.Analyze.Types (AnalyzeProject, analyzeProject)
 import Control.Applicative ((<|>))
 import Control.Effect.Diagnostics (Diagnostics, context, (<||>))
 import Control.Effect.Diagnostics qualified as Diag
+import Data.Aeson (ToJSON)
 import Discovery.Walk
 import Effect.Exec
 import Effect.ReadFS
+import GHC.Generics (Generic)
 import Path
 import Strategy.Go.GopkgLock qualified as GopkgLock
 import Strategy.Go.GopkgToml qualified as GopkgToml
@@ -38,6 +40,9 @@ data GodepProject = GodepProject
   , godepToml :: Maybe (Path Abs File)
   , godepLock :: Maybe (Path Abs File)
   }
+  deriving (Eq, Ord, Show, Generic)
+
+instance ToJSON GodepProject
 
 instance AnalyzeProject GodepProject where
   analyzeProject _ = getDeps

--- a/src/Strategy/Godep.hs
+++ b/src/Strategy/Godep.hs
@@ -13,8 +13,10 @@ import Strategy.Go.GopkgLock qualified as GopkgLock
 import Strategy.Go.GopkgToml qualified as GopkgToml
 import Types
 
-discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has ReadFS rsig run, Has Exec rsig run, Has Diagnostics rsig run) => Path Abs Dir -> m [DiscoveredProject run]
-discover dir = map mkProject <$> findProjects dir
+-- discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has ReadFS rsig run, Has Exec rsig run, Has Diagnostics rsig run) => Path Abs Dir -> m [DiscoveredProject run]
+-- discover dir = map mkProject <$> findProjects dir
+discover = undefined
+mkProject = undefined
 
 findProjects :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs Dir -> m [GodepProject]
 findProjects = walk' $ \dir _ files -> do
@@ -38,15 +40,15 @@ data GodepProject = GodepProject
   , godepLock :: Maybe (Path Abs File)
   }
 
-mkProject :: (Has ReadFS sig n, Has Exec sig n, Has Diagnostics sig n) => GodepProject -> DiscoveredProject n
-mkProject project =
-  DiscoveredProject
-    { projectType = "godep"
-    , projectBuildTargets = mempty
-    , projectDependencyResults = const $ getDeps project
-    , projectPath = godepDir project
-    , projectLicenses = pure []
-    }
+-- mkProject :: (Has ReadFS sig n, Has Exec sig n, Has Diagnostics sig n) => GodepProject -> DiscoveredProject n
+-- mkProject project =
+--   DiscoveredProject
+--     { projectType = "godep"
+--     , projectBuildTargets = mempty
+--     , projectDependencyResults = const $ getDeps project
+--     , projectPath = godepDir project
+--     , projectLicenses = pure []
+--     }
 
 getDeps :: (Has ReadFS sig m, Has Exec sig m, Has Diagnostics sig m) => GodepProject -> m DependencyResults
 getDeps project =

--- a/src/Strategy/Gomodules.hs
+++ b/src/Strategy/Gomodules.hs
@@ -14,10 +14,12 @@ import Strategy.Go.GoList qualified as GoList
 import Strategy.Go.Gomod qualified as Gomod
 import Types
 
-discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has ReadFS rsig run, Has Exec rsig run, Has Diagnostics rsig run) => Path Abs Dir -> m [DiscoveredProject run]
-discover dir = context "Gomodules" $ do
-  projects <- context "Finding projects" $ findProjects dir
-  pure (map mkProject projects)
+-- discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has ReadFS rsig run, Has Exec rsig run, Has Diagnostics rsig run) => Path Abs Dir -> m [DiscoveredProject run]
+-- discover dir = context "Gomodules" $ do
+--   projects <- context "Finding projects" $ findProjects dir
+--   pure (map mkProject projects)
+discover = undefined
+mkProject = undefined
 
 findProjects :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs Dir -> m [GomodulesProject]
 findProjects = walk' $ \dir _ files -> do
@@ -30,15 +32,15 @@ data GomodulesProject = GomodulesProject
   , gomodulesDir :: Path Abs Dir
   }
 
-mkProject :: (Has Exec sig n, Has ReadFS sig n, Has Diagnostics sig n) => GomodulesProject -> DiscoveredProject n
-mkProject project =
-  DiscoveredProject
-    { projectType = "gomod"
-    , projectBuildTargets = mempty
-    , projectDependencyResults = const $ getDeps project
-    , projectPath = gomodulesDir project
-    , projectLicenses = pure []
-    }
+-- mkProject :: (Has Exec sig n, Has ReadFS sig n, Has Diagnostics sig n) => GomodulesProject -> DiscoveredProject n
+-- mkProject project =
+--   DiscoveredProject
+--     { projectType = "gomod"
+--     , projectBuildTargets = mempty
+--     , projectDependencyResults = const $ getDeps project
+--     , projectPath = gomodulesDir project
+--     , projectLicenses = pure []
+--     }
 
 getDeps :: (Has Exec sig m, Has ReadFS sig m, Has Diagnostics sig m) => GomodulesProject -> m DependencyResults
 getDeps project = do

--- a/src/Strategy/Gomodules.hs
+++ b/src/Strategy/Gomodules.hs
@@ -7,9 +7,11 @@ module Strategy.Gomodules (
 
 import App.Fossa.Analyze.Types (AnalyzeProject, analyzeProject)
 import Control.Effect.Diagnostics (Diagnostics, context, (<||>))
+import Data.Aeson (ToJSON)
 import Discovery.Walk
 import Effect.Exec
 import Effect.ReadFS
+import GHC.Generics (Generic)
 import Path (Abs, Dir, File, Path)
 import Strategy.Go.GoList qualified as GoList
 import Strategy.Go.Gomod qualified as Gomod
@@ -30,6 +32,9 @@ data GomodulesProject = GomodulesProject
   { gomodulesGomod :: Path Abs File
   , gomodulesDir :: Path Abs Dir
   }
+  deriving (Eq, Ord, Show, Generic)
+
+instance ToJSON GomodulesProject
 
 instance AnalyzeProject GomodulesProject where
   analyzeProject _ = getDeps

--- a/src/Strategy/Googlesource/RepoManifest.hs
+++ b/src/Strategy/Googlesource/RepoManifest.hs
@@ -20,9 +20,11 @@ module Strategy.Googlesource.RepoManifest (
 
 import Prelude
 
+import App.Fossa.Analyze.Types (AnalyzeProject, analyzeProject)
 import Control.Applicative (optional, (<|>))
 import Control.Effect.Diagnostics
 import Control.Monad (unless)
+import Data.Aeson (ToJSON)
 import Data.Foldable (find)
 import Data.HashMap.Strict qualified as HM
 import Data.Map.Strict qualified as Map
@@ -33,6 +35,7 @@ import Data.Text.Prettyprint.Doc (pretty)
 import DepTypes
 import Discovery.Walk
 import Effect.ReadFS
+import GHC.Generics (Generic)
 import Graphing (Graphing, unfold)
 import Parse.XML
 import Path
@@ -40,7 +43,6 @@ import Text.GitConfig.Parser (Section (..), parseConfig)
 import Text.Megaparsec (errorBundlePretty)
 import Text.URI
 import Types
-import App.Fossa.Analyze.Types (AnalyzeProject, analyzeProject)
 
 discover :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs Dir -> m [DiscoveredProject RepoManifestProject]
 discover dir = context "RepoManifest" $ do
@@ -60,7 +62,9 @@ findProjects = walk' $ \_ _ files -> do
 newtype RepoManifestProject = RepoManifestProject
   { repoManifestXml :: Path Abs File
   }
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Ord, Show, Generic)
+
+instance ToJSON RepoManifestProject
 
 mkProject :: RepoManifestProject -> DiscoveredProject RepoManifestProject
 mkProject project =

--- a/src/Strategy/Googlesource/RepoManifest.hs
+++ b/src/Strategy/Googlesource/RepoManifest.hs
@@ -41,10 +41,12 @@ import Text.Megaparsec (errorBundlePretty)
 import Text.URI
 import Types
 
-discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has ReadFS rsig run, Has Diagnostics rsig run) => Path Abs Dir -> m [DiscoveredProject run]
-discover dir = context "RepoManifest" $ do
-  projects <- context "Finding projects" $ findProjects dir
-  pure (map mkProject projects)
+-- discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has ReadFS rsig run, Has Diagnostics rsig run) => Path Abs Dir -> m [DiscoveredProject run]
+-- discover dir = context "RepoManifest" $ do
+--   projects <- context "Finding projects" $ findProjects dir
+--   pure (map mkProject projects)
+discover = undefined
+mkProject = undefined
 
 -- We're looking for a file called "manifest.xml" in a directory called ".repo"
 findProjects :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs Dir -> m [RepoManifestProject]
@@ -61,15 +63,15 @@ newtype RepoManifestProject = RepoManifestProject
   }
   deriving (Eq, Ord, Show)
 
-mkProject :: (Has ReadFS sig n, Has Diagnostics sig n) => RepoManifestProject -> DiscoveredProject n
-mkProject project =
-  DiscoveredProject
-    { projectType = "repomanifest"
-    , projectBuildTargets = mempty
-    , projectDependencyResults = const $ getDeps project
-    , projectPath = parent $ repoManifestXml project
-    , projectLicenses = pure []
-    }
+-- mkProject :: (Has ReadFS sig n, Has Diagnostics sig n) => RepoManifestProject -> DiscoveredProject n
+-- mkProject project =
+--   DiscoveredProject
+--     { projectType = "repomanifest"
+--     , projectBuildTargets = mempty
+--     , projectDependencyResults = const $ getDeps project
+--     , projectPath = parent $ repoManifestXml project
+--     , projectLicenses = pure []
+--     }
 
 getDeps :: (Has ReadFS sig m, Has Diagnostics sig m) => RepoManifestProject -> m DependencyResults
 getDeps = analyze' . repoManifestXml

--- a/src/Strategy/Gradle.hs
+++ b/src/Strategy/Gradle.hs
@@ -33,7 +33,7 @@ import Control.Effect.Diagnostics (
  )
 import Control.Effect.Lift (Lift, sendIO)
 import Control.Effect.Path (withSystemTempDir)
-import Data.Aeson (FromJSON (..), Value (..), decodeStrict, withObject, (.:))
+import Data.Aeson (FromJSON (..), ToJSON, Value (..), decodeStrict, withObject, (.:))
 import Data.Aeson.Types (Parser, unexpected)
 import Data.ByteString (ByteString)
 import Data.ByteString qualified as BS
@@ -62,6 +62,7 @@ import Effect.Exec (AllowErr (..), Command (..), Exec, execThrow)
 import Effect.Grapher (LabeledGrapher, direct, edge, label, withLabeling)
 import Effect.Logger (Logger, logWarn)
 import Effect.ReadFS (ReadFS, doesFileExist)
+import GHC.Generics (Generic)
 import Graphing (Graphing)
 import Path (Abs, Dir, File, Path, fromAbsDir, parent, parseRelFile, (</>))
 import Strategy.Android.Util (isDefaultAndroidDevConfig, isDefaultAndroidTestConfig)
@@ -177,7 +178,9 @@ data GradleProject = GradleProject
   , gradleBuildFile :: Path Abs File
   , gradleProjects :: Set Text
   }
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Ord, Show, Generic)
+
+instance ToJSON GradleProject
 
 instance AnalyzeProject GradleProject where
   analyzeProject = getDeps

--- a/src/Strategy/Gradle.hs
+++ b/src/Strategy/Gradle.hs
@@ -91,22 +91,24 @@ gradleJsonDepsCmd initScriptFilepath baseCmd =
     , cmdAllowErr = Never
     }
 
-discover ::
-  ( Has (Lift IO) sig m
-  , Has ReadFS sig m
-  , Has Diagnostics sig m
-  , Has Exec sig m
-  , Has Logger sig m
-  , Has (Lift IO) rsig run
-  , Has Exec rsig run
-  , Has ReadFS rsig run
-  , Has Diagnostics rsig run
-  ) =>
-  Path Abs Dir ->
-  m [DiscoveredProject run]
-discover dir = context "Gradle" $ do
-  found <- context "Finding projects" $ findProjects dir
-  pure $ mkProject <$> found
+-- discover ::
+--   ( Has (Lift IO) sig m
+--   , Has ReadFS sig m
+--   , Has Diagnostics sig m
+--   , Has Exec sig m
+--   , Has Logger sig m
+--   , Has (Lift IO) rsig run
+--   , Has Exec rsig run
+--   , Has ReadFS rsig run
+--   , Has Diagnostics rsig run
+--   ) =>
+--   Path Abs Dir ->
+--   m [DiscoveredProject run]
+-- discover dir = context "Gradle" $ do
+--   found <- context "Finding projects" $ findProjects dir
+--   pure $ mkProject <$> found
+discover = undefined
+mkProject = undefined
 
 -- Run a Gradle command in a specific working directory, while correctly trying
 -- Gradle wrappers.
@@ -226,15 +228,15 @@ parseSubproject line =
     ("", _) -> Nothing -- no match
     (_, rest) -> Just $ Text.takeWhile (/= '\'') rest
 
-mkProject :: (Has Exec sig n, Has ReadFS sig n, Has (Lift IO) sig n, Has Diagnostics sig n) => GradleProject -> DiscoveredProject n
-mkProject project =
-  DiscoveredProject
-    { projectType = "gradle"
-    , projectBuildTargets = maybe ProjectWithoutTargets FoundTargets $ nonEmpty $ Set.map BuildTarget $ gradleProjects project
-    , projectDependencyResults = getDeps project
-    , projectPath = gradleDir project
-    , projectLicenses = pure []
-    }
+-- mkProject :: (Has Exec sig n, Has ReadFS sig n, Has (Lift IO) sig n, Has Diagnostics sig n) => GradleProject -> DiscoveredProject n
+-- mkProject project =
+--   DiscoveredProject
+--     { projectType = "gradle"
+--     , projectBuildTargets = maybe ProjectWithoutTargets FoundTargets $ nonEmpty $ Set.map BuildTarget $ gradleProjects project
+--     , projectDependencyResults = getDeps project
+--     , projectPath = gradleDir project
+--     , projectLicenses = pure []
+--     }
 
 getDeps :: (Has (Lift IO) sig m, Has Exec sig m, Has ReadFS sig m, Has Diagnostics sig m) => GradleProject -> FoundTargets -> m DependencyResults
 getDeps project targets = context "Gradle" $ do

--- a/src/Strategy/Haskell/Cabal.hs
+++ b/src/Strategy/Haskell/Cabal.hs
@@ -110,10 +110,13 @@ cabalGenPlanCmd =
 cabalPlanFilePath :: Path Rel File
 cabalPlanFilePath = $(mkRelFile "dist-newstyle/cache/plan.json")
 
-discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has ReadFS rsig run, Has Exec rsig run, Has Diagnostics rsig run) => Path Abs Dir -> m [DiscoveredProject run]
-discover dir = context "Cabal" $ do
-  projects <- context "Finding projects" $ findProjects dir
-  pure (map mkProject projects)
+-- discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has ReadFS rsig run, Has Exec rsig run, Has Diagnostics rsig run) => Path Abs Dir -> m [DiscoveredProject run]
+-- discover dir = context "Cabal" $ do
+--   projects <- context "Finding projects" $ findProjects dir
+--   pure (map mkProject projects)
+
+discover = undefined
+mkProject = undefined
 
 isCabalFile :: Path Abs File -> Bool
 isCabalFile file = isDotCabal || isCabalDotProject
@@ -132,15 +135,15 @@ findProjects = walk' $ \dir _ files -> do
     then pure ([CabalProject dir manifestFiles], WalkSkipAll)
     else pure ([], WalkContinue)
 
-mkProject :: (Has ReadFS sig n, Has Exec sig n, Has Diagnostics sig n) => CabalProject -> DiscoveredProject n
-mkProject project =
-  DiscoveredProject
-    { projectType = "cabal"
-    , projectBuildTargets = mempty
-    , projectDependencyResults = const $ getDeps project
-    , projectPath = cabalDir project
-    , projectLicenses = pure []
-    }
+-- mkProject :: (Has ReadFS sig n, Has Exec sig n, Has Diagnostics sig n) => CabalProject -> DiscoveredProject n
+-- mkProject project =
+--   DiscoveredProject
+--     { projectType = "cabal"
+--     , projectBuildTargets = mempty
+--     , projectDependencyResults = const $ getDeps project
+--     , projectPath = cabalDir project
+--     , projectLicenses = pure []
+--     }
 
 getDeps :: (Has ReadFS sig m, Has Exec sig m, Has Diagnostics sig m) => CabalProject -> m DependencyResults
 getDeps project =

--- a/src/Strategy/Haskell/Cabal.hs
+++ b/src/Strategy/Haskell/Cabal.hs
@@ -31,6 +31,7 @@ import Discovery.Walk
 import Effect.Exec
 import Effect.Grapher
 import Effect.ReadFS
+import GHC.Generics (Generic)
 import Graphing (Graphing)
 import Graphing qualified as G
 import Path
@@ -152,7 +153,9 @@ data CabalProject = CabalProject
   { cabalDir :: Path Abs Dir
   , cabalFiles :: [Path Abs File]
   }
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Ord, Show, Generic)
+
+instance ToJSON CabalProject
 
 instance AnalyzeProject CabalProject where
   analyzeProject _ = getDeps

--- a/src/Strategy/Haskell/Stack.hs
+++ b/src/Strategy/Haskell/Stack.hs
@@ -58,10 +58,13 @@ parseLocationType txt
   | txt `elem` ["project package", "archive"] = pure Local
   | otherwise = fail $ "Bad location type: " ++ toString txt
 
-discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has Exec rsig run, Has Diagnostics rsig run) => Path Abs Dir -> m [DiscoveredProject run]
-discover dir = context "Stack" $ do
-  projects <- context "Finding projects" $ findProjects dir
-  pure (map mkProject projects)
+-- discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has Exec rsig run, Has Diagnostics rsig run) => Path Abs Dir -> m [DiscoveredProject run]
+-- discover dir = context "Stack" $ do
+--   projects <- context "Finding projects" $ findProjects dir
+--   pure (map mkProject projects)
+
+discover = undefined
+mkProject = undefined
 
 findProjects :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs Dir -> m [StackProject]
 findProjects = walk' $ \dir _ files -> do
@@ -69,15 +72,15 @@ findProjects = walk' $ \dir _ files -> do
     Nothing -> pure ([], WalkContinue)
     Just file -> pure ([StackProject dir file], WalkSkipAll)
 
-mkProject :: (Has Exec sig n, Has Diagnostics sig n) => StackProject -> DiscoveredProject n
-mkProject project =
-  DiscoveredProject
-    { projectType = "stack"
-    , projectBuildTargets = mempty
-    , projectDependencyResults = const $ getDeps project
-    , projectPath = stackDir project
-    , projectLicenses = pure []
-    }
+-- mkProject :: (Has Exec sig n, Has Diagnostics sig n) => StackProject -> DiscoveredProject n
+-- mkProject project =
+--   DiscoveredProject
+--     { projectType = "stack"
+--     , projectBuildTargets = mempty
+--     , projectDependencyResults = const $ getDeps project
+--     , projectPath = stackDir project
+--     , projectLicenses = pure []
+--     }
 
 getDeps :: (Has Exec sig m, Has Diagnostics sig m) => StackProject -> m DependencyResults
 getDeps project =

--- a/src/Strategy/Haskell/Stack.hs
+++ b/src/Strategy/Haskell/Stack.hs
@@ -22,6 +22,7 @@ import Discovery.Walk
 import Effect.Exec
 import Effect.Grapher
 import Effect.ReadFS (ReadFS)
+import GHC.Generics (Generic)
 import Graphing qualified as G
 import Path
 import Types
@@ -89,7 +90,9 @@ data StackProject = StackProject
   { stackDir :: Path Abs Dir
   , stackFile :: Path Abs File
   }
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Ord, Show, Generic)
+
+instance ToJSON StackProject
 
 instance AnalyzeProject StackProject where
   analyzeProject _ = getDeps

--- a/src/Strategy/Leiningen.hs
+++ b/src/Strategy/Leiningen.hs
@@ -23,6 +23,7 @@ module Strategy.Leiningen (
 import App.Fossa.Analyze.Types (AnalyzeProject, analyzeProject)
 import Control.Applicative (optional)
 import Control.Effect.Diagnostics
+import Data.Aeson (ToJSON)
 import Data.EDN qualified as EDN
 import Data.EDN.Class.Parser (Parser)
 import Data.Foldable (traverse_)
@@ -39,6 +40,7 @@ import Discovery.Walk
 import Effect.Exec
 import Effect.Grapher
 import Effect.ReadFS (ReadFS)
+import GHC.Generics (Generic)
 import Graphing (Graphing)
 import Path
 import Types
@@ -93,7 +95,9 @@ data LeiningenProject = LeiningenProject
   { leinDir :: Path Abs Dir
   , leinProjectClj :: Path Abs File
   }
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Ord, Show, Generic)
+
+instance ToJSON LeiningenProject
 
 instance AnalyzeProject LeiningenProject where
   analyzeProject _ = getDeps

--- a/src/Strategy/Leiningen.hs
+++ b/src/Strategy/Leiningen.hs
@@ -58,10 +58,13 @@ leinVersionCmd =
     , cmdAllowErr = Always
     }
 
-discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has Exec rsig run, Has Diagnostics rsig run) => Path Abs Dir -> m [DiscoveredProject run]
-discover dir = context "Leiningen" $ do
-  projects <- context "Finding projects" $ findProjects dir
-  pure (map mkProject projects)
+--discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has Exec rsig run, Has Diagnostics rsig run) => Path Abs Dir -> m [DiscoveredProject run]
+--discover dir = context "Leiningen" $ do
+  --projects <- context "Finding projects" $ findProjects dir
+  --pure (map mkProject projects)
+
+discover = undefined
+mkProject = undefined
 
 findProjects :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs Dir -> m [LeiningenProject]
 findProjects = walk' $ \dir _ files -> do
@@ -76,15 +79,15 @@ findProjects = walk' $ \dir _ files -> do
 
       pure ([project], WalkContinue)
 
-mkProject :: (Has Exec sig n, Has Diagnostics sig n) => LeiningenProject -> DiscoveredProject n
-mkProject project =
-  DiscoveredProject
-    { projectType = "leiningen"
-    , projectBuildTargets = mempty
-    , projectDependencyResults = const $ getDeps project
-    , projectPath = leinDir project
-    , projectLicenses = pure []
-    }
+-- mkProject :: (Has Exec sig n, Has Diagnostics sig n) => LeiningenProject -> DiscoveredProject n
+-- mkProject project =
+--   DiscoveredProject
+--     { projectType = "leiningen"
+--     , projectBuildTargets = mempty
+--     , projectDependencyResults = const $ getDeps project
+--     , projectPath = leinDir project
+--     , projectLicenses = pure []
+--     }
 
 getDeps :: (Has Exec sig m, Has Diagnostics sig m) => LeiningenProject -> m DependencyResults
 getDeps = context "Leiningen" . context "Dynamic analysis" . analyze . leinProjectClj

--- a/src/Strategy/Maven.hs
+++ b/src/Strategy/Maven.hs
@@ -11,8 +11,10 @@ import Control.Algebra (Has)
 import Control.Effect.Diagnostics (Diagnostics, context, (<||>))
 import Control.Effect.Lift (Lift)
 import Control.Monad.IO.Class (MonadIO)
+import Data.Aeson (ToJSON)
 import Effect.Exec (Exec)
 import Effect.ReadFS (ReadFS)
+import GHC.Generics (Generic)
 import Path (Abs, Dir, Path, parent)
 import Strategy.Maven.DepTree qualified as DepTreeCmd
 import Strategy.Maven.PluginStrategy qualified as Plugin
@@ -46,7 +48,9 @@ mkProject closure =
     }
 
 newtype MavenProject = MavenProject {unMavenProject :: PomClosure.MavenProjectClosure}
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Ord, Show, Generic)
+
+instance ToJSON MavenProject
 
 instance AnalyzeProject MavenProject where
   analyzeProject _ = getDeps

--- a/src/Strategy/Maven.hs
+++ b/src/Strategy/Maven.hs
@@ -17,36 +17,38 @@ import Strategy.Maven.Pom qualified as Pom
 import Strategy.Maven.Pom.Closure qualified as PomClosure
 import Types (DependencyResults (..), DiscoveredProject (..), GraphBreadth (..))
 
-discover ::
-  ( MonadIO m
-  , Has (Lift IO) sig m
-  , Has Diagnostics sig m
-  , Has ReadFS sig m
-  , Has Exec rsig run
-  , Has ReadFS rsig run
-  , Has Diagnostics rsig run
-  , Has (Lift IO) rsig run
-  ) =>
-  Path Abs Dir ->
-  m [DiscoveredProject run]
-discover dir = context "Maven" $ do
-  closures <- context "Finding projects" (PomClosure.findProjects dir)
-  pure (map (mkProject dir) closures)
+-- discover ::
+--   ( MonadIO m
+--   , Has (Lift IO) sig m
+--   , Has Diagnostics sig m
+--   , Has ReadFS sig m
+--   , Has Exec rsig run
+--   , Has ReadFS rsig run
+--   , Has Diagnostics rsig run
+--   , Has (Lift IO) rsig run
+--   ) =>
+--   Path Abs Dir ->
+--   m [DiscoveredProject run]
+-- discover dir = context "Maven" $ do
+--   closures <- context "Finding projects" (PomClosure.findProjects dir)
+--   pure (map (mkProject dir) closures)
 
-mkProject ::
-  (Has ReadFS sig n, Has Exec sig n, Has (Lift IO) sig n, Has Diagnostics sig n) =>
-  -- | basedir; required for licenses
-  Path Abs Dir ->
-  PomClosure.MavenProjectClosure ->
-  DiscoveredProject n
-mkProject basedir closure =
-  DiscoveredProject
-    { projectType = "maven"
-    , projectPath = parent $ PomClosure.closurePath closure
-    , projectBuildTargets = mempty
-    , projectDependencyResults = const $ getDeps closure
-    , projectLicenses = pure $ Pom.getLicenses basedir closure
-    }
+discover = undefined
+mkProject = undefined
+-- mkProject ::
+--   (Has ReadFS sig n, Has Exec sig n, Has (Lift IO) sig n, Has Diagnostics sig n) =>
+--   -- | basedir; required for licenses
+--   Path Abs Dir ->
+--   PomClosure.MavenProjectClosure ->
+--   DiscoveredProject n
+-- mkProject basedir closure =
+--   DiscoveredProject
+--     { projectType = "maven"
+--     , projectPath = parent $ PomClosure.closurePath closure
+--     , projectBuildTargets = mempty
+--     , projectDependencyResults = const $ getDeps closure
+--     , projectLicenses = pure $ Pom.getLicenses basedir closure
+--     }
 
 getDeps ::
   ( Has (Lift IO) sig m

--- a/src/Strategy/Maven/Pom.hs
+++ b/src/Strategy/Maven/Pom.hs
@@ -35,10 +35,10 @@ data MavenStrategyOpts = MavenStrategyOpts
 analyze' :: MavenProjectClosure -> Graphing Dependency
 analyze' = buildProjectGraph
 
-getLicenses :: Path Abs Dir -> MavenProjectClosure -> [LicenseResult]
-getLicenses basedir closure = do
+getLicenses :: MavenProjectClosure -> [LicenseResult]
+getLicenses closure = do
   (abspath, pom) <- Map.elems (closurePoms closure)
-  case Path.makeRelative basedir abspath of
+  case Path.makeRelative (closureAnalysisRoot closure) abspath of
     Nothing -> []
     Just relpath ->
       let path = toFilePath relpath

--- a/src/Strategy/Maven/Pom/Closure.hs
+++ b/src/Strategy/Maven/Pom/Closure.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE RecordWildCards #-}
+
 module Strategy.Maven.Pom.Closure (
   findProjects,
   MavenProjectClosure (..),
@@ -9,6 +11,7 @@ import Algebra.Graph.AdjacencyMap.Algorithm qualified as AM
 import Control.Algebra
 import Control.Carrier.State.Strict
 import Control.Effect.Diagnostics
+import Data.Aeson (ToJSON, object, toJSON, (.=))
 import Data.Foldable (traverse_)
 import Data.List (isSuffixOf)
 import Data.Map.Strict (Map)
@@ -18,6 +21,7 @@ import Data.Set (Set)
 import Data.Set qualified as Set
 import Discovery.Walk
 import Effect.ReadFS
+import GHC.Generics (Generic)
 import Path
 import Path.IO qualified as PIO
 import Strategy.Maven.Pom.PomFile
@@ -104,4 +108,15 @@ data MavenProjectClosure = MavenProjectClosure
   , closureGraph :: AM.AdjacencyMap MavenCoordinate
   , closurePoms :: Map MavenCoordinate (Path Abs File, Pom)
   }
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Ord, Show, Generic)
+
+instance ToJSON MavenProjectClosure where
+  toJSON MavenProjectClosure{..} =
+    object
+      [ "closureAnalysisRoot" .= closureAnalysisRoot
+      , "closurePath" .= closurePath
+      , "closureRootCoord" .= closureRootCoord
+      , "closureRootPom" .= closureRootPom
+      , "closureGraph" .= AM.adjacencyMap closureGraph
+      , "closurePoms" .= closurePoms
+      ]

--- a/src/Strategy/Maven/Pom/Closure.hs
+++ b/src/Strategy/Maven/Pom/Closure.hs
@@ -43,7 +43,7 @@ buildProjectClosures basedir global = closures
     closures = map (\(path, (coord, pom)) -> toClosure path coord pom) (Map.toList projectRoots)
 
     toClosure :: Path Abs File -> MavenCoordinate -> Pom -> MavenProjectClosure
-    toClosure path coord pom = MavenProjectClosure path coord pom reachableGraph reachablePomMap
+    toClosure path coord pom = MavenProjectClosure basedir path coord pom reachableGraph reachablePomMap
       where
         reachableGraph = AM.induce (`Set.member` reachablePoms) $ globalGraph global
         reachablePomMap = Map.filterWithKey (\k _ -> Set.member k reachablePoms) $ globalPoms global
@@ -95,7 +95,10 @@ determineProjectRoots rootDir closure = go . Set.fromList
         frontier = Set.unions $ Set.map (\coord -> AM.postSet coord (globalGraph closure)) remainingCoords
 
 data MavenProjectClosure = MavenProjectClosure
-  { closurePath :: Path Abs File
+  { -- | the root of global fossa-analyze analysis; needed for pathfinder license scan
+    closureAnalysisRoot :: Path Abs Dir
+  , -- | path of the pom file used as the root of this project closure
+    closurePath :: Path Abs File
   , closureRootCoord :: MavenCoordinate
   , closureRootPom :: Pom
   , closureGraph :: AM.AdjacencyMap MavenCoordinate

--- a/src/Strategy/Maven/Pom/PomFile.hs
+++ b/src/Strategy/Maven/Pom/PomFile.hs
@@ -16,9 +16,11 @@ module Strategy.Maven.Pom.PomFile
 ) where
 
 import Control.Applicative (optional, (<|>))
+import Data.Aeson (ToJSON, ToJSONKey)
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
 import Data.Text (Text)
+import GHC.Generics (Generic)
 import Parse.XML
 
 ----- Validating POM files
@@ -83,14 +85,19 @@ data Pom = Pom
   , pomDependencies :: Map (Group, Artifact) MvnDepBody
   , pomLicenses :: [PomLicense]
   }
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Ord, Show, Generic)
+
+instance ToJSON Pom
 
 data MavenCoordinate = MavenCoordinate
   { coordGroup :: Text
   , coordArtifact :: Text
   , coordVersion :: Text
   }
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Ord, Show, Generic)
+
+instance ToJSON MavenCoordinate
+instance ToJSONKey MavenCoordinate
 
 data MvnDepBody = MvnDepBody
   { depVersion :: Maybe Text
@@ -98,7 +105,9 @@ data MvnDepBody = MvnDepBody
   , depScope :: Maybe Text
   , depOptional :: Maybe Text
   }
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Ord, Show, Generic)
+
+instance ToJSON MvnDepBody
 
 instance Semigroup Pom where
   -- left-biased, similar to Map.union
@@ -166,7 +175,9 @@ data PomLicense = PomLicense
   { pomLicenseName :: Maybe Text
   , pomLicenseUrl :: Maybe Text
   }
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Ord, Show, Generic)
+
+instance ToJSON PomLicense
 
 instance FromXML RawPom where
   parseElement el =

--- a/src/Strategy/Maven/Pom/Resolver.hs
+++ b/src/Strategy/Maven/Pom/Resolver.hs
@@ -95,7 +95,7 @@ recursiveLoadPom path = do
 -- pom file. when it's a directory, we default to pointing at the "pom.xml" in
 -- that directory.
 resolvePath :: forall sig m. (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs Dir -> Text -> m (Path Abs File)
-resolvePath cur txt = do
+resolvePath cur txt = context "Resolving parent pom.xml path" $ do
   let resolveToFile :: m (Path Abs File)
       resolveToFile = do
         file <- resolveFile cur txt
@@ -110,7 +110,7 @@ resolvePath cur txt = do
       checkFile file = do
         exists <- doesFileExist file
         unless exists $
-          fatal (FileReadError (show file) "resolvePath: resolved file does not exist: ")
+          fatal (FileReadError (show file) "resolvePath: resolved file does not exist")
         pure file
 
   resolveToFile <||> resolveToDir

--- a/src/Strategy/Mix.hs
+++ b/src/Strategy/Mix.hs
@@ -17,10 +17,12 @@ import Path
 import Strategy.Elixir.MixTree (MixProject (..), analyze)
 import Types (DiscoveredProject (..))
 
-discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has Logger rsig run, Has Exec rsig run, Has Diagnostics rsig run) => Path Abs Dir -> m [DiscoveredProject run]
-discover dir = context "Mix" $ do
-  projects <- context "Finding projects" $ findProjects dir
-  pure (map mkProject projects)
+-- discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has Logger rsig run, Has Exec rsig run, Has Diagnostics rsig run) => Path Abs Dir -> m [DiscoveredProject run]
+-- discover dir = context "Mix" $ do
+--   projects <- context "Finding projects" $ findProjects dir
+--   pure (map mkProject projects)
+discover = undefined
+mkProject = undefined
 
 findProjects :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs Dir -> m [MixProject]
 findProjects = walk' $ \dir _ files -> do
@@ -28,12 +30,12 @@ findProjects = walk' $ \dir _ files -> do
     Nothing -> pure ([], WalkContinue)
     Just file -> pure ([MixProject dir file], WalkSkipSome ["deps", "_build"])
 
-mkProject :: (Has Exec sig n, Has Diagnostics sig n, Has Logger sig n) => MixProject -> DiscoveredProject n
-mkProject project =
-  DiscoveredProject
-    { projectType = "mix"
-    , projectBuildTargets = mempty
-    , projectDependencyResults = const $ analyze project
-    , projectPath = mixDir project
-    , projectLicenses = pure []
-    }
+-- mkProject :: (Has Exec sig n, Has Diagnostics sig n, Has Logger sig n) => MixProject -> DiscoveredProject n
+-- mkProject project =
+--   DiscoveredProject
+--     { projectType = "mix"
+--     , projectBuildTargets = mempty
+--     , projectDependencyResults = const $ analyze project
+--     , projectPath = mixDir project
+--     , projectLicenses = pure []
+--     }

--- a/src/Strategy/Mix.hs
+++ b/src/Strategy/Mix.hs
@@ -10,19 +10,15 @@ import Discovery.Walk (
   findFileNamed,
   walk',
  )
-import Effect.Exec (Exec, Has)
-import Effect.Logger (Logger)
-import Effect.ReadFS (ReadFS)
+import Effect.ReadFS (Has, ReadFS)
 import Path
-import Strategy.Elixir.MixTree (MixProject (..), analyze)
+import Strategy.Elixir.MixTree (MixProject (..))
 import Types (DiscoveredProject (..))
 
--- discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has Logger rsig run, Has Exec rsig run, Has Diagnostics rsig run) => Path Abs Dir -> m [DiscoveredProject run]
--- discover dir = context "Mix" $ do
---   projects <- context "Finding projects" $ findProjects dir
---   pure (map mkProject projects)
-discover = undefined
-mkProject = undefined
+discover :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs Dir -> m [DiscoveredProject MixProject]
+discover dir = context "Mix" $ do
+  projects <- context "Finding projects" $ findProjects dir
+  pure (map mkProject projects)
 
 findProjects :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs Dir -> m [MixProject]
 findProjects = walk' $ \dir _ files -> do
@@ -30,12 +26,11 @@ findProjects = walk' $ \dir _ files -> do
     Nothing -> pure ([], WalkContinue)
     Just file -> pure ([MixProject dir file], WalkSkipSome ["deps", "_build"])
 
--- mkProject :: (Has Exec sig n, Has Diagnostics sig n, Has Logger sig n) => MixProject -> DiscoveredProject n
--- mkProject project =
---   DiscoveredProject
---     { projectType = "mix"
---     , projectBuildTargets = mempty
---     , projectDependencyResults = const $ analyze project
---     , projectPath = mixDir project
---     , projectLicenses = pure []
---     }
+mkProject :: MixProject -> DiscoveredProject MixProject
+mkProject project =
+  DiscoveredProject
+    { projectType = "mix"
+    , projectBuildTargets = mempty
+    , projectPath = mixDir project
+    , projectData = project
+    }

--- a/src/Strategy/Npm.hs
+++ b/src/Strategy/Npm.hs
@@ -2,19 +2,19 @@ module Strategy.Npm (
   discover,
 ) where
 
+import App.Fossa.Analyze.Types (AnalyzeProject, analyzeProject)
 import Control.Effect.Diagnostics (Diagnostics, context, (<||>))
 import Control.Effect.Diagnostics qualified as Diag
+import Data.Aeson (ToJSON)
 import Discovery.Walk
 import Effect.Exec
 import Effect.ReadFS
+import GHC.Generics (Generic)
 import Path
 import Strategy.Node.NpmList qualified as NpmList
 import Strategy.Node.NpmLock qualified as NpmLock
 import Strategy.Node.PackageJson qualified as PackageJson
 import Types
-import App.Fossa.Analyze.Types (AnalyzeProject, analyzeProject)
-import GHC.Generics (Generic)
-import Data.Aeson (ToJSON)
 
 discover :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs Dir -> m [DiscoveredProject NpmProject]
 discover dir = context "Npm" $ do

--- a/src/Strategy/Npm.hs
+++ b/src/Strategy/Npm.hs
@@ -13,10 +13,13 @@ import Strategy.Node.NpmLock qualified as NpmLock
 import Strategy.Node.PackageJson qualified as PackageJson
 import Types
 
-discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has ReadFS rsig run, Has Exec rsig run, Has Diagnostics rsig run) => Path Abs Dir -> m [DiscoveredProject run]
-discover dir = context "Npm" $ do
-  projects <- context "Finding projects" $ findProjects dir
-  pure (map mkProject projects)
+-- discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has ReadFS rsig run, Has Exec rsig run, Has Diagnostics rsig run) => Path Abs Dir -> m [DiscoveredProject run]
+-- discover dir = context "Npm" $ do
+--   projects <- context "Finding projects" $ findProjects dir
+--   pure (map mkProject projects)
+
+discover = undefined
+mkProject = undefined
 
 findProjects :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs Dir -> m [NpmProject]
 findProjects = walk' $ \dir _ files -> do
@@ -46,15 +49,15 @@ data NpmProject = NpmProject
   }
   deriving (Eq, Ord, Show)
 
-mkProject :: (Has Exec sig n, Has ReadFS sig n, Has Diagnostics sig n) => NpmProject -> DiscoveredProject n
-mkProject project =
-  DiscoveredProject
-    { projectType = "npm"
-    , projectBuildTargets = mempty
-    , projectDependencyResults = const $ getDeps project
-    , projectPath = npmDir project
-    , projectLicenses = pure []
-    }
+-- mkProject :: (Has Exec sig n, Has ReadFS sig n, Has Diagnostics sig n) => NpmProject -> DiscoveredProject n
+-- mkProject project =
+--   DiscoveredProject
+--     { projectType = "npm"
+--     , projectBuildTargets = mempty
+--     , projectDependencyResults = const $ getDeps project
+--     , projectPath = npmDir project
+--     , projectLicenses = pure []
+--     }
 
 getDeps :: (Has Exec sig m, Has ReadFS sig m, Has Diagnostics sig m) => NpmProject -> m DependencyResults
 getDeps project = context "Npm" $ analyzeNpmList project <||> analyzeNpmLock project <||> analyzeNpmJson project

--- a/src/Strategy/Npm.hs
+++ b/src/Strategy/Npm.hs
@@ -13,6 +13,8 @@ import Strategy.Node.NpmLock qualified as NpmLock
 import Strategy.Node.PackageJson qualified as PackageJson
 import Types
 import App.Fossa.Analyze.Types (AnalyzeProject, analyzeProject)
+import GHC.Generics (Generic)
+import Data.Aeson (ToJSON)
 
 discover :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs Dir -> m [DiscoveredProject NpmProject]
 discover dir = context "Npm" $ do
@@ -45,7 +47,9 @@ data NpmProject = NpmProject
   , npmPackageJson :: Path Abs File
   , npmPackageLock :: Maybe (Path Abs File)
   }
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Ord, Show, Generic)
+
+instance ToJSON NpmProject
 
 instance AnalyzeProject NpmProject where
   analyzeProject _ = getDeps

--- a/src/Strategy/NuGet/Nuspec.hs
+++ b/src/Strategy/NuGet/Nuspec.hs
@@ -16,6 +16,7 @@ import App.Fossa.Analyze.Types (AnalyzeProject, analyzeProject)
 import App.Pathfinder.Types (LicenseAnalyzeProject, licenseAnalyzeProject)
 import Control.Applicative (optional)
 import Control.Effect.Diagnostics
+import Data.Aeson (ToJSON)
 import Data.Foldable (find)
 import Data.List qualified as L
 import Data.Map.Strict qualified as Map
@@ -24,6 +25,7 @@ import Data.Text (Text)
 import DepTypes
 import Discovery.Walk
 import Effect.ReadFS
+import GHC.Generics (Generic)
 import Graphing (Graphing)
 import Graphing qualified
 import Parse.XML
@@ -51,7 +53,9 @@ findProjects = walk' $ \_ _ files -> do
 newtype NuspecProject = NuspecProject
   { nuspecFile :: Path Abs File
   }
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Ord, Show, Generic)
+
+instance ToJSON NuspecProject
 
 mkProject :: NuspecProject -> DiscoveredProject NuspecProject
 mkProject project =

--- a/src/Strategy/NuGet/Nuspec.hs
+++ b/src/Strategy/NuGet/Nuspec.hs
@@ -35,10 +35,11 @@ import Types (
   LicenseType (..),
  )
 
-discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has ReadFS rsig run, Has Diagnostics rsig run) => Path Abs Dir -> m [DiscoveredProject run]
-discover dir = context "Nuspec" $ do
-  projects <- context "Finding projects" $ findProjects dir
-  pure (map mkProject projects)
+discover = undefined
+--discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has ReadFS rsig run, Has Diagnostics rsig run) => Path Abs Dir -> m [DiscoveredProject run]
+--discover dir = context "Nuspec" $ do
+  --projects <- context "Finding projects" $ findProjects dir
+  --pure (map mkProject projects)
 
 findProjects :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs Dir -> m [NuspecProject]
 findProjects = walk' $ \_ _ files -> do
@@ -51,15 +52,16 @@ newtype NuspecProject = NuspecProject
   }
   deriving (Eq, Ord, Show)
 
-mkProject :: (Has ReadFS sig n, Has Diagnostics sig n) => NuspecProject -> DiscoveredProject n
-mkProject project =
-  DiscoveredProject
-    { projectType = "nuspec"
-    , projectBuildTargets = mempty
-    , projectDependencyResults = const $ getDeps project
-    , projectPath = parent $ nuspecFile project
-    , projectLicenses = analyzeLicenses (nuspecFile project)
-    }
+mkProject = undefined
+-- mkProject :: (Has ReadFS sig n, Has Diagnostics sig n) => NuspecProject -> DiscoveredProject n
+-- mkProject project =
+--   DiscoveredProject
+--     { projectType = "nuspec"
+--     , projectBuildTargets = mempty
+--     , projectDependencyResults = const $ getDeps project
+--     , projectPath = parent $ nuspecFile project
+--     , projectLicenses = analyzeLicenses (nuspecFile project)
+--     }
 
 getDeps :: (Has ReadFS sig m, Has Diagnostics sig m) => NuspecProject -> m DependencyResults
 getDeps = context "Nuspec" . context "Static analysis" . analyze' . nuspecFile

--- a/src/Strategy/NuGet/PackageReference.hs
+++ b/src/Strategy/NuGet/PackageReference.hs
@@ -29,10 +29,12 @@ import Types
 isPackageRefFile :: Path b File -> Bool
 isPackageRefFile file = any (\x -> x `L.isSuffixOf` fileName file) [".csproj", ".xproj", ".vbproj", ".dbproj", ".fsproj"]
 
-discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has ReadFS rsig run, Has Diagnostics rsig run) => Path Abs Dir -> m [DiscoveredProject run]
-discover dir = context "PackageReference" $ do
-  projects <- context "Finding projects" $ findProjects dir
-  pure (map mkProject projects)
+-- discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has ReadFS rsig run, Has Diagnostics rsig run) => Path Abs Dir -> m [DiscoveredProject run]
+-- discover dir = context "PackageReference" $ do
+--   projects <- context "Finding projects" $ findProjects dir
+--   pure (map mkProject projects)
+discover = undefined
+mkProject = undefined
 
 findProjects :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs Dir -> m [PackageReferenceProject]
 findProjects = walk' $ \_ _ files -> do
@@ -45,15 +47,15 @@ newtype PackageReferenceProject = PackageReferenceProject
   }
   deriving (Eq, Ord, Show)
 
-mkProject :: (Has ReadFS sig n, Has Diagnostics sig n) => PackageReferenceProject -> DiscoveredProject n
-mkProject project =
-  DiscoveredProject
-    { projectType = "packagereference"
-    , projectBuildTargets = mempty
-    , projectDependencyResults = const $ getDeps project
-    , projectPath = parent $ packageReferenceFile project
-    , projectLicenses = pure []
-    }
+-- mkProject :: (Has ReadFS sig n, Has Diagnostics sig n) => PackageReferenceProject -> DiscoveredProject n
+-- mkProject project =
+--   DiscoveredProject
+--     { projectType = "packagereference"
+--     , projectBuildTargets = mempty
+--     , projectDependencyResults = const $ getDeps project
+--     , projectPath = parent $ packageReferenceFile project
+--     , projectLicenses = pure []
+--     }
 
 getDeps :: (Has ReadFS sig m, Has Diagnostics sig m) => PackageReferenceProject -> m DependencyResults
 getDeps = context "PackageReference" . context "Static analysis" . analyze' . packageReferenceFile

--- a/src/Strategy/NuGet/PackageReference.hs
+++ b/src/Strategy/NuGet/PackageReference.hs
@@ -14,6 +14,7 @@ module Strategy.NuGet.PackageReference (
 import App.Fossa.Analyze.Types (AnalyzeProject, analyzeProject)
 import Control.Applicative (optional, (<|>))
 import Control.Effect.Diagnostics
+import Data.Aeson (ToJSON)
 import Data.Foldable (find)
 import Data.List qualified as L
 import Data.Map.Strict qualified as Map
@@ -21,6 +22,7 @@ import Data.Text (Text)
 import DepTypes
 import Discovery.Walk
 import Effect.ReadFS
+import GHC.Generics (Generic)
 import Graphing (Graphing)
 import Graphing qualified
 import Parse.XML
@@ -44,7 +46,9 @@ findProjects = walk' $ \_ _ files -> do
 newtype PackageReferenceProject = PackageReferenceProject
   { packageReferenceFile :: Path Abs File
   }
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Ord, Show, Generic)
+
+instance ToJSON PackageReferenceProject
 
 instance AnalyzeProject PackageReferenceProject where
   analyzeProject _ = getDeps

--- a/src/Strategy/NuGet/PackagesConfig.hs
+++ b/src/Strategy/NuGet/PackagesConfig.hs
@@ -23,10 +23,13 @@ import Parse.XML
 import Path
 import Types
 
-discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has ReadFS rsig run, Has Diagnostics rsig run) => Path Abs Dir -> m [DiscoveredProject run]
-discover dir = context "PackagesConfig" $ do
-  projects <- context "Finding Projects" $ findProjects dir
-  pure (map mkProject projects)
+-- discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has ReadFS rsig run, Has Diagnostics rsig run) => Path Abs Dir -> m [DiscoveredProject run]
+-- discover dir = context "PackagesConfig" $ do
+--   projects <- context "Finding Projects" $ findProjects dir
+--   pure (map mkProject projects)
+
+discover = undefined
+mkProject = undefined
 
 findProjects :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs Dir -> m [PackagesConfigProject]
 findProjects = walk' $ \_ _ files -> do
@@ -39,15 +42,15 @@ newtype PackagesConfigProject = PackagesConfigProject
   }
   deriving (Eq, Ord, Show)
 
-mkProject :: (Has ReadFS sig n, Has Diagnostics sig n) => PackagesConfigProject -> DiscoveredProject n
-mkProject project =
-  DiscoveredProject
-    { projectType = "packagesconfig"
-    , projectBuildTargets = mempty
-    , projectDependencyResults = const $ getDeps project
-    , projectPath = parent $ packagesConfigFile project
-    , projectLicenses = pure []
-    }
+-- mkProject :: (Has ReadFS sig n, Has Diagnostics sig n) => PackagesConfigProject -> DiscoveredProject n
+-- mkProject project =
+--   DiscoveredProject
+--     { projectType = "packagesconfig"
+--     , projectBuildTargets = mempty
+--     , projectDependencyResults = const $ getDeps project
+--     , projectPath = parent $ packagesConfigFile project
+--     , projectLicenses = pure []
+--     }
 
 getDeps :: (Has ReadFS sig m, Has Diagnostics sig m) => PackagesConfigProject -> m DependencyResults
 getDeps = context "PackagesConfig" . context "Static analysis" . analyze' . packagesConfigFile

--- a/src/Strategy/NuGet/PackagesConfig.hs
+++ b/src/Strategy/NuGet/PackagesConfig.hs
@@ -12,12 +12,14 @@ module Strategy.NuGet.PackagesConfig (
 
 import App.Fossa.Analyze.Types (AnalyzeProject, analyzeProject)
 import Control.Effect.Diagnostics
+import Data.Aeson (ToJSON)
 import Data.Foldable (find)
 import Data.Map.Strict qualified as Map
 import Data.Text (Text)
 import DepTypes
 import Discovery.Walk
 import Effect.ReadFS
+import GHC.Generics (Generic)
 import Graphing (Graphing)
 import Graphing qualified
 import Parse.XML
@@ -38,7 +40,9 @@ findProjects = walk' $ \_ _ files -> do
 newtype PackagesConfigProject = PackagesConfigProject
   { packagesConfigFile :: Path Abs File
   }
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Ord, Show, Generic)
+
+instance ToJSON PackagesConfigProject
 
 instance AnalyzeProject PackagesConfigProject where
   analyzeProject _ = getDeps

--- a/src/Strategy/NuGet/Paket.hs
+++ b/src/Strategy/NuGet/Paket.hs
@@ -10,6 +10,7 @@ module Strategy.NuGet.Paket (
   Remote (..),
 ) where
 
+import App.Fossa.Analyze.Types (AnalyzeProject, analyzeProject)
 import Control.Effect.Diagnostics
 import Control.Monad (guard)
 import Data.Char qualified as C
@@ -33,12 +34,10 @@ import Types
 
 type Parser = Parsec Void Text
 
--- discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has ReadFS rsig run, Has Diagnostics rsig run) => Path Abs Dir -> m [DiscoveredProject run]
--- discover dir = context "Paket" $ do
---   projects <- context "Finding projects" $ findProjects dir
---   pure (map mkProject projects)
-discover = undefined
-mkProject = undefined
+discover :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs Dir -> m [DiscoveredProject PaketProject]
+discover dir = context "Paket" $ do
+  projects <- context "Finding projects" $ findProjects dir
+  pure (map mkProject projects)
 
 findProjects :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs Dir -> m [PaketProject]
 findProjects = walk' $ \_ _ files -> do
@@ -51,15 +50,17 @@ newtype PaketProject = PaketProject
   }
   deriving (Eq, Ord, Show)
 
--- mkProject :: (Has ReadFS sig n, Has Diagnostics sig n) => PaketProject -> DiscoveredProject n
--- mkProject project =
---   DiscoveredProject
---     { projectType = "paket"
---     , projectBuildTargets = mempty
---     , projectDependencyResults = const $ getDeps project
---     , projectPath = parent $ paketLock project
---     , projectLicenses = pure []
---     }
+instance AnalyzeProject PaketProject where
+  analyzeProject _ = getDeps
+
+mkProject :: PaketProject -> DiscoveredProject PaketProject
+mkProject project =
+  DiscoveredProject
+    { projectType = "paket"
+    , projectBuildTargets = mempty
+    , projectPath = parent $ paketLock project
+    , projectData = project
+    }
 
 getDeps :: (Has ReadFS sig m, Has Diagnostics sig m) => PaketProject -> m DependencyResults
 getDeps = context "Paket" . context "Static analysis" . analyze' . paketLock

--- a/src/Strategy/NuGet/Paket.hs
+++ b/src/Strategy/NuGet/Paket.hs
@@ -33,10 +33,12 @@ import Types
 
 type Parser = Parsec Void Text
 
-discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has ReadFS rsig run, Has Diagnostics rsig run) => Path Abs Dir -> m [DiscoveredProject run]
-discover dir = context "Paket" $ do
-  projects <- context "Finding projects" $ findProjects dir
-  pure (map mkProject projects)
+-- discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has ReadFS rsig run, Has Diagnostics rsig run) => Path Abs Dir -> m [DiscoveredProject run]
+-- discover dir = context "Paket" $ do
+--   projects <- context "Finding projects" $ findProjects dir
+--   pure (map mkProject projects)
+discover = undefined
+mkProject = undefined
 
 findProjects :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs Dir -> m [PaketProject]
 findProjects = walk' $ \_ _ files -> do
@@ -49,15 +51,15 @@ newtype PaketProject = PaketProject
   }
   deriving (Eq, Ord, Show)
 
-mkProject :: (Has ReadFS sig n, Has Diagnostics sig n) => PaketProject -> DiscoveredProject n
-mkProject project =
-  DiscoveredProject
-    { projectType = "paket"
-    , projectBuildTargets = mempty
-    , projectDependencyResults = const $ getDeps project
-    , projectPath = parent $ paketLock project
-    , projectLicenses = pure []
-    }
+-- mkProject :: (Has ReadFS sig n, Has Diagnostics sig n) => PaketProject -> DiscoveredProject n
+-- mkProject project =
+--   DiscoveredProject
+--     { projectType = "paket"
+--     , projectBuildTargets = mempty
+--     , projectDependencyResults = const $ getDeps project
+--     , projectPath = parent $ paketLock project
+--     , projectLicenses = pure []
+--     }
 
 getDeps :: (Has ReadFS sig m, Has Diagnostics sig m) => PaketProject -> m DependencyResults
 getDeps = context "Paket" . context "Static analysis" . analyze' . paketLock

--- a/src/Strategy/NuGet/Paket.hs
+++ b/src/Strategy/NuGet/Paket.hs
@@ -13,6 +13,7 @@ module Strategy.NuGet.Paket (
 import App.Fossa.Analyze.Types (AnalyzeProject, analyzeProject)
 import Control.Effect.Diagnostics
 import Control.Monad (guard)
+import Data.Aeson (ToJSON)
 import Data.Char qualified as C
 import Data.Foldable (traverse_)
 import Data.Functor (void)
@@ -25,6 +26,7 @@ import DepTypes
 import Discovery.Walk
 import Effect.Grapher
 import Effect.ReadFS
+import GHC.Generics (Generic)
 import Graphing (Graphing)
 import Path
 import Text.Megaparsec hiding (label)
@@ -48,7 +50,9 @@ findProjects = walk' $ \_ _ files -> do
 newtype PaketProject = PaketProject
   { paketLock :: Path Abs File
   }
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Ord, Show, Generic)
+
+instance ToJSON PaketProject
 
 instance AnalyzeProject PaketProject where
   analyzeProject _ = getDeps

--- a/src/Strategy/NuGet/ProjectAssetsJson.hs
+++ b/src/Strategy/NuGet/ProjectAssetsJson.hs
@@ -19,6 +19,7 @@ import Data.Text qualified as Text
 import DepTypes
 import Discovery.Walk
 import Effect.ReadFS
+import GHC.Generics (Generic)
 import Graphing (Graphing, unfold)
 import Path
 import Types
@@ -37,7 +38,9 @@ findProjects = walk' $ \_ _ files -> do
 newtype ProjectAssetsJsonProject = ProjectAssetsJsonProject
   { projectAssetsJsonFile :: Path Abs File
   }
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Ord, Show, Generic)
+
+instance ToJSON ProjectAssetsJsonProject
 
 instance AnalyzeProject ProjectAssetsJsonProject where
   analyzeProject _ = getDeps

--- a/src/Strategy/NuGet/ProjectAssetsJson.hs
+++ b/src/Strategy/NuGet/ProjectAssetsJson.hs
@@ -22,10 +22,11 @@ import Graphing (Graphing, unfold)
 import Path
 import Types
 
-discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has ReadFS rsig run, Has Diagnostics rsig run) => Path Abs Dir -> m [DiscoveredProject run]
-discover dir = context "ProjectAssetsJson" $ do
-  projects <- context "Finding projects" $ findProjects dir
-  pure (map mkProject projects)
+-- discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has ReadFS rsig run, Has Diagnostics rsig run) => Path Abs Dir -> m [DiscoveredProject run]
+-- discover dir = context "ProjectAssetsJson" $ do
+--   projects <- context "Finding projects" $ findProjects dir
+--   pure (map mkProject projects)
+discover = undefined
 
 findProjects :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs Dir -> m [ProjectAssetsJsonProject]
 findProjects = walk' $ \_ _ files -> do
@@ -38,15 +39,16 @@ newtype ProjectAssetsJsonProject = ProjectAssetsJsonProject
   }
   deriving (Eq, Ord, Show)
 
-mkProject :: (Has ReadFS sig n, Has Diagnostics sig n) => ProjectAssetsJsonProject -> DiscoveredProject n
-mkProject project =
-  DiscoveredProject
-    { projectType = "projectassetsjson"
-    , projectBuildTargets = mempty
-    , projectDependencyResults = const $ getDeps project
-    , projectPath = parent $ projectAssetsJsonFile project
-    , projectLicenses = pure []
-    }
+-- mkProject :: (Has ReadFS sig n, Has Diagnostics sig n) => ProjectAssetsJsonProject -> DiscoveredProject n
+-- mkProject project =
+--   DiscoveredProject
+--     { projectType = "projectassetsjson"
+--     , projectBuildTargets = mempty
+--     , projectDependencyResults = const $ getDeps project
+--     , projectPath = parent $ projectAssetsJsonFile project
+--     , projectLicenses = pure []
+--     }
+mkProject = undefined
 
 getDeps :: (Has ReadFS sig m, Has Diagnostics sig m) => ProjectAssetsJsonProject -> m DependencyResults
 getDeps = context "ProjectAssetsJson" . context "Static analysis" . analyze' . projectAssetsJsonFile

--- a/src/Strategy/NuGet/ProjectJson.hs
+++ b/src/Strategy/NuGet/ProjectJson.hs
@@ -20,6 +20,7 @@ import Data.Text qualified as Text
 import DepTypes
 import Discovery.Walk
 import Effect.ReadFS
+import GHC.Generics (Generic)
 import Graphing (Graphing)
 import Graphing qualified
 import Path
@@ -37,7 +38,9 @@ findProjects = walk' $ \_ _ files -> do
 newtype ProjectJsonProject = ProjectJsonProject
   { projectJsonFile :: Path Abs File
   }
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Ord, Show, Generic)
+
+instance ToJSON ProjectJsonProject
 
 instance AnalyzeProject ProjectJsonProject where
   analyzeProject _ = getDeps

--- a/src/Strategy/NuGet/ProjectJson.hs
+++ b/src/Strategy/NuGet/ProjectJson.hs
@@ -24,8 +24,9 @@ import Graphing qualified
 import Path
 import Types
 
-discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has ReadFS rsig run, Has Diagnostics rsig run) => Path Abs Dir -> m [DiscoveredProject run]
-discover dir = map mkProject <$> findProjects dir
+-- discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has ReadFS rsig run, Has Diagnostics rsig run) => Path Abs Dir -> m [DiscoveredProject run]
+-- discover dir = map mkProject <$> findProjects dir
+discover = undefined
 
 findProjects :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs Dir -> m [ProjectJsonProject]
 findProjects = walk' $ \_ _ files -> do
@@ -38,15 +39,16 @@ newtype ProjectJsonProject = ProjectJsonProject
   }
   deriving (Eq, Ord, Show)
 
-mkProject :: (Has ReadFS sig n, Has Diagnostics sig n) => ProjectJsonProject -> DiscoveredProject n
-mkProject project =
-  DiscoveredProject
-    { projectType = "projectjson"
-    , projectBuildTargets = mempty
-    , projectDependencyResults = const $ getDeps project
-    , projectPath = parent $ projectJsonFile project
-    , projectLicenses = pure []
-    }
+-- mkProject :: (Has ReadFS sig n, Has Diagnostics sig n) => ProjectJsonProject -> DiscoveredProject n
+-- mkProject project =
+--   DiscoveredProject
+--     { projectType = "projectjson"
+--     , projectBuildTargets = mempty
+--     , projectDependencyResults = const $ getDeps project
+--     , projectPath = parent $ projectJsonFile project
+--     , projectLicenses = pure []
+--     }
+mkProject = undefined
 
 getDeps :: (Has ReadFS sig m, Has Diagnostics sig m) => ProjectJsonProject -> m DependencyResults
 getDeps = analyze' . projectJsonFile

--- a/src/Strategy/Pub.hs
+++ b/src/Strategy/Pub.hs
@@ -11,10 +11,12 @@ import Strategy.Dart.PubSpec (analyzePubSpecFile)
 import Strategy.Dart.PubSpecLock (analyzePubLockFile)
 import Types (DependencyResults (..), DiscoveredProject (..))
 
-discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has ReadFS rsig run, Has Exec rsig run, Has Diagnostics rsig run, Has Logger rsig run) => Path Abs Dir -> m [DiscoveredProject run]
-discover dir = context "Pub" $ do
-  projects <- context "Finding projects" $ findProjects dir
-  pure (map mkProject projects)
+-- discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has ReadFS rsig run, Has Exec rsig run, Has Diagnostics rsig run, Has Logger rsig run) => Path Abs Dir -> m [DiscoveredProject run]
+-- discover dir = context "Pub" $ do
+--   projects <- context "Finding projects" $ findProjects dir
+--   pure (map mkProject projects)
+discover = undefined
+mkProject = undefined
 
 findProjects :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs Dir -> m [PubProject]
 findProjects = walk' $ \dir _ files -> do
@@ -37,15 +39,15 @@ data PubProject = PubProject
   }
   deriving (Eq, Ord, Show)
 
-mkProject :: (Has Exec sig n, Has ReadFS sig n, Has Diagnostics sig n, Has Logger sig n) => PubProject -> DiscoveredProject n
-mkProject project =
-  DiscoveredProject
-    { projectType = "pub"
-    , projectBuildTargets = mempty
-    , projectDependencyResults = const $ getDeps project
-    , projectPath = pubSpecDir project
-    , projectLicenses = pure []
-    }
+-- mkProject :: (Has Exec sig n, Has ReadFS sig n, Has Diagnostics sig n, Has Logger sig n) => PubProject -> DiscoveredProject n
+-- mkProject project =
+--   DiscoveredProject
+--     { projectType = "pub"
+--     , projectBuildTargets = mempty
+--     , projectDependencyResults = const $ getDeps project
+--     , projectPath = pubSpecDir project
+--     , projectLicenses = pure []
+--     }
 
 getDeps :: (Has Exec sig m, Has ReadFS sig m, Has Diagnostics sig m, Has Logger sig m) => PubProject -> m DependencyResults
 getDeps project = do

--- a/src/Strategy/Pub.hs
+++ b/src/Strategy/Pub.hs
@@ -2,10 +2,12 @@ module Strategy.Pub (discover) where
 
 import App.Fossa.Analyze.Types (AnalyzeProject, analyzeProject)
 import Control.Effect.Diagnostics (Diagnostics, context, (<||>))
+import Data.Aeson (ToJSON)
 import Discovery.Walk (WalkStep (WalkContinue), findFileNamed, walk')
 import Effect.Exec (Exec, Has)
 import Effect.Logger (Logger)
 import Effect.ReadFS (ReadFS)
+import GHC.Generics (Generic)
 import Path
 import Strategy.Dart.PubDeps (analyzeDepsCmd)
 import Strategy.Dart.PubSpec (analyzePubSpecFile)
@@ -36,7 +38,9 @@ data PubProject = PubProject
   , pubLock :: Maybe (Path Abs File)
   , pubSpecDir :: Path Abs Dir
   }
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Ord, Show, Generic)
+
+instance ToJSON PubProject
 
 instance AnalyzeProject PubProject where
   analyzeProject _ = getDeps

--- a/src/Strategy/Python/Pipenv.hs
+++ b/src/Strategy/Python/Pipenv.hs
@@ -30,10 +30,11 @@ import Graphing (Graphing)
 import Path
 import Types
 
-discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has ReadFS rsig run, Has Exec rsig run, Has Diagnostics rsig run) => Path Abs Dir -> m [DiscoveredProject run]
-discover dir = context "Pipenv" $ do
-  projects <- context "Finding projects" $ findProjects dir
-  pure (map mkProject projects)
+-- discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has ReadFS rsig run, Has Exec rsig run, Has Diagnostics rsig run) => Path Abs Dir -> m [DiscoveredProject run]
+-- discover dir = context "Pipenv" $ do
+--   projects <- context "Finding projects" $ findProjects dir
+--   pure (map mkProject projects)
+discover = undefined
 
 findProjects :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs Dir -> m [PipenvProject]
 findProjects = walk' $ \_ _ files -> do
@@ -60,15 +61,16 @@ getDeps project = context "Pipenv" $ do
       , dependencyManifestFiles = [pipenvLockfile project]
       }
 
-mkProject :: (Has ReadFS sig n, Has Exec sig n, Has Diagnostics sig n) => PipenvProject -> DiscoveredProject n
-mkProject project =
-  DiscoveredProject
-    { projectType = "pipenv"
-    , projectBuildTargets = mempty
-    , projectDependencyResults = const $ getDeps project
-    , projectPath = parent $ pipenvLockfile project
-    , projectLicenses = pure []
-    }
+-- mkProject :: (Has ReadFS sig n, Has Exec sig n, Has Diagnostics sig n) => PipenvProject -> DiscoveredProject n
+-- mkProject project =
+--   DiscoveredProject
+--     { projectType = "pipenv"
+--     , projectBuildTargets = mempty
+--     , projectDependencyResults = const $ getDeps project
+--     , projectPath = parent $ pipenvLockfile project
+--     , projectLicenses = pure []
+--     }
+mkProject = undefined
 
 newtype PipenvProject = PipenvProject
   { pipenvLockfile :: Path Abs File

--- a/src/Strategy/Python/Pipenv.hs
+++ b/src/Strategy/Python/Pipenv.hs
@@ -27,6 +27,7 @@ import Discovery.Walk
 import Effect.Exec
 import Effect.Grapher
 import Effect.ReadFS
+import GHC.Generics (Generic)
 import Graphing (Graphing)
 import Path
 import Types
@@ -73,7 +74,9 @@ mkProject project =
 newtype PipenvProject = PipenvProject
   { pipenvLockfile :: Path Abs File
   }
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Ord, Show, Generic)
+
+instance ToJSON PipenvProject
 
 instance AnalyzeProject PipenvProject where
   analyzeProject _ = getDeps

--- a/src/Strategy/Python/Poetry.hs
+++ b/src/Strategy/Python/Poetry.hs
@@ -41,10 +41,11 @@ data PoetryProject = PoetryProject
   }
   deriving (Show, Eq, Ord)
 
-discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has Logger sig m, Has Logger rsig run, Has ReadFS rsig run, Has Diagnostics rsig run) => Path Abs Dir -> m [DiscoveredProject run]
-discover dir = context "Poetry" $ do
-  projects <- context "Finding projects" $ findProjects dir
-  pure (map mkProject projects)
+discover = undefined
+-- discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has Logger sig m, Has Logger rsig run, Has ReadFS rsig run, Has Diagnostics rsig run) => Path Abs Dir -> m [DiscoveredProject run]
+-- discover dir = context "Poetry" $ do
+--   projects <- context "Finding projects" $ findProjects dir
+--   pure (map mkProject projects)
 
 -- | Poetry build backend identifier required in [pyproject.toml](https://python-poetry.org/docs/pyproject/#poetry-and-pep-517).
 usesPoetryBackend :: Text -> Bool
@@ -90,15 +91,16 @@ findProjects = walk' $ \dir _ files -> do
     (Just _, Nothing) -> context "poetry.lock file found without accompanying pyproject.toml!" $ pure ([], WalkContinue)
     (Nothing, Nothing) -> pure ([], WalkContinue)
 
-mkProject :: (Has ReadFS sig n, Has Diagnostics sig n, Has Logger sig n) => PoetryProject -> DiscoveredProject n
-mkProject project =
-  DiscoveredProject
-    { projectType = "poetry"
-    , projectBuildTargets = mempty
-    , projectDependencyResults = const $ getDeps project
-    , projectPath = pyProjectPath $ projectDir project
-    , projectLicenses = pure []
-    }
+-- mkProject :: (Has ReadFS sig n, Has Diagnostics sig n, Has Logger sig n) => PoetryProject -> DiscoveredProject n
+-- mkProject project =
+--   DiscoveredProject
+--     { projectType = "poetry"
+--     , projectBuildTargets = mempty
+--     , projectDependencyResults = const $ getDeps project
+--     , projectPath = pyProjectPath $ projectDir project
+--     , projectLicenses = pure []
+--     }
+mkProject = undefined
 
 getDeps :: (Has ReadFS sig m, Has Diagnostics sig m, Has Logger sig m) => PoetryProject -> m DependencyResults
 getDeps project = do

--- a/src/Strategy/Python/Poetry.hs
+++ b/src/Strategy/Python/Poetry.hs
@@ -7,6 +7,7 @@ module Strategy.Python.Poetry (
   PoetryProject (..),
 ) where
 
+import App.Fossa.Analyze.Types (AnalyzeProject, analyzeProject)
 import Control.Algebra (Has)
 import Control.Applicative ((<|>))
 import Control.Effect.Diagnostics (Diagnostics, context)
@@ -41,11 +42,13 @@ data PoetryProject = PoetryProject
   }
   deriving (Show, Eq, Ord)
 
-discover = undefined
--- discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has Logger sig m, Has Logger rsig run, Has ReadFS rsig run, Has Diagnostics rsig run) => Path Abs Dir -> m [DiscoveredProject run]
--- discover dir = context "Poetry" $ do
---   projects <- context "Finding projects" $ findProjects dir
---   pure (map mkProject projects)
+instance AnalyzeProject PoetryProject where
+  analyzeProject _ = getDeps
+
+discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has Logger sig m) => Path Abs Dir -> m [DiscoveredProject PoetryProject]
+discover dir = context "Poetry" $ do
+  projects <- context "Finding projects" $ findProjects dir
+  pure (map mkProject projects)
 
 -- | Poetry build backend identifier required in [pyproject.toml](https://python-poetry.org/docs/pyproject/#poetry-and-pep-517).
 usesPoetryBackend :: Text -> Bool
@@ -91,16 +94,14 @@ findProjects = walk' $ \dir _ files -> do
     (Just _, Nothing) -> context "poetry.lock file found without accompanying pyproject.toml!" $ pure ([], WalkContinue)
     (Nothing, Nothing) -> pure ([], WalkContinue)
 
--- mkProject :: (Has ReadFS sig n, Has Diagnostics sig n, Has Logger sig n) => PoetryProject -> DiscoveredProject n
--- mkProject project =
---   DiscoveredProject
---     { projectType = "poetry"
---     , projectBuildTargets = mempty
---     , projectDependencyResults = const $ getDeps project
---     , projectPath = pyProjectPath $ projectDir project
---     , projectLicenses = pure []
---     }
-mkProject = undefined
+mkProject :: PoetryProject -> DiscoveredProject PoetryProject
+mkProject project =
+  DiscoveredProject
+    { projectType = "poetry"
+    , projectBuildTargets = mempty
+    , projectPath = pyProjectPath $ projectDir project
+    , projectData = project
+    }
 
 getDeps :: (Has ReadFS sig m, Has Diagnostics sig m, Has Logger sig m) => PoetryProject -> m DependencyResults
 getDeps project = do

--- a/src/Strategy/Python/Poetry.hs
+++ b/src/Strategy/Python/Poetry.hs
@@ -11,6 +11,7 @@ import App.Fossa.Analyze.Types (AnalyzeProject, analyzeProject)
 import Control.Algebra (Has)
 import Control.Applicative ((<|>))
 import Control.Effect.Diagnostics (Diagnostics, context)
+import Data.Aeson (ToJSON)
 import Data.Map (Map)
 import Data.Map.Strict qualified as Map
 import Data.Maybe (fromMaybe)
@@ -23,6 +24,7 @@ import Discovery.Walk (
  )
 import Effect.Logger (Logger, Pretty (pretty), logDebug)
 import Effect.ReadFS (ReadFS, readContentsToml)
+import GHC.Generics (Generic)
 import Graphing (Graphing)
 import Graphing qualified
 import Path (Abs, Dir, File, Path)
@@ -31,16 +33,22 @@ import Strategy.Python.Poetry.PoetryLock (PackageName (..), PoetryLock (..), Poe
 import Strategy.Python.Poetry.PyProject (PyProject (..), pyProjectCodec)
 import Types (DependencyResults (..), DiscoveredProject (..), GraphBreadth (..))
 
-newtype PyProjectTomlFile = PyProjectTomlFile {pyProjectTomlPath :: Path Abs File} deriving (Eq, Ord, Show)
-newtype PoetryLockFile = PoetryLockFile {poetryLockPath :: Path Abs File} deriving (Eq, Ord, Show)
-newtype ProjectDir = ProjectDir {pyProjectPath :: Path Abs Dir} deriving (Eq, Ord, Show)
+newtype PyProjectTomlFile = PyProjectTomlFile {pyProjectTomlPath :: Path Abs File} deriving (Eq, Ord, Show, Generic)
+newtype PoetryLockFile = PoetryLockFile {poetryLockPath :: Path Abs File} deriving (Eq, Ord, Show, Generic)
+newtype ProjectDir = ProjectDir {pyProjectPath :: Path Abs Dir} deriving (Eq, Ord, Show, Generic)
+
+instance ToJSON PyProjectTomlFile
+instance ToJSON PoetryLockFile
+instance ToJSON ProjectDir
 
 data PoetryProject = PoetryProject
   { projectDir :: ProjectDir
   , pyProjectToml :: PyProjectTomlFile
   , poetryLock :: Maybe PoetryLockFile
   }
-  deriving (Show, Eq, Ord)
+  deriving (Show, Eq, Ord, Generic)
+
+instance ToJSON PoetryProject
 
 instance AnalyzeProject PoetryProject where
   analyzeProject _ = getDeps

--- a/src/Strategy/Python/Setuptools.hs
+++ b/src/Strategy/Python/Setuptools.hs
@@ -18,10 +18,11 @@ import Strategy.Python.ReqTxt qualified as ReqTxt
 import Strategy.Python.SetupPy qualified as SetupPy
 import Types
 
-discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has ReadFS rsig run, Has Diagnostics rsig run) => Path Abs Dir -> m [DiscoveredProject run]
-discover dir = context "Setuptools" $ do
-  projects <- context "Finding projects" $ findProjects dir
-  pure (map mkProject projects)
+-- discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has ReadFS rsig run, Has Diagnostics rsig run) => Path Abs Dir -> m [DiscoveredProject run]
+-- discover dir = context "Setuptools" $ do
+--   projects <- context "Finding projects" $ findProjects dir
+--   pure (map mkProject projects)
+discover = undefined
 
 findProjects :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs Dir -> m [SetuptoolsProject]
 findProjects = walk' $ \dir _ files -> do
@@ -72,12 +73,13 @@ data SetuptoolsProject = SetuptoolsProject
   }
   deriving (Eq, Ord, Show)
 
-mkProject :: (Has ReadFS sig n, Has Diagnostics sig n) => SetuptoolsProject -> DiscoveredProject n
-mkProject project =
-  DiscoveredProject
-    { projectType = "setuptools"
-    , projectBuildTargets = mempty
-    , projectDependencyResults = const $ getDeps project
-    , projectPath = setuptoolsDir project
-    , projectLicenses = pure []
-    }
+-- mkProject :: (Has ReadFS sig n, Has Diagnostics sig n) => SetuptoolsProject -> DiscoveredProject n
+-- mkProject project =
+--   DiscoveredProject
+--     { projectType = "setuptools"
+--     , projectBuildTargets = mempty
+--     , projectDependencyResults = const $ getDeps project
+--     , projectPath = setuptoolsDir project
+--     , projectLicenses = pure []
+--     }
+mkProject = undefined

--- a/src/Strategy/Python/Setuptools.hs
+++ b/src/Strategy/Python/Setuptools.hs
@@ -61,7 +61,9 @@ analyzeReqTxts :: (Has ReadFS sig m, Has Diagnostics sig m) => SetuptoolsProject
 analyzeReqTxts = context "Analyzing requirements.txt files" . fmap mconcat . traverse ReqTxt.analyze' . setuptoolsReqTxt
 
 analyzeSetupPy :: (Has ReadFS sig m, Has Diagnostics sig m) => SetuptoolsProject -> m (Graphing Dependency)
-analyzeSetupPy project = context "Analyzing setup.py" (Diag.fromMaybeText "No setup.py found in this project" (setuptoolsSetupPy project)) >>= SetupPy.analyze'
+analyzeSetupPy project = context "Analyzing setup.py" $ do
+  setupPy <- Diag.fromMaybeText "No setup.py found in this project" (setuptoolsSetupPy project)
+  SetupPy.analyze' setupPy
 
 data SetuptoolsProject = SetuptoolsProject
   { setuptoolsReqTxt :: [Path Abs File]

--- a/src/Strategy/Python/Setuptools.hs
+++ b/src/Strategy/Python/Setuptools.hs
@@ -5,6 +5,7 @@ module Strategy.Python.Setuptools (
   mkProject,
 ) where
 
+import App.Fossa.Analyze.Types (AnalyzeProject, analyzeProject)
 import Control.Carrier.Output.IO
 import Control.Effect.Diagnostics (Diagnostics, context)
 import Control.Effect.Diagnostics qualified as Diag
@@ -18,11 +19,10 @@ import Strategy.Python.ReqTxt qualified as ReqTxt
 import Strategy.Python.SetupPy qualified as SetupPy
 import Types
 
--- discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has ReadFS rsig run, Has Diagnostics rsig run) => Path Abs Dir -> m [DiscoveredProject run]
--- discover dir = context "Setuptools" $ do
---   projects <- context "Finding projects" $ findProjects dir
---   pure (map mkProject projects)
-discover = undefined
+discover :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs Dir -> m [DiscoveredProject SetuptoolsProject]
+discover dir = context "Setuptools" $ do
+  projects <- context "Finding projects" $ findProjects dir
+  pure (map mkProject projects)
 
 findProjects :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs Dir -> m [SetuptoolsProject]
 findProjects = walk' $ \dir _ files -> do
@@ -73,13 +73,14 @@ data SetuptoolsProject = SetuptoolsProject
   }
   deriving (Eq, Ord, Show)
 
--- mkProject :: (Has ReadFS sig n, Has Diagnostics sig n) => SetuptoolsProject -> DiscoveredProject n
--- mkProject project =
---   DiscoveredProject
---     { projectType = "setuptools"
---     , projectBuildTargets = mempty
---     , projectDependencyResults = const $ getDeps project
---     , projectPath = setuptoolsDir project
---     , projectLicenses = pure []
---     }
-mkProject = undefined
+instance AnalyzeProject SetuptoolsProject where
+  analyzeProject _ = getDeps
+
+mkProject :: SetuptoolsProject -> DiscoveredProject SetuptoolsProject
+mkProject project =
+  DiscoveredProject
+    { projectType = "setuptools"
+    , projectBuildTargets = mempty
+    , projectPath = setuptoolsDir project
+    , projectData = project
+    }

--- a/src/Strategy/Python/Setuptools.hs
+++ b/src/Strategy/Python/Setuptools.hs
@@ -9,10 +9,12 @@ import App.Fossa.Analyze.Types (AnalyzeProject, analyzeProject)
 import Control.Carrier.Output.IO
 import Control.Effect.Diagnostics (Diagnostics, context)
 import Control.Effect.Diagnostics qualified as Diag
+import Data.Aeson (ToJSON)
 import Data.List (isInfixOf, isSuffixOf)
 import Data.Maybe (maybeToList)
 import Discovery.Walk
 import Effect.ReadFS
+import GHC.Generics (Generic)
 import Graphing (Graphing)
 import Path
 import Strategy.Python.ReqTxt qualified as ReqTxt
@@ -71,7 +73,9 @@ data SetuptoolsProject = SetuptoolsProject
   , setuptoolsSetupPy :: Maybe (Path Abs File)
   , setuptoolsDir :: Path Abs Dir
   }
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Ord, Show, Generic)
+
+instance ToJSON SetuptoolsProject
 
 instance AnalyzeProject SetuptoolsProject where
   analyzeProject _ = getDeps

--- a/src/Strategy/RPM.hs
+++ b/src/Strategy/RPM.hs
@@ -48,10 +48,11 @@ data Dependencies = Dependencies
   }
   deriving (Eq, Ord, Show)
 
-discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has ReadFS rsig run, Has Diagnostics rsig run) => Path Abs Dir -> m [DiscoveredProject run]
-discover dir = context "RPM" $ do
-  projects <- context "Finding projects" $ findProjects dir
-  pure (map mkProject projects)
+discover = undefined
+--discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has ReadFS rsig run, Has Diagnostics rsig run) => Path Abs Dir -> m [DiscoveredProject run]
+--discover dir = context "RPM" $ do
+  --projects <- context "Finding projects" $ findProjects dir
+  --pure (map mkProject projects)
 
 findProjects :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs Dir -> m [RpmProject]
 findProjects = walk' $ \dir _ files -> do
@@ -67,15 +68,16 @@ data RpmProject = RpmProject
   }
   deriving (Eq, Ord, Show)
 
-mkProject :: (Has ReadFS sig n, Has Diagnostics sig n) => RpmProject -> DiscoveredProject n
-mkProject project =
-  DiscoveredProject
-    { projectType = "rpm"
-    , projectBuildTargets = mempty
-    , projectDependencyResults = const $ getDeps project
-    , projectPath = rpmDir project
-    , projectLicenses = pure []
-    }
+mkProject = undefined
+-- mkProject :: (Has ReadFS sig n, Has Diagnostics sig n) => RpmProject -> DiscoveredProject n
+-- mkProject project =
+--   DiscoveredProject
+--     { projectType = "rpm"
+--     , projectBuildTargets = mempty
+--     , projectDependencyResults = const $ getDeps project
+--     , projectPath = rpmDir project
+--     , projectLicenses = pure []
+--     }
 
 getDeps :: (Has ReadFS sig m, Has Diagnostics sig m) => RpmProject -> m DependencyResults
 getDeps = context "RPM" . context "Static analysis" . analyze . rpmFiles

--- a/src/Strategy/RPM.hs
+++ b/src/Strategy/RPM.hs
@@ -14,6 +14,7 @@ module Strategy.RPM (
 import App.Fossa.Analyze.Types (AnalyzeProject, analyzeProject)
 import Control.Effect.Diagnostics
 import Control.Effect.Diagnostics qualified as Diag
+import Data.Aeson (ToJSON)
 import Data.List (isSuffixOf)
 import Data.Map.Strict qualified as Map
 import Data.Maybe (mapMaybe)
@@ -23,6 +24,7 @@ import Data.Text.Extra (splitOnceOn)
 import DepTypes
 import Discovery.Walk
 import Effect.ReadFS
+import GHC.Generics (Generic)
 import Graphing (Graphing)
 import Graphing qualified as G
 import Path
@@ -66,7 +68,9 @@ data RpmProject = RpmProject
   { rpmDir :: Path Abs Dir
   , rpmFiles :: [Path Abs File]
   }
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Ord, Show, Generic)
+
+instance ToJSON RpmProject
 
 instance AnalyzeProject RpmProject where
   analyzeProject _ = getDeps

--- a/src/Strategy/Rebar3.hs
+++ b/src/Strategy/Rebar3.hs
@@ -13,10 +13,12 @@ import Path
 import Strategy.Erlang.Rebar3Tree qualified as Rebar3Tree
 import Types
 
-discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has ReadFS rsig run, Has Exec rsig run, Has Diagnostics rsig run) => Path Abs Dir -> m [DiscoveredProject run]
-discover dir = context "Rebar3" $ do
-  projects <- context "Finding projects" $ findProjects dir
-  pure (map mkProject projects)
+-- discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has ReadFS rsig run, Has Exec rsig run, Has Diagnostics rsig run) => Path Abs Dir -> m [DiscoveredProject run]
+-- discover dir = context "Rebar3" $ do
+--   projects <- context "Finding projects" $ findProjects dir
+--   pure (map mkProject projects)
+discover = undefined
+mkProject = undefined
 
 findProjects :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs Dir -> m [RebarProject]
 findProjects = walk' $ \dir _ files -> do
@@ -30,15 +32,15 @@ data RebarProject = RebarProject
   }
   deriving (Eq, Ord, Show)
 
-mkProject :: (Has Exec sig n, Has ReadFS sig n, Has Diagnostics sig n) => RebarProject -> DiscoveredProject n
-mkProject project =
-  DiscoveredProject
-    { projectType = "rebar3"
-    , projectBuildTargets = mempty
-    , projectDependencyResults = const $ getDeps project
-    , projectPath = rebarDir project
-    , projectLicenses = pure []
-    }
+-- mkProject :: (Has Exec sig n, Has ReadFS sig n, Has Diagnostics sig n) => RebarProject -> DiscoveredProject n
+-- mkProject project =
+--   DiscoveredProject
+--     { projectType = "rebar3"
+--     , projectBuildTargets = mempty
+--     , projectDependencyResults = const $ getDeps project
+--     , projectPath = rebarDir project
+--     , projectLicenses = pure []
+--     }
 
 getDeps :: (Has Exec sig m, Has ReadFS sig m, Has Diagnostics sig m) => RebarProject -> m DependencyResults
 getDeps project = do

--- a/src/Strategy/Rebar3.hs
+++ b/src/Strategy/Rebar3.hs
@@ -7,9 +7,11 @@ module Strategy.Rebar3 (
 
 import App.Fossa.Analyze.Types (AnalyzeProject, analyzeProject)
 import Control.Effect.Diagnostics (Diagnostics, context)
+import Data.Aeson (ToJSON)
 import Discovery.Walk
 import Effect.Exec
 import Effect.ReadFS
+import GHC.Generics (Generic)
 import Path
 import Strategy.Erlang.Rebar3Tree qualified as Rebar3Tree
 import Types
@@ -29,7 +31,9 @@ data RebarProject = RebarProject
   { rebarDir :: Path Abs Dir
   , rebarFile :: Path Abs File
   }
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Ord, Show, Generic)
+
+instance ToJSON RebarProject
 
 instance AnalyzeProject RebarProject where
   analyzeProject _ = getDeps

--- a/src/Strategy/Scala.hs
+++ b/src/Strategy/Scala.hs
@@ -28,41 +28,44 @@ import Strategy.Maven.Pom.Closure qualified as PomClosure
 import Strategy.Maven.Pom.Resolver (buildGlobalClosure)
 import Types
 
-discover ::
-  ( Has Exec sig m
-  , Has ReadFS sig m
-  , Has Logger sig m
-  , Has Diagnostics sig m
-  , Applicative run
-  ) =>
-  Path Abs Dir ->
-  m [DiscoveredProject run]
-discover dir = context "Scala" $ do
-  projects <- findProjects dir
-  pure (map (mkProject dir) projects)
+-- discover ::
+--   ( Has Exec sig m
+--   , Has ReadFS sig m
+--   , Has Logger sig m
+--   , Has Diagnostics sig m
+--   , Applicative run
+--   ) =>
+--   Path Abs Dir ->
+--   m [DiscoveredProject run]
+-- discover dir = context "Scala" $ do
+--   projects <- findProjects dir
+--   pure (map (mkProject dir) projects)
 
-mkProject ::
-  Applicative n =>
-  -- | basedir; required for licenses
-  Path Abs Dir ->
-  MavenProjectClosure ->
-  DiscoveredProject n
-mkProject basedir closure =
-  DiscoveredProject
-    { projectType = "scala"
-    , projectPath = parent $ PomClosure.closurePath closure
-    , projectBuildTargets = mempty
-    , -- only do static analysis of generated pom files
-      projectDependencyResults =
-        const $
-          pure
-            DependencyResults
-              { dependencyGraph = Pom.analyze' closure
-              , dependencyGraphBreadth = Complete
-              , dependencyManifestFiles = [PomClosure.closurePath closure]
-              }
-    , projectLicenses = pure $ Pom.getLicenses basedir closure
-    }
+--mkProject ::
+--   Applicative n =>
+--   -- | basedir; required for licenses
+--   Path Abs Dir ->
+--   MavenProjectClosure ->
+--   DiscoveredProject n
+-- mkProject basedir closure =
+--   DiscoveredProject
+--     { projectType = "scala"
+--     , projectPath = parent $ PomClosure.closurePath closure
+--     , projectBuildTargets = mempty
+--     , -- only do static analysis of generated pom files
+--       projectDependencyResults =
+--         const $
+--           pure
+--             DependencyResults
+--               { dependencyGraph = Pom.analyze' closure
+--               , dependencyGraphBreadth = Complete
+--               , dependencyManifestFiles = [PomClosure.closurePath closure]
+--               }
+--     , projectLicenses = pure $ Pom.getLicenses basedir closure
+--     }
+
+discover = undefined
+mkProject = undefined
 
 pathToText :: Path ar fd -> Text
 pathToText = toText . toFilePath

--- a/src/Strategy/Scala.hs
+++ b/src/Strategy/Scala.hs
@@ -13,6 +13,7 @@ module Strategy.Scala (
 
 import App.Fossa.Analyze.Types (AnalyzeProject, analyzeProject)
 import Control.Carrier.Diagnostics
+import Data.Aeson (ToJSON)
 import Data.Maybe (mapMaybe)
 import Data.String.Conversion (decodeUtf8, toString, toText)
 import Data.Text (Text)
@@ -22,6 +23,7 @@ import Discovery.Walk
 import Effect.Exec
 import Effect.Logger hiding (group)
 import Effect.ReadFS
+import GHC.Generics (Generic)
 import Path
 import Strategy.Maven.Pom qualified as Pom
 import Strategy.Maven.Pom.Closure (MavenProjectClosure, buildProjectClosures)
@@ -42,7 +44,9 @@ discover dir = context "Scala" $ do
   pure (map mkProject projects)
 
 newtype ScalaProject = ScalaProject {unScalaProject :: PomClosure.MavenProjectClosure}
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Ord, Show, Generic)
+
+instance ToJSON ScalaProject
 
 instance AnalyzeProject ScalaProject where
   analyzeProject _ = pure . getDeps

--- a/src/Strategy/SwiftPM.hs
+++ b/src/Strategy/SwiftPM.hs
@@ -17,29 +17,35 @@ import Discovery.Walk (
  )
 import Effect.Logger (Logger, Pretty (pretty), logDebug)
 import Effect.ReadFS (ReadFS)
+import GHC.Generics (Generic)
 import Path
 import Strategy.Swift.PackageSwift (analyzePackageSwift)
 import Strategy.Swift.Xcode.Pbxproj (analyzeXcodeProjForSwiftPkg, hasSomeSwiftDeps)
 import Types (DependencyResults (..), DiscoveredProject (..), GraphBreadth (..))
+import Data.Aeson (ToJSON)
 
 data SwiftProject
   = PackageProject SwiftPackageProject
   | XcodeProject XcodeProjectUsingSwiftPm
-  deriving (Show, Eq, Ord)
+  deriving (Show, Eq, Ord, Generic)
 
 data SwiftPackageProject = SwiftPackageProject
   { swiftPkgManifest :: Path Abs File
   , swiftPkgProjectDir :: Path Abs Dir
   , swiftPkgResolved :: Maybe (Path Abs File)
   }
-  deriving (Show, Eq, Ord)
+  deriving (Show, Eq, Ord, Generic)
 
 data XcodeProjectUsingSwiftPm = XcodeProjectUsingSwiftPm
   { xCodeProjectFile :: Path Abs File
   , xCodeProjectDir :: Path Abs Dir
   , xCodeResolvedFile :: Maybe (Path Abs File)
   }
-  deriving (Show, Eq, Ord)
+  deriving (Show, Eq, Ord, Generic)
+
+instance ToJSON SwiftPackageProject
+instance ToJSON XcodeProjectUsingSwiftPm
+instance ToJSON SwiftProject
 
 discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has Logger sig m) => Path Abs Dir -> m [DiscoveredProject SwiftProject]
 discover dir = context "Swift" $ do

--- a/src/Strategy/SwiftPM.hs
+++ b/src/Strategy/SwiftPM.hs
@@ -8,6 +8,7 @@ module Strategy.SwiftPM (
 import App.Fossa.Analyze.Types (AnalyzeProject (..))
 import Control.Carrier.Simple (Has)
 import Control.Effect.Diagnostics (Diagnostics, context)
+import Data.Aeson (ToJSON)
 import Data.Functor (($>))
 import Data.Maybe (listToMaybe)
 import Discovery.Walk (
@@ -22,7 +23,6 @@ import Path
 import Strategy.Swift.PackageSwift (analyzePackageSwift)
 import Strategy.Swift.Xcode.Pbxproj (analyzeXcodeProjForSwiftPkg, hasSomeSwiftDeps)
 import Types (DependencyResults (..), DiscoveredProject (..), GraphBreadth (..))
-import Data.Aeson (ToJSON)
 
 data SwiftProject
   = PackageProject SwiftPackageProject

--- a/src/Strategy/SwiftPM.hs
+++ b/src/Strategy/SwiftPM.hs
@@ -40,11 +40,12 @@ data XcodeProjectUsingSwiftPm = XcodeProjectUsingSwiftPm
   }
   deriving (Show, Eq, Ord)
 
-discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has Logger sig m, Has ReadFS rsig run, Has Diagnostics rsig run) => Path Abs Dir -> m [DiscoveredProject run]
-discover dir = context "Swift" $ do
-  swiftPackageProjects <- context "Finding swift package projects" $ findSwiftPackageProjects dir
-  xCodeProjects <- context "Finding xcode projects using swift package manager" $ findXcodeProjects dir
-  pure $ map mkProject (swiftPackageProjects ++ xCodeProjects)
+-- discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has Logger sig m, Has ReadFS rsig run, Has Diagnostics rsig run) => Path Abs Dir -> m [DiscoveredProject run]
+-- discover dir = context "Swift" $ do
+--   swiftPackageProjects <- context "Finding swift package projects" $ findSwiftPackageProjects dir
+--   xCodeProjects <- context "Finding xcode projects using swift package manager" $ findXcodeProjects dir
+--   pure $ map mkProject (swiftPackageProjects ++ xCodeProjects)
+discover = undefined
 
 findSwiftPackageProjects :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs Dir -> m [SwiftProject]
 findSwiftPackageProjects = walk' $ \dir _ files -> do
@@ -96,20 +97,21 @@ debugXCodeWithoutSwiftDeps projFile =
       <> show projFile
       <> "), did not have any XCRemoteSwiftPackageReference, ignoring from swift analyses."
 
-mkProject :: (Has ReadFS sig n, Has Diagnostics sig n) => SwiftProject -> DiscoveredProject n
-mkProject project =
-  DiscoveredProject
-    { projectType = "swift"
-    , projectBuildTargets = mempty
-    , projectDependencyResults = const $ getDeps project
-    , projectPath = getProjectDir
-    , projectLicenses = pure []
-    }
-  where
-    getProjectDir :: Path Abs Dir
-    getProjectDir = case project of
-      PackageProject prj -> swiftPkgProjectDir prj
-      XcodeProject prj -> xCodeProjectDir prj
+mkProject = undefined
+-- mkProject :: (Has ReadFS sig n, Has Diagnostics sig n) => SwiftProject -> DiscoveredProject n
+-- mkProject project =
+--   DiscoveredProject
+--     { projectType = "swift"
+--     , projectBuildTargets = mempty
+--     , projectDependencyResults = const $ getDeps project
+--     , projectPath = getProjectDir
+--     , projectLicenses = pure []
+--     }
+--   where
+--     getProjectDir :: Path Abs Dir
+--     getProjectDir = case project of
+--       PackageProject prj -> swiftPkgProjectDir prj
+--       XcodeProject prj -> xCodeProjectDir prj
 
 getDeps :: (Has ReadFS sig m, Has Diagnostics sig m) => SwiftProject -> m DependencyResults
 getDeps project = do

--- a/src/Strategy/Yarn.hs
+++ b/src/Strategy/Yarn.hs
@@ -10,8 +10,9 @@ import Strategy.Yarn.V1.YarnLock qualified as V1
 import Strategy.Yarn.V2.YarnLock qualified as V2
 import Types
 import Prelude
+import App.Fossa.Analyze.Types (AnalyzeProject (..))
 
-discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has ReadFS rsig run, Has Diagnostics rsig run) => Path Abs Dir -> m [DiscoveredProject run]
+discover :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs Dir -> m [DiscoveredProject YarnProject]
 discover dir = context "Yarn" $ do
   projects <- context "Finding projects" $ findProjects dir
   pure (map mkProject projects)
@@ -29,15 +30,18 @@ findProjects = walk' $ \dir _ files -> do
 
       pure ([project], WalkSkipSome ["node_modules"])
 
-mkProject :: (Has ReadFS sig n, Has Diagnostics sig n) => YarnProject -> DiscoveredProject n
+mkProject :: YarnProject -> DiscoveredProject YarnProject
 mkProject project =
   DiscoveredProject
     { projectType = "yarn"
     , projectBuildTargets = mempty
-    , projectDependencyResults = const $ getDeps project
+    , projectData = project
     , projectPath = yarnDir project
-    , projectLicenses = pure []
+    --, projectLicenses = pure [] -- FIXME
     }
+
+instance AnalyzeProject YarnProject where
+  analyzeProject _ = getDeps
 
 getDeps :: (Has ReadFS sig m, Has Diagnostics sig m) => YarnProject -> m DependencyResults
 getDeps project = context "Yarn" $ getDepsV1 project <||> getDepsV2 project

--- a/src/Strategy/Yarn.hs
+++ b/src/Strategy/Yarn.hs
@@ -2,15 +2,17 @@ module Strategy.Yarn (
   discover,
 ) where
 
+import App.Fossa.Analyze.Types (AnalyzeProject (..))
 import Control.Effect.Diagnostics
+import Data.Aeson (ToJSON)
 import Discovery.Walk
 import Effect.ReadFS
+import GHC.Generics (Generic)
 import Path
 import Strategy.Yarn.V1.YarnLock qualified as V1
 import Strategy.Yarn.V2.YarnLock qualified as V2
 import Types
 import Prelude
-import App.Fossa.Analyze.Types (AnalyzeProject (..))
 
 discover :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs Dir -> m [DiscoveredProject YarnProject]
 discover dir = context "Yarn" $ do
@@ -70,4 +72,6 @@ data YarnProject = YarnProject
   { yarnDir :: Path Abs Dir
   , yarnLock :: Path Abs File
   }
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Ord, Show, Generic)
+
+instance ToJSON YarnProject

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -37,11 +37,14 @@ import DepTypes (
  )
 import Graphing (Graphing)
 import Path (Abs, Dir, File, Path, Rel, parseRelDir)
+import GHC.Generics (Generic)
 
 -- TODO: results should be within a graph of build targets && eliminate SubprojectType
 
 data FoundTargets = ProjectWithoutTargets | FoundTargets (NonEmptySet BuildTarget)
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Ord, Show, Generic)
+
+instance ToJSON FoundTargets
 
 instance Semigroup FoundTargets where
   a <> ProjectWithoutTargets = a
@@ -58,7 +61,9 @@ data DiscoveredProject a = DiscoveredProject
   , projectPath :: Path Abs Dir
   , projectBuildTargets :: FoundTargets
   , projectData :: a
-  }
+  } deriving (Eq, Ord, Show, Generic)
+
+instance ToJSON a => ToJSON (DiscoveredProject a)
 
 -- | The results from analyzing dependencies on a project. This contains the graph,
 -- the GraphBreadth (if it was partially analyzed, or fully analyzed), and the
@@ -90,7 +95,7 @@ instance ToJSON GraphBreadth where
         Partial -> "partial"
 
 newtype BuildTarget = BuildTarget {unBuildTarget :: Text}
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Ord, Show, ToJSON)
 
 {-
   The following filters separate the difference between the following filters:

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -35,9 +35,9 @@ import DepTypes (
   insertLocation,
   insertTag,
  )
+import GHC.Generics (Generic)
 import Graphing (Graphing)
 import Path (Abs, Dir, File, Path, Rel, parseRelDir)
-import GHC.Generics (Generic)
 
 -- TODO: results should be within a graph of build targets && eliminate SubprojectType
 
@@ -61,7 +61,8 @@ data DiscoveredProject a = DiscoveredProject
   , projectPath :: Path Abs Dir
   , projectBuildTargets :: FoundTargets
   , projectData :: a
-  } deriving (Eq, Ord, Show, Generic)
+  }
+  deriving (Eq, Ord, Show, Generic)
 
 instance ToJSON a => ToJSON (DiscoveredProject a)
 

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -53,12 +53,12 @@ instance Monoid FoundTargets where
 
 -- | A project found during project discovery, parameterized by the monad
 -- used to perform dependency analysis
-data DiscoveredProject m = DiscoveredProject
+data DiscoveredProject a = DiscoveredProject
   { projectType :: Text
   , projectPath :: Path Abs Dir
   , projectBuildTargets :: FoundTargets
-  , projectDependencyResults :: FoundTargets -> m DependencyResults
-  , projectLicenses :: m [LicenseResult]
+  , projectData :: a
+  --, projectLicenses :: m [LicenseResult] -- FIXME: remove
   }
 
 -- | The results from analyzing dependencies on a project. This contains the graph,

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -58,7 +58,6 @@ data DiscoveredProject a = DiscoveredProject
   , projectPath :: Path Abs Dir
   , projectBuildTargets :: FoundTargets
   , projectData :: a
-  --, projectLicenses :: m [LicenseResult] -- FIXME: remove
   }
 
 -- | The results from analyzing dependencies on a project. This contains the graph,


### PR DESCRIPTION
# Overview

This PR is a superset of <https://github.com/fossas/spectrometer/pull/357>, and **this PR is based on the branch from that PR**

This PR adds "debug bundles". Debug bundles are json files, named `fossa.debug.json`, created by running `fossa analyze` with the `--debug`. In addition to superseding the functionality of replay logs, debug bundles are meant to centralize all debug information in one place, replacing the need for customers to separately give us disparate information, like:

- stdout/stderr output from `fossa analyze`
- system information
- buildtool versions
- package manifest contents
- etc

What this PR does:

-   When `--debug` mode is enabled, we emit a new &ldquo;debug bundle&rdquo; file as `fossa.debug.json`
    -   The &ldquo;debug bundle&rdquo; is a json file that contains:
        -   scoped log messages
        -   scoped effect invocations
        -   scope timings (duration)
        -   scoped errors
        -   system information (cpus, memory allocation)
        -   `--record` -style effect journals for ReadFS and Exec
    -   It&rsquo;s effectively a rendering of the `fossa analyze` AST. &ldquo;scopes&rdquo; are Diagnostics `context`
-   Reworks the `DiscoveredProject` datatype to reduce a lot of the complexity around dependency analysis. Previously, we packed a function `:: FoundTargets -> m DependencyResults` into a the `DiscoveredProject m` record, and we needed to have constraints on `m`, so there were a bunch of superfluous constraints that leaked everywhere from `discover` / `mkProject` / `analyze` in each analyzer.
    -   Adds a new `AnalyzeProject` typeclass to implement dependency analysis on project types
    -   Adds a new `LicenseAnalyzeProject` typeclass to implement license analysis on project types (maven and nuspec for Pathfinder)
    -   Simplifies the `withDiscoveredProjects` function
    -   Decouples archive unpacking and `withDiscoveredProjects`
-   Removes the old `--record` flag. `--debug` now implies `--record` (again)
-   Emits project inference information in debug bundles, even in `--output` mode
-   Emits `DiscoveredProject` datatypes during analysis and discovery
-   Addresses some scenarios where `ReadFS` and `Exec` calls weren't being recorded (e.g., in project inference)

What this PR doesn&rsquo;t do, and will be introduced in a PR after this one:

-   Re-implement the `--replay` flag for new debug bundles
-   For each analyzer, emit relevant helpful files for debugging &#x2013; e.g. for gradle, `settings.gradle` is helpful. Or when skipping static analysis on `npm` projects, we still want to see `package-lock.json` and `package.json`
-   For each analyzer, emit buildtool versions &#x2013; e.g., for project-local gradle wrappers and global buildtools
-   Emit HTTP requests and responses
-   Emit the config file used in the project

What this PR doesn&rsquo;t do, and is out of scope (but would be helpful followup tasks):

-   Tooling around viewing and extracting information from debug bundles. These files are huge, and the inline files and command output are difficult to visually parse
-   Tooling around rendering a filesystem from debug bundles
-   Emitting the &ldquo;effective config file&rdquo;, which is the configuration file overlayed with cli flags. This turns out to be a non-trivial effort
- Other things mentioned in the debug bundles ticket

## Acceptance criteria

Debug bundles are discussed in [this ticket](https://github.com/fossas/team-analysis/issues/610).

At the bare minimum:
- Running `fossa analyze` with the `--debug` flag produces a `fossa.debug.json` "debug bundle" file, regardless of analysis outcome (i.e., the file should still be created if an error occurs -- e.g., "no projects found", "all projects filtered out", API errors, IO exceptions)
- When an error occurs in `--debug` mode, the debug bundle file contains relevant analysis details up to and including the point of failure
- Debug bundles contain at least the same amount of information as replay logs
- When running without the `--debug` flag, scan behavior is unchanged

## Testing plan

- Manual testing for criteria (1), (2)
  - Run `fossa analyze --debug` on an empty directory;
  - Run `fossa analyze --debug` with an invalid API key;
  - Run `fossa analyze --debug` and ctrl-c
- Unit tests for criteria (1) and (2)
- For (3): debug bundles contain the same replay log "journals" as the previous `fossa.debug.json`, so this is a given
- Manual testing for criteria (4)
  - Run `fossa analyze --output` on a valid project

## Risks

This changes core analyzer pipeline code, which is inherently risky. In particular, the changes around archive unpacking are the least-type-safe (as in, least likely to get picked up by the compiler if something is wrong there)

## References

<https://github.com/fossas/spectrometer/pull/357>

## Checklist

- [ ] I added tests for this PR's change (or confirmed tests are not viable).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] I linked this PR to any referenced GitHub issues, if they exist.
