### PR TITLE
Fixes mvn:tree tactic to exclude project as direct dependency for single && multi-module projects

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 # Spectrometer Changelog
 
+## v2.15.23
+- Maven: Fixes `mvn:dependency` tactic to exclude root project as direct dependency. ([#375](https://github.com/fossas/spectrometer/pull/375))
+
 ## v2.15.22
 - Adds branch and revision information to the URL reported at the end of a `fossa analyze --experimental-enable-monorepo` scan. ([#378](https://github.com/fossas/spectrometer/pull/378))
 

--- a/src/Graphing.hs
+++ b/src/Graphing.hs
@@ -40,6 +40,7 @@ module Graphing (
   pruneUnreachable,
   stripRoot,
   promoteToDirect,
+  shrinkRoots,
 
   -- * Conversions
   fromAdjacencyMap,
@@ -159,6 +160,15 @@ stripRoot (Graphing gr) = Graphing $ AM.overlay newDirectEdges (AM.removeVertex 
 
     newDirectEdges :: AM.AdjacencyMap (Node ty)
     newDirectEdges = AM.edges $ map (Root,) newDirect
+
+-- | Shrinks all root nodes.
+-- Remove current direct nodes. It will promote their immediate children as directs.
+-- Unlike @stripRoot@, it removes them from graphing, instead of preserving them (as node), and their edges.
+shrinkRoots :: forall ty. Ord ty => Graphing ty -> Graphing ty
+shrinkRoots (Graphing gr) = Graphing $ foldr AME.shrinkSingle gr currentDirect
+  where
+    currentDirect :: [Node ty]
+    currentDirect = Set.toList $ AM.postSet Root gr
 
 -- | Add a direct node to this Graphing
 direct :: Ord ty => ty -> Graphing ty

--- a/test/GraphingSpec.hs
+++ b/test/GraphingSpec.hs
@@ -80,3 +80,41 @@ spec = do
       expectDirect [] graph'
       expectDeps [1, 4, 5] graph'
       expectEdges [(1, 4), (4, 5)] graph'
+
+  describe "stripRoot" $ do
+    let graph :: Graphing Int
+        graph = Graphing.directs [1] <> Graphing.edges [(1, 2), (1, 3), (2, 4), (3, 6)]
+
+    it "should promote immediate children as direct nodes" $ do
+      let graph' = Graphing.stripRoot graph
+      expectDirect [2, 3] graph'
+
+    it "should preserve current root nodes in the graphing as nodes" $ do
+      let graph' = Graphing.stripRoot graph
+      expectDeps [1, 2, 3, 4, 6] graph'
+
+    it "should preserve edges of current root nodes in the graphing" $ do
+      let graph' = Graphing.stripRoot graph
+      expectEdges [(1, 2), (1, 3), (2, 4), (3, 6)] graph'
+
+  describe "shrinkRoots" $ do
+    let graph :: Graphing Int
+        graph = Graphing.directs [1] <> Graphing.edges [(1, 2), (1, 3), (2, 4), (3, 6)]
+
+    it "should remove direct nodes" $ do
+      let graph' = Graphing.shrinkRoots graph
+
+      expectDirect [2, 3] graph'
+      expectDeps [2, 3, 4, 6] graph'
+      expectEdges [(2, 4), (3, 6)] graph'
+
+    it "should not modify when there are no direct nodes" $ do
+      let graphWithoutDirectNodes :: Graphing Int
+          graphWithoutDirectNodes = Graphing.edges [(1, 2), (1, 3), (2, 4), (3, 6)]
+
+          graph' :: Graphing Int
+          graph' = Graphing.shrinkRoots graphWithoutDirectNodes
+
+      expectDirect [] graph'
+      expectDeps [1, 2, 3, 4, 6] graph'
+      expectEdges [(1, 2), (1, 3), (2, 4), (3, 6)] graph'


### PR DESCRIPTION
# Overview

These changes ensures, we remove "project identifier" from dependency listings. 

Currently, for given `pom.xml` file:

```xml
<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
  <modelVersion>4.0.0</modelVersion>
 
  <groupId>com.mycompany.app</groupId>
  <artifactId>my-app</artifactId>
  <version>1.0-SNAPSHOT</version>
 
  <properties>
    <maven.compiler.source>1.7</maven.compiler.source>
    <maven.compiler.target>1.7</maven.compiler.target>
  </properties>
 
  <dependencies>
    <dependency>
      <groupId>junit</groupId>
      <artifactId>junit</artifactId>
      <version>4.12</version>
      <scope>test</scope>
    </dependency>
  </dependencies>
</project>
```

We will include `com.mycompany.app:my-app` as root dependency. This is incorrect. Further, we will never be able to resolve the locator with this spec.

This PR aims to address this by shrinking project identifier dependencies. 

## Acceptance criteria

- For single module maven projects, when using `mvn:dependency` tactic, project is not considered a direct dependency
- For multi-module maven projects, when using `mvn:dependency` tactic, root project or sub projects are not considered dependencies (we can't resolve local sub-project as dependency). 

## Testing plan

- Ensure you have maven installed, and is accessible via PATH.

**Single module projects:**

- For single module project, analyze `pom.xml` from https://github.com/fossas/team-analysis/issues/738. Note that project identifier is not included as dependency. 

**Multi-module projects**

```
git clone https://github.com/mkyong/maven-examples.git
cd maven-examples
cd java-multi-modules
fossa analyze -o | jq 
```

Note that project or subproject identifiers are not included as dependency. 

## Risks

N/A

## References

Closes https://github.com/fossas/team-analysis/issues/738

## Checklist

- [x] I added tests for this PR's change (or confirmed tests are not viable).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] I linked this PR to any referenced GitHub issues, if they exist.
