### PR TITLE
Fix archive compression bug

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,6 @@
 # Spectrometer Changelog
 
-## Unreleased
+## v2.15.19
 
 - Fixes an issue with `fossa-deps.yml` `vendored-dependencies` entries where uploads would fail if the dependency was in a subdirectory. ([#373](https://github.com/fossas/spectrometer/pull/373))
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Spectrometer Changelog
 
+## Unreleased
+
+- Fixes an issue with `fossa-deps.yml` `vendored-dependencies` entries where uploads would fail if the dependency was in a subdirectory. ([#373](https://github.com/fossas/spectrometer/pull/373))
+
 ## v2.15.18
 
 - Monorepo: Speeds up commercial phrase detection by doing a first pass before trying to parse context. ([#371](https://github.com/fossas/spectrometer/issues/371))

--- a/src/App/Fossa/ArchiveUploader.hs
+++ b/src/App/Fossa/ArchiveUploader.hs
@@ -97,8 +97,6 @@ arcToLocator arc =
 
 compressFile :: Path Abs Dir -> Path Abs Dir -> FilePath -> IO FilePath
 compressFile outputDir directory fileToTar = do
-  -- Without using `fromAbsDir` for each of these directories, the conversion
-  -- is incorrect. `show outputDir` gives an incorrect result even though it typechecks.
   let finalFile = toString outputDir </> safeSeparators fileToTar
   entries <- Tar.pack (toString directory) [fileToTar]
   BS.writeFile finalFile $ GZip.compress $ Tar.write entries

--- a/src/App/Fossa/ArchiveUploader.hs
+++ b/src/App/Fossa/ArchiveUploader.hs
@@ -20,6 +20,7 @@ import Data.Aeson (
 import Data.Aeson.Extra
 import Data.ByteString.Lazy qualified as BS
 import Data.Functor.Extra ((<$$>))
+import Data.List (intercalate)
 import Data.Maybe (fromMaybe)
 import Data.String.Conversion
 import Data.Text (Text)
@@ -98,7 +99,7 @@ compressFile :: Path Abs Dir -> Path Abs Dir -> FilePath -> IO FilePath
 compressFile outputDir directory fileToTar = do
   -- Without using `fromAbsDir` for each of these directories, the conversion
   -- is incorrect. `show outputDir` gives an incorrect result even though it typechecks.
-  let finalFile = toString outputDir </> fileToTar
+  let finalFile = toString outputDir </> safeSeparators fileToTar
   entries <- Tar.pack (toString directory) [fileToTar]
   BS.writeFile finalFile $ GZip.compress $ Tar.write entries
   pure finalFile
@@ -110,3 +111,6 @@ hashFile :: FilePath -> IO Text
 hashFile fileToHash = do
   fileContent <- BS.readFile fileToHash
   pure . toText . show $ md5 fileContent
+
+safeSeparators :: FilePath -> FilePath
+safeSeparators = intercalate "_" . splitDirectories


### PR DESCRIPTION
# Overview

Fix a bug when using `vendored-dependencies` in `fossa-deps.yml`, where the vendored project was in a subdirectory.

## Acceptance criteria

Support vendored projects in subdirectories.

## Testing plan

1. I created a project with vendored dependencies and a `fossa-deps.yml` file. View it at [go/cpp-vsi-demo](http://go/cpp-vsi-demo) on the branch `with-fossa-deps`.
2. I ran a scan against that project and confirmed that everything now works as expected.

## Risks

None that I can think of in particular.

## Checklist

- [x] I added tests for this PR's change (or confirmed tests are not viable).
- [x] I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
