### PR TITLE
Use wiggins 2021-11-01-6b0a1ce

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Spectrometer Changelog
 
+## v2.19.4
+
+- Fixes an issue observed during VSI analysis where fingerprinting files with lines longer than 64KiB would fail. ([#427](https://github.com/fossas/spectrometer/pull/427))
+
 ## v2.19.3
 
 - Removes `fossa compatibility` command. ([#383](https://github.com/fossas/spectrometer/pull/383))

--- a/vendor_download.sh
+++ b/vendor_download.sh
@@ -45,7 +45,7 @@ esac
 TAG="latest"
 echo "Downloading asset information from latest tag for architecture '$ASSET_POSTFIX'"
 
-WIGGINS_TAG="2021-10-28-4a27736"
+WIGGINS_TAG="2021-11-01-6b0a1ce"
 echo "Downloading wiggins binary"
 echo "Using wiggins release: $WIGGINS_TAG"
 WIGGINS_RELEASE_JSON=vendor-bins/wiggins-release.json


### PR DESCRIPTION
Updates the wiggins plugin.
Solves an issue where fingerprinting files with lines larger than 64KiB would fail.