### PR TITLE
Discovered binaries reports origin path

### DIFF
--- a/src/App/Fossa/BinaryDeps.hs
+++ b/src/App/Fossa/BinaryDeps.hs
@@ -16,7 +16,7 @@ import Discovery.Walk (WalkStep (WalkContinue), walk')
 import Effect.Logger (Logger)
 import Effect.ReadFS (ReadFS, readContentsBSLimit)
 import Path (Abs, Dir, File, Path, isProperPrefixOf, (</>))
-import Path.Extra (renderRelative)
+import Path.Extra (renderSomeBase, tryMakeRelative)
 import Srclib.Converter qualified as Srclib
 import Srclib.Types (AdditionalDepData (..), SourceUnit (..), SourceUserDefDep (..))
 import Types (GraphBreadth (Complete))
@@ -105,4 +105,5 @@ strategies =
 strategyRawFingerprint :: (Has (Lift IO) sig m, Has Diagnostics sig m) => Path Abs Dir -> Path Abs File -> m SourceUserDefDep
 strategyRawFingerprint root file = do
   fp <- fingerprintRaw file
-  pure $ SourceUserDefDep (renderRelative root file) (renderFingerprint fp) "" (Just "Binary discovered in source tree") Nothing
+  let rel = tryMakeRelative root file
+  pure $ SourceUserDefDep (renderSomeBase rel) (renderFingerprint fp) "" (Just "Binary discovered in source tree") Nothing (Just rel)

--- a/src/App/Fossa/BinaryDeps/Jar.hs
+++ b/src/App/Fossa/BinaryDeps/Jar.hs
@@ -20,7 +20,7 @@ import Effect.Logger (Logger, logDebug, pretty)
 import Effect.ReadFS (ReadFS, readContentsText, readContentsXML)
 import GHC.Base ((<|>))
 import Path (Abs, Dir, File, Path, filename, mkRelDir, mkRelFile, (</>))
-import Path.Extra (renderRelative)
+import Path.Extra (renderRelative, renderSomeBase, tryMakeRelative)
 import Srclib.Types (SourceUserDefDep (..))
 import Strategy.Maven.Pom.PomFile (MavenCoordinate (..), Pom (..), RawPom, pomLicenseName, validatePom)
 
@@ -100,5 +100,6 @@ fileHasSuffix :: Path a File -> [String] -> Bool
 fileHasSuffix file = any (\suffix -> suffix `isSuffixOf` toString (filename file))
 
 toUserDefDep :: Path Abs Dir -> Path Abs File -> JarMetadata -> SourceUserDefDep
-toUserDefDep root file JarMetadata{..} =
-  SourceUserDefDep (renderRelative root file) jarVersion jarLicense (Just jarName) Nothing
+toUserDefDep root file JarMetadata{..} = do
+  let rel = tryMakeRelative root file
+  SourceUserDefDep (renderSomeBase rel) jarVersion jarLicense (Just jarName) Nothing (Just rel)

--- a/src/App/Fossa/ManualDeps.hs
+++ b/src/App/Fossa/ManualDeps.hs
@@ -138,6 +138,7 @@ toAdditionalData customDeps remoteDeps =
         , srcUserDepLicense = customLicense
         , srcUserDepDescription = customMetadata >>= depDescription
         , srcUserDepHomepage = customMetadata >>= depHomepage
+        , srcUserDepOrigin = Nothing
         }
     toUrl RemoteDependency{..} =
       SourceRemoteDep

--- a/src/App/Fossa/VSI/IAT/Resolve.hs
+++ b/src/App/Fossa/VSI/IAT/Resolve.hs
@@ -62,4 +62,5 @@ toUserDefDep UserDefinedAssertionMeta{..} =
     , srcUserDepLicense = assertedLicense
     , srcUserDepDescription = assertedDescription
     , srcUserDepHomepage = assertedUrl
+    , srcUserDepOrigin = Nothing
     }

--- a/src/Path/Extra.hs
+++ b/src/Path/Extra.hs
@@ -1,6 +1,7 @@
 module Path.Extra (
   tryMakeRelative,
   renderRelative,
+  renderSomeBase,
 ) where
 
 import Data.String.Conversion (toText)
