### PR TITLE
[Low Priority] Adds Fortran Package Manager Support

### DIFF
--- a/docs/strategies/fortran.md
+++ b/docs/strategies/fortran.md
@@ -1,0 +1,78 @@
+# Fortran Analysis
+
+| Strategy | Direct Deps        | Deep Deps | Edges | Classifies Dev & Test Deps |
+| -------- | ------------------ | --------- | ----- | -------------------------- |
+| fpm      | :heavy_check_mark: | :x:       | :x:   | :heavy_check_mark:         |
+
+## Project Discovery
+
+Find a file named `fpm.toml`. If `fpm.toml` is found, we do not scan in the `build` directory for more Fortran projects.
+
+## Analysis
+
+1. Parse `fpm.toml` file to identify direct dependencies.
+
+## Limitations
+
+- We do not report [path dependencies](https://github.com/fortran-lang/fpm/blob/main/manifest-reference.md#local-dependencies).
+- We do not report test or [development dependencies](https://github.com/fortran-lang/fpm/blob/main/manifest-reference.md#development-dependencies).
+- We only report direct dependencies.
+
+## Example
+
+Create a Fortran project managed by `fpm`. Execute `fpm new project_name`. This will create a directory named project_name with a manifest file, and a few example source files.
+
+Modify `fpm.toml` file to include direct dependency:
+
+```toml
+name = "fortran_example"
+version = "0.1.0"
+license = "license"
+author = "Jane Doe"
+maintainer = "jane.doe@example.com"
+copyright = "Copyright 2021, Jane Doe"
+
+[build]
+auto-executables = true
+auto-tests = true
+auto-examples = true
+
+[install]
+library = false
+
+[dependencies]
+toml-f = { git = "https://github.com/toml-f/toml-f", tag = "v0.2.1" }
+```
+
+Now modify `app/main.f90` to use `tomlf`:
+
+```fortran
+program main
+  use tomlf, only: get_tomlf_version
+  implicit none
+  
+  integer :: major
+  integer :: minor
+  integer :: patch
+  call get_tomlf_version(major, minor, patch)
+  
+  print *, "tomlf's major version is: ", major
+  print *, "tomlf's minor version is: ", minor
+  print *, "tomlf's patch version is: ", patch
+end program main
+```
+
+Execute `fpm build` to build the fortran project.
+
+Now you can call `fpm run` to execute the built application, here is an example output from this application:
+```
+ tomlf's major version is:            0
+ tomlf's minor version is:            2
+ tomlf's patch version is:            1
+```
+
+To analyze this project using fossa CLI, execute `fossa analyze --output --debug`. This will print identified dependency graphs, and debug logs only. It will not upload performed analysis to any endpoint.
+
+## References
+
+- [Fortran Package Manager](https://github.com/fortran-lang/fpm)

--- a/docs/strategies/fortran.md
+++ b/docs/strategies/fortran.md
@@ -1,5 +1,7 @@
 # Fortran Analysis
 
+Currently, we only support analysis of fortran project which are using [fortran package manager](https://github.com/fortran-lang/fpm).
+
 | Strategy | Direct Deps        | Deep Deps | Edges | Classifies Dev & Test Deps |
 | -------- | ------------------ | --------- | ----- | -------------------------- |
 | fpm      | :heavy_check_mark: | :x:       | :x:   | :heavy_check_mark:         |

--- a/docs/userguide.md
+++ b/docs/userguide.md
@@ -11,6 +11,7 @@
   - [clojure](#clojure)
   - [dart](#dart)
   - [erlang](#erlang)
+  - [fortran](#fortran)
   - [golang](#golang)
   - [haskell](#haskell)
   - [java](#java)
@@ -97,6 +98,10 @@ fossa analyze --help
 ### elixir
 
 - [mix](quickreference/mix.md)
+
+### fortran
+
+- [fpm](strategies/fortran.md)
 
 ### golang
 

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -246,6 +246,8 @@ library
     Strategy.Elixir.MixTree
     Strategy.Erlang.ConfigParser
     Strategy.Erlang.Rebar3Tree
+    Strategy.Fpm
+    Strategy.Fortran.FpmToml
     Strategy.Glide
     Strategy.Go.GlideLock
     Strategy.Go.GoList
@@ -357,6 +359,7 @@ test-suite unit-tests
     Erlang.Rebar3TreeSpec
     Extra.TextSpec
     Fossa.API.TypesSpec
+    Fortran.FpmTomlSpec
     Go.GlideLockSpec
     Go.GoListSpec
     Go.GomodSpec

--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -74,6 +74,7 @@ import Strategy.Carthage qualified as Carthage
 import Strategy.Cocoapods qualified as Cocoapods
 import Strategy.Composer qualified as Composer
 import Strategy.Conda qualified as Conda
+import Strategy.Fpm qualified as Fpm
 import Strategy.Glide qualified as Glide
 import Strategy.Godep qualified as Godep
 import Strategy.Gomodules qualified as Gomodules
@@ -199,6 +200,7 @@ discoverFuncs =
   , Cocoapods.discover
   , Composer.discover
   , Conda.discover
+  , Fpm.discover
   , Glide.discover
   , Godep.discover
   , Gomodules.discover

--- a/src/Strategy/Fortran/FpmToml.hs
+++ b/src/Strategy/Fortran/FpmToml.hs
@@ -1,0 +1,135 @@
+module Strategy.Fortran.FpmToml (
+  analyzeFpmToml,
+
+  -- * for testing
+  FpmToml (..),
+  FpmDependency (..),
+  FpmPathDependency (..),
+  FpmGitDependency (..),
+  buildGraph,
+  fpmTomlCodec,
+) where
+
+import Control.Applicative (Alternative ((<|>)))
+import Control.Effect.Diagnostics (Diagnostics, context)
+import Data.Foldable (asum)
+import Data.Map (Map, elems)
+import Data.Text (Text)
+import DepTypes (
+  DepEnvironment (EnvDevelopment, EnvProduction),
+  DepType (GitType),
+  Dependency (..),
+  VerConstraint (CEq),
+ )
+import Effect.ReadFS (Has, ReadFS, readContentsToml)
+import Graphing (Graphing, directs, induceJust)
+import Path
+import Toml (TomlCodec, (.=))
+import Toml qualified
+
+-- | Represents the content of the fpm manifest.
+-- Reference: https://github.com/fortran-lang/fpm/blob/main/manifest-reference.md#specifying-dependencies
+data FpmToml = FpmToml
+  { fpmName :: Text
+  , fpmDependencies :: Map Text FpmDependency
+  , fpmDevDependencies :: Map Text FpmDependency
+  , fpmExecutables :: [Map Text FpmDependency]
+  }
+  deriving (Eq, Ord, Show)
+
+fpmTomlCodec :: TomlCodec FpmToml
+fpmTomlCodec =
+  FpmToml
+    <$> Toml.text "name" .= fpmName
+    <*> Toml.tableMap Toml._KeyText fpmDependenciesCodec "dependencies" .= fpmDependencies
+    <*> Toml.tableMap Toml._KeyText fpmDependenciesCodec "dev-dependencies" .= fpmDevDependencies
+    <*> Toml.list fpmExecutableDependenciesCodec "executable" .= fpmExecutables
+
+data FpmDependency
+  = FpmGitDep FpmGitDependency
+  | FpmPathDep FpmPathDependency
+  deriving (Eq, Ord, Show)
+
+newtype FpmPathDependency = FpmPathDependency
+  { pathOf :: Text
+  }
+  deriving (Eq, Ord, Show)
+
+data FpmGitDependency = FpmGitDependency
+  { url :: Text
+  , branch :: Maybe Text
+  , tag :: Maybe Text
+  , rev :: Maybe Text
+  }
+  deriving (Eq, Ord, Show)
+
+fpmExecutableDependenciesCodec :: TomlCodec (Map Text FpmDependency)
+fpmExecutableDependenciesCodec = Toml.tableMap Toml._KeyText fpmDependenciesCodec "dependencies"
+
+fpmDependenciesCodec :: Toml.Key -> TomlCodec FpmDependency
+fpmDependenciesCodec key =
+  Toml.dimatch matchFpmPathDep FpmPathDep (Toml.table fpmPathDependencyCodec key)
+    <|> Toml.dimatch matchFpmGitDep FpmGitDep (Toml.table fpmGitDependencyCodec key)
+  where
+    matchFpmPathDep :: FpmDependency -> Maybe FpmPathDependency
+    matchFpmPathDep (FpmPathDep pathDep) = Just pathDep
+    matchFpmPathDep _ = Nothing
+
+    matchFpmGitDep :: FpmDependency -> Maybe FpmGitDependency
+    matchFpmGitDep (FpmGitDep gitDep) = Just gitDep
+    matchFpmGitDep _ = Nothing
+
+    fpmPathDependencyCodec :: TomlCodec FpmPathDependency
+    fpmPathDependencyCodec = FpmPathDependency <$> Toml.text "path" .= pathOf
+
+    fpmGitDependencyCodec :: TomlCodec FpmGitDependency
+    fpmGitDependencyCodec =
+      FpmGitDependency
+        <$> Toml.text "git" .= url
+        <*> Toml.dioptional (Toml.text "branch") .= branch
+        <*> Toml.dioptional (Toml.text "tag") .= tag
+        <*> Toml.dioptional (Toml.text "rev") .= rev
+
+buildGraph :: FpmToml -> Graphing Dependency
+buildGraph fpmToml = induceJust $ foldMap directs [deps, execDeps, devDeps]
+  where
+    deps :: [Maybe Dependency]
+    deps = map toProdDependency (elems $ fpmDependencies fpmToml)
+
+    execDeps :: [Maybe Dependency]
+    execDeps = map toProdDependency (foldMap elems $ fpmExecutables fpmToml)
+
+    devDeps :: [Maybe Dependency]
+    devDeps = map toDevDependency (elems $ fpmDevDependencies fpmToml)
+
+    toProdDependency :: FpmDependency -> Maybe Dependency
+    toProdDependency = toDependency $ Just EnvProduction
+
+    toDevDependency :: FpmDependency -> Maybe Dependency
+    toDevDependency = toDependency $ Just EnvDevelopment
+
+    toDependency :: Maybe DepEnvironment -> FpmDependency -> Maybe Dependency
+    toDependency _ (FpmPathDep _) = Nothing
+    toDependency env (FpmGitDep dep) =
+      Just $
+        Dependency
+          { dependencyType = GitType
+          , dependencyName = url dep
+          , dependencyVersion = CEq <$> asum [rev dep, tag dep, branch dep]
+          , dependencyLocations = []
+          , dependencyEnvironments =
+              case env of
+                Nothing -> []
+                Just e -> [e]
+          , dependencyTags = mempty
+          }
+
+analyzeFpmToml ::
+  ( Has ReadFS sig m
+  , Has Diagnostics sig m
+  ) =>
+  Path Abs File ->
+  m (Graphing Dependency)
+analyzeFpmToml tomlFile = do
+  fpmTomlContent <- readContentsToml fpmTomlCodec tomlFile
+  context "Building dependency graph from fpm.toml" $ pure $ buildGraph fpmTomlContent

--- a/src/Strategy/Fpm.hs
+++ b/src/Strategy/Fpm.hs
@@ -1,0 +1,53 @@
+module Strategy.Fpm (discover) where
+
+import Control.Effect.Diagnostics (Diagnostics, context)
+import Discovery.Walk (WalkStep (WalkContinue, WalkSkipSome), findFileNamed, walk')
+import Effect.ReadFS (Has, ReadFS)
+import Path
+import Strategy.Fortran.FpmToml (analyzeFpmToml)
+import Types (DependencyResults (..), DiscoveredProject (..), GraphBreadth (Partial))
+
+discover ::
+  ( Has ReadFS sig m
+  , Has Diagnostics sig m
+  , Has ReadFS rsig run
+  , Has Diagnostics rsig run
+  ) =>
+  Path Abs Dir ->
+  m [DiscoveredProject run]
+discover dir = context "Fpm" $ do
+  projects <- context "Finding projects" $ findProjects dir
+  pure (map mkProject projects)
+
+findProjects :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs Dir -> m [FpmProject]
+findProjects = walk' $ \dir _ files -> do
+  let fmpSpecFile = findFileNamed "fpm.toml" files
+  case (fmpSpecFile) of
+    Just fpmToml -> pure ([FpmProject fpmToml dir], WalkSkipSome ["build"])
+    Nothing -> pure ([], WalkContinue)
+
+data FpmProject = FpmProject
+  { fpmSpec :: Path Abs File
+  , fpmSpecDir :: Path Abs Dir
+  }
+  deriving (Eq, Ord, Show)
+
+mkProject :: (Has ReadFS sig n, Has Diagnostics sig n) => FpmProject -> DiscoveredProject n
+mkProject project =
+  DiscoveredProject
+    { projectType = "fpm"
+    , projectBuildTargets = mempty
+    , projectDependencyResults = const $ getDeps project
+    , projectPath = fpmSpecDir project
+    , projectLicenses = pure []
+    }
+
+getDeps :: (Has ReadFS sig m, Has Diagnostics sig m) => FpmProject -> m DependencyResults
+getDeps project = do
+  graph <- analyzeFpmToml $ fpmSpec project
+  pure $
+    DependencyResults
+      { dependencyGraph = graph
+      , dependencyGraphBreadth = Partial
+      , dependencyManifestFiles = [fpmSpec project]
+      }

--- a/test/Fortran/FpmTomlSpec.hs
+++ b/test/Fortran/FpmTomlSpec.hs
@@ -1,0 +1,78 @@
+module Fortran.FpmTomlSpec (
+  spec,
+) where
+
+import Data.Map (fromList)
+import Data.Text (Text)
+import Data.Text.IO qualified as TIO
+import DepTypes (
+  DepEnvironment (EnvDevelopment, EnvProduction),
+  DepType (GitType),
+  Dependency (Dependency),
+  VerConstraint (CEq),
+ )
+import GraphUtil (expectDeps, expectEdges)
+import Strategy.Fortran.FpmToml (
+  FpmDependency (..),
+  FpmGitDependency (..),
+  FpmPathDependency (..),
+  FpmToml (..),
+  buildGraph,
+  fpmTomlCodec,
+ )
+import Test.Hspec (
+  Spec,
+  describe,
+  it,
+  runIO,
+  shouldBe,
+ )
+import Toml qualified
+
+mkPathFpmDep :: Text -> FpmDependency
+mkPathFpmDep name = FpmPathDep $ FpmPathDependency name
+
+mkGitDep :: Text -> Maybe Text -> [DepEnvironment] -> Dependency
+mkGitDep name version envs = Dependency GitType name (CEq <$> version) [] envs mempty
+
+mkGitFpmDep :: FpmGitDependency
+mkGitFpmDep = FpmGitDependency "git-url" Nothing Nothing Nothing
+
+expectedFpmToml :: FpmToml
+expectedFpmToml =
+  FpmToml
+    "example"
+    ( fromList
+        [ ("my-utils", mkPathFpmDep "utils")
+        , ("dep-head", FpmGitDep mkGitFpmDep)
+        , ("dep-branch", FpmGitDep $ mkGitFpmDep{branch = Just "main"})
+        , ("dep-tag", FpmGitDep $ mkGitFpmDep{tag = Just "v0.2.1"})
+        , ("dep-rev", FpmGitDep $ mkGitFpmDep{rev = Just "2f5eaba"})
+        ]
+    )
+    (fromList [("dep-dev", FpmGitDep mkGitFpmDep{url = "git-url-dev-dep", rev = Just "2f5eaba"})])
+    [fromList [("dep-exec", FpmGitDep mkGitFpmDep{url = "git-url-exec"})]]
+
+spec :: Spec
+spec = do
+  content <- runIO (TIO.readFile "test/Fortran/testdata/fpm.toml")
+  describe "fpmTomlCodec" $
+    it "should parse fpm.toml file" $
+      Toml.decode fpmTomlCodec content `shouldBe` Right expectedFpmToml
+
+  describe "buildGraph" $ do
+    let graph = buildGraph expectedFpmToml
+    let graphDeps =
+          [ mkGitDep "git-url" Nothing [EnvProduction]
+          , mkGitDep "git-url" (Just "main") [EnvProduction]
+          , mkGitDep "git-url" (Just "v0.2.1") [EnvProduction]
+          , mkGitDep "git-url" (Just "2f5eaba") [EnvProduction]
+          , mkGitDep "git-url-dev-dep" (Just "2f5eaba") [EnvDevelopment]
+          , mkGitDep "git-url-exec" (Nothing) [EnvProduction]
+          ]
+
+    it "should not have any edges" $
+      expectEdges [] graph
+
+    it "should have deps" $ do
+      expectDeps graphDeps graph

--- a/test/Fortran/testdata/fpm.toml
+++ b/test/Fortran/testdata/fpm.toml
@@ -1,0 +1,16 @@
+name = "example"
+
+[[ executable ]]
+name = "app-tool"
+[executable.dependencies]
+dep-exec = { git = "git-url-exec" }
+
+[dependencies]
+my-utils = { path = "utils" }
+dep-head = { git = "git-url" }
+dep-branch = { git = "git-url", branch = "main" }
+dep-tag = { git = "git-url", tag = "v0.2.1" }
+dep-rev = { git = "git-url", rev = "2f5eaba" }
+
+[dev-dependencies]
+dep-dev = { git = "git-url-dev-dep", rev = "2f5eaba" }


### PR DESCRIPTION
# Overview

Adds support for fortran package manager.

Fortran package manager, as of moment, only supports two types of dependencies:
- Path Dependency
- Git Dependency (with constraint on branch, commit, and exact tag value)

## Acceptance criteria

- Dependencies specified in `fpm.toml` are analyzed

## Testing plan

- You can create example fortran application using fpm OR get example project from here: https://github.com/meghfossa/example-projects.git (in fortran directory)
- Run `fossa analyze -o | jq` (you should see fortran git dependencies)

## Risks

N/A

## References

I intent to do a writeup as a ticket so knowledge on fpm is captured/documented. But this will not be a priority item. 

## Checklist

- [ ] I added tests for this PR's change (or confirmed tests are not viable).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] I linked this PR to any referenced GitHub issues, if they exist.
