### PR TITLE
Refines jsonDeps to support older gradle versions

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 # Spectrometer Changelog
 
+## v2.16.1
+- Gradle: Supports analysis of projects using gralde v3.3 or below. ([#370](https://github.com/fossas/spectrometer/pull/370))
+
 ## v2.16.0
 - Swift: Supports dependencies analysis for dependencies managed by Swift Package Manager. ([#354](https://github.com/fossas/spectrometer/pull/354))
 

--- a/scripts/jsondeps.gradle
+++ b/scripts/jsondeps.gradle
@@ -115,7 +115,7 @@ allprojects {
             def configToKeyValue = { config ->
                 def jsonDeps = []
                 // config.resolvedConfiguration: https://docs.gradle.org/current/javadoc/org/gradle/api/artifacts/ResolvedConfiguration.html
-                config.resolvedConfiguration.firstLevelModuleDependencies.each { dep ->
+                config.resolvedConfiguration.getFirstLevelModuleDependencies().each { dep ->
                     println "DEBUG: Found direct dependency in configuration"
                     println dep
                     def result = depToJSON dep
@@ -127,33 +127,53 @@ allprojects {
                 return "\"${config.name}\":[${combined}]"
             }
 
+            // Gets dependencies of resolved configurations.
+            // If the configuration is not resolvable, or exception is thrown returns 0 dependencies.
+            def getResolvedConfigDepsOrEmptyOf = { config -> 
+                def configsDeps = null                
+                
+                // From gradle v3.3 onwards, isCanBeResolved used to infer if the configuration is resolvable.
+                // Reference: https://docs.gradle.org/7.1/javadoc/org/gradle/api/artifacts/Configuration.html#isCanBeResolved--
+                def supportedMethod = config.respondsTo("isCanBeResolved") ? "isCanBeResolved" : null
+ 
+                // Some configurations aren't meant to be resolved, because they're just meant to be containers of
+                // dependency constraints. This only occurs for gradle version v3.3 onwards.
+                // 
+                // References:
+                // - https://discuss.gradle.org/t/what-is-a-configuration-which-cant-be-directly-resolved/30721
+                // - https://docs.gradle.org/current/userguide/declaring_dependencies.html#sec:resolvable-consumable-configs
+                try {
+
+                    // We know that we are working against gradle version greater or equal to v3.3
+                    // So, configuration has resolvable property. If the configuration is not resolvable return nothing.
+                    if (supportedMethod != null && !config."${supportedMethod}"()) {
+                        println "DEBUG: Configuration is not resolvable"
+                        return null
+                    }
+
+                    // At this point, we are working against gradle: 
+                    // - v3.3 or greater, and configuration is resolvable.
+                    // - v3.2.1 or lower, and configuration does not have canResolve property and are inherently resolvable.
+                    configsDeps = configToKeyValue config
+                    println configsDeps
+                    println "DEBUG: Configuration is resolved"
+                } catch (Exception ignored) {
+                    println "DEBUG: An exception occurred"
+                    println ignored
+                    ignored.printStackTrace()
+                }
+                return configsDeps
+            }
+
             // project: https://docs.gradle.org/current/javadoc/org/gradle/api/Project.html
             def projectToJSON = { project ->
                 def jsonConfigs = []
                 project.configurations.each { config ->
                     println "DEBUG: Trying to resolve configuration"
                     println config
-                    try {
-                        // Some configurations aren't meant to be resolved,
-                        // because they're just meant to be containers of
-                        // dependency constraints.
-                        //
-                        // See also:
-                        // - https://discuss.gradle.org/t/what-is-a-configuration-which-cant-be-directly-resolved/30721
-                        // - https://docs.gradle.org/current/userguide/declaring_dependencies.html#sec:resolvable-consumable-configs
-                        if (config.canBeResolved) {
-                            println "DEBUG: Configuration is resolvable"
-                            def result = configToKeyValue config
-                            println "DEBUG: Configuration resolved"
-                            println result
-                            jsonConfigs << result
-                        } else {
-                            println "DEBUG: Configuration is not resolvable"
-                        }
-                    } catch (Exception ignored) {
-                        println "DEBUG: An exception occurred"
-                        println ignored
-                        ignored.printStackTrace()
+                    def data = getResolvedConfigDepsOrEmptyOf config
+                    if (data != null) {
+                        jsonConfigs << data
                     }
                 }
                 def combined = jsonConfigs.join(",")

--- a/scripts/jsondeps.gradle
+++ b/scripts/jsondeps.gradle
@@ -171,9 +171,9 @@ allprojects {
                 project.configurations.each { config ->
                     println "DEBUG: Trying to resolve configuration"
                     println config
-                    def data = getResolvedConfigDepsOrEmptyOf config
-                    if (data != null) {
-                        jsonConfigs << data
+                    def jsonConfigWithDeps = getResolvedConfigDepsOrEmptyOf config
+                    if (jsonConfigWithDeps != null) {
+                        jsonConfigs << jsonConfigWithDeps
                     }
                 }
                 def combined = jsonConfigs.join(",")

--- a/scripts/jsondeps.gradle
+++ b/scripts/jsondeps.gradle
@@ -129,26 +129,26 @@ allprojects {
 
             // Gets dependencies of resolved configurations.
             // If the configuration is not resolvable, or exception is thrown returns 0 dependencies.
+            // 
+            // Note:
+            // -----
+            // Some configurations aren't meant to be resolved, because they're just meant to be containers of
+            // dependency constraints. This only occurs for gradle version v3.3 onwards.
+            // 
+            // References:
+            // -----------
+            // - https://discuss.gradle.org/t/what-is-a-configuration-which-cant-be-directly-resolved/30721
+            // - https://docs.gradle.org/current/userguide/declaring_dependencies.html#sec:resolvable-consumable-configs
             def getResolvedConfigDepsOrEmptyOf = { config -> 
-                def configsDeps = null                
-                
-                // From gradle v3.3 onwards, isCanBeResolved used to infer if the configuration is resolvable.
-                // Reference: https://docs.gradle.org/7.1/javadoc/org/gradle/api/artifacts/Configuration.html#isCanBeResolved--
-                def supportedMethod = config.respondsTo("isCanBeResolved") ? "isCanBeResolved" : null
- 
-                // Some configurations aren't meant to be resolved, because they're just meant to be containers of
-                // dependency constraints. This only occurs for gradle version v3.3 onwards.
-                // 
-                // References:
-                // - https://discuss.gradle.org/t/what-is-a-configuration-which-cant-be-directly-resolved/30721
-                // - https://docs.gradle.org/current/userguide/declaring_dependencies.html#sec:resolvable-consumable-configs
+                def configsDeps = null              
                 try {
-
                     // We know that we are working against gradle version greater or equal to v3.3
-                    // So, configuration has resolvable property. If the configuration is not resolvable return nothing.
-                    if (supportedMethod != null && !config."${supportedMethod}"()) {
-                        println "DEBUG: Configuration is not resolvable"
-                        return null
+                    // So, configuration has resolvable property. If the configuration is not resolvable return null.
+                    if (config.respondsTo("isCanBeResolved")) {
+                        if (config.isCanBeResolved()) {
+                            println "DEBUG: Configuration is not resolvable"
+                            return null
+                        }
                     }
 
                     // At this point, we are working against gradle: 

--- a/scripts/jsondeps.gradle
+++ b/scripts/jsondeps.gradle
@@ -144,16 +144,14 @@ allprojects {
                 try {
                     // We know that we are working against gradle version greater or equal to v3.3
                     // So, configuration has resolvable property. If the configuration is not resolvable return null.
-                    if (config.respondsTo("isCanBeResolved")) {
-                        if (config.isCanBeResolved() == false) {
-                            println "DEBUG: Configuration is not resolvable"
-                            return null
-                        }
+                    if (config.respondsTo("isCanBeResolved") && !config.isCanBeResolved()) {
+                        println "DEBUG: Configuration is not resolvable"
+                        return null
                     }
 
-                    // At this point, we are working against gradle: 
-                    // - v3.3 or greater, and configuration is resolvable.
-                    // - v3.2.1 or lower, and configuration does not have canResolve property and are inherently resolvable.
+                    // At this point, we know one of these must be true: 
+                    // - We are on Gradle v3.3 or newer (because isCanBeResolved is present) and the configuration is resolvable (isCanBeResolved() == true, therefore did not exit early above).
+                    // - We are on Gradle v3.2.1 or older (because isCanBeResolved is not present). Configurations in Gradle v3.2.1 or older are always resolvable.
                     configsDeps = configToKeyValue config
                     println configsDeps
                     println "DEBUG: Configuration is resolved"

--- a/scripts/jsondeps.gradle
+++ b/scripts/jsondeps.gradle
@@ -145,7 +145,7 @@ allprojects {
                     // We know that we are working against gradle version greater or equal to v3.3
                     // So, configuration has resolvable property. If the configuration is not resolvable return null.
                     if (config.respondsTo("isCanBeResolved")) {
-                        if (config.isCanBeResolved()) {
+                        if (config.isCanBeResolved() == false) {
                             println "DEBUG: Configuration is not resolvable"
                             return null
                         }


### PR DESCRIPTION
# Overview

It correctly queries dependencies of configurations, when working with gradle v3.3 or below.

## Acceptance criteria

- Successfully analyzes project with gradle version below v3.3

## Testing plan

1. Create example project with gradle 2
```
curl -s "https://get.sdkman.io" | bash
source "/Users/megh/.sdkman/bin/sdkman-init.sh"
sdk install gradle 2.7
sdk install java 8.0.292.hs-adpt
gradle init 
```

Add dependencies as you see fit. 

Few example deps:
```
'org.codehaus.groovy:groovy:3.+'
'org.codehaus.groovy:groovy-json:3.+'
'com.codevineyard:hello-world:1.0.1!!'
'org.neo4j.driver:neo4j-java-driver:4.3.4'
```

2. Create example project with gradle 7 (similar to aforementioned gradle2 procedure)

Analyze using `fossa analyze -o | jq`. 

## Risks

N/A. Everything is still under try/catch. I don't anticipate any issues here.

## References

Closes: https://github.com/fossas/team-analysis/issues/740

## Checklist

- [ ] I added tests for this PR's change (or confirmed tests are not viable).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] I linked this PR to any referenced GitHub issues, if they exist.
