### PR TITLE
dep envs are now sets

### DIFF
--- a/src/App/Fossa/VSI/Types.hs
+++ b/src/App/Fossa/VSI/Types.hs
@@ -55,7 +55,7 @@ toDependency locator =
     <*> Right (locatorProject locator)
     <*> (Right . Just . CEq $ locatorRevision locator)
     <*> Right []
-    <*> Right []
+    <*> Right mempty
     <*> Right mempty
 
 validateDepType :: Locator -> Either ToDependencyError DepType

--- a/src/DepTypes.hs
+++ b/src/DepTypes.hs
@@ -13,6 +13,8 @@ module DepTypes (
 import Data.Aeson
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
+import Data.Set (Set)
+import Data.Set qualified as Set
 import Data.Text (Text)
 import GHC.Generics (Generic)
 
@@ -24,13 +26,13 @@ data Dependency = Dependency
   , dependencyName :: Text
   , dependencyVersion :: Maybe VerConstraint
   , dependencyLocations :: [Text]
-  , dependencyEnvironments :: [DepEnvironment] -- FIXME: this should be a Set
+  , dependencyEnvironments :: Set DepEnvironment -- FIXME: this should be a Set
   , dependencyTags :: Map Text [Text]
   }
   deriving (Eq, Ord, Show)
 
 insertEnvironment :: DepEnvironment -> Dependency -> Dependency
-insertEnvironment env dep = dep{dependencyEnvironments = env : dependencyEnvironments dep}
+insertEnvironment env dep = dep{dependencyEnvironments = env `Set.insert` dependencyEnvironments dep}
 
 insertTag :: Text -> Text -> Dependency -> Dependency
 insertTag key value dep = dep{dependencyTags = Map.insertWith (++) key [value] (dependencyTags dep)}

--- a/src/DepTypes.hs
+++ b/src/DepTypes.hs
@@ -26,7 +26,7 @@ data Dependency = Dependency
   , dependencyName :: Text
   , dependencyVersion :: Maybe VerConstraint
   , dependencyLocations :: [Text]
-  , dependencyEnvironments :: Set DepEnvironment -- FIXME: this should be a Set
+  , dependencyEnvironments :: Set DepEnvironment
   , dependencyTags :: Map Text [Text]
   }
   deriving (Eq, Ord, Show)

--- a/src/Strategy/Cargo.hs
+++ b/src/Strategy/Cargo.hs
@@ -204,12 +204,12 @@ toDependency pkg =
       , dependencyName = pkgIdName pkg
       , dependencyVersion = Just $ CEq $ pkgIdVersion pkg
       , dependencyLocations = []
-      , dependencyEnvironments = []
+      , dependencyEnvironments = mempty
       , dependencyTags = Map.empty
       }
   where
     applyLabel :: CargoLabel -> Dependency -> Dependency
-    applyLabel (CargoDepKind env) dep = dep{dependencyEnvironments = env : dependencyEnvironments dep}
+    applyLabel (CargoDepKind env) = insertEnvironment env
 
 -- Possible values here are "build", "dev", and null.
 -- Null refers to productions, while dev and build refer to development-time dependencies

--- a/src/Strategy/Carthage.hs
+++ b/src/Strategy/Carthage.hs
@@ -146,7 +146,7 @@ toDependency entry =
     , dependencyName = entryToDepName entry
     , dependencyVersion = Just (CEq (resolvedVersion entry))
     , dependencyTags = Map.empty
-    , dependencyEnvironments = []
+    , dependencyEnvironments = mempty
     , dependencyLocations = [] -- TODO: git location?
     }
 

--- a/src/Strategy/Cocoapods/Podfile.hs
+++ b/src/Strategy/Cocoapods/Podfile.hs
@@ -42,7 +42,7 @@ buildGraph podfile = Graphing.fromList (map toDependency direct)
         , dependencyLocations = case Map.lookup SourceProperty properties of
             Just repo -> [repo]
             _ -> [source podfile]
-        , dependencyEnvironments = []
+        , dependencyEnvironments = mempty
         , dependencyTags = Map.empty
         }
 

--- a/src/Strategy/Cocoapods/PodfileLock.hs
+++ b/src/Strategy/Cocoapods/PodfileLock.hs
@@ -61,7 +61,7 @@ toDependency externalSrc pkg = foldr applyLabel start
         , dependencyName = depName
         , dependencyVersion = Nothing
         , dependencyLocations = []
-        , dependencyEnvironments = []
+        , dependencyEnvironments = mempty
         , dependencyTags = Map.empty
         }
 

--- a/src/Strategy/Composer.hs
+++ b/src/Strategy/Composer.hs
@@ -127,10 +127,10 @@ buildGraph lock = run . withLabeling toDependency $ do
           , dependencyName = pkgName pkg
           , dependencyVersion = Nothing
           , dependencyLocations = []
-          , dependencyEnvironments = []
+          , dependencyEnvironments = mempty
           , dependencyTags = Map.empty
           }
 
     addLabel :: CompLabel -> Dependency -> Dependency
     addLabel (DepVersion ver) dep = dep{dependencyVersion = Just (CEq ver)}
-    addLabel (CompEnv env) dep = dep{dependencyEnvironments = env : dependencyEnvironments dep}
+    addLabel (CompEnv env) dep = insertEnvironment env dep

--- a/src/Strategy/Conda/CondaList.hs
+++ b/src/Strategy/Conda/CondaList.hs
@@ -35,7 +35,7 @@ buildGraph deps = Graphing.fromList (map toDependency deps)
         , dependencyName = listName
         , dependencyVersion = CEq <$> listVersion
         , dependencyLocations = []
-        , dependencyEnvironments = []
+        , dependencyEnvironments = mempty
         , dependencyTags = Map.empty
         }
 

--- a/src/Strategy/Conda/EnvironmentYml.hs
+++ b/src/Strategy/Conda/EnvironmentYml.hs
@@ -30,7 +30,7 @@ buildGraph envYmlFile = Graphing.fromList (map toDependency allDeps)
         , dependencyName = depName
         , dependencyVersion = CEq <$> depVersion -- todo - properly handle version constraints
         , dependencyLocations = []
-        , dependencyEnvironments = []
+        , dependencyEnvironments = mempty
         , dependencyTags = Map.empty
         }
 

--- a/src/Strategy/Dart/PubSpec.hs
+++ b/src/Strategy/Dart/PubSpec.hs
@@ -17,6 +17,7 @@ import Data.Foldable (asum, for_)
 import Data.Map (Map, toList)
 import Data.Map.Strict qualified as Map
 import Data.Maybe (fromMaybe, maybeToList)
+import Data.Set qualified as Set
 import Data.Text (Text)
 import Data.Yaml (FromJSON (parseJSON), (.:), (.:?))
 import Data.Yaml qualified as Yaml
@@ -116,7 +117,7 @@ toDependency environment name (HostedSource (PubSpecDepHostedSource version _ ur
       , dependencyName = unPackageName name
       , dependencyVersion = CEq <$> version
       , dependencyLocations = maybeToList url
-      , dependencyEnvironments = [environment]
+      , dependencyEnvironments = Set.singleton environment
       , dependencyTags = Map.empty
       }
 toDependency environment _ (GitSource (PubSpecDepGitSource gitRef gitUrl)) =
@@ -126,7 +127,7 @@ toDependency environment _ (GitSource (PubSpecDepGitSource gitRef gitUrl)) =
       , dependencyName = gitUrl
       , dependencyVersion = CEq <$> gitRef
       , dependencyLocations = []
-      , dependencyEnvironments = [environment]
+      , dependencyEnvironments = Set.singleton environment
       , dependencyTags = Map.empty
       }
 toDependency _ _ (SdkSource _) = Nothing

--- a/src/Strategy/Dart/PubSpecLock.hs
+++ b/src/Strategy/Dart/PubSpecLock.hs
@@ -24,6 +24,7 @@ import Data.Aeson.Types qualified as AesonTypes
 import Data.Foldable (asum, for_)
 import Data.Map (Map)
 import Data.Map.Strict qualified as Map
+import Data.Set qualified as Set
 import Data.Text (Text)
 import Data.Text qualified as Text
 import Data.Yaml (FromJSON (parseJSON), (.:), (.:?))
@@ -128,7 +129,7 @@ toDependency pkg meta =
     , dependencyName = depName
     , dependencyVersion = depVersion
     , dependencyLocations = depLocation
-    , dependencyEnvironments = pubLockPackageEnvironment meta
+    , dependencyEnvironments = Set.fromList $ pubLockPackageEnvironment meta
     , dependencyTags = Map.empty
     }
   where

--- a/src/Strategy/Elixir/MixTree.hs
+++ b/src/Strategy/Elixir/MixTree.hs
@@ -305,7 +305,7 @@ buildGraph deps depsResolved = unfold deps subDeps toDependency
         , dependencyName = dName md depsResolved
         , dependencyVersion = dVersion md depsResolved
         , dependencyLocations = []
-        , dependencyEnvironments = []
+        , dependencyEnvironments = mempty
         , dependencyTags = Map.empty
         }
 

--- a/src/Strategy/Erlang/Rebar3Tree.hs
+++ b/src/Strategy/Erlang/Rebar3Tree.hs
@@ -79,7 +79,7 @@ buildGraph deps = unfold deps subDeps toDependency
         , dependencyName = if Text.isInfixOf "github.com" depLocation then depLocation else depName
         , dependencyVersion = Just (CEq depVersion)
         , dependencyLocations = []
-        , dependencyEnvironments = []
+        , dependencyEnvironments = mempty
         , dependencyTags = Map.empty
         }
 

--- a/src/Strategy/Go/GlideLock.hs
+++ b/src/Strategy/Go/GlideLock.hs
@@ -41,7 +41,7 @@ buildGraph lockfile = Graphing.fromList (map toDependency direct)
         , dependencyName = depName
         , dependencyVersion = Just (CEq depVersion)
         , dependencyLocations = []
-        , dependencyEnvironments = []
+        , dependencyEnvironments = mempty
         , dependencyTags = Map.empty
         }
 

--- a/src/Strategy/Go/Types.hs
+++ b/src/Strategy/Go/Types.hs
@@ -47,7 +47,7 @@ golangPackageToDependency pkg = foldr applyLabel start
         , dependencyName = goImportPath pkg
         , dependencyVersion = Nothing
         , dependencyLocations = []
-        , dependencyEnvironments = []
+        , dependencyEnvironments = mempty
         , dependencyTags = Map.empty
         }
 

--- a/src/Strategy/Googlesource/RepoManifest.hs
+++ b/src/Strategy/Googlesource/RepoManifest.hs
@@ -26,6 +26,7 @@ import Control.Monad (unless)
 import Data.Foldable (find)
 import Data.HashMap.Strict qualified as HM
 import Data.Map.Strict qualified as Map
+import Data.Set qualified as Set
 import Data.String.Conversion (toString, toText)
 import Data.Text (Text)
 import Data.Text.Prettyprint.Doc (pretty)
@@ -279,7 +280,7 @@ buildGraph projects = unfold projects (const []) toDependency
         , dependencyVersion = Just (CEq validatedProjectRevision)
         , dependencyLocations = [render validatedProjectUrl]
         , dependencyTags = Map.empty
-        , dependencyEnvironments = [EnvProduction]
+        , dependencyEnvironments = Set.singleton EnvProduction
         }
 
 data ManifestGitConfigError

--- a/src/Strategy/Gradle.hs
+++ b/src/Strategy/Gradle.hs
@@ -346,7 +346,7 @@ buildGraph projectsAndDeps = run . withLabeling toDependency $ Map.traverseWithK
         , dependencyName = name
         , dependencyVersion = Just (CEq version)
         , dependencyLocations = []
-        , dependencyEnvironments = []
+        , dependencyEnvironments = mempty
         , dependencyTags = Map.empty
         }
 
@@ -356,7 +356,7 @@ buildGraph projectsAndDeps = run . withLabeling toDependency $ Map.traverseWithK
         , dependencyName = name
         , dependencyVersion = Nothing
         , dependencyLocations = []
-        , dependencyEnvironments = []
+        , dependencyEnvironments = mempty
         , dependencyTags = Map.empty
         }
 

--- a/src/Strategy/Haskell/Cabal.hs
+++ b/src/Strategy/Haskell/Cabal.hs
@@ -182,7 +182,7 @@ toDependency plan =
     , dependencyName = planName plan
     , dependencyVersion = Just $ CEq $ planVersion plan
     , dependencyLocations = []
-    , dependencyEnvironments = []
+    , dependencyEnvironments = mempty
     , dependencyTags = Map.empty
     }
 

--- a/src/Strategy/Haskell/Stack.hs
+++ b/src/Strategy/Haskell/Stack.hs
@@ -120,7 +120,7 @@ toDependency dep =
     , dependencyName = unPackageName $ stackName dep
     , dependencyVersion = Just $ CEq $ stackVersion dep
     , dependencyLocations = []
