### PR TITLE
Run the checksum from inside the release dir

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -247,10 +247,12 @@ jobs:
         zip -j release/compat-attribution_${{ steps.get-version.outputs.VERSION }}_windows_amd64.zip Windows-binaries/compat-attribution.exe
 
     - name: Create checksums
+      # We have to run from within the release dir so that "release" isn't prepended to the relative path of the zip file.
       run: |
-        sha256sum "release/fossa_${{ steps.get-version.outputs.VERSION }}_linux_amd64.zip" > "release/fossa_${{ steps.get-version.outputs.VERSION }}_linux_amd64.zip.sha256"
-        sha256sum "release/fossa_${{ steps.get-version.outputs.VERSION }}_darwin_amd64.zip" > "release/fossa_${{ steps.get-version.outputs.VERSION }}_darwin_amd64.zip.sha256"
-        sha256sum "release/fossa_${{ steps.get-version.outputs.VERSION }}_windows_amd64.zip" > "release/fossa_${{ steps.get-version.outputs.VERSION }}_windows_amd64.zip.sha256"
+        cd release
+        sha256sum "fossa_${{ steps.get-version.outputs.VERSION }}_linux_amd64.zip" > "fossa_${{ steps.get-version.outputs.VERSION }}_linux_amd64.zip.sha256"
+        sha256sum "fossa_${{ steps.get-version.outputs.VERSION }}_darwin_amd64.zip" > "fossa_${{ steps.get-version.outputs.VERSION }}_darwin_amd64.zip.sha256"
+        sha256sum "fossa_${{ steps.get-version.outputs.VERSION }}_windows_amd64.zip" > "fossa_${{ steps.get-version.outputs.VERSION }}_windows_amd64.zip.sha256"
 
     - name: Release
       uses: softprops/action-gh-release@v1


### PR DESCRIPTION
sha256sum outputs checksums in the format of `somehash path/to/file`.
When a user downloads `somezipfile` and `somezipfile.sha256`, we want to be able to run `sha256sum somezipfile.sha256`.  However, to get the correct path name in the checksum file, we have to run from the downloader's POV, which means that `somezipfile` needs to be in the current directory when the sum is calculated.

closes fossas/team-analysis#801