### PR TITLE
Adds composer docs

### DIFF
--- a/docs/strategies/composer.md
+++ b/docs/strategies/composer.md
@@ -1,0 +1,57 @@
+# Composer Analysis
+
+When developing in PHP, the [composer](https://getcomposer.org/) is most commonly used to manage dependencies.
+
+| Strategy      | Direct Deps        | Deep Deps          | Edges              | Classifies Dev Dependencies |
+| ------------- | ------------------ | ------------------ | ------------------ | --------------------------- |
+| composer.lock | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark:          |
+
+## Project Discovery
+
+Find a file named `composer.lock`.
+
+## Analysis
+
+1. Parse `composer.lock` to identify direct and deep dependencies.
+
+## Example 
+
+1. Execute `composer init` to create a new project or create `composer.json` manually:
+
+Example composer.json:
+```json
+{
+    "name": "fossa/php-project",
+    "description": "example php project",
+    "require": {
+        "michelf/php-markdown": "^1.9"
+    },
+    "require-dev": {
+        "webmozart/assert": "^1.10"
+    },
+    "authors": [
+        {
+            "name": "Megh",
+            "email": "megh@fossa.com"
+        }
+    ]
+}
+```
+
+3. Execute `composer update` to install and pin dependencies - this will create (or modify) composer.lock file.
+4. Execute `fossa analyze -o` on the project to print analyzed dependency graphing (this will not upload any analysis to any endpoint)
+
+## FAQ
+
+### How do I *only perform analysis* for the composer?
+
+You can explicitly specify an analysis target in `.fossa.yml` file. The example below will exclude all analysis targets except for the composer. 
+
+```yaml
+# .fossa.yml 
+
+version: 3
+targets:
+  only:
+    - type: composer
+```

--- a/docs/strategies/composer.md
+++ b/docs/strategies/composer.md
@@ -1,6 +1,6 @@
 # Composer Analysis
 
-When developing in PHP, the [composer](https://getcomposer.org/) is most commonly used to manage dependencies.
+When developing in PHP, [composer](https://getcomposer.org/) is commonly used to manage dependencies.
 
 | Strategy      | Direct Deps        | Deep Deps          | Edges              | Classifies Dev Dependencies |
 | ------------- | ------------------ | ------------------ | ------------------ | --------------------------- |
@@ -38,7 +38,7 @@ Example composer.json:
 }
 ```
 
-3. Execute `composer update` to install and pin dependencies - this will create (or modify) composer.lock file.
+3. Execute `composer update` to install and pin dependencies - this will create (or modify) the `composer.lock` file.
 4. Execute `fossa analyze -o` on the project to print analyzed dependency graphing (this will not upload any analysis to any endpoint)
 
 ## FAQ

--- a/docs/userguide.md
+++ b/docs/userguide.md
@@ -17,6 +17,7 @@
   - [javascript/typescript](#javascripttypescript)
   - [.NET](#net)
   - [objective-c](#objective-c)
+  - [php](#php)
   - [python](#python)
   - [ruby](#ruby)
   - [rust](#rust)
@@ -128,6 +129,10 @@ fossa analyze --help
 
 - [carthage](quickreference/carthage.md)
 - [cocoapods](quickreference/cocoapods.md)
+
+### php
+
+- [composer](strategies/composer.md)
 
 ### python
 

--- a/test/GraphingSpec.hs
+++ b/test/GraphingSpec.hs
@@ -12,7 +12,7 @@ spec = do
   describe "unfold" $ do
     it "should unfold deeply" $ do
       let graph :: Graphing Int
-          graph = unfold [10] (\x -> if x > 0 then [x -2] else []) id
+          graph = unfold [10] (\x -> if x > 0 then [x - 2] else []) id
 
       expectDirect [10] graph
       expectDeps [10, 8, 6, 4, 2, 0] graph
@@ -29,7 +29,7 @@ spec = do
   describe "promoteToDirect" $ do
     it "should promote nodes to direct" $ do
       let graph :: Graphing Int
-          graph = Graphing.promoteToDirect (< 5) (unfold [10] (\x -> if x > 0 then [x -2] else []) id)
+          graph = Graphing.promoteToDirect (< 5) (unfold [10] (\x -> if x > 0 then [x - 2] else []) id)
       expectDirect [0, 2, 4, 10] graph
       expectDeps [10, 8, 6, 4, 2, 0] graph
       expectEdges [(10, 8), (8, 6), (6, 4), (4, 2), (2, 0)] graph


### PR DESCRIPTION
# Overview

Adds missing composer docs for PHP integration.

## Acceptance criteria

- Composer strategy docs are in referenced in user guide
- Composer strategy docs describe discovery, and provide an example

## Testing plan

N/A

## Risks

N/A

## References

Closes https://github.com/fossas/team-analysis/issues/759

## Checklist

- [x] I added tests for this PR's change (or confirmed tests are not viable).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] I linked this PR to any referenced GitHub issues, if they exist.
