### PR TITLE
[No Priority] Adds ide integration (autocomplete, validation, etc) for fossa configuration files

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -29,4 +29,5 @@ _Example:_ Closes org/repo#123.
 - [ ] I added tests for this PR's change (or confirmed tests are not viable).
 - [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
 - [ ] I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
+- [ ] I updated `*schema.json` if I have made changes for `.fossa.yml`, `fossa-deps.{json, yaml, yml}`. You may also need to update these if you have added/removed new dependency (e.g. pip) or analysis target type (e.g. poetry).
 - [ ] I linked this PR to any referenced GitHub issues, if they exist.

--- a/docs/references/files/fossa-deps.schema.json
+++ b/docs/references/files/fossa-deps.schema.json
@@ -1,0 +1,181 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "fossa-deps",
+    "description": "fossa-deps for dependency specification for FOSSA CLI",
+    "$defs": {
+        "referenced-dependency": {
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Name of the dependency. This name will be used to search for dependency in relevant registries."
+                },
+                "type": {
+                    "enum": [
+                        "cargo",
+                        "carthage",
+                        "composer",
+                        "cpan",
+                        "gem",
+                        "git",
+                        "go",
+                        "hackage",
+                        "hex",
+                        "maven",
+                        "npm",
+                        "nuget",
+                        "paket",
+                        "pub",
+                        "pypi",
+                        "cocoapods",
+                        "swift",
+                        "url"
+                    ],
+                    "description": "Type of the dependency. It informs FOSSA which relevant registries to search for dependency's distribution."
+                },
+                "version": {
+                    "type": "string",
+                    "description": "Version of the dependency. It informs FOSSA which version of the dependency to scan. If not provided, latest version will be used."
+                }
+            },
+            "required": [
+                "name",
+                "type"
+            ],
+            "additionalProperties": false
+        },
+        "custom-dependency": {
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "Name of the dependency. This will be the name used in FOSSA's dashboard.",
+                    "minLength": 1
+                },
+                "version": {
+                    "type": "string",
+                    "description": "Version of the dependency. This will be the version used in FOSSA's dashboard.",
+                    "minLength": 1
+                },
+                "licence": {
+                    "type": "string",
+                    "description": "Licence of the dependency. This string will be used to infer licence type.",
+                    "minLength": 1
+                },
+                "metadata": {
+                    "type": "object",
+                    "properties": {
+                        "description": {
+                            "type": "string",
+                            "description": "Description of the dependency (if any)"
+                        },
+                        "homepage": {
+                            "type": "string",
+                            "description": "Homepage of the dependency. This should be web address."
+                        }
+                    }
+                }
+            },
+            "required": [
+                "name",
+                "version",
+                "licence"
+            ],
+            "additionalProperties": false
+        },
+        "vendored-dependency": {
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "Name of the dependency. This will be the name associated with this vendored dependency in FOSSA's dashboard",
+                    "minLength": 1
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Path to directory, which will be archived and upload to provided endpoint for licence scanning.",
+                    "minLength": 1
+                },
+                "version": {
+                    "type": "string",
+                    "description": "Version of the dependency. This will be the version associated with this vendored dependency in FOSSA's dashboard",
+                }
+            },
+            "required": [
+                "name",
+                "path"
+            ],
+            "additionalProperties": false
+        },
+        "remote-dependency": {
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "Name of the dependency. This will be the version used in FOSSA's dashboard.",
+                    "minLength": 1
+                },
+                "url": {
+                    "type": "string",
+                    "description": "Url of the dependency's source code. This will be the downloaded by FOSSA for scanning with the analysis.",
+                    "minLength": 1
+                },
+                "version": {
+                    "type": "string",
+                    "description": "Version of the dependency."
+                },
+                "metadata": {
+                    "type": "object",
+                    "properties": {
+                        "description": {
+                            "type": "string",
+                            "description": "Description of the dependency (if any)"
+                        },
+                        "homepage": {
+                            "type": "string",
+                            "description": "Homepage of the dependency. This should be web address."
+                        }
+                    }
+                }
+            },
+            "required": [
+                "name",
+                "url",
+                "version"
+            ],
+            "additionalProperties": false
+        }
+    },
+    "type": "object",
+    "properties": {
+        "version": {
+            "type": "integer"
+        },
+        "referenced-dependencies": {
+            "type": "array",
+            "description": "Reference dependency to locate from registry and include it project's dependency and licence scanning.",
+            "items": {
+                "$ref": "#/$defs/referenced-dependency"
+            }
+        },
+        "custom-dependencies": {
+            "type": "array",
+            "description": "Custom dependency and their licence for project",
+            "items": {
+                "$ref": "#/$defs/custom-dependency"
+            }
+        },
+        "vendored-dependencies": {
+            "type": "array",
+            "description": "Local dependencies upload to server for licence scanning",
+            "items": {
+                "$ref": "#/$defs/vendored-dependency"
+            }
+        },
+        "remote-dependencies": {
+            "type": "array",
+            "description": "Remote dependencies to licence scanning",
+            "items": {
+                "$ref": "#/$defs/remote-dependency"
+            }
+        }
+    },
+    "required": []
+}