-    , dependencyEnvironments = []
+    , dependencyEnvironments = mempty
     , dependencyTags = Map.empty
     }
 

--- a/src/Strategy/Leiningen.hs
+++ b/src/Strategy/Leiningen.hs
@@ -164,7 +164,7 @@ toDependency node = foldr applyLabel start
         , dependencyName = nodeName node
         , dependencyVersion = Just (CEq (nodeVersion node))
         , dependencyLocations = []
-        , dependencyEnvironments = []
+        , dependencyEnvironments = mempty
         , dependencyTags = Map.empty
         }
     applyLabel (ScopeLabel "test") dep = insertEnvironment EnvTesting dep

--- a/src/Strategy/Maven/DepTree.hs
+++ b/src/Strategy/Maven/DepTree.hs
@@ -16,6 +16,7 @@ import Control.Effect.Exception (finally)
 import Control.Effect.Lift (Lift, sendIO)
 import Data.Char (isSpace)
 import Data.Foldable (for_)
+import Data.Set qualified as Set
 import Data.String.Conversion (toString, toText)
 import Data.Text (Text)
 import Data.Text qualified as Text
@@ -154,7 +155,8 @@ toDependency PackageId{groupName, artifactName, artifactVersion, buildTag} =
     , dependencyName = groupName <> ":" <> artifactName
     , dependencyVersion = Just $ CEq artifactVersion
     , dependencyLocations = []
-    , dependencyEnvironments = maybe [EnvProduction] ((: []) . toBuildTag) buildTag
+    , -- TODO: cleanup logic, no need to use list
+      dependencyEnvironments = Set.fromList $ maybe [EnvProduction] ((: []) . toBuildTag) buildTag
     , dependencyTags = mempty
     }
 

--- a/src/Strategy/Maven/PluginStrategy.hs
+++ b/src/Strategy/Maven/PluginStrategy.hs
@@ -11,6 +11,7 @@ import Control.Effect.Lift (Lift)
 import Data.Foldable (traverse_)
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
+import Data.Set qualified as Set
 import DepTypes (
   DepEnvironment (..),
   DepType (MavenType),
@@ -67,7 +68,7 @@ buildGraph PluginOutput{..} = run $
         , dependencyName = artifactGroupId <> ":" <> artifactArtifactId
         , dependencyVersion = Just (CEq artifactVersion)
         , dependencyLocations = []
-        , dependencyEnvironments = [EnvTesting | "test" `elem` artifactScopes]
+        , dependencyEnvironments = Set.fromList $ [EnvTesting | "test" `elem` artifactScopes]
         , dependencyTags =
             Map.fromList $
               ("scopes", artifactScopes) :

--- a/src/Strategy/Maven/Pom.hs
+++ b/src/Strategy/Maven/Pom.hs
@@ -74,7 +74,7 @@ toDependency (MavenPackage group artifact version) = foldr applyLabel start
         , dependencyName = group <> ":" <> artifact
         , dependencyVersion = CEq <$> version
         , dependencyLocations = []
-        , dependencyEnvironments = []
+        , dependencyEnvironments = mempty
         , dependencyTags = Map.empty
         }
 
@@ -82,7 +82,7 @@ toDependency (MavenPackage group artifact version) = foldr applyLabel start
     applyLabel lbl dep = case lbl of
       MavenLabelScope scope ->
         if scope == "test"
-          then dep{dependencyEnvironments = EnvTesting : dependencyEnvironments dep}
+          then insertEnvironment EnvTesting dep
           else addTag "scope" scope dep
       MavenLabelOptional opt -> addTag "optional" opt dep
 

--- a/src/Strategy/Node/NpmList.hs
+++ b/src/Strategy/Node/NpmList.hs
@@ -36,7 +36,7 @@ buildGraph top = unfold direct getDeps toDependency
         , dependencyName = nodeName
         , dependencyVersion = CEq <$> outputVersion nodeOutput
         , dependencyLocations = []
-        , dependencyEnvironments = []
+        , dependencyEnvironments = mempty
         , dependencyTags = Map.empty
         }
 

--- a/src/Strategy/Node/NpmLock.hs
+++ b/src/Strategy/Node/NpmLock.hs
@@ -103,8 +103,8 @@ buildGraph packageJson = run . withLabeling toDependency $ do
     toDependency pkg = foldr addLabel (start pkg)
 
     addLabel :: NpmPackageLabel -> Dependency -> Dependency
-    addLabel (NpmPackageEnv env) dep = dep{dependencyEnvironments = env : dependencyEnvironments dep}
-    addLabel (NpmPackageLocation loc) dep = dep{dependencyLocations = loc : dependencyLocations dep}
+    addLabel (NpmPackageEnv env) = insertEnvironment env
+    addLabel (NpmPackageLocation loc) = insertLocation loc
 
     start :: NpmPackage -> Dependency
     start NpmPackage{..} =
@@ -113,6 +113,6 @@ buildGraph packageJson = run . withLabeling toDependency $ do
         , dependencyName = pkgName
         , dependencyVersion = Just $ CEq pkgVersion
         , dependencyLocations = []
-        , dependencyEnvironments = []
+        , dependencyEnvironments = mempty
         , dependencyTags = Map.empty
         }

--- a/src/Strategy/Node/PackageJson.hs
+++ b/src/Strategy/Node/PackageJson.hs
@@ -12,8 +12,19 @@ import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
 import Data.Set (Set)
 import Data.Text (Text)
-import DepTypes
-import Effect.Grapher
+import DepTypes (
+  DepEnvironment (..),
+  DepType (NodeJSType),
+  Dependency (..),
+  VerConstraint (CCompatible),
+  insertEnvironment,
+ )
+import Effect.Grapher (
+  LabeledGrapher,
+  direct,
+  label,
+  withLabeling,
+ )
 import Effect.ReadFS
 import Graphing (Graphing)
 import Path
@@ -62,8 +73,7 @@ buildGraph PackageJson{..} = run . withLabeling toDependency $ do
     toDependency dep = foldr addLabel (start dep)
 
     addLabel :: NodePackageLabel -> Dependency -> Dependency
-    addLabel (NodePackageEnv env) dep =
-      dep{dependencyEnvironments = env : dependencyEnvironments dep}
+    addLabel (NodePackageEnv env) = insertEnvironment env
 
     start :: NodePackage -> Dependency
     start NodePackage{..} =
@@ -72,6 +82,6 @@ buildGraph PackageJson{..} = run . withLabeling toDependency $ do
         , dependencyName = pkgName
         , dependencyVersion = Just (CCompatible pkgConstraint)
         , dependencyLocations = []
-        , dependencyEnvironments = []
+        , dependencyEnvironments = mempty
         , dependencyTags = Map.empty
         }

--- a/src/Strategy/NuGet/Nuspec.hs
+++ b/src/Strategy/NuGet/Nuspec.hs
@@ -148,6 +148,6 @@ buildGraph project = Graphing.fromList (map toDependency direct)
         , dependencyName = depID
         , dependencyVersion = Just (CEq depVersion)
         , dependencyLocations = []
-        , dependencyEnvironments = []
+        , dependencyEnvironments = mempty
         , dependencyTags = Map.empty
         }

--- a/src/Strategy/NuGet/PackageReference.hs
+++ b/src/Strategy/NuGet/PackageReference.hs
@@ -110,6 +110,6 @@ buildGraph project = Graphing.fromList (map toDependency direct)
         , dependencyName = depID
         , dependencyVersion = fmap CEq depVersion
         , dependencyLocations = []
-        , dependencyEnvironments = []
+        , dependencyEnvironments = mempty
         , dependencyTags = Map.empty
         }

--- a/src/Strategy/NuGet/PackagesConfig.hs
+++ b/src/Strategy/NuGet/PackagesConfig.hs
@@ -91,6 +91,6 @@ buildGraph = Graphing.fromList . map toDependency . deps
         , dependencyName = depID
         , dependencyVersion = Just (CEq depVersion)
         , dependencyLocations = []
-        , dependencyEnvironments = []
+        , dependencyEnvironments = mempty
         , dependencyTags = Map.empty
         }

--- a/src/Strategy/NuGet/Paket.hs
+++ b/src/Strategy/NuGet/Paket.hs
@@ -95,7 +95,7 @@ toDependency pkg = foldr applyLabel start
         , dependencyName = pkgName pkg
         , dependencyVersion = Nothing
         , dependencyLocations = []
-        , dependencyEnvironments = []
+        , dependencyEnvironments = mempty
         , dependencyTags = Map.empty
         }
 

--- a/src/Strategy/NuGet/ProjectAssetsJson.hs
+++ b/src/Strategy/NuGet/ProjectAssetsJson.hs
@@ -108,6 +108,6 @@ buildGraph project = unfold direct deepList toDependency
         , dependencyName = depName
         , dependencyVersion = Just (CEq depVersion)
         , dependencyLocations = []
-        , dependencyEnvironments = []
+        , dependencyEnvironments = mempty
         , dependencyTags = Map.empty
         }

--- a/src/Strategy/NuGet/ProjectJson.hs
+++ b/src/Strategy/NuGet/ProjectJson.hs
@@ -107,7 +107,7 @@ buildGraph project = Graphing.fromList (map toDependency direct)
             Just '*' -> Just (CCompatible version)
             _ -> Just (CEq version)
         , dependencyLocations = []
-        , dependencyEnvironments = []
+        , dependencyEnvironments = mempty
         , dependencyTags = case dependencyType of
             Nothing -> Map.empty
             Just depType -> Map.insert "type" [depType] Map.empty

--- a/src/Strategy/Python/Pipenv.hs
+++ b/src/Strategy/Python/Pipenv.hs
@@ -94,8 +94,8 @@ buildGraph lock maybeDeps = run . withLabeling toDependency $ do
     toDependency pkg = foldr applyLabel start
       where
         applyLabel :: PipLabel -> Dependency -> Dependency
-        applyLabel (PipSource loc) dep = dep{dependencyLocations = loc : dependencyLocations dep}
-        applyLabel (PipEnvironment env) dep = dep{dependencyEnvironments = env : dependencyEnvironments dep}
+        applyLabel (PipSource loc) = insertLocation loc
+        applyLabel (PipEnvironment env) = insertEnvironment env
 
         start =
           Dependency
@@ -103,7 +103,7 @@ buildGraph lock maybeDeps = run . withLabeling toDependency $ do
             , dependencyName = pipPkgName pkg
             , dependencyVersion = CEq <$> pipPkgVersion pkg
             , dependencyLocations = []
-            , dependencyEnvironments = []
+            , dependencyEnvironments = mempty
             , dependencyTags = Map.empty
             }
 

--- a/src/Strategy/Python/Poetry.hs
+++ b/src/Strategy/Python/Poetry.hs
@@ -185,7 +185,7 @@ graphFromLockFile poetryLock = Graphing.gmap pkgNameToDependency (edges <> Graph
             , dependencyName = unPackageName name
             , dependencyVersion = Nothing
             , dependencyLocations = []
-            , dependencyEnvironments = []
+            , dependencyEnvironments = mempty
             , dependencyTags = Map.empty
             }
         )

--- a/src/Strategy/Python/Poetry/Common.hs
+++ b/src/Strategy/Python/Poetry/Common.hs
@@ -14,6 +14,7 @@ import Data.Foldable (asum, for_)
 import Data.Map (Map)
 import Data.Map.Strict qualified as Map
 import Data.Maybe (fromMaybe)
+import Data.Set qualified as Set
 import Data.Text (Text, replace, toLower)
 import DepTypes (
   DepEnvironment (EnvDevelopment, EnvOther, EnvProduction, EnvTesting),
@@ -102,7 +103,7 @@ poetrytoDependency depEnvs name deps =
     , dependencyName = depName
     , dependencyVersion = depVersion
     , dependencyLocations = depLocations
-    , dependencyEnvironments = depEnvironment
+    , dependencyEnvironments = Set.fromList depEnvironment
     , dependencyTags = depTags
     }
   where
@@ -164,7 +165,7 @@ toMap pkgs = Map.fromList $ (\x -> (canonicalPkgName x, toDependency x)) <$> (fi
         , dependencyName = toDepName pkg
         , dependencyVersion = toDepVersion pkg
         , dependencyLocations = toDepLocs pkg
-        , dependencyEnvironments = toDepEnvironment pkg
+        , dependencyEnvironments = Set.singleton $ toDepEnvironment pkg
         , dependencyTags = Map.empty
         }
 
