### PR TITLE
Fix typo in report docs

### DIFF
--- a/docs/references/subcommands/report.md
+++ b/docs/references/subcommands/report.md
@@ -29,7 +29,7 @@ Where `60` is the maximum number of seconds to wait for the report to be downloa
 By default, `fossa report` displays issues in a human-readable format. To instead print issues as JSON, use:
 
 ```sh
-fossa report attribtion --json
+fossa report attribution --json
 ```
 
 *NOTE: Currently, text reports are not supported, and the report will be*


### PR DESCRIPTION
# Overview

Fixes a small typo in the docs for the report subcommand.

## Acceptance criteria

Fixes a typo in a code block which consumers will copy/paste and run. This ensures it will work as expected.

## Testing plan

- Check out the updated docs.

## Risks

- Low/No Risk.

## References

- N/A

## Checklist

- [ ] I added tests for this PR's change (or confirmed tests are not viable).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] I updated `*schema.json` if I have made changes for `.fossa.yml`, `fossa-deps.{json, yaml, yml}`. You may also need to update these if you have added/removed new dependency (e.g. pip) or analysis target type (e.g. poetry).
- [ ] I linked this PR to any referenced GitHub issues, if they exist.