--- a/docs/references/files/fossa-yml.v3.schema.json
+++ b/docs/references/files/fossa-yml.v3.schema.json
@@ -80,7 +80,7 @@
                 }
             }
         },
-        "target": {
+        "targetFilter": {
             "type": "object",
             "properties": {
                 "type": {
@@ -246,14 +246,14 @@
                     "type": "array",
                     "description": "The list of `only` targets that should be scanned.",
                     "items": {
-                        "$ref": "#/$defs/target"
+                        "$ref": "#/$defs/targetFilter"
                     }
                 },
                 "exclude": {
                     "type": "array",
                     "description": "The list of `exclude` targets which should be excluded from scanning. The targets listed in the exclude section will override the targets listed in the only sections.\n\nThis feature is used most effectively to remove specific targets from a directory.",
                     "items": {
-                        "$ref": "#/$defs/target"
+                        "$ref": "#/$defs/targetFilter"
                     }
                 }
             }

--- a/docs/references/files/fossa-yml.v3.schema.json
+++ b/docs/references/files/fossa-yml.v3.schema.json
@@ -1,0 +1,285 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": ".fossa.yaml",
+    "description": ".fossa.yaml specification for FOSSA CLI 2.x or greater",
+    "$defs": {
+        "project": {
+            "type": "object",
+            "description": "The project fields allow you to configure settings for the project you are interacting with through the FOSSA API.",
+            "properties": {
+                "id": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "The project ID defines a unique ID that the FOSSA API will use to reference this project. The project ID can be found in the UI on the project settings page listed as the `Project Locator` underneath the `Project Title` setting.\n\nBy default, it will use git remote origin url as project id if it's git repository. If it does not recognize version control system (vcs), project directory's name will be used."
+                },
+                "name": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "The name field sets the projects visible name in the FOSSA dashboard. By default, this will be set to the project's ID."
+                },
+                "team": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "The name of the team in your FOSSA organization to associate this project with."
+                },
+                "policy": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "The name of the policy in your FOSSA organization to associate this project with."
+                },
+                "link": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "An external link that will appear in the FOSSA UI for this specific project."
+                },
+                "url": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "The URL of your project that will appear in FOSSA. This URL is intended to be the URL to the repository of this project."
+                },
+                "jiraProjectKey": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "The Jira Project Key to associate with your project for improved issue triage. Refer to https://docs.fossa.com/docs/atlassian-jira#linking-fossa-projects-to-jira-projects for more information."
+                },
+                "releaseGroup": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "minLength": 1,
+                            "description": "The name of release group."
+                        },
+                        "release": {
+                            "type": "string",
+                            "minLength": 1,
+                            "description": "The release associated with the release group"
+                        }
+                    },
+                    "description": "The `name:` and `release:` of the release group's release to add your project to in the FOSSA dashboard. If you choose to associate a project with a release group, you **must** supply both name and release.",
+                    "required": [
+                        "name",
+                        "release"
+                    ]
+                }
+            }
+        },
+        "revision": {
+            "type": "object",
+            "description": "The revision fields are used to help FOSSA differentiate between one upload for a project and another, just as GitHub uses commit hashes and branch names.",
+            "properties": {
+                "branch": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "project branch is an optional setting used for organizing project revisions in the FOSSA UI. The branch field is intended to function similar to how Git defines a branch."
+                },
+                "commit": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "The commit is used to identify a specific scan for a project (determined by project.id). This is intended to be used identically to how Git treats commit hashes. If not provided, cli will parse current HEAD state from .git directory. If project does not have version control system, unix timestamp will be used."
+                }
+            }
+        },
+        "target": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "oneOf": [
+                        {
+                            "const": "bundler",
+                            "description": "For bundler targets (ruby)"
+                        },
+                        {
+                            "const": "cargo",
+                            "description": "For cargo targets (rust)"
+                        },
+                        {
+                            "const": "carthage",
+                            "description": "For carthage targets (ios, objective-c)"
+                        },
+                        {
+                            "const": "cocoapods",
+                            "description": "For cocoapod targets (ios, objective-c, swift)"
+                        },
+                        {
+                            "const": "composer",
+                            "description": "For composer targets (php)"
+                        },
+                        {
+                            "const": "conda",
+                            "description": "For conda targets"
+                        },
+                        {
+                            "const": "glide",
+                            "description": "For glide targets (golang)"
+                        },
+                        {
+                            "const": "godep",
+                            "description": "For godep targets (golang)"
+                        },
+                        {
+                            "const": "gradle",
+                            "description": "For gradle targets (kotlin and java)"
+                        },
+                        {
+                            "const": "leiningen",
+                            "description": "For leiningen targets (clojure)"
+                        },
+                        {
+                            "const": "maven",
+                            "description": "For maven targets (kotlin and java)"
+                        },
+                        {
+                            "const": "mix",
+                            "description": "For mix targets (elixir)"
+                        },
+                        {
+                            "const": "npm",
+                            "description": "For npm targets (javascript)"
+                        },
+                        {
+                            "const": "pub",
+                            "description": "For pub targets (dart, flutter)"
+                        },
+                        {
+                            "const": "rebar3",
+                            "description": "For rebar3 targets (erlang)"
+                        },
+                        {
+                            "const": "rpm",
+                            "description": "For rpm targets"
+                        },
+                        {
+                            "const": "scala",
+                            "description": "For scala targets"
+                        },
+                        {
+                            "const": "swift",
+                            "description": "For swift targets"
+                        },
+                        {
+                            "const": "yarn",
+                            "description": "For yarn targets (javascript)"
+                        },
+                        {
+                            "const": "repomanifest",
+                            "description": "For repomanifest"
+                        },
+                        {
+                            "const": "cabal",
+                            "description": "For cabal targets (haskell)"
+                        },
+                        {
+                            "const": "stack",
+                            "description": "For stack targets (haskell)"
+                        },
+                        {
+                            "const": "nuspec",
+                            "description": "For nuspec targets (dotnet)"
+                        },
+                        {
+                            "const": "packagereference",
+                            "description": "For package reference targets (dotnet)"
+                        },
+                        {
+                            "const": "paket",
+                            "description": "For paket targets (dotnet)"
+                        },
+                        {
+                            "const": "projectassetjson",
+                            "description": "For project asset json targets (dotnet)"
+                        },
+                        {
+                            "const": "pipenv",
+                            "description": "For pipenv targets (python)"
+                        },
+                        {
+                            "const": "poetry",
+                            "description": "For poetry targets (python)"
+                        },
+                        {
+                            "const": "setuptools",
+                            "description": "For setuptools targets (python)"
+                        }
+                    ],
+                    "description": "Target (package manager)"
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Associated path with target type (if any)"
+                }
+            }
+        }
+    },
+    "type": "object",
+    "properties": {
+        "version": {
+            "type": "integer",
+            "const": 3,
+            "description": "Specifies the version of configuration file. Versions 1 and 2 were used by CLI versions up until CLI 2.0.0 and are no longer supported.\n\nCLI 2.x and greater only supports version 3."
+        },
+        "server": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Sets the endpoint that the CLI will send requests to. This field should only be modified if your FOSSA account lives on a different server than app.fossa.com.\n\nThis is most commonly needed with on-premise instances of FOSSA."
+        },
+        "apiKey": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Sets the https://docs.fossa.com/docs/api-reference#api-tokens that is required for accessing the FOSSA API and uploading data (e.g. `fossa analyze`) or retrieving information (e.g. `fossa test`) about a project."
+        },
+        "project": {
+            "$ref": "#/$defs/project"
+        },
+        "revision": {
+            "type": "array",
+            "items": {
+                "$ref": "#/$defs/revision"
+            }
+        },
+        "targets": {
+            "type": "object",
+            "description": "The targets filtering allows you to specify the exact targets which be should be scanned.",
+            "properties": {
+                "only": {
+                    "type": "array",
+                    "description": "The list of `only` targets that should be scanned.",
+                    "items": {
+                        "$ref": "#/$defs/target"
+                    }
+                },
+                "exclude": {
+                    "type": "array",
+                    "description": "The list of `exclude` targets which should be excluded from scanning. The targets listed in the exclude section will override the targets listed in the only sections.\n\nThis feature is used most effectively to remove specific targets from a directory.",
+                    "items": {
+                        "$ref": "#/$defs/target"
+                    }
+                }
+            }
+        },
+        "paths": {
+            "type": "object",
+            "description": "The paths filtering section allows you to specify which paths should be scanned and which should not. The paths should be listed as their location from the root of your project.",
+            "properties": {
+                "only": {
+                    "type": "array",
+                    "description": "The list of paths to only allow scanning within.",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "exclude": {
+                    "type": "array",
+                    "description": "The list of paths to exclude from scanning in your directory.",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        }
+    },
+    "required": [
+        "version"
+    ]
+}


### PR DESCRIPTION
# Overview

This adds json schema for
1) `.fossa.yml`
2) `fossa-deps.{json,yaml}`