@@ -197,9 +198,9 @@ toMap pkgs = Map.fromList $ (\x -> (canonicalPkgName x, toDependency x)) <$> (fi
           ref <- poetryLockPackageSourceReference lockPkgSrc
           if poetryLockPackageSourceType lockPkgSrc /= "legacy" then Just ref else Nothing
 
-    toDepEnvironment :: PoetryLockPackage -> [DepEnvironment]
+    toDepEnvironment :: PoetryLockPackage -> DepEnvironment
     toDepEnvironment pkg = case poetryLockPackageCategory pkg of
-      "dev" -> [EnvDevelopment]
-      "main" -> [EnvProduction]
-      "test" -> [EnvTesting]
-      other -> [EnvOther other]
+      "dev" -> EnvDevelopment
+      "main" -> EnvProduction
+      "test" -> EnvTesting
+      other -> EnvOther other

--- a/src/Strategy/Python/Util.hs
+++ b/src/Strategy/Python/Util.hs
@@ -31,7 +31,7 @@ buildGraph = Graphing.fromList . map toDependency
         , dependencyName = depName req
         , dependencyVersion = depVersion req
         , dependencyLocations = []
-        , dependencyEnvironments = []
+        , dependencyEnvironments = mempty
         , dependencyTags = maybe Map.empty toTags (depMarker req)
         }
 

--- a/src/Strategy/RPM.hs
+++ b/src/Strategy/RPM.hs
@@ -103,7 +103,7 @@ toDependency pkg =
     , dependencyName = rpmDepName pkg
     , dependencyVersion = rpmConstraint pkg
     , dependencyLocations = []
-    , dependencyEnvironments = []
+    , dependencyEnvironments = mempty
     , dependencyTags = Map.empty
     }
 

--- a/src/Strategy/Ruby/BundleShow.hs
+++ b/src/Strategy/Ruby/BundleShow.hs
@@ -42,7 +42,7 @@ buildGraph = Graphing.fromList . map toDependency
         , dependencyName = depName
         , dependencyVersion = Just (CEq depVersion)
         , dependencyLocations = []
-        , dependencyEnvironments = []
+        , dependencyEnvironments = mempty
         , dependencyTags = Map.empty
         }
 

--- a/src/Strategy/Ruby/GemfileLock.hs
+++ b/src/Strategy/Ruby/GemfileLock.hs
@@ -84,7 +84,7 @@ toDependency pkg = foldr applyLabel start
         , dependencyName = pkgName pkg
         , dependencyVersion = Nothing
         , dependencyLocations = []
-        , dependencyEnvironments = []
+        , dependencyEnvironments = mempty
         , dependencyTags = Map.empty
         }
 

--- a/src/Strategy/Swift/PackageResolved.hs
+++ b/src/Strategy/Swift/PackageResolved.hs
@@ -73,6 +73,6 @@ resolvedDependenciesOf resolvedContent = map toDependency $ pinnedPackages resol
                 , repositoryBranch pkg
                 ]
         , dependencyLocations = []
-        , dependencyEnvironments = []
+        , dependencyEnvironments = mempty
         , dependencyTags = mempty
         }

--- a/src/Strategy/Swift/PackageSwift.hs
+++ b/src/Strategy/Swift/PackageSwift.hs
@@ -247,7 +247,7 @@ toDependency (GitSource pkgDep) =
       , dependencyName = srcOf pkgDep
       , dependencyVersion = toConstraint <$> versionRequirement pkgDep
       , dependencyLocations = []
-      , dependencyEnvironments = []
+      , dependencyEnvironments = mempty
       , dependencyTags = Map.empty
       }
   where

--- a/src/Strategy/Swift/Xcode/Pbxproj.hs
+++ b/src/Strategy/Swift/Xcode/Pbxproj.hs
@@ -74,7 +74,7 @@ toDependency src =
     , dependencyName = urlOf src
     , dependencyVersion = Just $ toConstraint $ requirementOf src
     , dependencyLocations = []
-    , dependencyEnvironments = []
+    , dependencyEnvironments = mempty
     , dependencyTags = Map.empty
     }
   where

--- a/src/Strategy/Yarn/V1/YarnLock.hs
+++ b/src/Strategy/Yarn/V1/YarnLock.hs
@@ -74,6 +74,6 @@ buildGraph lockfile =
               YL.GitRemote url rev -> [url <> "@" <> rev]
               YL.DirectoryLocal dirPath -> [dirPath]
               YL.DirectoryLocalSymLinked dirPath -> [dirPath]
-        , dependencyEnvironments = []
+        , dependencyEnvironments = mempty
         , dependencyTags = Map.empty
         }

--- a/src/Strategy/Yarn/V2/YarnLock.hs
+++ b/src/Strategy/Yarn/V2/YarnLock.hs
@@ -134,7 +134,7 @@ packageToDependency (NpmPackage maybeScope name version) =
       , dependencyVersion = Just (CEq version)
       , dependencyLocations = []
       , dependencyTags = Map.empty
-      , dependencyEnvironments = []
+      , dependencyEnvironments = mempty
       }
 packageToDependency (GitPackage repo commit) =
   Just
@@ -144,7 +144,7 @@ packageToDependency (GitPackage repo commit) =
       , dependencyVersion = Just (CEq commit)
       , dependencyLocations = []
       , dependencyTags = Map.empty
-      , dependencyEnvironments = []
+      , dependencyEnvironments = mempty
       }
 packageToDependency (TarPackage url) =
   Just
@@ -154,5 +154,5 @@ packageToDependency (TarPackage url) =
       , dependencyVersion = Nothing
       , dependencyLocations = []
       , dependencyTags = Map.empty
-      , dependencyEnvironments = []
+      , dependencyEnvironments = mempty
       }

--- a/test/Cargo/MetadataSpec.hs
+++ b/test/Cargo/MetadataSpec.hs
@@ -5,6 +5,7 @@ module Cargo.MetadataSpec (
 import Data.Aeson
 import Data.ByteString.Lazy qualified as BL
 import Data.Map.Strict qualified as Map
+import Data.Set qualified as Set
 import Data.Text (Text)
 import Data.Text qualified as Text
 import DepTypes
@@ -26,7 +27,7 @@ mkPkgId :: Text.Text -> Text.Text -> PackageId
 mkPkgId name ver = PackageId name ver registrySource
 
 mkDep :: Text -> Text -> [DepEnvironment] -> Dependency
-mkDep name version envs = Dependency CargoType name (Just $ CEq version) [] envs Map.empty
+mkDep name version envs = Dependency CargoType name (Just $ CEq version) [] (Set.fromList envs) Map.empty
 
 ansiTermId :: PackageId
 ansiTermId = mkPkgId "ansi_term" "0.11.0"

--- a/test/Clojure/ClojureSpec.hs
+++ b/test/Clojure/ClojureSpec.hs
@@ -4,6 +4,7 @@ module Clojure.ClojureSpec (
 
 import Data.EDN qualified as EDN
 import Data.Map.Strict qualified as Map
+import Data.Set qualified as Set
 import Data.Text.IO qualified as TIO
 import DepTypes
 import GraphUtil
@@ -31,7 +32,7 @@ clojureComplete =
     , dependencyName = "clojure-complete"
     , dependencyVersion = Just (CEq "0.2.5")
     , dependencyLocations = []
-    , dependencyEnvironments = []
+    , dependencyEnvironments = mempty
     , dependencyTags = Map.empty
     }
 
@@ -43,7 +44,7 @@ koanEngine =
     , dependencyName = "koan-engine"
     , dependencyVersion = Just (CEq "0.2.5")
     , dependencyLocations = []
-    , dependencyEnvironments = []
+    , dependencyEnvironments = mempty
     , dependencyTags = Map.empty
     }
 
@@ -54,7 +55,7 @@ fresh =
     , dependencyName = "fresh"
     , dependencyVersion = Just (CEq "1.0.2")
     , dependencyLocations = []
-    , dependencyEnvironments = []
+    , dependencyEnvironments = mempty
     , dependencyTags = Map.empty
     }
 
@@ -66,7 +67,7 @@ leinKoan =
     , dependencyName = "lein-koan"
     , dependencyVersion = Just (CEq "0.1.5")
     , dependencyLocations = []
-    , dependencyEnvironments = [EnvTesting]
+    , dependencyEnvironments = Set.singleton EnvTesting
     , dependencyTags = Map.empty
     }
 
@@ -78,7 +79,7 @@ nrepl =
     , dependencyName = "nrepl"
     , dependencyVersion = Just (CEq "0.6.0")
     , dependencyLocations = []
-    , dependencyEnvironments = []
+    , dependencyEnvironments = mempty
     , dependencyTags = Map.empty
     }
 
@@ -92,7 +93,7 @@ clojure =
     , dependencyName = "org.clojure:clojure"
     , dependencyVersion = Just (CEq "1.10.0")
     , dependencyLocations = []
-    , dependencyEnvironments = []
+    , dependencyEnvironments = mempty
     , dependencyTags = Map.empty
     }
 
@@ -103,7 +104,7 @@ clojureSpecsAlpha =
     , dependencyName = "org.clojure:core.specs.alpha"
     , dependencyVersion = Just (CEq "0.2.44")
     , dependencyLocations = []
-    , dependencyEnvironments = []
+    , dependencyEnvironments = mempty
     , dependencyTags = Map.empty
     }
 
@@ -114,6 +115,6 @@ clojureSpecAlpha =
     , dependencyName = "org.clojure:spec.alpha"
     , dependencyVersion = Just (CEq "0.2.176")
     , dependencyLocations = []
-    , dependencyEnvironments = []
+    , dependencyEnvironments = mempty
     , dependencyTags = Map.empty
     }

--- a/test/Cocoapods/PodfileLockSpec.hs
+++ b/test/Cocoapods/PodfileLockSpec.hs
@@ -29,7 +29,7 @@ podDepOf name version =
     , dependencyName = name
     , dependencyVersion = CEq <$> version
     , dependencyLocations = []
-    , dependencyEnvironments = []
+    , dependencyEnvironments = mempty
     , dependencyTags = Map.empty
     }
 
@@ -40,7 +40,7 @@ gitDepOf name version =
     , dependencyName = name
     , dependencyVersion = CEq <$> version
     , dependencyLocations = []
-    , dependencyEnvironments = []
+    , dependencyEnvironments = mempty
     , dependencyTags = Map.empty
     }
 

--- a/test/Cocoapods/PodfileSpec.hs
+++ b/test/Cocoapods/PodfileSpec.hs
@@ -17,7 +17,7 @@ dependencyOne =
     , dependencyName = "one"
     , dependencyVersion = Just (CEq "1.0.0")
     , dependencyLocations = ["test.repo"]
-    , dependencyEnvironments = []
+    , dependencyEnvironments = mempty
     , dependencyTags = Map.empty
     }
 
@@ -28,7 +28,7 @@ dependencyTwo =
     , dependencyName = "two"
     , dependencyVersion = Just (CEq "2.0.0")
     , dependencyLocations = ["custom.repo"]
-    , dependencyEnvironments = []
+    , dependencyEnvironments = mempty
     , dependencyTags = Map.empty
     }
 
@@ -39,7 +39,7 @@ dependencyThree =
     , dependencyName = "three"
     , dependencyVersion = Just (CEq "3.0.0")
     , dependencyLocations = ["test.repo"]
-    , dependencyEnvironments = []
+    , dependencyEnvironments = mempty
     , dependencyTags = Map.empty
     }
 
@@ -50,7 +50,7 @@ dependencyFour =
     , dependencyName = "four"
     , dependencyVersion = Nothing
     , dependencyLocations = ["test.repo"]
-    , dependencyEnvironments = []
+    , dependencyEnvironments = mempty
     , dependencyTags = Map.empty
     }
 

--- a/test/Composer/ComposerLockSpec.hs
+++ b/test/Composer/ComposerLockSpec.hs
@@ -5,6 +5,7 @@ module Composer.ComposerLockSpec (
 import Data.Aeson
 import Data.ByteString qualified as BS
 import Data.Map.Strict qualified as Map
+import Data.Set qualified as Set
 import DepTypes
 import GraphUtil
 import Strategy.Composer
@@ -17,7 +18,7 @@ dependencyOne =
     , dependencyName = "one"
     , dependencyVersion = Just (CEq "1.0.0")
     , dependencyLocations = []
-    , dependencyEnvironments = [EnvProduction]
+    , dependencyEnvironments = Set.singleton EnvProduction
     , dependencyTags = Map.empty
     }
 
@@ -28,7 +29,7 @@ dependencyTwo =
     , dependencyName = "two"
     , dependencyVersion = Just (CEq "2.0.0")
     , dependencyLocations = []
-    , dependencyEnvironments = [EnvProduction]
+    , dependencyEnvironments = Set.singleton EnvProduction
     , dependencyTags = Map.empty
     }
 
@@ -39,7 +40,7 @@ dependencyThree =
     , dependencyName = "three"
     , dependencyVersion = Just (CEq "3.0.0")
     , dependencyLocations = []
-    , dependencyEnvironments = [EnvProduction]
+    , dependencyEnvironments = Set.singleton EnvProduction
     , dependencyTags = Map.empty
     }
 
@@ -50,7 +51,7 @@ dependencyFour =
     , dependencyName = "four"
     , dependencyVersion = Just (CEq "4.0.0")
     , dependencyLocations = []
-    , dependencyEnvironments = [EnvProduction]
+    , dependencyEnvironments = Set.singleton EnvProduction
     , dependencyTags = Map.empty
     }
 
