### PR TITLE
Support skipping VSI resolution

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Spectrometer Changelog
 
+## v2.19.6
+
+- Adds the ability to skip resolving dependencies from FOSSA projects discovered during VSI scans ([#435](https://github.com/fossas/spectrometer/pull/435))
+
 ## v2.19.5
 
 - Fixes an issue observed during VSI analysis where fingerprinting files with lines longer than 64KiB would fail. ([#427](https://github.com/fossas/spectrometer/pull/427))

--- a/src/App/Fossa/Main.hs
+++ b/src/App/Fossa/Main.hs
@@ -55,6 +55,7 @@ import App.Fossa.VPS.Test qualified as VPSTest
 import App.Fossa.VPS.Types (FilterExpressions (..), NinjaFilePaths (..), NinjaScanID (..))
 import App.Fossa.VSI.IAT.AssertUserDefinedBinaries (assertUserDefinedBinariesMain)
 import App.Fossa.VSI.IAT.Types (UserDefinedAssertionMeta (..))
+import App.Fossa.VSI.Types qualified as VSI
 import App.OptionExtensions (jsonOption, uriOption)
 import App.Types (
   BaseDir (BaseDir, unBaseDir),
@@ -219,7 +220,7 @@ appMain = do
 
       let analyzeOverride = override{overrideBranch = analyzeBranch <|> ((fileConfig >>= configRevision) >>= configBranch)}
           combinedFilters = normalizedFilters fileConfig analyzeOptions
-          modeOptions = ModeOptions analyzeVSIMode assertionMode analyzeBinaryDiscoveryMode
+          modeOptions = ModeOptions analyzeVSIMode (VSI.SkipResolution analyzeSkipVSIGraphResolution) assertionMode analyzeBinaryDiscoveryMode
           doAnalyze destination = analyzeMain analyzeBaseDir logSeverity destination analyzeOverride analyzeUnpackArchives analyzeJsonOutput analyzeIncludeAllDeps modeOptions combinedFilters analyzePreferences
 
       if analyzeOutput
@@ -438,6 +439,7 @@ analyzeOpts =
     <*> vsiAnalyzeOpt
     <*> binaryDiscoveryOpt
     <*> iatAssertionOpt
+    <*> many skipVSIGraphResolutionOpt
     <*> monorepoOpts
     <*> baseDirArg
 
@@ -455,6 +457,14 @@ iatAssertionOpt :: Parser AnalyzeVSIAssertionMode
 iatAssertionOpt =
   (AnalyzeVSIAssertionEnabled <$> strOption (long "experimental-link-project-binary" <> hidden))
     <|> pure AnalyzeVSIAssertionDisabled
+
+skipVSIGraphResolutionOpt :: Parser VSI.Locator
+skipVSIGraphResolutionOpt = (option (eitherReader parseLocator) (long "experimental-skip-vsi-graph" <> hidden))
+  where
+    parseLocator :: String -> Either String VSI.Locator
+    parseLocator s = case VSI.parseLocator (toText s) of
+      Left err -> Left $ toString (toText err)
+      Right loc -> pure loc
 
 filterOpt :: Parser TargetFilter
 filterOpt = option (eitherReader parseFilter) (long "filter" <> help "(deprecated) Analysis-Target filters (default: none)" <> metavar "ANALYSIS-TARGET")
@@ -723,6 +733,7 @@ data AnalyzeOptions = AnalyzeOptions
   , analyzeVSIMode :: VSIAnalysisMode
   , analyzeBinaryDiscoveryMode :: BinaryDiscoveryMode
   , analyzeAssertMode :: AnalyzeVSIAssertionMode
+  , analyzeSkipVSIGraphResolution :: [VSI.Locator]
   , monorepoAnalysisOpts :: MonorepoAnalysisOpts
   , analyzeBaseDir :: FilePath
   }

--- a/src/App/Fossa/Main.hs
+++ b/src/App/Fossa/Main.hs
@@ -80,6 +80,7 @@ import Data.Bool (bool)
 import Data.Flag (Flag, flagOpt, fromFlag)
 import Data.Foldable (for_)
 import Data.Functor.Extra ((<$$>))
+import Data.Set qualified as Set
 import Data.String.Conversion (toString, toText)
 import Data.Text (Text)
 import Data.Text qualified as Text
@@ -220,7 +221,7 @@ appMain = do
 
       let analyzeOverride = override{overrideBranch = analyzeBranch <|> ((fileConfig >>= configRevision) >>= configBranch)}
           combinedFilters = normalizedFilters fileConfig analyzeOptions
-          modeOptions = ModeOptions analyzeVSIMode (VSI.SkipResolution analyzeSkipVSIGraphResolution) assertionMode analyzeBinaryDiscoveryMode
+          modeOptions = ModeOptions analyzeVSIMode (VSI.SkipResolution $ Set.fromList analyzeSkipVSIGraphResolution) assertionMode analyzeBinaryDiscoveryMode
           doAnalyze destination = analyzeMain analyzeBaseDir logSeverity destination analyzeOverride analyzeUnpackArchives analyzeJsonOutput analyzeIncludeAllDeps modeOptions combinedFilters analyzePreferences
 
       if analyzeOutput

--- a/src/App/Fossa/VSI/IAT/Resolve.hs
+++ b/src/App/Fossa/VSI/IAT/Resolve.hs
@@ -14,11 +14,13 @@ import App.Fossa.VSI.IAT.Types (
 import App.Fossa.VSI.IAT.Types qualified as IAT
 import App.Fossa.VSI.Types qualified as VSI
 import Control.Algebra (Has)
-import Control.Effect.Diagnostics (Diagnostics, context)
+import Control.Effect.Diagnostics (Diagnostics, context, fatalText, recover)
 import Control.Effect.Lift (Lift)
+import Data.Maybe (fromMaybe, isNothing)
 import Data.String.Conversion (toText)
+import Data.Text (Text, intercalate)
 import Fossa.API.Types (ApiOpts)
-import Graphing (Graphing, direct, edges)
+import Graphing (Graphing, direct, edges, empty)
 import Srclib.Types (
   SourceUserDefDep (..),
  )
@@ -30,7 +32,7 @@ resolveUserDefined apiOpts deps = context ("Resolving user defined dependencies 
     then pure Nothing
     else pure . Just $ map toUserDefDep assertions
 
-resolveRevision :: (Has (Lift IO) sig m, Has Diagnostics sig m) => ApiOpts -> VSI.Locator -> m [VSI.Locator]
+resolveRevision :: (Has (Lift IO) sig m, Has Diagnostics sig m) => ApiOpts -> VSI.Locator -> m (Maybe [VSI.Locator])
 resolveRevision apiOpts locator =
   context ("Resolving dependencies for " <> VSI.renderLocator locator) $
     -- In the future we plan to support either returning a partial graph to the server for resolution there,
@@ -39,23 +41,51 @@ resolveRevision apiOpts locator =
     -- Since users may only register revision assertions as a byproduct of running CLI analysis,
     -- revision assertions are always for "custom" projects.
     if VSI.isTopLevelProject locator
-      then Fossa.resolveProjectDependencies apiOpts locator
-      else pure []
+      then recover $ Fossa.resolveProjectDependencies apiOpts locator
+      else pure . Just $ []
 
 resolveGraph :: (Has (Lift IO) sig m, Has Diagnostics sig m) => ApiOpts -> [VSI.Locator] -> VSI.SkipResolution -> m (Graphing VSI.Locator)
 resolveGraph apiOpts locators skipResolving = context ("Resolving graph for " <> toText (show $ fmap VSI.renderLocator locators)) $ do
-  subgraphs <- traverse (resolveSubgraph apiOpts skipResolving) locators
-  pure $ mconcat subgraphs
+  -- If any of the resulting graphs are Nothing, we failed to fetch the graph from the server.
+  -- This typically means that the user doesn't have access to the project, or the project doesn't exist.
+  -- Collect failed locators and report them to the user, along with mitigation suggestions.
+  subgraphs <- traverseZip (resolveSubgraph apiOpts skipResolving) locators
+  if any resolutionFailed subgraphs
+    then fatalText $ resolveGraphFailureBundle subgraphs
+    else pure . mconcat $ fmap unwrap subgraphs
+  where
+    resolutionFailed (_, b) = isNothing b
+    unwrap (_, b) = fromMaybe empty b
 
-resolveSubgraph :: (Has (Lift IO) sig m, Has Diagnostics sig m) => ApiOpts -> VSI.SkipResolution -> VSI.Locator -> m (Graphing VSI.Locator)
-resolveSubgraph apiOpts skip locator = do
-  -- Pass through the list of skipped locators all the way here:
-  -- we want to still record the direct dependency, we just don't want to resolve it.
-  if VSI.shouldSkipResolving skip locator
-    then pure $ direct locator
-    else do
-      resolved <- resolveRevision apiOpts locator
-      pure $ direct locator <> edges (map edge resolved)
+resolveGraphFailureBundle :: [(VSI.Locator, Maybe (Graphing VSI.Locator))] -> Text
+resolveGraphFailureBundle subgraphs =
+  "Failed to resolve dependencies for the following FOSSA projects:\n\t"
+    <> intercalate "\n\t" (renderFailed subgraphs)
+    <> "\n\n"
+    <> "You may not have access to the projects, or they may not exist.\n"
+    <> "If desired you can use --experimental-skip-vsi-graph to skip resolving the dependencies of these projects."
+  where
+    renderFailed [] = []
+    renderFailed ((a, b) : xs) = case b of
+      Just _ -> renderFailed xs
+      Nothing -> VSI.renderLocator a : renderFailed xs
+
+-- | Given a traverseable list and a monadic function that resolves them to b, traverse and zip the list into a pair of (a, b)
+traverseZip :: (Has (Lift IO) sig m, Traversable t) => (a -> m b) -> t a -> m (t (a, b))
+traverseZip f = traverse (pairM f)
+  where
+    pairM :: Has (Lift IO) sig m => (a -> m b) -> a -> m (a, b)
+    pairM transform a = transform a >>= (\b -> pure (a, b))
+
+-- Pass through the list of skipped locators all the way here:
+-- we want to still record the direct dependency, we just don't want to resolve it.
+resolveSubgraph :: (Has (Lift IO) sig m, Has Diagnostics sig m) => ApiOpts -> VSI.SkipResolution -> VSI.Locator -> m (Maybe (Graphing VSI.Locator))
+resolveSubgraph _ skip locator | VSI.shouldSkipResolving skip locator = pure . Just $ direct locator
+resolveSubgraph apiOpts _ locator = do
+  resolved <- resolveRevision apiOpts locator
+  case resolved of
+    Just deps -> pure . Just $ direct locator <> edges (map edge deps)
+    Nothing -> pure Nothing
   where
     edge dep = (locator, dep)
 

--- a/src/App/Fossa/VSI/IAT/Resolve.hs
+++ b/src/App/Fossa/VSI/IAT/Resolve.hs
@@ -62,7 +62,7 @@ resolveGraphFailureBundle subgraphs =
   "Failed to resolve dependencies for the following FOSSA projects:\n\t"
     <> intercalate "\n\t" (renderFailed subgraphs)
     <> "\n\n"
-    <> "You may not have access to the projects, or they may not exist.\n"
+    <> "You may not have access to the projects, or they may not exist (see the warnings below for details).\n"
     <> "If desired you can use --experimental-skip-vsi-graph to skip resolving the dependencies of these projects."
   where
     renderFailed [] = []

--- a/src/App/Fossa/VSI/IAT/Resolve.hs
+++ b/src/App/Fossa/VSI/IAT/Resolve.hs
@@ -49,11 +49,9 @@ resolveGraph apiOpts locators skipResolving = context ("Resolving graph for " <>
 
 resolveSubgraph :: (Has (Lift IO) sig m, Has Diagnostics sig m) => ApiOpts -> VSI.SkipResolution -> VSI.Locator -> m (Graphing VSI.Locator)
 resolveSubgraph apiOpts skip locator = do
-  -- Pass through the list of skipped locators all the way here because we want to still record the direct dependency,
-  -- we just don't want to resolve it.
-  -- While this is an inefficient comparison since we're not making this list into a map or similar for quick lookups,
-  -- we expect the list of ignored locators to be very small.
-  if locator `elem` (VSI.unVSISkipResolution skip)
+  -- Pass through the list of skipped locators all the way here:
+  -- we want to still record the direct dependency, we just don't want to resolve it.
+  if VSI.shouldSkipResolving skip locator
     then pure $ direct locator
     else do
       resolved <- resolveRevision apiOpts locator

--- a/src/App/Fossa/VSI/Types.hs
+++ b/src/App/Fossa/VSI/Types.hs
@@ -3,6 +3,8 @@
 module App.Fossa.VSI.Types (
   Locator (..),
   LocatorParseError (..),
+  SkipResolution (..),
+  filterSkipped,
   parseLocator,
   renderLocator,
   isUserDefined,
@@ -13,6 +15,7 @@ module App.Fossa.VSI.Types (
 
 import Control.Effect.Diagnostics (ToDiagnostic, renderDiagnostic)
 import Data.Aeson (FromJSON (parseJSON), withObject, (.:))
+import Data.String.Conversion (ToText, toText)
 import Data.Text (Text)
 import DepTypes (DepType (..), Dependency (..), VerConstraint (CEq))
 import Effect.Logger (Pretty (pretty), viaShow)
@@ -44,9 +47,23 @@ renderLocator Locator{..} = locatorFetcher <> "+" <> locatorProject <> "$" <> lo
 newtype LocatorParseError = RevisionRequired Srclib.Locator
   deriving (Eq, Ord, Show)
 
+instance ToText LocatorParseError where
+  toText (RevisionRequired locator) =
+    "Revision is required on locator: " <> Srclib.renderLocator locator
+
 instance ToDiagnostic LocatorParseError where
   renderDiagnostic (RevisionRequired locator) =
     "Revision is required on locator: " <> viaShow locator
+
+-- | VSI locally resolves the dependencies of some VSI dependencies using the FOSSA API.
+-- In the case where a user doesn't have access to view a project that is a dependency of their project,
+-- we can't perform this resolution.
+-- To handle this case we provide users with an escape hatch, which is an argument allowing them to skip resolving some of their dependencies.
+-- This type canonicalizes that request.
+newtype SkipResolution = SkipResolution {unVSISkipResolution :: [Locator]}
+
+filterSkipped :: [Locator] -> SkipResolution -> [Locator]
+filterSkipped locs skip = filter (`notElem` unVSISkipResolution skip) locs
 
 toDependency :: Locator -> Either ToDependencyError Dependency
 toDependency locator =

--- a/src/App/Fossa/VSIDeps.hs
+++ b/src/App/Fossa/VSIDeps.hs
@@ -26,12 +26,12 @@ import Types (GraphBreadth (Complete))
 
 -- | VSI analysis is sufficiently different from other analysis types that it cannot be just another strategy.
 -- Instead, VSI analysis is run separately over the entire scan directory, outputting its own source unit.
-analyzeVSIDeps :: (MonadIO m, Has Diagnostics sig m, Has Exec sig m, Has (Lift IO) sig m) => Path Abs Dir -> ApiOpts -> AllFilters -> m SourceUnit
-analyzeVSIDeps dir apiOpts filters = do
+analyzeVSIDeps :: (MonadIO m, Has Diagnostics sig m, Has Exec sig m, Has (Lift IO) sig m) => Path Abs Dir -> ApiOpts -> AllFilters -> VSI.SkipResolution -> m SourceUnit
+analyzeVSIDeps dir apiOpts filters skipResolving = do
   (direct, userDeps) <- pluginAnalyze $ generateVSIStandaloneOpts dir (toPathFilters filters) apiOpts
 
   resolvedUserDeps <- resolveUserDefined apiOpts userDeps
-  resolvedGraph <- resolveGraph apiOpts direct
+  resolvedGraph <- resolveGraph apiOpts direct skipResolving
   dependencies <- fromEither $ Graphing.gtraverse VSI.toDependency resolvedGraph
 
   pure $ toSourceUnit (toProject dir dependencies) resolvedUserDeps


### PR DESCRIPTION
# Overview

Supports _another_ new hidden flag, `experimental-skip-vsi-graph`.
This flag enables users to skip resolving the dependencies of projects to which they don't have access.

Additionally, locators that fail to resolve are collected and rendered all at once, instead of failing on the first one.
This is intended to remove the need for users to run the same scan multiple times (which may take a substantial amount of time) to catch all failures. We also provide a suggested remediation step for users pointing them to this new flag.

Failing to resolve dependencies now looks like this:
```
[ERROR] ----------
  An error occurred:

      Failed to resolve dependencies for the following FOSSA projects:
      	custom+24357/internal-json-parser2$1635972409
      	custom+24357/parser2$1635972367

      You may not have access to the projects, or they may not exist (see the warnings below for details).
      If desired you can use --experimental-skip-vsi-graph to skip resolving the dependencies of these projects.

      Traceback:
        - Resolving graph for ["git+github.com/hunter-packages/tesseract$cd651045033e09df8b3474dce5f4aedbee22490e","custom+24357/internal-json-parser2$1635972409","custom+24357/parser2$1635972367","git+github.com/adderly/folly$73f2085759f2dc872bf23f90d8bd354445433c01"]
        - analyze-vsi
        - fossa-analyze

  >>>

    Relevant warnings include:

      Response from FOSSA API: invalid project or revision

      Traceback:
        - Resolving dependencies for custom+24357/internal-json-parser2$1635972409
        - Resolving graph for ["git+github.com/hunter-packages/tesseract$cd651045033e09df8b3474dce5f4aedbee22490e","custom+24357/internal-json-parser2$1635972409","custom+24357/parser2$1635972367","git+github.com/adderly/folly$73f2085759f2dc872bf23f90d8bd354445433c01"]
        - analyze-vsi
        - fossa-analyze

      --

      Response from FOSSA API: invalid project or revision

      Traceback:
        - Resolving dependencies for custom+24357/parser2$1635972367
        - Resolving graph for ["git+github.com/hunter-packages/tesseract$cd651045033e09df8b3474dce5f4aedbee22490e","custom+24357/internal-json-parser2$1635972409","custom+24357/parser2$1635972367","git+github.com/adderly/folly$73f2085759f2dc872bf23f90d8bd354445433c01"]
        - analyze-vsi
        - fossa-analyze
```

Background:

Support for multistage builds in VSI is accomplished via IAT. The short version is that we can tell FOSSA “this  fingerprint corresponds to this user defined dependency” and “this fingerprint corresponds to this top level project in FOSSA”.
In the latter case, when we match a binary that is thusly associated, the CLI requests the dependencies from Core for that project and uploads them as part of the graph, so we can support deep deps.

An unintended side effect of this process is that the following scenario is possible (and was reported by one of our beta users):
* User A analyzes a project, let’s call it `Project A`, with `--experimental-link-project-binary --enable-vsi`.
* User B analyzes a project, let’s call it `Project B`, that contains one or more of the binaries associated to `Project A` with the `--enable-vsi` flag.
* User B is not authorized to view `Project A`, so when the CLI asks FOSSA for the dependencies FOSSA reports the project doesn’t exist.

This PR adds a new flag that allows users to signal to FOSSA that it shouldn't try to resolve dependencies for the provided project(s), because they know that resolution will fail.

This isn't an ideal end state, but until we can send the partial graph to the server to be resolved there this is what we have to do.

## Acceptance criteria

I performed the following steps:

1. Created an org in FOSSA.
2. Invited two users to the org.
3. Configured them with their own teams.
3. Set them up to be team admins, with no org-level access (so they can only view things inside their teams).
4. Scanned a project in User A's team that registered a binary.
5. Scanned a project containing that binary with User B.
6. Observed an error saying that User A's project doesn't exist.
7. Used the new flag to ignore User A's project and rescanned.
8. Observed the scan complete successfully, and observed User A's project showing as a direct dependency of User B's project, just without any of its deps.

## Testing plan

Do the same thing as the AC with your own projects/users. Feel free to use the [C/C++ Demo](https://github.com/fossas/cpp-vsi-demo) if you want an example project.

## Risks

Not particularly risky.

## Checklist

- [x] I added tests for this PR's change (or confirmed tests are not viable).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] I updated `*schema.json` if I have made changes for `.fossa.yml`, `fossa-deps.{json, yaml, yml}`. You may also need to update these if you have added/removed new dependency (e.g. pip) or analysis target type (e.g. poetry).
- [x] I linked this PR to any referenced GitHub issues, if they exist.
