### PR TITLE
Prepend PATH in current shell on Windows install

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -70,12 +70,12 @@ Expand-Archive -Path $zipFile -DestinationPath $extractDir -Force
 $ErrorActionPreference = $OldEAP
 
 $fossa = "$extractDir\fossa.exe"
-$env:Path += ";$extractDir"
+$env:Path = "$extractDir;" + $env:Path
 Write-Host "The fossa-cli installation directory has been added to the PATH for this session."
 
 Write-Host "Installed fossa at: $fossa"
 Write-Host "Get started by running: fossa.exe --help"
 
-Write-Host "Running fossa.exe --version"
+Write-Host "Running $fossa --version"
 # Doesn't run without '&', seems to tell PS to treat the output as a command
 & $fossa --version


### PR DESCRIPTION
# Overview

Improves the installation UX on Windows for users that have already installed fossa-cli. This is done by prepending Spectrometer's install directory to the user's PATH (highest priority) instead of appending it. This is a low risk change as it only affects the user's currently running shell, not their stored profile preferences.

Also makes it explicit which `fossa.exe` is being run by the installer by printing its full path.

## Acceptance criteria

If a Windows user with fossa-cli installs Spectrometer and immediately tries to run `fossa`, it should run Spectrometer and not fossa-cli.

## Testing plan

Make sure your PowerShell profile (i.e. `notepad $profile`) includes the fossa-cli installation directory:

```powershell
$env:Path += ";$env:ProgramData\fossa-cli"
```

Before this change:

```
PS C:\Users\Rodrigo\source\fossa\spectrometer> fossa --version
fossa-cli version 1.1.10 (revision 7013d3b0203df9e648cd25466cac4913e54452cc compiled with go version go1.16.5 linux/amd64)
PS C:\Users\Rodrigo\source\fossa\spectrometer> .\install.ps1
The fossa-cli installation directory has been added to the PATH for this session.
Installed fossa at: C:\Users\Rodrigo\AppData\Local\fossa-cli\fossa.exe
Get started by running: fossa.exe --help
Running fossa.exe --version
spectrometer: version 2.17.0 (revision 79853b7dd651 compiled with ghc-8.10)
PS C:\Users\Rodrigo\source\fossa\spectrometer> fossa --version
fossa-cli version 1.1.10 (revision 7013d3b0203df9e648cd25466cac4913e54452cc compiled with go version go1.16.5 linux/amd64)
```

After:

```
PS C:\Users\Rodrigo\source\fossa\spectrometer> fossa --version
fossa-cli version 1.1.10 (revision 7013d3b0203df9e648cd25466cac4913e54452cc compiled with go version go1.16.5 linux/amd64)
PS C:\Users\Rodrigo\source\fossa\spectrometer> .\install.ps1                                                                         The fossa-cli installation directory has been added to the PATH for this session.
Installed fossa at: C:\Users\Rodrigo\AppData\Local\fossa-cli\fossa.exe
Get started by running: fossa.exe --help
Running C:\Users\Rodrigo\AppData\Local\fossa-cli\fossa.exe --version
spectrometer: version 2.17.0 (revision 79853b7dd651 compiled with ghc-8.10)
PS C:\Users\Rodrigo\source\fossa\spectrometer> fossa --version
spectrometer: version 2.17.0 (revision 79853b7dd651 compiled with ghc-8.10)
```

## Risks

N/A

## References

Closes https://github.com/fossas/spectrometer/issues/394.

## Checklist

- [x] ~I added tests for this PR's change~ (or confirmed tests are not viable).
- [x] ~If this PR introduced a user-visible change, I added documentation into `docs/`.~
- [x] ~I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.~
- [x] I linked this PR to any referenced GitHub issues, if they exist.