@@ -61,7 +62,7 @@ dependencyFive =
     , dependencyName = "five"
     , dependencyVersion = Just (CEq "5.0.0")
     , dependencyLocations = []
-    , dependencyEnvironments = [EnvDevelopment]
+    , dependencyEnvironments = Set.singleton EnvDevelopment
     , dependencyTags = Map.empty
     }
 
@@ -72,7 +73,7 @@ dependencySourceless =
     , dependencyName = "sourceless"
     , dependencyVersion = Just (CEq "5.0.0")
     , dependencyLocations = []
-    , dependencyEnvironments = [EnvProduction]
+    , dependencyEnvironments = Set.singleton EnvProduction
     , dependencyTags = Map.empty
     }
 

--- a/test/Conda/CondaListSpec.hs
+++ b/test/Conda/CondaListSpec.hs
@@ -21,7 +21,7 @@ expected = run . evalGrapher $ do
       , dependencyName = "biopython"
       , dependencyVersion = Just (CEq "1.78")
       , dependencyLocations = []
-      , dependencyEnvironments = []
+      , dependencyEnvironments = mempty
       , dependencyTags = Map.empty
       }
   direct $
@@ -30,7 +30,7 @@ expected = run . evalGrapher $ do
       , dependencyName = "blas"
       , dependencyVersion = Just (CEq "1.0")
       , dependencyLocations = []
-      , dependencyEnvironments = []
+      , dependencyEnvironments = mempty
       , dependencyTags = Map.empty
       }
   direct $
@@ -39,7 +39,7 @@ expected = run . evalGrapher $ do
       , dependencyName = "ca-certificates"
       , dependencyVersion = Just (CEq "2021.1.19")
       , dependencyLocations = []
-      , dependencyEnvironments = []
+      , dependencyEnvironments = mempty
       , dependencyTags = Map.empty
       }
 

--- a/test/Conda/EnvironmentYmlSpec.hs
+++ b/test/Conda/EnvironmentYmlSpec.hs
@@ -24,7 +24,7 @@ dependencyOne =
     , dependencyName = "name"
     , dependencyVersion = Just (CEq "version1")
     , dependencyLocations = []
-    , dependencyEnvironments = []
+    , dependencyEnvironments = mempty
     , dependencyTags = Map.empty
     }
 
@@ -35,7 +35,7 @@ dependencyTwo =
     , dependencyName = "name"
     , dependencyVersion = Just (CEq "version2")
     , dependencyLocations = []
-    , dependencyEnvironments = []
+    , dependencyEnvironments = mempty
     , dependencyTags = Map.empty
     }
 
@@ -46,7 +46,7 @@ dependencyThree =
     , dependencyName = "name"
     , dependencyVersion = Nothing
     , dependencyLocations = []
-    , dependencyEnvironments = []
+    , dependencyEnvironments = mempty
     , dependencyTags = Map.empty
     }
 
@@ -58,7 +58,7 @@ expectedGraph = run . evalGrapher $ do
       , dependencyName = "biopython"
       , dependencyVersion = Just (CEq "1.78")
       , dependencyLocations = []
-      , dependencyEnvironments = []
+      , dependencyEnvironments = mempty
       , dependencyTags = Map.empty
       }
   direct $
@@ -67,7 +67,7 @@ expectedGraph = run . evalGrapher $ do
       , dependencyName = "blas"
       , dependencyVersion = Just (CEq "1.0")
       , dependencyLocations = []
-      , dependencyEnvironments = []
+      , dependencyEnvironments = mempty
       , dependencyTags = Map.empty
       }
   direct $
@@ -76,7 +76,7 @@ expectedGraph = run . evalGrapher $ do
       , dependencyName = "ca-certificates"
       , dependencyVersion = Just (CEq "2021.1.19")
       , dependencyLocations = []
-      , dependencyEnvironments = []
+      , dependencyEnvironments = mempty
       , dependencyTags = Map.empty
       }
 

--- a/test/Dart/PubDepsSpec.hs
+++ b/test/Dart/PubDepsSpec.hs
@@ -92,7 +92,7 @@ spec = do
             , dependencyName = "pkg_a"
             , dependencyVersion = Just $ CEq "1.8.0"
             , dependencyLocations = ["https://pub.dartlang.org"]
-            , dependencyEnvironments = []
+            , dependencyEnvironments = mempty
             , dependencyTags = Map.empty
             }
         ]
@@ -104,7 +104,7 @@ spec = do
             , dependencyName = "pkg_a"
             , dependencyVersion = Just $ CEq "1.8.0"
             , dependencyLocations = ["https://pub.dartlang.org"]
-            , dependencyEnvironments = []
+            , dependencyEnvironments = mempty
             , dependencyTags = Map.empty
             }
         , Dependency
@@ -112,7 +112,7 @@ spec = do
             , dependencyName = "pkg_deep"
             , dependencyVersion = Just $ CEq "1.10.0"
             , dependencyLocations = ["https://pub.dartlang.org"]
-            , dependencyEnvironments = []
+            , dependencyEnvironments = mempty
             , dependencyTags = Map.empty
             }
         , Dependency
@@ -120,7 +120,7 @@ spec = do
             , dependencyName = "pkg_deeper"
             , dependencyVersion = Just $ CEq "1.20.0"
             , dependencyLocations = ["https://pub.dartlang.org"]
-            , dependencyEnvironments = []
+            , dependencyEnvironments = mempty
             , dependencyTags = Map.empty
             }
         ]
@@ -133,7 +133,7 @@ spec = do
               , dependencyName = "pkg_a"
               , dependencyVersion = Just $ CEq "1.8.0"
               , dependencyLocations = ["https://pub.dartlang.org"]
-              , dependencyEnvironments = []
+              , dependencyEnvironments = mempty
               , dependencyTags = Map.empty
               }
           , Dependency
@@ -141,7 +141,7 @@ spec = do
               , dependencyName = "pkg_deep"
               , dependencyVersion = Just $ CEq "1.10.0"
               , dependencyLocations = ["https://pub.dartlang.org"]
-              , dependencyEnvironments = []
+              , dependencyEnvironments = mempty
               , dependencyTags = Map.empty
               }
           )
@@ -151,7 +151,7 @@ spec = do
               , dependencyName = "pkg_deep"
               , dependencyVersion = Just $ CEq "1.10.0"
               , dependencyLocations = ["https://pub.dartlang.org"]
-              , dependencyEnvironments = []
+              , dependencyEnvironments = mempty
               , dependencyTags = Map.empty
               }
           , Dependency
@@ -159,7 +159,7 @@ spec = do
               , dependencyName = "pkg_deeper"
               , dependencyVersion = Just $ CEq "1.20.0"
               , dependencyLocations = ["https://pub.dartlang.org"]
-              , dependencyEnvironments = []
+              , dependencyEnvironments = mempty
               , dependencyTags = Map.empty
               }
           )
@@ -239,7 +239,7 @@ spec = do
             , dependencyName = "pkg_a"
             , dependencyVersion = Just $ CEq "1.8.0"
             , dependencyLocations = []
-            , dependencyEnvironments = []
+            , dependencyEnvironments = mempty
             , dependencyTags = Map.empty
             }
         ]
@@ -250,7 +250,7 @@ spec = do
             , dependencyName = "pkg_a"
             , dependencyVersion = Just $ CEq "1.8.0"
             , dependencyLocations = []
-            , dependencyEnvironments = []
+            , dependencyEnvironments = mempty
             , dependencyTags = Map.empty
             }
         ]
@@ -305,7 +305,7 @@ spec = do
             , dependencyName = "pkg_a"
             , dependencyVersion = Just $ CEq "1.8.0"
             , dependencyLocations = ["https://pub.dartlang.org"]
-            , dependencyEnvironments = []
+            , dependencyEnvironments = mempty
             , dependencyTags = Map.empty
             }
         ]
@@ -317,7 +317,7 @@ spec = do
             , dependencyName = "pkg_a"
             , dependencyVersion = Just $ CEq "1.8.0"
             , dependencyLocations = ["https://pub.dartlang.org"]
-            , dependencyEnvironments = []
+            , dependencyEnvironments = mempty
             , dependencyTags = Map.empty
             }
         , Dependency
@@ -325,7 +325,7 @@ spec = do
             , dependencyName = "pkg_deeper"
             , dependencyVersion = Just $ CEq "1.20.0"
             , dependencyLocations = ["https://pub.dartlang.org"]
-            , dependencyEnvironments = []
+            , dependencyEnvironments = mempty
             , dependencyTags = Map.empty
             }
         ]
@@ -338,7 +338,7 @@ spec = do
               , dependencyName = "pkg_a"
               , dependencyVersion = Just $ CEq "1.8.0"
               , dependencyLocations = ["https://pub.dartlang.org"]
-              , dependencyEnvironments = []
+              , dependencyEnvironments = mempty
               , dependencyTags = Map.empty
               }
           , Dependency
@@ -346,7 +346,7 @@ spec = do
               , dependencyName = "pkg_deeper"
               , dependencyVersion = Just $ CEq "1.20.0"
               , dependencyLocations = ["https://pub.dartlang.org"]
-              , dependencyEnvironments = []
+              , dependencyEnvironments = mempty
               , dependencyTags = Map.empty
               }
           )

--- a/test/Dart/PubSpecLockSpec.hs
+++ b/test/Dart/PubSpecLockSpec.hs
@@ -4,6 +4,7 @@ module Dart.PubSpecLockSpec (
 
 import Data.ByteString qualified as BS
 import Data.Map qualified as Map
+import Data.Set qualified as Set
 import Data.Yaml (decodeEither')
 import DepTypes
 import GraphUtil (expectDeps, expectDirect)
@@ -109,7 +110,7 @@ spec = do
               , dependencyName = "pkg_a"
               , dependencyVersion = Just $ CEq "1.1"
               , dependencyLocations = ["https://pub.dartlang.org"]
-              , dependencyEnvironments = [EnvDevelopment]
+              , dependencyEnvironments = Set.singleton EnvDevelopment
               , dependencyTags = Map.empty
               }
       toDependency (PackageName "pkg_a") pkg `shouldBe` expectedDependency
@@ -128,7 +129,7 @@ spec = do
               , dependencyName = "https://github.com/user/pkg"
               , dependencyVersion = Just $ CEq "release-0.9"
               , dependencyLocations = []
-              , dependencyEnvironments = []
+              , dependencyEnvironments = mempty
               , dependencyTags = Map.empty
               }
       toDependency (PackageName "pkg_b") pkg `shouldBe` expectedDependency
@@ -183,7 +184,7 @@ spec = do
             , dependencyName = "pkg_direct"
             , dependencyVersion = Nothing
             , dependencyLocations = ["some-url-1"]
-            , dependencyEnvironments = []
+            , dependencyEnvironments = mempty
             , dependencyTags = Map.empty
             }
         ]
@@ -195,7 +196,7 @@ spec = do
             , dependencyName = "pkg_direct"
             , dependencyVersion = Nothing
             , dependencyLocations = ["some-url-1"]
-            , dependencyEnvironments = []
+            , dependencyEnvironments = mempty
             , dependencyTags = Map.empty
             }
         , Dependency
@@ -203,7 +204,7 @@ spec = do
             , dependencyName = "pkg_deep"
             , dependencyVersion = Nothing
             , dependencyLocations = ["some-url-2"]
-            , dependencyEnvironments = []
+            , dependencyEnvironments = mempty
             , dependencyTags = Map.empty
             }
         ]

--- a/test/Dart/PubSpecSpec.hs
+++ b/test/Dart/PubSpecSpec.hs
@@ -4,6 +4,7 @@ module Dart.PubSpecSpec (
 
 import Data.ByteString qualified as BS
 import Data.Map.Strict qualified as Map
+import Data.Set qualified as Set
 import Data.Yaml (decodeEither')
 import DepTypes
 import GraphUtil (expectDeps, expectDirect, expectEdges)
@@ -75,7 +76,7 @@ spec = do
                 , dependencyName = "pkg_default"
                 , dependencyVersion = Just $ CEq "1.3.0"
                 , dependencyLocations = []
-                , dependencyEnvironments = [EnvProduction]
+                , dependencyEnvironments = Set.singleton EnvProduction
                 , dependencyTags = Map.empty
                 }
             , Dependency
@@ -83,7 +84,7 @@ spec = do
                 , dependencyName = "pkg_hosted"
                 , dependencyVersion = Just $ CEq "^1.0.0"
                 , dependencyLocations = ["http://pub.dev"]
-                , dependencyEnvironments = [EnvProduction]
+                , dependencyEnvironments = Set.singleton EnvProduction
                 , dependencyTags = Map.empty
                 }
             , Dependency
@@ -91,7 +92,7 @@ spec = do
                 , dependencyName = "https://github.com/user/pkg_a.git"
                 , dependencyVersion = Nothing
                 , dependencyLocations = []
-                , dependencyEnvironments = [EnvProduction]
+                , dependencyEnvironments = Set.singleton EnvProduction
                 , dependencyTags = Map.empty
                 }
             , Dependency
