### PR TITLE
Compute checksums in binary mode and sanity-check them

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -250,9 +250,13 @@ jobs:
       # We have to run from within the release dir so that "release" isn't prepended to the relative path of the zip file.
       run: |
         cd release
-        sha256sum "fossa_${{ steps.get-version.outputs.VERSION }}_linux_amd64.zip" > "fossa_${{ steps.get-version.outputs.VERSION }}_linux_amd64.zip.sha256"
-        sha256sum "fossa_${{ steps.get-version.outputs.VERSION }}_darwin_amd64.zip" > "fossa_${{ steps.get-version.outputs.VERSION }}_darwin_amd64.zip.sha256"
-        sha256sum "fossa_${{ steps.get-version.outputs.VERSION }}_windows_amd64.zip" > "fossa_${{ steps.get-version.outputs.VERSION }}_windows_amd64.zip.sha256"
+        sha256sum --binary "fossa_${{ steps.get-version.outputs.VERSION }}_linux_amd64.zip" > "fossa_${{ steps.get-version.outputs.VERSION }}_linux_amd64.zip.sha256"
+        sha256sum --binary "fossa_${{ steps.get-version.outputs.VERSION }}_darwin_amd64.zip" > "fossa_${{ steps.get-version.outputs.VERSION }}_darwin_amd64.zip.sha256"
+        sha256sum --binary "fossa_${{ steps.get-version.outputs.VERSION }}_windows_amd64.zip" > "fossa_${{ steps.get-version.outputs.VERSION }}_windows_amd64.zip.sha256"
+
+        echo "Sanity-checking the checksums."
+
+        cat *.sha256 | sha256sum --check --status
 
     - name: Release
       uses: softprops/action-gh-release@v1


### PR DESCRIPTION
Binary mode only makes a difference on platforms with a real difference between binary and test files.  MS-DOS (not windows!) is cited as an example in multiple articles, but if anyone is using spectrometer on MS-DOS I think we can safely say it's not supported.