### PR TITLE
add checksums for zip files

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -246,6 +246,12 @@ jobs:
         zip -j release/pathfinder_${{ steps.get-version.outputs.VERSION }}_windows_amd64.zip Windows-binaries/pathfinder.exe
         zip -j release/compat-attribution_${{ steps.get-version.outputs.VERSION }}_windows_amd64.zip Windows-binaries/compat-attribution.exe
 
+    - name: Create checksums
+      run: |
+        sha256sum "release/fossa_${{ steps.get-version.outputs.VERSION }}_linux_amd64.zip" > "release/fossa_${{ steps.get-version.outputs.VERSION }}_linux_amd64.zip.sha256"
+        sha256sum "release/fossa_${{ steps.get-version.outputs.VERSION }}_darwin_amd64.zip" > "release/fossa_${{ steps.get-version.outputs.VERSION }}_darwin_amd64.zip.sha256"
+        sha256sum "release/fossa_${{ steps.get-version.outputs.VERSION }}_windows_amd64.zip" > "release/fossa_${{ steps.get-version.outputs.VERSION }}_windows_amd64.zip.sha256"
+
     - name: Release
       uses: softprops/action-gh-release@v1
       with:


### PR DESCRIPTION
Update GH actions release flow to post checksums of the zip files we host.  This can help confirm that the version a customer downloads is the same version that was posted in the release.  While this does not mitigate our anything in our main threat model (which is a malicious actor gaining access to the repo on Github itself, from which they could spoof these checksums), the posted checksum can be saved, and later used as proof that the release artifacts have not changed.