@@ -99,7 +100,7 @@ spec = do
                 , dependencyName = "pkg_dev_default"
                 , dependencyVersion = Just $ CEq "^1.0.0"
                 , dependencyLocations = []
-                , dependencyEnvironments = [EnvDevelopment]
+                , dependencyEnvironments = Set.singleton EnvDevelopment
                 , dependencyTags = Map.empty
                 }
             ]
@@ -136,7 +137,7 @@ spec = do
                 , dependencyName = "https://github.com/user/pkg_b"
                 , dependencyVersion = Just $ CEq "develop"
                 , dependencyLocations = []
-                , dependencyEnvironments = [EnvProduction]
+                , dependencyEnvironments = Set.singleton EnvProduction
                 , dependencyTags = Map.empty
                 }
             ]

--- a/test/Elixir/MixTreeSpec.hs
+++ b/test/Elixir/MixTreeSpec.hs
@@ -220,7 +220,7 @@ spec = do
   describe "buildGraph" $ do
     it "should identify dependency type correctly" $ do
       expectDep
-        (Dependency GitType "https://github.com/dep/one.git" Nothing ([]) ([]) Map.empty)
+        (Dependency GitType "https://github.com/dep/one.git" Nothing ([]) mempty Map.empty)
         ( buildGraph
             [ MixDep
                 { depName = PackageName "one"
@@ -233,7 +233,7 @@ spec = do
         )
 
       expectDep
-        (Dependency HexType "pkgZ" Nothing ([]) ([]) Map.empty)
+        (Dependency HexType "pkgZ" Nothing ([]) mempty Map.empty)
         ( buildGraph
             [ MixDep
                 { depName = PackageName "pkgZ"
@@ -247,7 +247,7 @@ spec = do
 
     it "should use git ref for version, when dependency is GitType" $ do
       expectDep
-        (Dependency GitType "https://github.com/some-url.git" (Just $ CEq "2a08250") ([]) ([]) Map.empty)
+        (Dependency GitType "https://github.com/some-url.git" (Just $ CEq "2a08250") ([]) mempty Map.empty)
         ( buildGraph
             ( [ MixDep
                   { depName = PackageName "pkgY"
@@ -273,7 +273,7 @@ spec = do
 
     it "should use locked ref for version, when locked ref exists" $ do
       expectDep
-        (Dependency HexType "pkgX" (Just $ CEq "2.0.1") ([]) ([]) Map.empty)
+        (Dependency HexType "pkgX" (Just $ CEq "2.0.1") ([]) mempty Map.empty)
         ( buildGraph
             ( [ MixDep
                   { depName = PackageName "pkgX"
@@ -299,7 +299,7 @@ spec = do
 
     it "should use version constraint for version, when locked ref or resolved version does not exists" $ do
       expectDep
-        (Dependency HexType "pkgW" (Just $ CCompatible "2.0") ([]) ([]) Map.empty)
+        (Dependency HexType "pkgW" (Just $ CCompatible "2.0") ([]) mempty Map.empty)
         ( buildGraph
             ( [ MixDep
                   { depName = PackageName "pkgW"
@@ -406,10 +406,10 @@ spec = do
               )
 
       let expectedDeps =
-            [ Dependency HexType "pkgParentA" (Just $ CEq "A") [] [] Map.empty
-            , Dependency HexType "pkgParentB" (Just $ CEq "B") [] [] Map.empty
-            , Dependency HexType "pkgChildC" (Just $ CEq "C") [] [] Map.empty
-            , Dependency HexType "pkgChildD" (Just $ CEq "D") [] [] Map.empty
+            [ Dependency HexType "pkgParentA" (Just $ CEq "A") [] mempty Map.empty
+            , Dependency HexType "pkgParentB" (Just $ CEq "B") [] mempty Map.empty
+            , Dependency HexType "pkgChildC" (Just $ CEq "C") [] mempty Map.empty
+            , Dependency HexType "pkgChildD" (Just $ CEq "D") [] mempty Map.empty
             ]
       let expectedEdges =
             [ (head expectedDeps, expectedDeps !! 1)

--- a/test/Erlang/Rebar3TreeSpec.hs
+++ b/test/Erlang/Rebar3TreeSpec.hs
@@ -20,7 +20,7 @@ dependencyOne =
     , dependencyName = "https://github.com/dep/one"
     , dependencyVersion = Just (CEq "1.0.0")
     , dependencyLocations = []
-    , dependencyEnvironments = []
+    , dependencyEnvironments = mempty
     , dependencyTags = Map.empty
     }
 
@@ -31,7 +31,7 @@ dependencyTwo =
     , dependencyName = "two"
     , dependencyVersion = Just (CEq "2.0.0")
     , dependencyLocations = []
-    , dependencyEnvironments = []
+    , dependencyEnvironments = mempty
     , dependencyTags = Map.empty
     }
 dependencyThree :: Dependency
@@ -41,7 +41,7 @@ dependencyThree =
     , dependencyName = "three"
     , dependencyVersion = Just (CEq "3.0.0")
     , dependencyLocations = []
-    , dependencyEnvironments = []
+    , dependencyEnvironments = mempty
     , dependencyTags = Map.empty
     }
 
@@ -52,7 +52,7 @@ dependencyFour =
     , dependencyName = "https://github.com/dep/four"
     , dependencyVersion = Just (CEq "4.0.0")
     , dependencyLocations = []
-    , dependencyEnvironments = []
+    , dependencyEnvironments = mempty
     , dependencyTags = Map.empty
     }
 
@@ -63,7 +63,7 @@ dependencyFive =
     , dependencyName = "five"
     , dependencyVersion = Just (CEq "5.0.0")
     , dependencyLocations = []
-    , dependencyEnvironments = []
+    , dependencyEnvironments = mempty
     , dependencyTags = Map.empty
     }
 

--- a/test/Go/GlideLockSpec.hs
+++ b/test/Go/GlideLockSpec.hs
@@ -22,7 +22,7 @@ expected = run . evalGrapher $ do
       , dependencyName = "github.com/pkg/one"
       , dependencyVersion = Just (CEq "1234")
       , dependencyLocations = []
-      , dependencyEnvironments = []
+      , dependencyEnvironments = mempty
       , dependencyTags = Map.empty
       }
   direct $
@@ -31,7 +31,7 @@ expected = run . evalGrapher $ do
       , dependencyName = "github.com/pkg/three/v3"
       , dependencyVersion = Just (CEq "4bd8")
       , dependencyLocations = []
-      , dependencyEnvironments = []
+      , dependencyEnvironments = mempty
       , dependencyTags = Map.empty
       }
 

--- a/test/Go/GoListSpec.hs
+++ b/test/Go/GoListSpec.hs
@@ -42,7 +42,7 @@ expected = run . evalGrapher $ do
       , dependencyName = "github.com/pkg/one"
       , dependencyVersion = Just (CEq "commithash")
       , dependencyLocations = []
-      , dependencyEnvironments = []
+      , dependencyEnvironments = mempty
       , dependencyTags = Map.empty
       }
   direct $
@@ -51,7 +51,7 @@ expected = run . evalGrapher $ do
       , dependencyName = "github.com/pkg/two"
       , dependencyVersion = Just (CEq "v2.0.0")
       , dependencyLocations = []
-      , dependencyEnvironments = []
+      , dependencyEnvironments = mempty
       , dependencyTags = Map.empty
       }
 

--- a/test/Go/GomodSpec.hs
+++ b/test/Go/GomodSpec.hs
@@ -28,7 +28,7 @@ dep name revision =
     , dependencyName = name
     , dependencyVersion = Just (CEq revision)
     , dependencyLocations = []
-    , dependencyEnvironments = []
+    , dependencyEnvironments = mempty
     , dependencyTags = Map.empty
     }
 

--- a/test/Go/GopkgLockSpec.hs
+++ b/test/Go/GopkgLockSpec.hs
@@ -40,7 +40,7 @@ expected = run . evalGrapher $ do
       , dependencyName = "repo/name/A"
       , dependencyVersion = Just (CEq "3012a1dbe2e4bd1391d42b32f0577cb7bbc7f005")
       , dependencyLocations = []
-      , dependencyEnvironments = []
+      , dependencyEnvironments = mempty
       , dependencyTags = Map.empty
       }
   direct $
@@ -49,7 +49,7 @@ expected = run . evalGrapher $ do
       , dependencyName = "repo/name/B"
       , dependencyVersion = Just (CEq "12345")
       , dependencyLocations = []
-      , dependencyEnvironments = []
+      , dependencyEnvironments = mempty
       , dependencyTags = Map.empty
       }
   direct $
@@ -58,7 +58,7 @@ expected = run . evalGrapher $ do
       , dependencyName = "repo/name/C"
       , dependencyVersion = Just (CEq "12345")
       , dependencyLocations = ["https://someotherlocation/"]
-      , dependencyEnvironments = []
+      , dependencyEnvironments = mempty
       , dependencyTags = Map.empty
       }
 

--- a/test/Go/GopkgTomlSpec.hs
+++ b/test/Go/GopkgTomlSpec.hs
@@ -65,7 +65,7 @@ expected = run . evalGrapher $ do
       , dependencyName = "cat/fossa"
       , dependencyVersion = Just (CEq "v3.0.0")
       , dependencyLocations = ["https://someotherlocation/"]
-      , dependencyEnvironments = []
+      , dependencyEnvironments = mempty
       , dependencyTags = Map.empty
       }
   direct $
@@ -74,7 +74,7 @@ expected = run . evalGrapher $ do
       , dependencyName = "repo/name/A"
       , dependencyVersion = Just (CEq "v1.0.0")
       , dependencyLocations = []
-      , dependencyEnvironments = []
+      , dependencyEnvironments = mempty
       , dependencyTags = Map.empty
       }
   direct $
@@ -83,7 +83,7 @@ expected = run . evalGrapher $ do
       , dependencyName = "repo/name/B"
       , dependencyVersion = Just (CEq "overridebranch")
       , dependencyLocations = []
-      , dependencyEnvironments = []
+      , dependencyEnvironments = mempty
       , dependencyTags = Map.empty
       }
   direct $
@@ -92,7 +92,7 @@ expected = run . evalGrapher $ do
       , dependencyName = "repo/name/C"
       , dependencyVersion = Just (CEq "branchname")
       , dependencyLocations = []
-      , dependencyEnvironments = []
+      , dependencyEnvironments = mempty
       , dependencyTags = Map.empty
       }
 

--- a/test/Go/TransitiveSpec.hs
+++ b/test/Go/TransitiveSpec.hs
@@ -155,7 +155,7 @@ fooDep =
     , dependencyName = "github.com/example/foo"
     , dependencyVersion = Nothing
     , dependencyLocations = []
-    , dependencyEnvironments = []
+    , dependencyEnvironments = mempty
     , dependencyTags = mempty
     }
 
@@ -166,7 +166,7 @@ barDep =
     , dependencyName = "github.com/example/bar"
     , dependencyVersion = Nothing
     , dependencyLocations = []
-    , dependencyEnvironments = []
+    , dependencyEnvironments = mempty
     , dependencyTags = mempty
     }
 
@@ -177,6 +177,6 @@ bazDep =
     , dependencyName = "github.com/example/baz"
     , dependencyVersion = Nothing
     , dependencyLocations = []
-    , dependencyEnvironments = []
+    , dependencyEnvironments = mempty
     , dependencyTags = mempty
     }

--- a/test/Googlesource/RepoManifestSpec.hs
+++ b/test/Googlesource/RepoManifestSpec.hs
@@ -7,6 +7,7 @@ module Googlesource.RepoManifestSpec (
 
 import Control.Carrier.Diagnostics hiding (withResult)
 import Data.Map.Strict qualified as Map
+import Data.Set qualified as Set
 import Data.String.Conversion (toString)
 import Data.Text.IO qualified as TIO
 import DepTypes
@@ -121,7 +122,7 @@ dependencyOne =
     , dependencyVersion = Just (CEq "refs/tags/android-10.0.0_r29")
     , dependencyLocations = ["https://android.googlesource.com/platform/art"]
     , dependencyTags = Map.empty
-    , dependencyEnvironments = [EnvProduction]
+    , dependencyEnvironments = Set.singleton EnvProduction
     }
 
 dependencyTwo :: Dependency
@@ -132,7 +133,7 @@ dependencyTwo =
     , dependencyVersion = Just (CEq "57b7d1574276f5e7f895c884df29f45859da74b6")
     , dependencyLocations = ["https://android.googlesource.com/platform/bionic"]
     , dependencyTags = Map.empty
-    , dependencyEnvironments = [EnvProduction]
+    , dependencyEnvironments = Set.singleton EnvProduction
     }
 
 dependencyThree :: Dependency
@@ -143,7 +144,7 @@ dependencyThree =
     , dependencyVersion = Just (CEq "google/android-6.0.1_r74")
     , dependencyLocations = ["https://android.othersource.com/platform/bootable/recovery"]
     , dependencyTags = Map.empty