## Why?

I wanted to add schema for off-the-shelf IDE integration (auto-complete, documentation, and validation of format) for our configs files. I intend to integrate these schemas with: https://github.com/schemastore/schemastore/
(I will link our raw.githubusercontent link to the store - https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md#adding-to-catalog, as part of second PR)

This should provide (out of box) integration with:

- Visual Studio Code (all yaml extensions/langauge servers - redhat, microsoft)
- IntelliJ IDEA
- PhpStorm
- PyCharm
- Rider
- RubyMine
- Visual Studio 2013+
- Visual Studio for Mac
- WebStorm
- JSONBuddy

Consequently, this should make it easier to work with our configs, and ultimately provide better end user experience. 

## Acceptance criteria

- Validation with schema works, and documentations are readily visible 

## Testing plan

On visual studio code, you can for now use yaml language server for testing this locally:

```yaml
# yaml-language-server: $schema=fossa-yaml.v3.schema.json

# type .fossa.yml fields here and see vs-code autocomplete, and provide docs
```

## Screenshot

<img width="864" alt="CleanShot 2021-10-22 at 18 28 20@2x" src="https://user-images.githubusercontent.com/86321858/138535338-7d4f3a2b-ca11-497d-a3d4-4576d2e9b020.png">

![image](https://user-images.githubusercontent.com/86321858/138535352-c7f3e579-5420-4b96-a70a-342214b6afa0.png)


## Risks

- Adds miniscule maintenance burden 

## References

I wanted to get this in as, .fossa.yml format will change significantly for users migrating.
Part of: https://github.com/fossas/team-analysis/issues/770

## Checklist

- [x] I added tests for this PR's change (or confirmed tests are not viable).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] I linked this PR to any referenced GitHub issues, if they exist.
