### PR TITLE
fix windows regex

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -50,7 +50,7 @@ Write-Verbose "Looking up release ($releaseTag)..."
 
 $releasePage = Invoke-RestMethod $latestUri
 
-if ($releasePage -inotmatch 'href=\"(.*?releases\/download\/.*?windows.*?)\"')
+if ($releasePage -inotmatch 'href=\"(.*?releases\/download\/fossa_(v?\d+\.\d+\.\d+)_windows.*\.zip)\"')
 {
     throw "Did not find Windows release at $latestUri"
 }


### PR DESCRIPTION
Our windows installer is broken, we were previously relying on `fossa` being the first release artifact in the list.  We now use `fossa` as part of the match.  This is a temporary fix until I can redo the windows installer to parse JSON instead of regex'ing the releases HTML page.