-    , dependencyEnvironments = [EnvProduction]
+    , dependencyEnvironments = Set.singleton EnvProduction
     }
 
 dependencyFour :: Dependency
@@ -154,7 +155,7 @@ dependencyFour =
     , dependencyVersion = Just (CEq "1111")
     , dependencyLocations = ["https://android.othersource.com/platform/cts"]
     , dependencyTags = Map.empty
-    , dependencyEnvironments = [EnvProduction]
+    , dependencyEnvironments = Set.singleton EnvProduction
     }
 
 dependencyFive :: Dependency
@@ -165,7 +166,7 @@ dependencyFive =
     , dependencyVersion = Just (CEq "refs/tags/android-10.0.0_r29")
     , dependencyLocations = ["https://android.googlesource.com/platform/dalvik"]
     , dependencyTags = Map.empty
-    , dependencyEnvironments = [EnvProduction]
+    , dependencyEnvironments = Set.singleton EnvProduction
     }
 
 validatedProjectOne :: ValidatedProject

--- a/test/Gradle/GradleSpec.hs
+++ b/test/Gradle/GradleSpec.hs
@@ -4,6 +4,7 @@ module Gradle.GradleSpec (
 
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
+import Data.Set qualified as Set
 import Data.Text (Text)
 import DepTypes
 import GraphUtil
@@ -18,7 +19,7 @@ projectOne =
     , dependencyName = ":projectOne"
     , dependencyVersion = Nothing
     , dependencyLocations = []
-    , dependencyEnvironments = [EnvOther "config"]
+    , dependencyEnvironments = Set.singleton $ EnvOther "config"
     , dependencyTags = Map.empty
     }
 
@@ -29,7 +30,7 @@ projectTwo =
     , dependencyName = ":projectTwo"
     , dependencyVersion = Nothing
     , dependencyLocations = []
-    , dependencyEnvironments = [EnvDevelopment, EnvOther "config"]
+    , dependencyEnvironments = Set.fromList [EnvDevelopment, EnvOther "config"]
     , dependencyTags = Map.empty
     }
 
@@ -40,7 +41,7 @@ projectThree =
     , dependencyName = ":projectThree"
     , dependencyVersion = Nothing
     , dependencyLocations = []
-    , dependencyEnvironments = [EnvDevelopment, EnvTesting]
+    , dependencyEnvironments = Set.fromList [EnvDevelopment, EnvTesting]
     , dependencyTags = Map.empty
     }
 
@@ -51,7 +52,7 @@ packageOne =
     , dependencyName = "mygroup:packageOne"
     , dependencyVersion = Just (CEq "1.0.0")
     , dependencyLocations = []
-    , dependencyEnvironments = [EnvDevelopment]
+    , dependencyEnvironments = Set.singleton EnvDevelopment
     , dependencyTags = Map.empty
     }
 
@@ -62,7 +63,7 @@ packageTwo =
     , dependencyName = "mygroup:packageTwo"
     , dependencyVersion = Just (CEq "2.0.0")
     , dependencyLocations = []
-    , dependencyEnvironments = [EnvTesting]
+    , dependencyEnvironments = Set.singleton EnvTesting
     , dependencyTags = Map.empty
     }
 
@@ -73,7 +74,7 @@ mkProject name env =
     , dependencyName = name
     , dependencyVersion = Nothing
     , dependencyLocations = []
-    , dependencyEnvironments = [env, EnvOther "config"]
+    , dependencyEnvironments = Set.fromList [env, EnvOther "config"]
     , dependencyTags = Map.empty
     }
 
@@ -90,7 +91,7 @@ mkMavenDep name env =
     , dependencyName = name
     , dependencyVersion = Just (CEq "2.0.0")
     , dependencyLocations = []
-    , dependencyEnvironments = [env]
+    , dependencyEnvironments = Set.singleton env
     , dependencyTags = Map.empty
     }
 

--- a/test/Maven/DepTreeSpec.hs
+++ b/test/Maven/DepTreeSpec.hs
@@ -1,5 +1,6 @@
 module Maven.DepTreeSpec (spec) where
 
+import Data.Set qualified as Set
 import Data.Text (Text)
 import Data.Text.IO qualified as TextIO
 import DepTypes (
@@ -33,11 +34,46 @@ spec =
 
     it "should build dependency graph without project as dependency" $ do
       -- Setup
-      let depRngCore = Dependency MavenType "org.apache.commons:commons-rng-core" (Just $ CEq "1.4-SNAPSHOT") [] [EnvProduction] (mempty)
-      let depMath3 = Dependency MavenType "org.apache.commons:commons-math3" (Just $ CEq "3.6.1") [] [EnvTesting] (mempty)
-      let depJunit = Dependency MavenType "junit:junit" (Just $ CEq "4.13.1") [] [EnvTesting] (mempty)
-      let depRngClientApi = Dependency MavenType "org.apache.commons:commons-rng-client-api" (Just $ CEq "1.4-SNAPSHOT") [] [EnvProduction] (mempty)
-      let depHamcrestCore = Dependency MavenType "org.hamcrest:hamcrest-core" (Just $ CEq "1.3") [] [EnvTesting] (mempty)
+      let depRngCore =
+            Dependency
+              MavenType
+              "org.apache.commons:commons-rng-core"
+              (Just $ CEq "1.4-SNAPSHOT")
+              []
+              (Set.singleton EnvProduction)
+              (mempty)
+      let depMath3 =
+            Dependency
+              MavenType
+              "org.apache.commons:commons-math3"
+              (Just $ CEq "3.6.1")
+              []
+              (Set.singleton EnvTesting)
+              (mempty)
+      let depJunit =
+            Dependency
+              MavenType
+              "junit:junit"
+              (Just $ CEq "4.13.1")
+              []
+              (Set.singleton EnvTesting)
+              (mempty)
+      let depRngClientApi =
+            Dependency
+              MavenType
+              "org.apache.commons:commons-rng-client-api"
+              (Just $ CEq "1.4-SNAPSHOT")
+              []
+              (Set.singleton EnvProduction)
+              (mempty)
+      let depHamcrestCore =
+            Dependency
+              MavenType
+              "org.hamcrest:hamcrest-core"
+              (Just $ CEq "1.3")
+              []
+              (Set.singleton EnvTesting)
+              (mempty)
 
       -- Act
       let graph = buildGraph fixtureSingleGraph
@@ -75,7 +111,7 @@ spec =
               , dependencyName = "org.apache.commons:commons-rng-parent"
               , dependencyVersion = Just (CEq "1.4-SNAPSHOT")
               , dependencyLocations = []
-              , dependencyEnvironments = [EnvProduction]
+              , dependencyEnvironments = Set.singleton EnvProduction
               , dependencyTags = mempty
               }
       toDependency p `shouldBe` d

--- a/test/Maven/PluginStrategySpec.hs
+++ b/test/Maven/PluginStrategySpec.hs
@@ -3,6 +3,7 @@ module Maven.PluginStrategySpec (
 ) where
 
 import Data.Map.Strict qualified as Map
+import Data.Set qualified as Set
 import DepTypes
 import GraphUtil
 import Strategy.Maven.Plugin
@@ -16,7 +17,7 @@ packageOne =
     , dependencyName = "mygroup:packageOne"
     , dependencyVersion = Just (CEq "1.0.0")
     , dependencyLocations = []
-    , dependencyEnvironments = [EnvTesting]
+    , dependencyEnvironments = Set.singleton EnvTesting
     , dependencyTags = Map.fromList [("scopes", ["compile", "test"])]
     }
 
@@ -27,7 +28,7 @@ packageTwo =
     , dependencyName = "mygroup:packageTwo"
     , dependencyVersion = Just (CEq "2.0.0")
     , dependencyLocations = []
-    , dependencyEnvironments = []
+    , dependencyEnvironments = mempty
     , dependencyTags = Map.fromList [("scopes", ["compile"]), ("optional", ["true"])]
     }
 

--- a/test/Node/NpmLockSpec.hs
+++ b/test/Node/NpmLockSpec.hs
@@ -3,6 +3,7 @@ module Node.NpmLockSpec (
 ) where
 
 import Data.Map.Strict qualified as Map
+import Data.Set qualified as Set
 import DepTypes
 import GraphUtil
 import Strategy.Node.NpmLock
@@ -59,7 +60,7 @@ packageOne =
     , dependencyName = "packageOne"
     , dependencyVersion = Just (CEq "1.0.0")
     , dependencyLocations = ["https://example.com/one.tgz"]
-    , dependencyEnvironments = [EnvProduction]
+    , dependencyEnvironments = Set.singleton EnvProduction
     , dependencyTags = Map.empty
     }
 
@@ -70,7 +71,7 @@ packageTwo =
     , dependencyName = "packageTwo"
     , dependencyVersion = Just (CEq "2.0.0")
     , dependencyLocations = ["https://example.com/two.tgz"]
-    , dependencyEnvironments = [EnvDevelopment]
+    , dependencyEnvironments = Set.singleton EnvDevelopment
     , dependencyTags = Map.empty
     }
 
@@ -81,7 +82,7 @@ packageThree =
     , dependencyName = "packageThree"
     , dependencyVersion = Just (CEq "3.0.0")
     , dependencyLocations = []
-    , dependencyEnvironments = [EnvDevelopment]
+    , dependencyEnvironments = Set.singleton EnvDevelopment
     , dependencyTags = Map.empty
     }
 

--- a/test/Node/PackageJsonSpec.hs
+++ b/test/Node/PackageJsonSpec.hs
@@ -3,6 +3,7 @@ module Node.PackageJsonSpec (
 ) where
 
 import Data.Map.Strict qualified as Map
+import Data.Set qualified as Set
 import DepTypes
 import GraphUtil
 import Strategy.Node.PackageJson
@@ -22,7 +23,7 @@ packageOne =
     , dependencyName = "packageOne"
     , dependencyVersion = Just (CCompatible "^1.0.0")
     , dependencyLocations = []
-    , dependencyEnvironments = [EnvProduction]
+    , dependencyEnvironments = Set.singleton EnvProduction
     , dependencyTags = Map.empty
     }
 
@@ -33,7 +34,7 @@ packageTwo =
     , dependencyName = "packageTwo"
     , dependencyVersion = Just (CCompatible "^2.0.0")
     , dependencyLocations = []
-    , dependencyEnvironments = [EnvDevelopment]
+    , dependencyEnvironments = Set.singleton EnvDevelopment
     , dependencyTags = Map.empty
     }
 

--- a/test/NuGet/NuspecSpec.hs
+++ b/test/NuGet/NuspecSpec.hs
@@ -18,7 +18,7 @@ dependencyOne =
     , dependencyName = "one"
     , dependencyVersion = Just (CEq "1.0.0")
     , dependencyLocations = []
-    , dependencyEnvironments = []
+    , dependencyEnvironments = mempty
     , dependencyTags = Map.empty
     }
 
@@ -29,7 +29,7 @@ dependencyTwo =
     , dependencyName = "two"
     , dependencyVersion = Just (CEq "2.0.0")
     , dependencyLocations = []
-    , dependencyEnvironments = []
+    , dependencyEnvironments = mempty
     , dependencyTags = Map.empty
     }
 
@@ -40,7 +40,7 @@ dependencyThree =
     , dependencyName = "three"
     , dependencyVersion = Just (CEq "3.0.0")
     , dependencyLocations = []
-    , dependencyEnvironments = []
+    , dependencyEnvironments = mempty
     , dependencyTags = Map.empty
     }
 

--- a/test/NuGet/PackageReferenceSpec.hs
+++ b/test/NuGet/PackageReferenceSpec.hs
@@ -18,7 +18,7 @@ dependencyOne =
     , dependencyName = "one"
     , dependencyVersion = Just (CEq "1.0.0")
     , dependencyLocations = []
-    , dependencyEnvironments = []
+    , dependencyEnvironments = mempty
     , dependencyTags = Map.empty
     }
 
@@ -29,7 +29,7 @@ dependencyTwo =
     , dependencyName = "two"
     , dependencyVersion = Just (CEq "2.0.0")
     , dependencyLocations = []
-    , dependencyEnvironments = []
+    , dependencyEnvironments = mempty
     , dependencyTags = Map.empty
     }
 
@@ -40,7 +40,7 @@ dependencyThree =
     , dependencyName = "three"
     , dependencyVersion = Just (CEq "3.0.0")
     , dependencyLocations = []
-    , dependencyEnvironments = []
+    , dependencyEnvironments = mempty
     , dependencyTags = Map.empty
     }
 
@@ -51,7 +51,7 @@ dependencyFour =
     , dependencyName = "four"
     , dependencyVersion = Nothing
     , dependencyLocations = []
-    , dependencyEnvironments = []
+    , dependencyEnvironments = mempty
     , dependencyTags = Map.empty
     }
 

--- a/test/NuGet/PackagesConfigSpec.hs
+++ b/test/NuGet/PackagesConfigSpec.hs
@@ -18,7 +18,7 @@ dependencyOne =
     , dependencyName = "one"
     , dependencyVersion = Just (CEq "1.0.0")
     , dependencyLocations = []
