### PR TITLE
Fossa-deps file support bower type (for custom integration for users moving from 1.x)

### DIFF
--- a/docs/userguide.md
+++ b/docs/userguide.md
@@ -255,6 +255,7 @@ The `name` and `type` fields are required and specify the name of the dependency
 
 Supported dependency types:
 
+- `bower` - Bower dependencies that are typically found at found at [bower.io](https://registry.bower.io).
 - `cargo` - Rust dependencies that are typically found at [crates.io](https://crates.io/).
 - `carthage` - Dependencies as specified by the [Carthage](https://github.com/Carthage/Carthage) package manager.
 - `composer` - Dependencies specified by the PHP package manager [Composer](https://getcomposer.org/), which are located on [Packagist](https://packagist.org/).

--- a/src/App/Fossa/ManualDeps.hs
+++ b/src/App/Fossa/ManualDeps.hs
@@ -239,6 +239,7 @@ instance FromJSON DependencyMetadata where
 -- Parse supported dependency types into their respective type or return Nothing.
 depTypeFromText :: Text -> Maybe DepType
 depTypeFromText text = case text of
+  "bower" -> Just BowerType
   "cargo" -> Just CargoType
   "carthage" -> Just CarthageType
   "composer" -> Just ComposerType

--- a/src/DepTypes.hs
+++ b/src/DepTypes.hs
@@ -52,6 +52,8 @@ data DepEnvironment
 data DepType
   = -- | An archive upload dependency.
     ArchiveType
+  | -- | Bower dependency
+    BowerType
   | -- | A first-party subproject
     SubprojectType
   | -- | Dependency found from the composer fetcher.

--- a/src/Srclib/Converter.hs
+++ b/src/Srclib/Converter.hs
@@ -99,6 +99,7 @@ verConstraintToRevision = \case
 depTypeToFetcher :: DepType -> Text
 depTypeToFetcher = \case
   ArchiveType -> "archive"
+  BowerType -> "bower"
   CarthageType -> "cart"
   CargoType -> "cargo"
   ComposerType -> "comp"
@@ -126,6 +127,7 @@ depTypeToFetcher = \case
 -- | GooglesourceType and SubprojectType are not supported with this function, since they're ambiguous.
 fetcherToDepType :: Text -> Maybe DepType
 fetcherToDepType fetcher | depTypeToFetcher ArchiveType == fetcher = Just ArchiveType
+fetcherToDepType fetcher | depTypeToFetcher BowerType == fetcher = Just BowerType
 fetcherToDepType fetcher | depTypeToFetcher CarthageType == fetcher = Just CarthageType
 fetcherToDepType fetcher | depTypeToFetcher CargoType == fetcher = Just CargoType
 fetcherToDepType fetcher | depTypeToFetcher ComposerType == fetcher = Just ComposerType


### PR DESCRIPTION
# Overview

This PR adds Bower dependency type, to allow customers migrating from 1.x and customer intending to use fossa-deps file with bower dependencies.  

We already have bower fetcher in the core. 

## Acceptance criteria

- fossa-deps accepts bower type for reference dependencies in 

## Testing plan

1. Create fossa-deps.json file which uses bower:
```json
{
  "referenced-dependencies": [
    {
      "name": "jquery",
      "version": "3.6.0",
      "type": "bower"
    }
  ]
}

```
2. Perform `fossa analyze --output | jq`, note bower locator being used. 

## Risks

N/A

## References

N/A

## Checklist

~- [ ] I added tests for this PR's change (or confirmed tests are not viable).~
~- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.~
~- [ ] I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.~
~- [ ] I linked this PR to any referenced GitHub issues, if they exist.~