@@ -18,6 +19,10 @@ tryMakeRelative absDir absFile =
 -- | Render the relative path between a Path Abs Dir and a Path Abs File that is supposed to be in that dir.
 -- Intended for convenience when displaying the newly relative path; to interact with it use `tryMakeRelative` instead.
 renderRelative :: Path Abs Dir -> Path Abs File -> Text
-renderRelative absDir absFile = case tryMakeRelative absDir absFile of
+renderRelative absDir absFile = renderSomeBase $ tryMakeRelative absDir absFile
+
+-- | Render the file regardless of the kind of base.
+renderSomeBase :: SomeBase f -> Text
+renderSomeBase path = case path of
   Abs p -> toText . toFilePath $ p
   Rel p -> toText . toFilePath $ p

--- a/src/Srclib/Types.hs
+++ b/src/Srclib/Types.hs
@@ -17,6 +17,7 @@ import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import Data.Text qualified as Text
 import Path (File, SomeBase)
+import Path.Extra (renderSomeBase)
 import Types (GraphBreadth (..))
 
 data SourceUnit = SourceUnit
@@ -60,6 +61,7 @@ data SourceUserDefDep = SourceUserDefDep
   , srcUserDepLicense :: Text
   , srcUserDepDescription :: Maybe Text
   , srcUserDepHomepage :: Maybe Text
+  , srcUserDepOrigin :: Maybe (SomeBase File)
   }
   deriving (Eq, Ord, Show)
 
@@ -133,6 +135,7 @@ instance ToJSON SourceUserDefDep where
       , "License" .= srcUserDepLicense
       , "Description" .= srcUserDepDescription
       , "Homepage" .= srcUserDepHomepage
+      , "Origin" .= fmap renderSomeBase srcUserDepOrigin
       ]
 
 instance ToJSON SourceRemoteDep where


### PR DESCRIPTION
# Overview

Reports an origin for uploaded `SourceUserDefDep`s.

The background here is that Motorola requested a feature which we call "binary discovery" ([reference documentation](https://www.notion.so/fossa/Binary-Discovery-5a1afa2e9ee64c48ae822e870e7cf06b)). The TL;DR of this feature is that we, as a strategy in Spectrometer, identify files with binary content in the project and report them as unlicensed user-defined dependencies in Core.

This, maybe predictably, led to a follow up feature request from Motorola: "please display the path at which the binary is located _in the report under the `File Path(s)` column_". This PR makes that happen.

"Origin", in this context, means the path at which the user defined dependency was identified. It's optional on the type and if provided, hydrates `origin_paths` in the dependency lock.

This then is used to provide the actual point of the PR, which is hydrating `File Path(s)` in the report for the project when using binary discovery.

## Acceptance criteria

I booted a core instance that supports this information and ran a scan.
I then verified that:

* Origin paths are displayed in the UI (when they're clicked they just say "this file wasn't uploaded", but that's fine).
* The report correctly hydrates the `File Path(s)` column with this origin.

## Testing plan

1. Boot core with the branch `discovered-binary-origins`. Make sure the "File paths in reports" feature flag is enabled.
2. Create a project with a binary file inside (or add a binary file to a project you already have).
3. Run a scan with Spectrometer on this branch with the flag `--experimental-enable-binary-discovery`.
4. Run a report, selecting to display the file paths. Validate that the file path of the binary appears in that report.

## Screenshots

Showing this working:

<img width="1166" alt="Screen Shot 2021-10-15 at 2 15 43 PM" src="https://user-images.githubusercontent.com/55713231/137554947-cfe2740c-8b6d-4a67-8e2c-b4bb5b72cddb.png">

<img width="1166" alt="Screen Shot 2021-10-15 at 2 16 03 PM" src="https://user-images.githubusercontent.com/55713231/137554951-bb766882-95ff-48d1-b964-4b853e9f3988.png">

And showing that user defined deps _without_ origins are still displayed properly:

<img width="1166" alt="Screen Shot 2021-10-15 at 2 17 33 PM" src="https://user-images.githubusercontent.com/55713231/137554965-503179a8-a441-4dfc-9899-50be8304f30e.png">

## Risks

Not particularly risky.

## Checklist

- [x] I added tests for this PR's change (or confirmed tests are not viable).
- [x] I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