-    , dependencyEnvironments = []
+    , dependencyEnvironments = mempty
     , dependencyTags = Map.empty
     }
 
@@ -29,7 +29,7 @@ dependencyTwo =
     , dependencyName = "two"
     , dependencyVersion = Just (CEq "2.0.0")
     , dependencyLocations = []
-    , dependencyEnvironments = []
+    , dependencyEnvironments = mempty
     , dependencyTags = Map.empty
     }
 

--- a/test/NuGet/PaketSpec.hs
+++ b/test/NuGet/PaketSpec.hs
@@ -17,7 +17,7 @@ dependencyOne =
     , dependencyName = "one"
     , dependencyVersion = Just (CEq "1.0.0")
     , dependencyLocations = ["nuget.com"]
-    , dependencyEnvironments = []
+    , dependencyEnvironments = mempty
     , dependencyTags = Map.fromList [("location", ["NUGET"]), ("group", ["MAIN"])]
     }
 
@@ -28,7 +28,7 @@ dependencyTwo =
     , dependencyName = "two"
     , dependencyVersion = Just (CEq "2.0.0")
     , dependencyLocations = ["nuget-v2.com", "nuget.com"]
-    , dependencyEnvironments = []
+    , dependencyEnvironments = mempty
     , dependencyTags = Map.fromList [("location", ["NUGET"]), ("group", ["MAIN", "TEST"])]
     }
 
@@ -39,7 +39,7 @@ dependencyThree =
     , dependencyName = "three"
     , dependencyVersion = Just (CEq "3.0.0")
     , dependencyLocations = ["custom-site.com"]
-    , dependencyEnvironments = []
+    , dependencyEnvironments = mempty
     , dependencyTags = Map.fromList [("location", ["HTTP"]), ("group", ["MAIN"])]
     }
 
@@ -50,7 +50,7 @@ dependencyFour =
     , dependencyName = "four"
     , dependencyVersion = Just (CEq "4.0.0")
     , dependencyLocations = ["nuget-v2.com"]
-    , dependencyEnvironments = []
+    , dependencyEnvironments = mempty
     , dependencyTags = Map.fromList [("location", ["NUGET"]), ("group", ["TEST"])]
     }
 
@@ -61,7 +61,7 @@ dependencyFive =
     , dependencyName = "five"
     , dependencyVersion = Just (CEq "5.0.0")
     , dependencyLocations = ["nuget-v2.com"]
-    , dependencyEnvironments = []
+    , dependencyEnvironments = mempty
     , dependencyTags = Map.fromList [("location", ["NUGET"]), ("group", ["TEST"])]
     }
 
@@ -72,7 +72,7 @@ dependencySix =
     , dependencyName = "six"
     , dependencyVersion = Just (CEq "6.0.0")
     , dependencyLocations = ["github.com"]
-    , dependencyEnvironments = []
+    , dependencyEnvironments = mempty
     , dependencyTags = Map.fromList [("location", ["GITHUB"]), ("group", ["TEST"])]
     }
 

--- a/test/NuGet/ProjectAssetsJsonSpec.hs
+++ b/test/NuGet/ProjectAssetsJsonSpec.hs
@@ -17,7 +17,7 @@ dependencyOne =
     , dependencyName = "one"
     , dependencyVersion = Just (CEq "1.0.0")
     , dependencyLocations = []
-    , dependencyEnvironments = []
+    , dependencyEnvironments = mempty
     , dependencyTags = Map.empty
     }
 
@@ -28,7 +28,7 @@ dependencyTwo =
     , dependencyName = "two"
     , dependencyVersion = Just (CEq "2.0.0")
     , dependencyLocations = []
-    , dependencyEnvironments = []
+    , dependencyEnvironments = mempty
     , dependencyTags = Map.empty
     }
 
@@ -39,7 +39,7 @@ dependencyThree =
     , dependencyName = "three"
     , dependencyVersion = Just (CEq "3.0.0")
     , dependencyLocations = []
-    , dependencyEnvironments = []
+    , dependencyEnvironments = mempty
     , dependencyTags = Map.empty
     }
 
@@ -50,7 +50,7 @@ dependencyFour =
     , dependencyName = "four"
     , dependencyVersion = Just (CEq "4.0.0")
     , dependencyLocations = []
-    , dependencyEnvironments = []
+    , dependencyEnvironments = mempty
     , dependencyTags = Map.empty
     }
 

--- a/test/NuGet/ProjectJsonSpec.hs
+++ b/test/NuGet/ProjectJsonSpec.hs
@@ -17,7 +17,7 @@ dependencyOne =
     , dependencyName = "one"
     , dependencyVersion = Just (CEq "1.0.0")
     , dependencyLocations = []
-    , dependencyEnvironments = []
+    , dependencyEnvironments = mempty
     , dependencyTags = Map.empty
     }
 
@@ -28,7 +28,7 @@ dependencyTwo =
     , dependencyName = "two"
     , dependencyVersion = Just (CCompatible "2.*")
     , dependencyLocations = []
-    , dependencyEnvironments = []
+    , dependencyEnvironments = mempty
     , dependencyTags = Map.empty
     }
 
@@ -39,7 +39,7 @@ dependencyThree =
     , dependencyName = "three"
     , dependencyVersion = Just (CEq "3.0.0")
     , dependencyLocations = []
-    , dependencyEnvironments = []
+    , dependencyEnvironments = mempty
     , dependencyTags = Map.fromList [("type", ["sometype"])]
     }
 

--- a/test/Python/PipenvSpec.hs
+++ b/test/Python/PipenvSpec.hs
@@ -5,6 +5,7 @@ module Python.PipenvSpec (
 import Data.Aeson (eitherDecodeStrict)
 import Data.ByteString qualified as BS
 import Data.Map.Strict qualified as Map
+import Data.Set qualified as Set
 import DepTypes
 import GraphUtil
 import Strategy.Python.Pipenv
@@ -86,7 +87,7 @@ depOne =
     , dependencyName = "pkgOne"
     , dependencyVersion = Just (CEq "1.0.0")
     , dependencyLocations = []
-    , dependencyEnvironments = [EnvDevelopment]
+    , dependencyEnvironments = Set.singleton EnvDevelopment
     , dependencyTags = Map.empty
     }
 
@@ -97,7 +98,7 @@ depTwo =
     , dependencyName = "pkgTwo"
     , dependencyVersion = Just (CEq "2.0.0")
     , dependencyLocations = ["https://my-package-index/"]
-    , dependencyEnvironments = [EnvProduction]
+    , dependencyEnvironments = Set.singleton EnvProduction
     , dependencyTags = Map.empty
     }
 
@@ -108,7 +109,7 @@ depThree =
     , dependencyName = "pkgThree"
     , dependencyVersion = Just (CEq "3.0.0")
     , dependencyLocations = []
-    , dependencyEnvironments = [EnvProduction]
+    , dependencyEnvironments = Set.singleton EnvProduction
     , dependencyTags = Map.empty
     }
 
@@ -119,7 +120,7 @@ depFour =
     , dependencyName = "pkgFour"
     , dependencyVersion = Nothing
     , dependencyLocations = []
-    , dependencyEnvironments = [EnvProduction]
+    , dependencyEnvironments = Set.singleton EnvProduction
     , dependencyTags = Map.empty
     }
 

--- a/test/Python/Poetry/CommonSpec.hs
+++ b/test/Python/Poetry/CommonSpec.hs
@@ -3,6 +3,7 @@ module Python.Poetry.CommonSpec (
 ) where
 
 import Data.Map qualified as Map
+import Data.Set qualified as Set
 import Data.Text (Text)
 import Data.Text.IO qualified as TIO
 import DepTypes (DepEnvironment (..), DepType (..), Dependency (..), VerConstraint (..))
@@ -134,12 +135,12 @@ expectedDeps =
   , dep PipType "pytest" Nothing devEnvs
   ]
   where
-    dep :: DepType -> Text -> Maybe VerConstraint -> [DepEnvironment] -> Dependency
-    dep t n v e = Dependency t n v [] e Map.empty
-    prodEnvs :: [DepEnvironment]
-    prodEnvs = [EnvProduction]
-    devEnvs :: [DepEnvironment]
-    devEnvs = [EnvDevelopment]
+    dep :: DepType -> Text -> Maybe VerConstraint -> DepEnvironment -> Dependency
+    dep t n v e = Dependency t n v [] (Set.singleton e) Map.empty
+    prodEnvs :: DepEnvironment
+    prodEnvs = EnvProduction
+    devEnvs :: DepEnvironment
+    devEnvs = EnvDevelopment
 
 spec :: Spec
 spec = do
@@ -201,7 +202,7 @@ spec = do
                 , dependencyName = "pkgOne"
                 , dependencyVersion = Just $ CEq "1.21.0"
                 , dependencyLocations = []
-                , dependencyEnvironments = [EnvProduction]
+                , dependencyEnvironments = Set.singleton EnvProduction
                 , dependencyTags = Map.empty
                 }
             )
@@ -228,7 +229,7 @@ spec = do
                   , dependencyName = "https://github.com/someUser/pkgWithGitSource.git"
                   , dependencyVersion = Just $ CEq "v1.1.1"
                   , dependencyLocations = []
-                  , dependencyEnvironments = [EnvProduction]
+                  , dependencyEnvironments = Set.singleton EnvProduction
                   , dependencyTags = Map.empty
                   }
               )
@@ -255,7 +256,7 @@ spec = do
                   , dependencyName = "https://some-url.com/some-dir/pkgThree-3.92.1.tar.gz"
                   , dependencyVersion = Just $ CEq "3.92.1"
                   , dependencyLocations = []
-                  , dependencyEnvironments = [EnvProduction]
+                  , dependencyEnvironments = Set.singleton EnvProduction
                   , dependencyTags = Map.empty
                   }
               )
@@ -297,7 +298,7 @@ spec = do
                   , dependencyName = "myprivatepkg"
                   , dependencyVersion = Just $ CEq "0.0.1"
                   , dependencyLocations = ["https://gitlab.com/api/v4/projects/packages/pypi/simple"]
-                  , dependencyEnvironments = [EnvProduction]
+                  , dependencyEnvironments = Set.singleton EnvProduction
                   , dependencyTags = Map.empty
                   }
               )

--- a/test/Python/PoetrySpec.hs
+++ b/test/Python/PoetrySpec.hs
@@ -15,6 +15,7 @@ import Strategy.Python.Poetry.PoetryLock (
   PoetryMetadata (..),
  )
 
+import Data.Set qualified as Set
 import Strategy.Python.Poetry.PyProject (PoetryDependency (..), PyProject (..), PyProjectBuildSystem (..), PyProjectPoetry (..))
 import Test.Hspec
 
@@ -53,18 +54,18 @@ candidatePoetryLock =
 expectedGraph :: Graphing Dependency
 expectedGraph =
   Graphing.edge
-    (Dependency PipType "flow_pipes" (Just $ CEq "1.21.0") [] [EnvProduction] Map.empty)
-    (Dependency PipType "flow_pipes_gravity" (Just $ CEq "1.1.1") [] [EnvProduction] Map.empty)
-    <> Graphing.direct (Dependency PipType "flow_pipes" (Just $ CEq "1.21.0") [] [EnvProduction] Map.empty)
+    (Dependency PipType "flow_pipes" (Just $ CEq "1.21.0") [] (Set.singleton EnvProduction) Map.empty)
+    (Dependency PipType "flow_pipes_gravity" (Just $ CEq "1.1.1") [] (Set.singleton EnvProduction) Map.empty)
+    <> Graphing.direct (Dependency PipType "flow_pipes" (Just $ CEq "1.21.0") [] (Set.singleton EnvProduction) Map.empty)
 
 expectedGraphWithNoDeps :: Graphing Dependency
-expectedGraphWithNoDeps = Graphing.deep (Dependency PipType "somePkg" (Just $ CEq "1.21.0") [] [EnvProduction] Map.empty)
+expectedGraphWithNoDeps = Graphing.deep (Dependency PipType "somePkg" (Just $ CEq "1.21.0") [] (Set.singleton EnvProduction) Map.empty)
 
 expectedGraphWithDeps :: Graphing Dependency
 expectedGraphWithDeps =
   Graphing.edge
-    (Dependency PipType "somePkg" (Just $ CEq "1.21.0") [] [EnvProduction] Map.empty)
-    (Dependency PipType "pkgOneChildOne" (Just $ CEq "1.22.0") [] [EnvProduction] Map.empty)
+    (Dependency PipType "somePkg" (Just $ CEq "1.21.0") [] (Set.singleton EnvProduction) Map.empty)
+    (Dependency PipType "pkgOneChildOne" (Just $ CEq "1.22.0") [] (Set.singleton EnvProduction) Map.empty)
 
 spec :: Spec
 spec = do

