### PR TITLE
Fixes `lein` analysis for common CI workflows

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,7 +1,7 @@
 # Spectrometer Changelog
 
 ## v2.15.24
-- Leiningen: Executes `lein --version` before performing any analysis, to ensure Leiningen has performed its install tasks (done on its first invocation).
+- Leiningen: Executes `lein --version` before performing any analysis, to ensure Leiningen has performed its install tasks (done on its first invocation). ([#379](https://github.com/fossas/spectrometer/pull/379))
 
 ## v2.15.23
 - Maven: Fixes `mvn:dependency` tactic to exclude root project as direct dependency. ([#375](https://github.com/fossas/spectrometer/pull/375))

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 # Spectrometer Changelog
 
+## v2.15.24
+- Leiningen: Executes `lein --version` before performing any analysis, to ensure Leiningen has performed its install tasks (done on its first invocation).
+
 ## v2.15.23
 - Maven: Fixes `mvn:dependency` tactic to exclude root project as direct dependency. ([#375](https://github.com/fossas/spectrometer/pull/375))
 


### PR DESCRIPTION
# Overview

This change ensures `lein` analysis invokes `lein --version` command before invoking any analysis command. This ensures
- `lein` has completed it's first invocation tasks, so output of subsequent commands are not impacted.

## Acceptance criteria

On clean lein install, fossa can perform analysis successfully. 

## Testing plan

Example project: https://github.com/meghfossa/example-projects/tree/main/clojure/with-lein
To install lein:
```
wget https://raw.github.com/technomancy/leiningen/stable/bin/lein
chmod +x lein
sudo cp lein /usr/local/bin/
```

1. Install lein
2. Delete lein directory: `rm -rf ~/.lein` (you don't need to do this if it's fresh install, and you have not invoked `lein`)
3. Run `fossa analyze . -o | jq` (it should be successful) 

## Risks

N/A

## References

Closes https://github.com/fossas/team-analysis/issues/743

## Checklist

- [x] I added tests for this PR's change (or confirmed tests are not viable).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] I linked this PR to any referenced GitHub issues, if they exist.
