### PR TITLE
Adds Experimental Gradle Configurations flag

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,11 @@
 # Spectrometer Changelog
 
+## v2.19.4
+
+- Adds experimental capability for filtering gradle configuration for analysis. ([#425](https://github.com/fossas/spectrometer/pull/425))
+
+Refer to: [Gradle documentation](docs/references/strategies/languages/gradle/gradle.md#experimental-only-selecting-set-of-configurations-for-analysis) for more details.
+
 ## v2.19.3
 
 - Removes `fossa compatibility` command. ([#383](https://github.com/fossas/spectrometer/pull/383))

--- a/docs/references/files/fossa-yml.md
+++ b/docs/references/files/fossa-yml.md
@@ -116,6 +116,18 @@ Default:
 - No VCS: The CLI will leave the branch field empty.
 
 
+### `experimental.gradle.configurations-only:`
+
+Set of gradle configurations to filter for in the analysis. Any configurations not listed will be excluded from analysis.
+
+```yaml
+experimental:
+  gradle:
+    configurations-only:
+      - example-1-config-to-include
+      - example-2-config-to-include
+```
+
 ### `targets:`
 The targets filtering section allows you to specify the exact targets which be should be scanned. 
 

--- a/docs/references/files/fossa-yml.md
+++ b/docs/references/files/fossa-yml.md
@@ -115,19 +115,6 @@ Default:
 - SVN: The CLI will run `svn info` and compare the "URL" and "Repository Root" fields in an attempt to determine a branch.
 - No VCS: The CLI will leave the branch field empty.
 
-
-### `experimental.gradle.configurations-only:`
-
-Set of gradle configurations to filter for in the analysis. Any configurations not listed will be excluded from analysis.
-
-```yaml
-experimental:
-  gradle:
-    configurations-only:
-      - example-1-config-to-include
-      - example-2-config-to-include
-```
-
 ### `targets:`
 The targets filtering section allows you to specify the exact targets which be should be scanned. 
 

--- a/docs/references/files/fossa-yml.v3.schema.json
+++ b/docs/references/files/fossa-yml.v3.schema.json
@@ -210,6 +210,25 @@
                     "description": "Associated path with target type (if any)"
                 }
             }
+        },
+        "experimental": {
+            "type": "object",
+            "description": "Experimental preferences with fossa cli.",
+            "properties": {
+                "gradle": {
+                    "type": "object",
+                    "description": "Gradle preferences for all targets",
+                    "properties": {
+                        "configurations-only": {
+                            "type": "array",
+                            "description": "Configurations to only include in analysis (by default excludes any other configurations not listed)",
+                            "items": {"type": "string"},
+                            "minItems": 1,
+                            "uniqueItems": true 
+                        }
+                    }
+                }
+            }
         }
     },
     "type": "object",

--- a/docs/references/strategies/languages/gradle/gradle.md
+++ b/docs/references/strategies/languages/gradle/gradle.md
@@ -31,6 +31,7 @@ Gradle users generally specify their builds using a `build.gradle` file (written
   - [Manually specifying Gradle dependencies](#manually-specifying-gradle-dependencies)
   - [Configurations For Development and Testing](#configurations-for-development-and-testing)
   - [Android Gradle Configurations For Development and Testing](#android-gradle-configurations-for-development-and-testing)
+  - [Only Selecting Set of Configurations For Analysis](#only-selecting-set-of-configurations-for-analysis)
 
 ## Concepts
 
@@ -274,4 +275,18 @@ We classify following configurations, and dependencies originating from it as a 
 - kotlinCompilerPluginClasspathRelease
 - kotlinKlibCommonizerClasspath
 - kotlinNativeCompilerPluginClasspath
+```
+
+## Only Selecting Set of Configurations For Analysis
+
+You can use [configuration file](../../../files/fossa-yml.md) to provide set of configurations to filter the analysis for. Any configurations not listed will be excluded from analysis.
+
+```yaml
+version: 3
+
+experimental:
+  gradle:
+    configurations-only:
+      - example-1-config-to-include
+      - example-2-config-to-include
 ```

--- a/docs/references/strategies/languages/gradle/gradle.md
+++ b/docs/references/strategies/languages/gradle/gradle.md
@@ -31,7 +31,7 @@ Gradle users generally specify their builds using a `build.gradle` file (written
   - [Manually specifying Gradle dependencies](#manually-specifying-gradle-dependencies)
   - [Configurations For Development and Testing](#configurations-for-development-and-testing)
   - [Android Gradle Configurations For Development and Testing](#android-gradle-configurations-for-development-and-testing)
-  - [Only Selecting Set of Configurations For Analysis](#only-selecting-set-of-configurations-for-analysis)
+  - [(Experimental) Only Selecting Set of Configurations For Analysis](#experimental-only-selecting-set-of-configurations-for-analysis)
 
 ## Concepts
 
@@ -277,9 +277,9 @@ We classify following configurations, and dependencies originating from it as a 
 - kotlinNativeCompilerPluginClasspath
 ```
 
-## Only Selecting Set of Configurations For Analysis
+## (Experimental) Only Selecting Set of Configurations For Analysis
 
-You can use [configuration file](../../../files/fossa-yml.md) to provide set of configurations to filter the analysis for. Any configurations not listed will be excluded from analysis.
+You can use [configuration file](../../../files/fossa-yml.md) to provide set of configurations to filter the analysis for. Any configurations not listed will be excluded from analysis. This feature is experimental and may be changed or removed at any time, without warning.
 
 ```yaml
 version: 3

--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -20,6 +20,7 @@ import App.Fossa.Analyze.Debug (collectDebugBundle, diagToDebug)
 import App.Fossa.Analyze.GraphMangler (graphingToGraph)
 import App.Fossa.Analyze.Project (ProjectResult (..), mkResult)
 import App.Fossa.Analyze.Types (
+  AnalyzePreferences (..),
   AnalyzeProject (..),
   AnalyzeTaskEffs,
  )
@@ -43,6 +44,7 @@ import Control.Carrier.Diagnostics qualified as Diag
 import Control.Carrier.Diagnostics.StickyContext (stickyDiag)
 import Control.Carrier.Finally (Has, runFinally)
 import Control.Carrier.Output.IO (Output, output, runOutput)
+import Control.Carrier.Reader (Reader, runReader)
 import Control.Carrier.StickyLogger (StickyLogger, logSticky', runStickyLogger)
 import Control.Carrier.TaskPool (
   Progress (..),
@@ -182,11 +184,13 @@ analyzeMain ::
   Flag IncludeAll ->
   ModeOptions ->
   AllFilters ->
+  AnalyzePreferences ->
   IO ()
-analyzeMain workdir logSeverity destination project unpackArchives jsonOutput includeAll modeOptions filters =
+analyzeMain workdir logSeverity destination project unpackArchives jsonOutput includeAll modeOptions filters preferences =
   withDefaultLogger logSeverity
     . Diag.logWithExit_
     . runReadFSIO
+    . runReader preferences
     . runExecIO
     $ case logSeverity of
       -- In --debug mode, emit a debug bundle to "fossa.debug.json"
@@ -211,6 +215,7 @@ runDependencyAnalysis ::
   , Has ReadFS sig m
   , Has Exec sig m
   , Has (Output ProjectResult) sig m
+  , Has (Reader AnalyzePreferences) sig m
   , MonadIO m
   ) =>
   -- | Analysis base directory
@@ -313,6 +318,7 @@ analyze ::
   , Has Debug sig m
   , Has Exec sig m
   , Has ReadFS sig m
+  , Has (Reader AnalyzePreferences) sig m
   , MonadIO m
   ) =>
   BaseDir ->

--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -20,7 +20,7 @@ import App.Fossa.Analyze.Debug (collectDebugBundle, diagToDebug)
 import App.Fossa.Analyze.GraphMangler (graphingToGraph)
 import App.Fossa.Analyze.Project (ProjectResult (..), mkResult)
 import App.Fossa.Analyze.Types (
-  AnalyzePreferences (..),
+  AnalyzeExperimentalPreferences (..),
   AnalyzeProject (..),
   AnalyzeTaskEffs,
  )
@@ -184,7 +184,7 @@ analyzeMain ::
   Flag IncludeAll ->
   ModeOptions ->
   AllFilters ->
-  AnalyzePreferences ->
+  AnalyzeExperimentalPreferences ->
   IO ()
 analyzeMain workdir logSeverity destination project unpackArchives jsonOutput includeAll modeOptions filters preferences =
   withDefaultLogger logSeverity
@@ -215,7 +215,7 @@ runDependencyAnalysis ::
   , Has ReadFS sig m
   , Has Exec sig m
   , Has (Output ProjectResult) sig m
-  , Has (Reader AnalyzePreferences) sig m
+  , Has (Reader AnalyzeExperimentalPreferences) sig m
   , MonadIO m
   ) =>
   -- | Analysis base directory
@@ -318,7 +318,7 @@ analyze ::
   , Has Debug sig m
   , Has Exec sig m
   , Has ReadFS sig m
-  , Has (Reader AnalyzePreferences) sig m
+  , Has (Reader AnalyzeExperimentalPreferences) sig m
   , MonadIO m
   ) =>
   BaseDir ->

--- a/src/App/Fossa/Analyze/Types.hs
+++ b/src/App/Fossa/Analyze/Types.hs
@@ -1,16 +1,24 @@
 module App.Fossa.Analyze.Types (
   AnalyzeProject (..),
   AnalyzeTaskEffs,
+  AnalyzePreferences (..),
 ) where
 
 import Control.Carrier.Diagnostics
 import Control.Effect.Debug (Debug)
 import Control.Effect.Lift
+import Control.Effect.Reader (Reader)
 import Control.Monad.IO.Class (MonadIO)
+import Data.Set (Set)
+import Data.Text (Text)
 import Effect.Exec (Exec)
 import Effect.Logger (Logger)
 import Effect.ReadFS (ReadFS)
 import Types
+
+newtype AnalyzePreferences = AnalyzePreferences
+  {gradleOnlyConfigsAllowed :: Maybe (Set Text)}
+  deriving (Show, Eq, Ord)
 
 type AnalyzeTaskEffs sig m =
   ( Has (Lift IO) sig m
@@ -20,6 +28,7 @@ type AnalyzeTaskEffs sig m =
   , Has Logger sig m
   , Has Diagnostics sig m
   , Has Debug sig m
+  , Has (Reader AnalyzePreferences) sig m
   )
 
 class AnalyzeProject a where

--- a/src/App/Fossa/Analyze/Types.hs
+++ b/src/App/Fossa/Analyze/Types.hs
@@ -1,7 +1,7 @@
 module App.Fossa.Analyze.Types (
   AnalyzeProject (..),
   AnalyzeTaskEffs,
-  AnalyzePreferences (..),
+  AnalyzeExperimentalPreferences (..),
 ) where
 
 import Control.Carrier.Diagnostics
@@ -16,7 +16,7 @@ import Effect.Logger (Logger)
 import Effect.ReadFS (ReadFS)
 import Types
 
-newtype AnalyzePreferences = AnalyzePreferences
+newtype AnalyzeExperimentalPreferences = AnalyzeExperimentalPreferences
   {gradleOnlyConfigsAllowed :: Maybe (Set Text)}
   deriving (Show, Eq, Ord)
 
@@ -28,7 +28,7 @@ type AnalyzeTaskEffs sig m =
   , Has Logger sig m
   , Has Diagnostics sig m
   , Has Debug sig m
-  , Has (Reader AnalyzePreferences) sig m
+  , Has (Reader AnalyzeExperimentalPreferences) sig m
   )
 
 class AnalyzeProject a where

--- a/src/App/Fossa/Configuration.hs
+++ b/src/App/Fossa/Configuration.hs
@@ -10,6 +10,8 @@ module App.Fossa.Configuration (
   ConfigRevision (..),
   ConfigTargets (..),
   ConfigPaths (..),
+  ExperimentalConfigs (..),
+  ExperimentalGradleConfigs (..),
 ) where
 
 import App.Docs (fossaYmlDocUrl)
@@ -19,6 +21,8 @@ import Control.Effect.Lift (Lift)
 import Data.Aeson (FromJSON (parseJSON), withObject, (.!=), (.:), (.:?))
 import Data.Functor (($>))
 import Data.Maybe (fromMaybe)
+import Data.Set (Set)
+import Data.Set qualified as Set
 import Data.Text (Text)
 import Data.Text.Prettyprint.Doc (Doc, Pretty (pretty), vsep)
 import Effect.Logger (Severity (SevWarn), logWarn, withDefaultLogger)
@@ -37,6 +41,7 @@ data ConfigFile = ConfigFile
   , configRevision :: Maybe ConfigRevision
   , configTargets :: Maybe ConfigTargets
   , configPaths :: Maybe ConfigPaths
+  , configExperimental :: Maybe ExperimentalConfigs
   }
   deriving (Eq, Ord, Show)
 
@@ -70,6 +75,14 @@ data ConfigPaths = ConfigPaths
   }
   deriving (Eq, Ord, Show)
 
+newtype ExperimentalConfigs = ExperimentalConfigs
+  {gradle :: Maybe ExperimentalGradleConfigs}
+  deriving (Eq, Ord, Show)
+
+newtype ExperimentalGradleConfigs = ExperimentalGradleConfigs
+  {gradleConfigsOnly :: Set (Text)}
+  deriving (Eq, Ord, Show)
+
 instance FromJSON ConfigFile where
   parseJSON = withObject "ConfigFile" $ \obj ->
     ConfigFile <$> obj .: "version"
@@ -79,6 +92,7 @@ instance FromJSON ConfigFile where
       <*> obj .:? "revision"
       <*> obj .:? "targets"
       <*> obj .:? "paths"
+      <*> obj .:? "experimental"
 
 instance FromJSON ConfigProject where
   parseJSON = withObject "ConfigProject" $ \obj ->
@@ -105,6 +119,14 @@ instance FromJSON ConfigPaths where
   parseJSON = withObject "ConfigPaths" $ \obj ->
     ConfigPaths <$> (obj .:? "only" .!= [])
       <*> (obj .:? "exclude" .!= [])
+
+instance FromJSON ExperimentalConfigs where
+  parseJSON = withObject "ExperimentalConfigs" $ \obj ->
+    ExperimentalConfigs <$> obj .:? "gradle"
+
+instance FromJSON ExperimentalGradleConfigs where
+  parseJSON = withObject "ExperimentalGradleConfigs" $ \obj ->
+    ExperimentalGradleConfigs <$> (obj .: "configurations-only" .!= Set.fromList [])
 
 defaultFile :: Path Rel File
 defaultFile = $(mkRelFile ".fossa.yml")

--- a/src/App/Fossa/ListTargets.hs
+++ b/src/App/Fossa/ListTargets.hs
@@ -5,7 +5,7 @@ module App.Fossa.ListTargets (
 ) where
 
 import App.Fossa.Analyze (DiscoverFunc (DiscoverFunc), discoverFuncs)
-import App.Fossa.Analyze.Types (AnalyzePreferences)
+import App.Fossa.Analyze.Types (AnalyzeExperimentalPreferences)
 import App.Types (BaseDir (..))
 import Control.Carrier.AtomicCounter
 import Control.Carrier.Debug (ignoreDebug)
@@ -30,7 +30,7 @@ import Path
 import Path.IO (makeRelative)
 import Types (BuildTarget (..), DiscoveredProject (..), FoundTargets (..))
 
-listTargetsMain :: AnalyzePreferences -> Severity -> BaseDir -> IO ()
+listTargetsMain :: AnalyzeExperimentalPreferences -> Severity -> BaseDir -> IO ()
 listTargetsMain preferences logSeverity (BaseDir basedir) = do
   capabilities <- getNumCapabilities
 
@@ -54,7 +54,7 @@ runAll ::
   , MonadIO m
   , Has AtomicCounter sig m
   , Has Debug sig m
-  , Has (Reader AnalyzePreferences) sig m
+  , Has (Reader AnalyzeExperimentalPreferences) sig m
   ) =>
   Path Abs Dir ->
   m ()

--- a/src/App/Fossa/ListTargets.hs
+++ b/src/App/Fossa/ListTargets.hs
@@ -5,10 +5,12 @@ module App.Fossa.ListTargets (
 ) where
 
 import App.Fossa.Analyze (DiscoverFunc (DiscoverFunc), discoverFuncs)
+import App.Fossa.Analyze.Types (AnalyzePreferences)
 import App.Types (BaseDir (..))
 import Control.Carrier.AtomicCounter
 import Control.Carrier.Debug (ignoreDebug)
 import Control.Carrier.Finally
+import Control.Carrier.Reader (Reader, runReader)
 import Control.Carrier.StickyLogger (StickyLogger, logSticky', runStickyLogger)
 import Control.Carrier.TaskPool
 import Control.Concurrent (getNumCapabilities)
@@ -28,8 +30,8 @@ import Path
 import Path.IO (makeRelative)
 import Types (BuildTarget (..), DiscoveredProject (..), FoundTargets (..))
 
-listTargetsMain :: Severity -> BaseDir -> IO ()
-listTargetsMain logSeverity (BaseDir basedir) = do
+listTargetsMain :: AnalyzePreferences -> Severity -> BaseDir -> IO ()
+listTargetsMain preferences logSeverity (BaseDir basedir) = do
   capabilities <- getNumCapabilities
 
   ignoreDebug
@@ -40,6 +42,7 @@ listTargetsMain logSeverity (BaseDir basedir) = do
     . runReadFSIO
     . runExecIO
     . runAtomicCounter
+    . runReader preferences
     $ runAll basedir
 
 runAll ::
@@ -51,6 +54,7 @@ runAll ::
   , MonadIO m
   , Has AtomicCounter sig m
   , Has Debug sig m
+  , Has (Reader AnalyzePreferences) sig m
   ) =>
   Path Abs Dir ->
   m ()

--- a/src/App/Fossa/Main.hs
+++ b/src/App/Fossa/Main.hs
@@ -15,9 +15,11 @@ import App.Fossa.Analyze (
   VSIAnalysisMode (..),
   analyzeMain,
  )
+import App.Fossa.Analyze.Types (AnalyzePreferences (..))
 import App.Fossa.Configuration (
   ConfigFile (
     configApiKey,
+    configExperimental,
     configPaths,
     configProject,
     configRevision,
@@ -28,6 +30,8 @@ import App.Fossa.Configuration (
   ConfigProject (configProjID),
   ConfigRevision (configBranch, configCommit),
   ConfigTargets (targetsExclude, targetsOnly),
+  ExperimentalConfigs (gradle),
+  ExperimentalGradleConfigs (gradleConfigsOnly),
   mergeFileCmdMetadata,
   readConfigFileIO,
  )
@@ -168,6 +172,7 @@ appMain = do
 
   let CmdOptions{..} = maybe cmdConfig (mergeFileCmdConfig cmdConfig) fileConfig
 
+  let analyzePreferences = AnalyzePreferences (gradleConfigsOnly <$> (gradle =<< configExperimental =<< fileConfig))
   let logSeverity = bool SevInfo SevDebug optDebug
 
   maybeApiKey <- checkAPIKey optAPIKey
@@ -215,7 +220,7 @@ appMain = do
       let analyzeOverride = override{overrideBranch = analyzeBranch <|> ((fileConfig >>= configRevision) >>= configBranch)}
           combinedFilters = normalizedFilters fileConfig analyzeOptions
           modeOptions = ModeOptions analyzeVSIMode assertionMode analyzeBinaryDiscoveryMode
-          doAnalyze destination = analyzeMain analyzeBaseDir logSeverity destination analyzeOverride analyzeUnpackArchives analyzeJsonOutput analyzeIncludeAllDeps modeOptions combinedFilters
+          doAnalyze destination = analyzeMain analyzeBaseDir logSeverity destination analyzeOverride analyzeUnpackArchives analyzeJsonOutput analyzeIncludeAllDeps modeOptions combinedFilters analyzePreferences
 
       if analyzeOutput
         then doAnalyze OutputStdout
@@ -245,7 +250,7 @@ appMain = do
     --
     ListTargetsCommand dir -> do
       baseDir <- validateDir dir
-      listTargetsMain logSeverity baseDir
+      listTargetsMain analyzePreferences logSeverity baseDir
     --
     VPSCommand VPSOptions{..} -> do
       apikey <- requireKey maybeApiKey

--- a/src/App/Fossa/Main.hs
+++ b/src/App/Fossa/Main.hs
@@ -15,7 +15,7 @@ import App.Fossa.Analyze (
   VSIAnalysisMode (..),
   analyzeMain,
  )
-import App.Fossa.Analyze.Types (AnalyzePreferences (..))
+import App.Fossa.Analyze.Types (AnalyzeExperimentalPreferences (..))
 import App.Fossa.Configuration (
   ConfigFile (
     configApiKey,
@@ -172,7 +172,7 @@ appMain = do
 
   let CmdOptions{..} = maybe cmdConfig (mergeFileCmdConfig cmdConfig) fileConfig
 
-  let analyzePreferences = AnalyzePreferences (gradleConfigsOnly <$> (gradle =<< configExperimental =<< fileConfig))
+  let analyzePreferences = AnalyzeExperimentalPreferences (gradleConfigsOnly <$> (gradle =<< configExperimental =<< fileConfig))
   let logSeverity = bool SevInfo SevDebug optDebug
 
   maybeApiKey <- checkAPIKey optAPIKey

--- a/src/Strategy/Gradle.hs
+++ b/src/Strategy/Gradle.hs
@@ -21,8 +21,9 @@ module Strategy.Gradle (
   ConfigName (..),
 ) where
 
-import App.Fossa.Analyze.Types (AnalyzeProject, analyzeProject)
+import App.Fossa.Analyze.Types (AnalyzePreferences (..), AnalyzeProject, analyzeProject)
 import Control.Algebra (Has, run)
+import Control.Carrier.Reader (Reader)
 import Control.Effect.Diagnostics (
   Diagnostics,
   context,
@@ -33,6 +34,7 @@ import Control.Effect.Diagnostics (
  )
 import Control.Effect.Lift (Lift, sendIO)
 import Control.Effect.Path (withSystemTempDir)
+import Control.Effect.Reader (asks)
 import Data.Aeson (FromJSON (..), ToJSON, Value (..), decodeStrict, withObject, (.:))
 import Data.Aeson.Types (Parser, unexpected)
 import Data.ByteString (ByteString)
@@ -238,7 +240,16 @@ mkProject project =
     , projectData = project
     }
 
-getDeps :: (Has (Lift IO) sig m, Has Exec sig m, Has ReadFS sig m, Has Diagnostics sig m) => FoundTargets -> GradleProject -> m DependencyResults
+getDeps ::
+  ( Has (Lift IO) sig m
+  , Has Exec sig m
+  , Has ReadFS sig m
+  , Has Diagnostics sig m
+  , Has (Reader AnalyzePreferences) sig m
+  ) =>
+  FoundTargets ->
+  GradleProject ->
+  m DependencyResults
 getDeps targets project = context "Gradle" $ do
   graph <- analyze targets (gradleDir project)
   pure $
@@ -259,6 +270,7 @@ analyze ::
   , Has Exec sig m
   , Has ReadFS sig m
   , Has Diagnostics sig m
+  , Has (Reader AnalyzePreferences) sig m
   ) =>
   FoundTargets ->
   Path Abs Dir ->
@@ -273,6 +285,12 @@ analyze foundTargets dir = withSystemTempDir "fossa-gradle" $ \tmpDir -> do
         ProjectWithoutTargets -> gradleJsonDepsCmd initScriptFilepath
 
   stdout <- context "running gradle script" $ runGradle dir cmd
+
+  onlyConfigurations <- do
+    configs <- asks gradleOnlyConfigsAllowed
+    case (Set.map ConfigName) <$> configs of
+      Nothing -> pure Set.empty
+      Just c -> pure c
 
   let text = decodeUtf8 $ BL.toStrict stdout
 
@@ -299,12 +317,21 @@ analyze foundTargets dir = withSystemTempDir "fossa-gradle" $ \tmpDir -> do
       packagesToOutput :: Map (PackageName, ConfigName) [JsonDep]
       packagesToOutput = Map.fromList packagePathsWithDecoded
 
-  context "Building dependency graph" $ pure (buildGraph packagesToOutput)
+  context "Building dependency graph" $ pure (buildGraph packagesToOutput onlyConfigurations)
 
 -- TODO: use LabeledGraphing to add labels for environments
-buildGraph :: Map (PackageName, ConfigName) [JsonDep] -> Graphing Dependency
-buildGraph projectsAndDeps = run . withLabeling toDependency $ Map.traverseWithKey addProject projectsAndDeps
+buildGraph :: Map (PackageName, ConfigName) [JsonDep] -> Set ConfigName -> Graphing Dependency
+buildGraph projectsAndDeps onlyConfigs = run . withLabeling toDependency $ Map.traverseWithKey addProject filteredProjectAndDeps
   where
+    filteredProjectAndDeps :: Map (PackageName, ConfigName) [JsonDep]
+    filteredProjectAndDeps = Map.filterWithKey (\(_, config) _ -> isConfigIncluded config) (projectsAndDeps)
+
+    isConfigExcluded :: ConfigName -> Bool
+    isConfigExcluded c = not (Set.null onlyConfigs) && Set.notMember c onlyConfigs
+
+    isConfigIncluded :: ConfigName -> Bool
+    isConfigIncluded = not . isConfigExcluded
+
     -- add top-level projects from the output
     addProject :: Has (LabeledGrapher JsonDep GradleLabel) sig m => (PackageName, ConfigName) -> [JsonDep] -> m ()
     addProject (projName, configName) projDeps = do
@@ -317,14 +344,21 @@ buildGraph projectsAndDeps = run . withLabeling toDependency $ Map.traverseWithK
         mkRecursiveEdges dep envLabel
 
     -- Infers environment label based on the name of configuration.
+    -- When, we are only including set of configurations, as provided by users
+    -- We mark all of them as other environment titled by configuration, so that
+    -- user's selected configuration will not be removed due to having been unused, 
+    -- and subsequently will be submitted to server.
     -- Ref: https://docs.gradle.org/current/userguide/java_library_plugin.html#sec:java_library_configurations_graph
     configNameToLabel :: ConfigName -> GradleLabel
-    configNameToLabel conf = case unConfigName conf of
-      "compileOnly" -> Env EnvDevelopment
-      x | x `elem` ["testImplementation", "testCompileOnly", "testRuntimeOnly", "testCompileClasspath", "testRuntimeClasspath"] -> Env EnvTesting
-      x | isDefaultAndroidDevConfig x -> Env EnvDevelopment
-      x | isDefaultAndroidTestConfig x -> Env EnvTesting
-      x -> Env $ EnvOther x
+    configNameToLabel conf =
+      if (not . Set.null $ onlyConfigs)
+        then Env $ EnvOther (unConfigName conf)
+        else case unConfigName conf of
+          "compileOnly" -> Env EnvDevelopment
+          x | x `elem` ["testImplementation", "testCompileOnly", "testRuntimeOnly", "testCompileClasspath", "testRuntimeClasspath"] -> Env EnvTesting
+          x | isDefaultAndroidDevConfig x -> Env EnvDevelopment
+          x | isDefaultAndroidTestConfig x -> Env EnvTesting
+          x -> Env $ EnvOther x
 
     toDependency :: JsonDep -> Set GradleLabel -> Dependency
     toDependency dep = foldr applyLabel $ jsonDepToDep dep

--- a/src/Strategy/Gradle.hs
+++ b/src/Strategy/Gradle.hs
@@ -21,7 +21,7 @@ module Strategy.Gradle (
   ConfigName (..),
 ) where
 
-import App.Fossa.Analyze.Types (AnalyzePreferences (..), AnalyzeProject, analyzeProject)
+import App.Fossa.Analyze.Types (AnalyzeExperimentalPreferences (..), AnalyzeProject, analyzeProject)
 import Control.Algebra (Has, run)
 import Control.Carrier.Reader (Reader)
 import Control.Effect.Diagnostics (
@@ -245,7 +245,7 @@ getDeps ::
   , Has Exec sig m
   , Has ReadFS sig m
   , Has Diagnostics sig m
-  , Has (Reader AnalyzePreferences) sig m
+  , Has (Reader AnalyzeExperimentalPreferences) sig m
   ) =>
   FoundTargets ->
   GradleProject ->
@@ -270,7 +270,7 @@ analyze ::
   , Has Exec sig m
   , Has ReadFS sig m
   , Has Diagnostics sig m
-  , Has (Reader AnalyzePreferences) sig m
+  , Has (Reader AnalyzeExperimentalPreferences) sig m
   ) =>
   FoundTargets ->
   Path Abs Dir ->

--- a/src/Strategy/Gradle.hs
+++ b/src/Strategy/Gradle.hs
@@ -346,7 +346,7 @@ buildGraph projectsAndDeps onlyConfigs = run . withLabeling toDependency $ Map.t
     -- Infers environment label based on the name of configuration.
     -- When, we are only including set of configurations, as provided by users
     -- We mark all of them as other environment titled by configuration, so that
-    -- user's selected configuration will not be removed due to having been unused, 
+    -- user's selected configuration will not be removed due to having been unused,
     -- and subsequently will be submitted to server.
     -- Ref: https://docs.gradle.org/current/userguide/java_library_plugin.html#sec:java_library_configurations_graph
     configNameToLabel :: ConfigName -> GradleLabel

--- a/test/App/Fossa/AnalyzeSpec.hs
+++ b/test/App/Fossa/AnalyzeSpec.hs
@@ -1,7 +1,7 @@
 module App.Fossa.AnalyzeSpec (spec) where
 
 import App.Fossa.Analyze (DiscoverFunc, discoverFuncs)
-import App.Fossa.Analyze.Types (AnalyzePreferences)
+import App.Fossa.Analyze.Types (AnalyzeExperimentalPreferences)
 import Control.Carrier.Debug (DebugC)
 import Control.Carrier.Diagnostics (DiagnosticsC)
 import Control.Carrier.Reader (ReaderC)
@@ -10,7 +10,7 @@ import Effect.Logger (LoggerC)
 import Effect.ReadFS (ReadFSIOC)
 import Test.Hspec (Spec, describe, it, shouldBe)
 
-type SomeMonad = ReaderC AnalyzePreferences (DebugC (DiagnosticsC (LoggerC (ExecIOC (ReadFSIOC IO)))))
+type SomeMonad = ReaderC AnalyzeExperimentalPreferences (DebugC (DiagnosticsC (LoggerC (ExecIOC (ReadFSIOC IO)))))
 
 spec :: Spec
 spec =

--- a/test/App/Fossa/AnalyzeSpec.hs
+++ b/test/App/Fossa/AnalyzeSpec.hs
@@ -1,14 +1,16 @@
 module App.Fossa.AnalyzeSpec (spec) where
 
 import App.Fossa.Analyze (DiscoverFunc, discoverFuncs)
+import App.Fossa.Analyze.Types (AnalyzePreferences)
 import Control.Carrier.Debug (DebugC)
 import Control.Carrier.Diagnostics (DiagnosticsC)
+import Control.Carrier.Reader (ReaderC)
 import Effect.Exec (ExecIOC)
 import Effect.Logger (LoggerC)
 import Effect.ReadFS (ReadFSIOC)
 import Test.Hspec (Spec, describe, it, shouldBe)
 
-type SomeMonad = DebugC (DiagnosticsC (LoggerC (ExecIOC (ReadFSIOC IO))))
+type SomeMonad = ReaderC AnalyzePreferences (DebugC (DiagnosticsC (LoggerC (ExecIOC (ReadFSIOC IO)))))
 
 spec :: Spec
 spec =

--- a/test/App/Fossa/Configuration/ConfigurationSpec.hs
+++ b/test/App/Fossa/Configuration/ConfigurationSpec.hs
@@ -8,6 +8,7 @@ module App.Fossa.Configuration.ConfigurationSpec (
 import App.Fossa.Configuration
 import App.Types (ReleaseGroupMetadata (..))
 import Control.Carrier.Diagnostics qualified as Diag
+import Data.Set qualified as Set
 import Effect.ReadFS
 import Path
 import Path.IO (getCurrentDir)
@@ -24,6 +25,7 @@ expectedConfigFile =
     , configRevision = Just expectedConfigRevision
     , configTargets = Just expectedConfigTargets
     , configPaths = Nothing
+    , configExperimental = Just expectedExperimentalConfig
     }
 
 expectedConfigProject :: ConfigProject
@@ -58,6 +60,12 @@ expectedConfigTargets =
   ConfigTargets
     { targetsOnly = [directoryTarget, simpleTarget, complexTarget]
     , targetsExclude = []
+    }
+
+expectedExperimentalConfig :: ExperimentalConfigs
+expectedExperimentalConfig =
+  ExperimentalConfigs
+    { gradle = Just $ ExperimentalGradleConfigs (Set.fromList ["onlyProdConfigs", "onlyProdConfigs2"])
     }
 
 simpleTarget :: TargetFilter

--- a/test/App/Fossa/Configuration/testdata/validconfig.yml
+++ b/test/App/Fossa/Configuration/testdata/validconfig.yml
@@ -27,3 +27,9 @@ targets:
     - type: gradle
       path: .
       target: specific-target
+
+experimental:
+  gradle:
+    configurations-only:
+      - onlyProdConfigs
+      - onlyProdConfigs2


### PR DESCRIPTION
# Overview

- Adds experimental gradle configurations in fossa configurations file (`experimental.gradle.configurations-only`)
- Filters dependency graph for provided gradle configurations (based on exact matching)

## Acceptance criteria

- Gradle analysis can be filtered to include only set of gradle configurations
- In case of gradle configuration to be filtered is of not used (of dev, test, or other env), provided gralde  
- Gradle configurations can be listed under experimental section in configuration file

## Testing plan

1. Get any open source project built by gradle (https://github.com/android/sunflower)
2. Run `fossa analyze | jq > default.json`
3. Add `.fossa.yml`
```yaml
version: 3

experimental:
  gradle:
    configurations-only:
      - kaptAndroidTest
```
4. Run `fossa analyze | jq > with-gradle-flags.json`
5. Run `gradle -q app:dependencies --configuration kaptAndroidTest` 

Assert that,
- `default.json` and `with-gradle-flags.json` (they should have different amount of dependencies)
- Dependency graph of (5) matches result of `with-gradle-flags.json`

## Risks / Other Notes

- Not the best plumbing for configurations, but since this is all getting refactored in future, I chose the simplest approach of adding `Reader` in AnalyzeEff

- When gradle configurations are provided for filtering, this PR marks every dependency environment as Other, to explicitly, avoid getting them filtered from final output. 

## References

Closes https://github.com/fossas/team-analysis/issues/800

## Checklist

- [x] I added tests for this PR's change (or confirmed tests are not viable).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] I updated `*schema.json` if I have made changes for `.fossa.yml`, `fossa-deps.{json, yaml, yml}`. You may also need to update these if you have added/removed new dependency (e.g. pip) or analysis target type (e.g. poetry).
- [x] I linked this PR to any referenced GitHub issues, if they exist.