--- a/test/Python/ReqTxtSpec.hs
+++ b/test/Python/ReqTxtSpec.hs
@@ -42,7 +42,7 @@ expected = run . evalGrapher $ do
                 (CLess "2.0.0")
             )
       , dependencyLocations = []
-      , dependencyEnvironments = []
+      , dependencyEnvironments = mempty
       , dependencyTags = Map.empty
       }
   direct $
@@ -51,7 +51,7 @@ expected = run . evalGrapher $ do
       , dependencyName = "pkgTwo"
       , dependencyVersion = Nothing
       , dependencyLocations = []
-      , dependencyEnvironments = []
+      , dependencyEnvironments = mempty
       , dependencyTags = Map.empty
       }
   direct $
@@ -60,7 +60,7 @@ expected = run . evalGrapher $ do
       , dependencyName = "pkgThree"
       , dependencyVersion = Just (CURI "https://example.com")
       , dependencyLocations = []
-      , dependencyEnvironments = []
+      , dependencyEnvironments = mempty
       , dependencyTags = Map.empty
       }
 

--- a/test/Python/RequirementsSpec.hs
+++ b/test/Python/RequirementsSpec.hs
@@ -41,7 +41,7 @@ depOne =
     , dependencyName = "one"
     , dependencyVersion = Just (CEq "1.0")
     , dependencyLocations = []
-    , dependencyEnvironments = []
+    , dependencyEnvironments = mempty
     , dependencyTags = Map.empty
     }
 
@@ -52,7 +52,7 @@ depTwo =
     , dependencyName = "two"
     , dependencyVersion = Just (CLessOrEq "2.0.0")
     , dependencyLocations = []
-    , dependencyEnvironments = []
+    , dependencyEnvironments = mempty
     , dependencyTags = Map.empty
     }
 
@@ -63,7 +63,7 @@ depThree =
     , dependencyName = "three"
     , dependencyVersion = Just (CEq "3.0.0")
     , dependencyLocations = []
-    , dependencyEnvironments = []
+    , dependencyEnvironments = mempty
     , dependencyTags = Map.empty
     }
 
@@ -74,7 +74,7 @@ depFour =
     , dependencyName = "four"
     , dependencyVersion = Just (CEq "4.0.0")
     , dependencyLocations = []
-    , dependencyEnvironments = []
+    , dependencyEnvironments = mempty
     , dependencyTags = Map.empty
     }
 

--- a/test/Python/SetupPySpec.hs
+++ b/test/Python/SetupPySpec.hs
@@ -42,7 +42,7 @@ expected = run . evalGrapher $ do
                 (CLess "2.0.0")
             )
       , dependencyLocations = []
-      , dependencyEnvironments = []
+      , dependencyEnvironments = mempty
       , dependencyTags = Map.empty
       }
   direct $
@@ -51,7 +51,7 @@ expected = run . evalGrapher $ do
       , dependencyName = "pkgTwo"
       , dependencyVersion = Nothing
       , dependencyLocations = []
-      , dependencyEnvironments = []
+      , dependencyEnvironments = mempty
       , dependencyTags = Map.empty
       }
   direct $
@@ -60,7 +60,7 @@ expected = run . evalGrapher $ do
       , dependencyName = "pkgThree"
       , dependencyVersion = Just (CURI "https://example.com")
       , dependencyLocations = []
-      , dependencyEnvironments = []
+      , dependencyEnvironments = mempty
       , dependencyTags = Map.empty
       }
 

--- a/test/Ruby/BundleShowSpec.hs
+++ b/test/Ruby/BundleShowSpec.hs
@@ -21,7 +21,7 @@ expected = run . evalGrapher $ do
       , dependencyName = "pkgOne"
       , dependencyVersion = Just (CEq "1.0.0")
       , dependencyLocations = []
-      , dependencyEnvironments = []
+      , dependencyEnvironments = mempty
       , dependencyTags = Map.empty
       }
   direct $
@@ -30,7 +30,7 @@ expected = run . evalGrapher $ do
       , dependencyName = "pkgTwo"
       , dependencyVersion = Just (CEq "2.0.0")
       , dependencyLocations = []
-      , dependencyEnvironments = []
+      , dependencyEnvironments = mempty
       , dependencyTags = Map.empty
       }
 

--- a/test/Ruby/GemfileLockSpec.hs
+++ b/test/Ruby/GemfileLockSpec.hs
@@ -17,7 +17,7 @@ dependencyOne =
     , dependencyName = "dep-one"
     , dependencyVersion = Just (CEq "1.0.0")
     , dependencyLocations = ["temp@12345"]
-    , dependencyEnvironments = []
+    , dependencyEnvironments = mempty
     , dependencyTags = Map.empty
     }
 
@@ -28,7 +28,7 @@ dependencyTwo =
     , dependencyName = "dep-two"
     , dependencyVersion = Just (CEq "2.0.0")
     , dependencyLocations = ["remote"]
-    , dependencyEnvironments = []
+    , dependencyEnvironments = mempty
     , dependencyTags = Map.empty
     }
 
@@ -39,7 +39,7 @@ dependencyThree =
     , dependencyName = "dep-three"
     , dependencyVersion = Just (CEq "3.0.0")
     , dependencyLocations = ["remote"]
-    , dependencyEnvironments = []
+    , dependencyEnvironments = mempty
     , dependencyTags = Map.empty
     }
 

--- a/test/Swift/PackageSwiftSpec.hs
+++ b/test/Swift/PackageSwiftSpec.hs
@@ -86,9 +86,9 @@ spec = do
   describe "buildGraph, when no resolved content is discovered" $ do
     it "should use git dependency type, when constraint is of branch, revision, or exact type" $ do
       let expectedDeps =
-            [ Dependency GitType "some-url" (CEq <$> Just "some-ref") [] [] Map.empty
-            , Dependency GitType "some-url" (CEq <$> Just "some-branch") [] [] Map.empty
-            , Dependency GitType "some-url" (CEq <$> Just "1.0.0") [] [] Map.empty
+            [ Dependency GitType "some-url" (CEq <$> Just "some-ref") [] mempty Map.empty
+            , Dependency GitType "some-url" (CEq <$> Just "some-branch") [] mempty Map.empty
+            , Dependency GitType "some-url" (CEq <$> Just "1.0.0") [] mempty Map.empty
             ]
       let graph =
             buildGraph
@@ -120,12 +120,12 @@ spec = do
               )
               Nothing
       let expectedDeps =
-            [ Dependency SwiftType "some-url-dep" Nothing [] [] Map.empty
-            , Dependency SwiftType "some-url-dep" (CEq <$> Just "^3.0.0") [] [] Map.empty
-            , Dependency SwiftType "some-url-dep" (CEq <$> Just "^2.0.0") [] [] Map.empty
-            , Dependency SwiftType "some-url-dep" (CEq <$> Just "~1.0.0") [] [] Map.empty
-            , Dependency SwiftType "some-url-dep" (CEq <$> Just ">=2.5.0 <2.5.6") [] [] Map.empty
-            , Dependency SwiftType "some-url-dep" (CEq <$> Just ">=3.0.5 <=3.0.7") [] [] Map.empty
+            [ Dependency SwiftType "some-url-dep" Nothing [] mempty Map.empty
+            , Dependency SwiftType "some-url-dep" (CEq <$> Just "^3.0.0") [] mempty Map.empty
+            , Dependency SwiftType "some-url-dep" (CEq <$> Just "^2.0.0") [] mempty Map.empty
+            , Dependency SwiftType "some-url-dep" (CEq <$> Just "~1.0.0") [] mempty Map.empty
+            , Dependency SwiftType "some-url-dep" (CEq <$> Just ">=2.5.0 <2.5.6") [] mempty Map.empty
+            , Dependency SwiftType "some-url-dep" (CEq <$> Just ">=3.0.5 <=3.0.7") [] mempty Map.empty
             ]
       expectDirect expectedDeps graph
       expectDeps expectedDeps graph
@@ -134,10 +134,10 @@ spec = do
   describe "buildGraph, when resolved content is discovered" $ do
     it "should use git dependency type, when constraint is of branch, revision, or exact type" $ do
       let expectedDirectDeps =
-            [ Dependency GitType "dep-A" (CEq <$> Just "some-rev-A") [] [] Map.empty
-            , Dependency GitType "dep-B" (CEq <$> Just "some-rev-B") [] [] Map.empty
+            [ Dependency GitType "dep-A" (CEq <$> Just "some-rev-A") [] mempty Map.empty
+            , Dependency GitType "dep-B" (CEq <$> Just "some-rev-B") [] mempty Map.empty
             ]
-      let expectedDeepDeps = [Dependency GitType "dep-A-C" (CEq <$> Just "5.1.0") [] [] Map.empty]
+      let expectedDeepDeps = [Dependency GitType "dep-A-C" (CEq <$> Just "5.1.0") [] mempty Map.empty]
 
       let graph =
             buildGraph

--- a/test/Swift/Xcode/PbxprojSpec.hs
+++ b/test/Swift/Xcode/PbxprojSpec.hs
@@ -60,10 +60,10 @@ makeXCRSwiftRef :: SwiftPackageGitDepRequirement -> XCRemoteSwiftPackageReferenc
 makeXCRSwiftRef = XCRemoteSwiftPackageReference mockUrl
 
 makeGitDep :: Text -> Text -> Dependency
-makeGitDep name c = Dependency GitType name (CEq <$> Just c) [] [] Map.empty
+makeGitDep name c = Dependency GitType name (CEq <$> Just c) [] mempty Map.empty
 
 makeSwiftDep :: Text -> Text -> Dependency
-makeSwiftDep name c = Dependency SwiftType name (CEq <$> Just c) [] [] Map.empty
+makeSwiftDep name c = Dependency SwiftType name (CEq <$> Just c) [] mempty Map.empty
 
 spec :: Spec
 spec = do

--- a/test/Yarn/V2/LockfileSpec.hs
+++ b/test/Yarn/V2/LockfileSpec.hs
@@ -180,7 +180,7 @@ underscoreFromGitDep =
     { dependencyType = GitType
     , dependencyName = "https://github.com/jashkenas/underscore.git"
     , dependencyVersion = Just (CEq "cbb48b79fc1205aa04feb03dbc055cdd28a12652")
-    , dependencyEnvironments = []
+    , dependencyEnvironments = mempty
     , dependencyLocations = []
     , dependencyTags = Map.empty
     }
@@ -191,7 +191,7 @@ underscoreFromNpmDep =
     { dependencyType = NodeJSType
     , dependencyName = "underscore"
     , dependencyVersion = Just (CEq "1.13.1")
-    , dependencyEnvironments = []
+    , dependencyEnvironments = mempty
     , dependencyLocations = []
     , dependencyTags = Map.empty
     }

--- a/test/Yarn/YarnLockV1Spec.hs
+++ b/test/Yarn/YarnLockV1Spec.hs
@@ -18,7 +18,7 @@ packageOne =
     , dependencyName = "packageOne"
     , dependencyVersion = Just (CEq "1.0.0")
     , dependencyLocations = ["https://registry.npmjs.org/packageOne"]
-    , dependencyEnvironments = []
+    , dependencyEnvironments = mempty
     , dependencyTags = Map.empty
     }
 
@@ -29,7 +29,7 @@ packageTwo =
     , dependencyName = "packageTwo"
     , dependencyVersion = Just (CEq "2.0.0")
     , dependencyLocations = ["https://registry.npmjs.org/packageTwo"]
-    , dependencyEnvironments = []
+    , dependencyEnvironments = mempty
     , dependencyTags = Map.empty
     }
 
@@ -40,7 +40,7 @@ packageThree =
     , dependencyName = "packageThree"
     , dependencyVersion = Just (CEq "3.0.0")
     , dependencyLocations = ["https://registry.npmjs.org/packageThree"]
-    , dependencyEnvironments = []
+    , dependencyEnvironments = mempty
     , dependencyTags = Map.empty
     }
 
@@ -51,7 +51,7 @@ packageFour =
     , dependencyName = "packageFour"
     , dependencyVersion = Just (CEq "4.0.0")
     , dependencyLocations = ["https://registry.npmjs.org/packageFour"]
-    , dependencyEnvironments = []
+    , dependencyEnvironments = mempty
     , dependencyTags = Map.empty
     }
 
@@ -62,7 +62,7 @@ packageFive =
     , dependencyName = "packageFive"
     , dependencyVersion = Just (CEq "5.0.0")
     , dependencyLocations = ["https://someurl.io/somefile.gz"]
-    , dependencyEnvironments = []
+    , dependencyEnvironments = mempty
     , dependencyTags = Map.empty
     }
 


### PR DESCRIPTION
# Overview

Change `dependencyEnvironments` to be a `Set`, as opposed to a list.  This is needed for #374.

Part of the work for fossas/team-analysis#707

This change is REALLY simple, and only has one logical change, which is to use `Set` instead of list, but we use this everywhere, so the diff seems huge.

## Checklist

- [x] I added tests for this PR's change (or confirmed tests are not viable).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] I linked this PR to any referenced GitHub issues, if they exist.
