### PR TITLE
Silence errors if commands fail but work as root

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -48,13 +48,13 @@ execute() {
   srcdir="${tmpdir}"
   (cd "${tmpdir}" && unzip -o "${TARBALL}")
   log_debug "setting up bindir: $BINDIR"
-  mkdir -p $BINDIR || sudo mkdir -p $BINDIR
+  mkdir -p "$BINDIR" 2> /dev/null || sudo mkdir -p "$BINDIR"
   for binexe in "fossa" ; do
     if [ "$OS" = "windows" ]; then
       binexe="${binexe}.exe"
     fi
     log_debug "installing binary: $binexe"
-    cp "${srcdir}/${binexe}" "${BINDIR}/${binexe}" || sudo cp "${srcdir}/${binexe}" "${BINDIR}/${binexe}"
+    cp "${srcdir}/${binexe}" "${BINDIR}/" 2> /dev/null || sudo cp "${srcdir}/${binexe}" "${BINDIR}/"
     log_info "installed ${BINDIR}/${binexe}"
   done
 }


### PR DESCRIPTION
# Overview

Closes https://github.com/fossas/spectrometer/issues/390. Mimics the same behavior as fossa-cli.

## Acceptance criteria

Avoid displaying contradictory error messages to users.

## Testing plan

_How did you validate that this PR works? How did you check that the acceptance criteria were fulfilled?_

On a Unix system with a user that has a non-empty `sudo` password, run install.sh twice. Tested on Ubuntu 20.04 (WSL2).

## Risks

¯\\\_(ツ)_/¯

## References

Closes https://github.com/fossas/spectrometer/issues/390.

## Checklist

- [x] ~~I added tests for this PR's change~~ (or confirmed tests are not viable).
- [x] ~If this PR introduced a user-visible change, I added documentation into `docs/`.~
- [x] ~I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.~
- [x] I linked this PR to any referenced GitHub issues, if they exist.
