### PR TITLE
[DNM]: Explicit imports

### DIFF
--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -58,6 +58,7 @@ common lang
     -Wall -Wincomplete-uni-patterns -Wcompat
     -Wincomplete-record-updates -Wmissing-home-modules
     -Wmissing-export-lists -Wredundant-constraints
+    -Wmissing-import-lists
 
 -- TODO: base16-bytestring isn't a direct dep, but we need to add version bounds because cpio-conduit fails to compile with a newer version. Remove the dependency on base16-bytestring once we fix or bump cpio-conduit
 -- TODO: Switch `semver` back to `versions` once https://github.com/fosskers/versions/issues/47 is fixed? This package maintainer seems much more responsive. Contrast https://github.com/brendanhay/semver/issues/12.

--- a/src/App/Fossa/API/BuildLink.hs
+++ b/src/App/Fossa/API/BuildLink.hs
@@ -7,17 +7,27 @@ module App.Fossa.API.BuildLink (
   samlUrlPath,
 ) where
 
-import App.Fossa.FossaAPIV1 (Organization (..), getOrganization)
-import App.Types
-import Control.Effect.Diagnostics hiding (fromMaybe)
-import Control.Effect.Lift
+import App.Fossa.FossaAPIV1 (
+  Organization (Organization, orgUsesSAML, organizationId),
+  getOrganization,
+ )
+import App.Types (ProjectRevision (ProjectRevision, projectBranch, projectRevision))
+import Control.Effect.Diagnostics (Diagnostics, Has, recover)
+import Control.Effect.Lift (Lift)
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import Data.Text.Extra (showT)
-import Fossa.API.Types (ApiOpts (..))
-import Srclib.Types (Locator (..))
+import Fossa.API.Types (ApiOpts (apiOptsUri))
+import Srclib.Types (Locator (Locator, locatorFetcher, locatorProject, locatorRevision))
 import Text.URI qualified as URI
-import Text.URI.Builder
+import Text.URI.Builder (
+  PathComponent (PathComponent),
+  Query (Pair),
+  TrailingSlash (TrailingSlash),
+  renderPath,
+  setPath,
+  setQuery,
+ )
 import Text.URI.QQ (uri)
 
 fossaProjectUrlPath :: Locator -> ProjectRevision -> [PathComponent]

--- a/src/App/Fossa/API/BuildWait.hs
+++ b/src/App/Fossa/API/BuildWait.hs
@@ -16,7 +16,7 @@ import Control.Concurrent (threadDelay)
 import Control.Concurrent.Async qualified as Async
 import Control.Effect.Diagnostics (
   Diagnostics,
-  ToDiagnostic (..),
+  ToDiagnostic (renderDiagnostic),
   fatal,
   fatalText,
   recover,
@@ -26,7 +26,7 @@ import Control.Effect.StickyLogger (StickyLogger, logSticky')
 import Data.Functor (($>))
 import Data.Text (Text)
 import Effect.Logger (Logger, pretty, viaShow)
-import Fossa.API.Types (ApiOpts, Issues (..))
+import Fossa.API.Types (ApiOpts, Issues (issuesStatus))
 
 pollDelaySeconds :: Int
 pollDelaySeconds = 8

--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -18,20 +18,34 @@ import App.Docs (userGuideUrl)
 import App.Fossa.API.BuildLink (getFossaBuildUrl)
 import App.Fossa.Analyze.Debug (collectDebugBundle, diagToDebug)
 import App.Fossa.Analyze.GraphMangler (graphingToGraph)
-import App.Fossa.Analyze.Project (ProjectResult (..), mkResult)
+import App.Fossa.Analyze.Project (
+  ProjectResult (projectResultGraph, projectResultPath, projectResultType),
+  mkResult,
+ )
 import App.Fossa.Analyze.Types (
-  AnalyzeExperimentalPreferences (..),
-  AnalyzeProject (..),
+  AnalyzeExperimentalPreferences,
+  AnalyzeProject (analyzeProject),
   AnalyzeTaskEffs,
  )
 import App.Fossa.BinaryDeps (analyzeBinaryDeps)
-import App.Fossa.FossaAPIV1 (UploadResponse (..), getProject, projectIsMonorepo, uploadAnalysis, uploadContributors)
+import App.Fossa.FossaAPIV1 (
+  UploadResponse (uploadError, uploadLocator),
+  getProject,
+  projectIsMonorepo,
+  uploadAnalysis,
+  uploadContributors,
+ )
 import App.Fossa.ManualDeps (analyzeFossaDepsFile)
-import App.Fossa.ProjectInference (inferProjectDefault, inferProjectFromVCS, mergeOverride, saveRevision)
+import App.Fossa.ProjectInference (
+  inferProjectDefault,
+  inferProjectFromVCS,
+  mergeOverride,
+  saveRevision,
+ )
 import App.Fossa.VSI.IAT.AssertRevisionBinaries (assertRevisionBinaries)
 import App.Fossa.VSIDeps (analyzeVSIDeps)
 import App.Types (
-  BaseDir (..),
+  BaseDir (BaseDir, unBaseDir),
   OverrideProject,
   ProjectMetadata,
   ProjectRevision (projectBranch, projectName, projectRevision),
@@ -47,7 +61,7 @@ import Control.Carrier.Output.IO (Output, output, runOutput)
 import Control.Carrier.Reader (Reader, runReader)
 import Control.Carrier.StickyLogger (StickyLogger, logSticky', runStickyLogger)
 import Control.Carrier.TaskPool (
-  Progress (..),
+  Progress (Progress, pCompleted, pQueued, pRunning),
   TaskPool,
   forkTask,
   withTaskPool,
@@ -75,7 +89,7 @@ import Discovery.Projects (withDiscoveredProjects)
 import Effect.Exec (Exec, runExecIO)
 import Effect.Logger (
   Logger,
-  Severity (..),
+  Severity (SevDebug, SevError, SevInfo, SevWarn),
   logDebug,
   logError,
   logInfo,
@@ -83,7 +97,7 @@ import Effect.Logger (
   withDefaultLogger,
  )
 import Effect.ReadFS (ReadFS, runReadFSIO)
-import Fossa.API.Types (ApiOpts (..))
+import Fossa.API.Types (ApiOpts)
 import Path (Abs, Dir, Path, fromAbsDir, toFilePath)
 import Path.IO (makeRelative)
 import Prettyprinter (
@@ -99,7 +113,11 @@ import Prettyprinter.Render.Terminal (
   color,
  )
 import Srclib.Converter qualified as Srclib
-import Srclib.Types (Locator (locatorProject, locatorRevision), SourceUnit, parseLocator)
+import Srclib.Types (
+  Locator (locatorProject, locatorRevision),
+  SourceUnit,
+  parseLocator,
+ )
 import Strategy.Bundler qualified as Bundler
 import Strategy.Cargo qualified as Cargo
 import Strategy.Carthage qualified as Carthage
@@ -132,7 +150,16 @@ import Strategy.RPM qualified as RPM
 import Strategy.Rebar3 qualified as Rebar3
 import Strategy.Scala qualified as Scala
 import Strategy.SwiftPM qualified as SwiftPM
-import Types (DiscoveredProject (..), FoundTargets)
+import Types (
+  DiscoveredProject (
+    DiscoveredProject,
+    projectBuildTargets,
+    projectData,
+    projectPath,
+    projectType
+  ),
+  FoundTargets,
+ )
 import VCS.Git (fetchGitContributors)
 
 data ScanDestination

--- a/src/App/Fossa/Analyze/Debug.hs
+++ b/src/App/Fossa/Analyze/Debug.hs
@@ -18,10 +18,23 @@ module App.Fossa.Analyze.Debug (
   debugEverything,
 ) where
 
-import Control.Carrier.Debug
-import Control.Carrier.Diagnostics (Diagnostics (Context, Fatal))
+import Control.Carrier.Debug (
+  Algebra (alg),
+  Debug,
+  DebugC,
+  Has,
+  Scope,
+  debugError,
+  debugLog,
+  debugScope,
+  ignoring,
+  recording,
+  runDebug,
+  type (:+:) (L, R),
+ )
 import Control.Carrier.Lift (sendIO)
 import Control.Carrier.Simple (SimpleC, interpret, sendSimple)
+import Control.Effect.Diagnostics (Diagnostics (Context, Fatal))
 import Control.Effect.Lift (Lift)
 import Control.Effect.Record (Journal, RecordC, runRecord)
 import Control.Effect.Sum (Member, inj)
@@ -32,9 +45,21 @@ import Data.String.Conversion (toText)
 import Data.Text (Text)
 import Data.Text.IO qualified as TIO
 import Data.Word (Word64)
-import Effect.Exec (Exec, ExecF (..))
-import Effect.Logger (Logger, LoggerF (..))
-import Effect.ReadFS (ReadFS, ReadFSF (..))
+import Effect.Exec (Exec, ExecF (Exec))
+import Effect.Logger (Logger, LoggerF (Log, LogStdout))
+import Effect.ReadFS (
+  ReadFS,
+  ReadFSF (
+    DoesDirExist,
+    DoesFileExist,
+    ListDir,
+    ReadContentsBS',
+    ReadContentsBSLimit',
+    ReadContentsText',
+    ResolveDir',
+    ResolveFile'
+  ),
+ )
 import GHC.Conc qualified as Conc
 import GHC.Environment qualified as Environment
 import GHC.Generics (Generic)

--- a/src/App/Fossa/Analyze/Graph.hs
+++ b/src/App/Fossa/Analyze/Graph.hs
@@ -12,14 +12,13 @@ module App.Fossa.Analyze.Graph (
   graphDirect,
 ) where
 
-import Data.Aeson
+import Data.Aeson (KeyValue ((.=)), ToJSON (toJSON), object)
 import Data.Bifunctor (bimap)
 import Data.Function ((&))
 import Data.IntMap qualified as IM
 import Data.IntSet qualified as IS
 import Data.Sequence qualified as S
-
-import DepTypes
+import DepTypes (Dependency)
 
 -- | Opaque reference to a dependency in the graph. Used for adding edges to the graph (See: 'addEdge')
 newtype DepRef = DepRef {unDepRef :: Int} deriving (Eq, Ord, Show)

--- a/src/App/Fossa/Analyze/GraphBuilder.hs
+++ b/src/App/Fossa/Analyze/GraphBuilder.hs
@@ -13,10 +13,15 @@ module App.Fossa.Analyze.GraphBuilder (
 ) where
 
 import App.Fossa.Analyze.Graph qualified as G
-import Control.Algebra
-import Control.Carrier.Simple
-import Control.Carrier.State.Strict
-import DepTypes
+import Control.Algebra (Algebra, Has)
+import Control.Carrier.Simple (
+  Simple,
+  SimpleStateC,
+  interpretState,
+  sendSimple,
+ )
+import Control.Carrier.State.Strict (modify, state)
+import DepTypes (Dependency)
 
 data SGraphBuilder a where
   AddNode :: Dependency -> SGraphBuilder G.DepRef

--- a/src/App/Fossa/Analyze/GraphMangler.hs
+++ b/src/App/Fossa/Analyze/GraphMangler.hs
@@ -4,15 +4,20 @@ module App.Fossa.Analyze.GraphMangler (
 
 import Algebra.Graph.AdjacencyMap (AdjacencyMap)
 import Algebra.Graph.AdjacencyMap qualified as AM
-import Control.Algebra
+import App.Fossa.Analyze.Graph qualified as G
+import App.Fossa.Analyze.GraphBuilder (
+  GraphBuilder,
+  addDirect,
+  addEdge,
+  addNode,
+  evalGraphBuilder,
+ )
+import Control.Algebra (Has, run)
 import Data.Foldable (traverse_)
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
 import Data.Set qualified as Set
-
-import App.Fossa.Analyze.Graph qualified as G
-import App.Fossa.Analyze.GraphBuilder
-import DepTypes
+import DepTypes (Dependency)
 import Graphing (Graphing)
 import Graphing qualified
 

--- a/src/App/Fossa/Analyze/Project.hs
+++ b/src/App/Fossa/Analyze/Project.hs
@@ -4,12 +4,20 @@ module App.Fossa.Analyze.Project (
 ) where
 
 import Data.Text (Text)
-import DepTypes
 import Graphing (Graphing)
 import Graphing qualified
-import Path
+import Path (Abs, Dir, File, Path, SomeBase)
 import Path.Extra (tryMakeRelative)
-import Types
+import Types (
+  Dependency,
+  DependencyResults (
+    dependencyGraph,
+    dependencyGraphBreadth,
+    dependencyManifestFiles
+  ),
+  DiscoveredProject (projectPath, projectType),
+  GraphBreadth,
+ )
 
 mkResult :: Path Abs Dir -> DiscoveredProject n -> (DependencyResults) -> ProjectResult
 mkResult basedir project dependencyResults =

--- a/src/App/Fossa/Analyze/Record.hs
+++ b/src/App/Fossa/Analyze/Record.hs
@@ -8,8 +8,17 @@ module App.Fossa.Analyze.Record (
 ) where
 
 import App.Version (fullVersionDescription)
-import Control.Effect.Record
-import Data.Aeson
+import Control.Effect.Record (Journal)
+import Data.Aeson (
+  FromJSON (parseJSON),
+  KeyValue ((.=)),
+  ToJSON (toJSON),
+  eitherDecodeFileStrict',
+  encodeFile,
+  object,
+  withObject,
+  (.:),
+ )
 import Data.Text (Text)
 import Effect.Exec (ExecF)
 import Effect.ReadFS (ReadFSF)

--- a/src/App/Fossa/Analyze/Types.hs
+++ b/src/App/Fossa/Analyze/Types.hs
@@ -4,9 +4,9 @@ module App.Fossa.Analyze.Types (
   AnalyzeExperimentalPreferences (..),
 ) where
 
-import Control.Carrier.Diagnostics
 import Control.Effect.Debug (Debug)
-import Control.Effect.Lift
+import Control.Effect.Diagnostics (Diagnostics)
+import Control.Effect.Lift (Has, Lift)
 import Control.Effect.Reader (Reader)
 import Control.Monad.IO.Class (MonadIO)
 import Data.Set (Set)
@@ -14,7 +14,7 @@ import Data.Text (Text)
 import Effect.Exec (Exec)
 import Effect.Logger (Logger)
 import Effect.ReadFS (ReadFS)
-import Types
+import Types (DependencyResults, FoundTargets)
 
 newtype AnalyzeExperimentalPreferences = AnalyzeExperimentalPreferences
   {gradleOnlyConfigsAllowed :: Maybe (Set Text)}

--- a/src/App/Fossa/ArchiveUploader.hs
+++ b/src/App/Fossa/ArchiveUploader.hs
@@ -7,27 +7,34 @@ module App.Fossa.ArchiveUploader (
 import App.Fossa.FossaAPIV1 qualified as Fossa
 import Codec.Archive.Tar qualified as Tar
 import Codec.Compression.GZip qualified as GZip
-import Control.Carrier.Diagnostics qualified as Diag
-import Control.Effect.Lift
+import Control.Effect.Diagnostics qualified as Diag (Diagnostics)
+import Control.Effect.Lift (Has, Lift, sendIO)
 import Control.Effect.Path (withSystemTempDir)
-import Crypto.Hash
+import Crypto.Hash (Digest, MD5, hashlazy)
 import Data.Aeson (
   FromJSON (parseJSON),
   withObject,
   (.:),
   (.:?),
  )
-import Data.Aeson.Extra
+import Data.Aeson.Extra (TextLike (unTextLike), forbidMembers)
 import Data.ByteString.Lazy qualified as BS
 import Data.Functor.Extra ((<$$>))
 import Data.List (intercalate)
 import Data.Maybe (fromMaybe)
-import Data.String.Conversion
+import Data.String.Conversion (
+  ToString (toString),
+  ToText (toText),
+ )
 import Data.Text (Text)
-import Fossa.API.Types
-import Path hiding ((</>))
-import Srclib.Types (Locator (..))
-import System.FilePath.Posix
+import Fossa.API.Types (
+  ApiOpts,
+  Archive (Archive, archiveName, archiveVersion),
+  ArchiveComponents (ArchiveComponents),
+ )
+import Path (Abs, Dir, Path)
+import Srclib.Types (Locator (Locator, locatorFetcher, locatorProject, locatorRevision))
+import System.FilePath.Posix (splitDirectories, (</>))
 
 data VendoredDependency = VendoredDependency
   { vendoredName :: Text

--- a/src/App/Fossa/BinaryDeps.hs
+++ b/src/App/Fossa/BinaryDeps.hs
@@ -1,25 +1,32 @@
 module App.Fossa.BinaryDeps (analyzeBinaryDeps) where
 
-import App.Fossa.Analyze.Project (ProjectResult (..))
+import App.Fossa.Analyze.Project (ProjectResult (ProjectResult))
 import App.Fossa.BinaryDeps.Jar (resolveJar)
 import App.Fossa.VSI.IAT.Fingerprint (fingerprintRaw)
-import App.Fossa.VSI.IAT.Types (Fingerprint (..))
+import App.Fossa.VSI.IAT.Types (Fingerprint (unFingerprint))
 import Control.Algebra (Has)
-import Control.Carrier.Diagnostics (Diagnostics, fromEither)
+import Control.Effect.Diagnostics (Diagnostics, fromEither)
 import Control.Effect.Lift (Lift)
 import Control.Monad (filterM)
 import Data.ByteString qualified as BS
 import Data.String.Conversion (toText)
 import Data.Text (Text)
 import Data.Text qualified as Text
-import Discovery.Filters (AllFilters (..), FilterCombination (combinedPaths))
+import Discovery.Filters (
+  AllFilters (excludeFilters, includeFilters),
+  FilterCombination (combinedPaths),
+ )
 import Discovery.Walk (WalkStep (WalkContinue), walk')
 import Effect.Logger (Logger)
 import Effect.ReadFS (ReadFS, readContentsBSLimit)
 import Path (Abs, Dir, File, Path, isProperPrefixOf, (</>))
 import Path.Extra (tryMakeRelative)
 import Srclib.Converter qualified as Srclib
-import Srclib.Types (AdditionalDepData (..), SourceUnit (..), SourceUserDefDep (..))
+import Srclib.Types (
+  AdditionalDepData (AdditionalDepData),
+  SourceUnit (additionalData),
+  SourceUserDefDep (SourceUserDefDep),
+ )
 import Types (GraphBreadth (Complete))
 
 -- | Binary detection is sufficiently different from other analysis types that it cannot be just another strategy.

--- a/src/App/Fossa/BinaryDeps/Jar.hs
+++ b/src/App/Fossa/BinaryDeps/Jar.hs
@@ -4,8 +4,14 @@
 module App.Fossa.BinaryDeps.Jar (resolveJar) where
 
 import Control.Algebra (Has)
-import Control.Carrier.Diagnostics (Diagnostics, context, fromMaybeText, recover, (<||>))
 import Control.Carrier.Finally (runFinally)
+import Control.Effect.Diagnostics (
+  Diagnostics,
+  context,
+  fromMaybeText,
+  recover,
+  (<||>),
+ )
 import Control.Effect.Lift (Lift)
 import Data.List (isSuffixOf, sortOn)
 import Data.Map (Map)
@@ -21,8 +27,14 @@ import Effect.ReadFS (ReadFS, readContentsText, readContentsXML)
 import GHC.Base ((<|>))
 import Path (Abs, Dir, File, Path, filename, mkRelDir, mkRelFile, (</>))
 import Path.Extra (renderRelative, tryMakeRelative)
-import Srclib.Types (SourceUserDefDep (..))
-import Strategy.Maven.Pom.PomFile (MavenCoordinate (..), Pom (..), RawPom, pomLicenseName, validatePom)
+import Srclib.Types (SourceUserDefDep (SourceUserDefDep))
+import Strategy.Maven.Pom.PomFile (
+  MavenCoordinate (coordArtifact, coordGroup, coordVersion),
+  Pom (Pom, pomCoord, pomLicenses),
+  RawPom,
+  pomLicenseName,
+  validatePom,
+ )
 
 data JarMetadata = JarMetadata
   { jarName :: Text

--- a/src/App/Fossa/Configuration.hs
+++ b/src/App/Fossa/Configuration.hs
@@ -15,7 +15,19 @@ module App.Fossa.Configuration (
 ) where
 
 import App.Docs (fossaYmlDocUrl)
-import App.Types
+import App.Types (
+  ProjectMetadata (
+    ProjectMetadata,
+    projectJiraKey,
+    projectLink,
+    projectPolicy,
+    projectReleaseGroup,
+    projectTeam,
+    projectTitle,
+    projectUrl
+  ),
+  ReleaseGroupMetadata,
+ )
 import Control.Carrier.Diagnostics qualified as Diag
 import Control.Effect.Lift (Lift)
 import Data.Aeson (FromJSON (parseJSON), withObject, (.!=), (.:), (.:?))
@@ -25,13 +37,19 @@ import Data.Set (Set)
 import Data.Set qualified as Set
 import Data.Text (Text)
 import Effect.Logger (Severity (SevWarn), logWarn, withDefaultLogger)
-import Effect.ReadFS
-import Path
+import Effect.ReadFS (
+  Has,
+  ReadFS,
+  doesFileExist,
+  readContentsYaml,
+  runReadFSIO,
+ )
+import Path (Abs, Dir, File, Path, Rel, mkRelFile, (</>))
 import Path.IO (getCurrentDir)
 import Prettyprinter (Doc, Pretty (pretty), vsep)
 import System.Exit (die)
-import Text.Megaparsec
-import Types
+import Text.Megaparsec ((<|>))
+import Types (TargetFilter)
 
 data ConfigFile = ConfigFile
   { configVersion :: Int

--- a/src/App/Fossa/Container.hs
+++ b/src/App/Fossa/Container.hs
@@ -21,11 +21,31 @@ module App.Fossa.Container (
 ) where
 
 import App.Fossa.EmbeddedBinary (BinaryPaths, toExecutablePath, withSyftBinary)
-import App.Types (OverrideProject (..), ProjectRevision (..))
-import Control.Carrier.Diagnostics hiding (fromMaybe)
+import App.Types (
+  OverrideProject (OverrideProject, overrideBranch, overrideName, overrideRevision),
+  ProjectRevision (ProjectRevision),
+ )
+import Control.Carrier.Diagnostics (
+  Diagnostics,
+  Has,
+  context,
+  fromEitherShow,
+  fromMaybeText,
+  logWithExit_,
+ )
 import Control.Effect.Lift (Lift, sendIO)
-import Control.Monad.IO.Class
-import Data.Aeson
+import Control.Monad.IO.Class (MonadIO)
+import Data.Aeson (
+  FromJSON (parseJSON),
+  KeyValue ((.=)),
+  ToJSON (toJSON),
+  Value,
+  encode,
+  object,
+  withObject,
+  (.:),
+  (.:?),
+ )
 import Data.Aeson.Types (parseEither)
 import Data.ByteString.Lazy qualified as BL
 import Data.Functor.Extra ((<$$>))
@@ -36,8 +56,22 @@ import Data.Maybe (fromMaybe, listToMaybe)
 import Data.String.Conversion (decodeUtf8, toText)
 import Data.Text (Text, pack)
 import Data.Text.Extra (breakOnAndRemove)
-import Effect.Exec (AllowErr (Never), Command (..), Exec, execJson, execThrow, runExecIO)
-import Effect.Logger
+import Effect.Exec (
+  AllowErr (Never),
+  Command (Command, cmdAllowErr, cmdArgs, cmdName),
+  Exec,
+  execJson,
+  execThrow,
+  runExecIO,
+ )
+import Effect.Logger (
+  Logger,
+  Severity,
+  logDebug,
+  logInfo,
+  logStdout,
+  withDefaultLogger,
+ )
 import Effect.ReadFS (ReadFS, readContentsJson, resolveFile, runReadFSIO)
 import Options.Applicative (Parser, argument, help, metavar, str)
 import Path (toFilePath)

--- a/src/App/Fossa/Container/Analyze.hs
+++ b/src/App/Fossa/Container/Analyze.hs
@@ -3,10 +3,10 @@ module App.Fossa.Container.Analyze (
 ) where
 
 import App.Fossa.API.BuildLink (getFossaBuildUrl)
-import App.Fossa.Analyze (ScanDestination (..))
-import App.Fossa.Container (ImageText (..), extractRevision, runSyft, toContainerScan)
+import App.Fossa.Analyze (ScanDestination (OutputStdout, UploadScan))
+import App.Fossa.Container (ImageText, extractRevision, runSyft, toContainerScan)
 import App.Fossa.FossaAPIV1 (UploadResponse (uploadError, uploadLocator), uploadContainerScan)
-import App.Types (OverrideProject (..), ProjectRevision (..))
+import App.Types (OverrideProject, ProjectRevision (projectBranch, projectName, projectRevision))
 import Control.Carrier.Diagnostics (Diagnostics, logWithExit_)
 import Control.Effect.Lift (Lift)
 import Control.Monad.IO.Class (MonadIO)
@@ -14,7 +14,18 @@ import Data.Aeson (encode)
 import Data.Foldable (traverse_)
 import Data.Maybe (fromMaybe)
 import Data.String.Conversion (decodeUtf8)
-import Effect.Logger
+import Effect.Logger (
+  Has,
+  Logger,
+  Pretty (pretty),
+  Severity,
+  logDebug,
+  logError,
+  logInfo,
+  logStdout,
+  viaShow,
+  withDefaultLogger,
+ )
 import Srclib.Types (parseLocator)
 
 analyzeMain :: ScanDestination -> Severity -> OverrideProject -> ImageText -> IO ()

--- a/src/App/Fossa/Container/Test.hs
+++ b/src/App/Fossa/Container/Test.hs
@@ -5,19 +5,40 @@ module App.Fossa.Container.Test (
   testMain,
 ) where
 
-import App.Fossa.API.BuildWait
-import App.Fossa.Container
-import App.Types (OverrideProject (..), ProjectRevision (..))
-import Control.Carrier.Diagnostics
+import App.Fossa.API.BuildWait (
+  timeout,
+  waitForBuild,
+  waitForIssues,
+ )
+import App.Fossa.Container (
+  ImageText,
+  extractRevision,
+  runSyft,
+  toContainerScan,
+ )
+import App.Types (OverrideProject, ProjectRevision (projectName, projectRevision))
+import Control.Carrier.Diagnostics (
+  Diagnostics,
+  Has,
+  logWithExit_,
+ )
 import Control.Carrier.StickyLogger (StickyLogger, logSticky, runStickyLogger)
-import Control.Effect.Lift
+import Control.Effect.Lift (Lift, sendIO)
 import Control.Monad.IO.Class (MonadIO)
 import Data.Aeson qualified as Aeson
 import Data.Functor (void)
 import Data.String.Conversion (decodeUtf8)
 import Data.Text.IO (hPutStrLn)
-import Effect.Logger
-import Fossa.API.Types (ApiOpts (..), Issues (..))
+import Effect.Logger (
+  Logger,
+  Pretty (pretty),
+  Severity (SevInfo),
+  logError,
+  logInfo,
+  logStdout,
+  withDefaultLogger,
+ )
+import Fossa.API.Types (ApiOpts, Issues (issuesCount, issuesIssues))
 import System.Exit (exitFailure)
 import System.IO (stderr)
 

--- a/src/App/Fossa/EmbeddedBinary.hs
+++ b/src/App/Fossa/EmbeddedBinary.hs
@@ -16,12 +16,30 @@ module App.Fossa.EmbeddedBinary (
 
 import Control.Effect.Exception (bracket)
 import Control.Effect.Lift (Has, Lift, sendIO)
-import Control.Monad.IO.Class
-import Data.ByteString (ByteString, writeFile)
-import Data.FileEmbed.Extra
-import Path
-import Path.IO
-import Prelude hiding (writeFile)
+import Control.Monad.IO.Class (MonadIO (liftIO))
+import Data.ByteString (ByteString)
+import Data.ByteString qualified as BS
+import Data.FileEmbed.Extra (embedFileIfExists)
+import Path (
+  Abs,
+  Dir,
+  File,
+  Path,
+  Rel,
+  fromAbsFile,
+  mkRelDir,
+  mkRelFile,
+  parent,
+  (</>),
+ )
+import Path.IO (
+  Permissions (executable),
+  ensureDir,
+  getPermissions,
+  getTempDir,
+  removeDirRecur,
+  setPermissions,
+ )
 
 data PackagedBinary
   = Syft
@@ -90,7 +108,7 @@ writeBinary dest bin = sendIO . writeExecutable dest $ case bin of
 writeExecutable :: Path Abs File -> ByteString -> IO ()
 writeExecutable path content = do
   ensureDir $ parent path
-  writeFile (fromAbsFile path) content
+  BS.writeFile (fromAbsFile path) content
   makeExecutable path
 
 extractedPath :: PackagedBinary -> Path Rel File

--- a/src/App/Fossa/Main.hs
+++ b/src/App/Fossa/Main.hs
@@ -5,17 +5,19 @@ module App.Fossa.Main (
 ) where
 
 import App.Fossa.Analyze (
-  BinaryDiscoveryMode (..),
-  IATAssertionMode (..),
+  BinaryDiscoveryMode (BinaryDiscoveryDisabled, BinaryDiscoveryEnabled),
+  IATAssertionMode (IATAssertionDisabled, IATAssertionEnabled),
   IncludeAll (IncludeAll),
-  JsonOutput (..),
+  JsonOutput (JsonOutput),
   ModeOptions (ModeOptions),
-  ScanDestination (..),
-  UnpackArchives (..),
-  VSIAnalysisMode (..),
+  ScanDestination (OutputStdout, UploadScan),
+  UnpackArchives (UnpackArchives),
+  VSIAnalysisMode (VSIAnalysisDisabled, VSIAnalysisEnabled),
   analyzeMain,
  )
-import App.Fossa.Analyze.Types (AnalyzeExperimentalPreferences (..))
+import App.Fossa.Analyze.Types (
+  AnalyzeExperimentalPreferences (AnalyzeExperimentalPreferences),
+ )
 import App.Fossa.Configuration (
   ConfigFile (
     configApiKey,
@@ -35,7 +37,12 @@ import App.Fossa.Configuration (
   mergeFileCmdMetadata,
   readConfigFileIO,
  )
-import App.Fossa.Container (ImageText (..), dumpSyftScanMain, imageTextArg, parseSyftOutputMain)
+import App.Fossa.Container (
+  ImageText,
+  dumpSyftScanMain,
+  imageTextArg,
+  parseSyftOutputMain,
+ )
 import App.Fossa.Container.Analyze qualified as ContainerAnalyze
 import App.Fossa.Container.Test qualified as ContainerTest
 import App.Fossa.EmbeddedBinary qualified as Embed
@@ -50,11 +57,20 @@ import App.Fossa.Test qualified as Test
 import App.Fossa.VPS.AOSPNotice (aospNoticeMain)
 import App.Fossa.VPS.NinjaGraph (ninjaGraphMain)
 import App.Fossa.VPS.Report qualified as VPSReport
-import App.Fossa.VPS.Scan (FollowSymlinks (..), LicenseOnlyScan (..), SkipIPRScan (..), scanMain)
+import App.Fossa.VPS.Scan (
+  FollowSymlinks (FollowSymlinks),
+  LicenseOnlyScan (LicenseOnlyScan),
+  SkipIPRScan (SkipIPRScan),
+  scanMain,
+ )
 import App.Fossa.VPS.Test qualified as VPSTest
-import App.Fossa.VPS.Types (FilterExpressions (..), NinjaFilePaths (..), NinjaScanID (..))
+import App.Fossa.VPS.Types (
+  FilterExpressions (FilterExpressions),
+  NinjaFilePaths (NinjaFilePaths),
+  NinjaScanID (NinjaScanID),
+ )
 import App.Fossa.VSI.IAT.AssertUserDefinedBinaries (assertUserDefinedBinariesMain)
-import App.Fossa.VSI.IAT.Types (UserDefinedAssertionMeta (..))
+import App.Fossa.VSI.IAT.Types (UserDefinedAssertionMeta (UserDefinedAssertionMeta))
 import App.OptionExtensions (jsonOption, uriOption)
 import App.Types (
   BaseDir (BaseDir, unBaseDir),
@@ -66,8 +82,8 @@ import App.Types (
     overrideName,
     overrideRevision
   ),
-  ProjectMetadata (..),
-  ReleaseGroupMetadata (..),
+  ProjectMetadata (ProjectMetadata),
+  ReleaseGroupMetadata (ReleaseGroupMetadata),
  )
 import App.Util (validateDir, validateFile)
 import App.Version (fullVersionDescription)
@@ -82,13 +98,17 @@ import Data.Functor.Extra ((<$$>))
 import Data.String.Conversion (toString, toText)
 import Data.Text (Text)
 import Data.Text qualified as Text
-import Discovery.Filters (AllFilters (..), FilterCombination (..), targetFilterParser)
+import Discovery.Filters (
+  AllFilters (AllFilters),
+  FilterCombination (FilterCombination),
+  targetFilterParser,
+ )
 import Effect.Logger (
   Severity (SevDebug, SevInfo),
   logWarn,
   withDefaultLogger,
  )
-import Fossa.API.Types (ApiKey (..), ApiOpts (..))
+import Fossa.API.Types (ApiKey (ApiKey), ApiOpts (ApiOpts))
 import Options.Applicative (
   Alternative (many, (<|>)),
   Parser,

--- a/src/App/Fossa/Monorepo.hs
+++ b/src/App/Fossa/Monorepo.hs
@@ -1,27 +1,58 @@
 module App.Fossa.Monorepo (
   monorepoMain,
   toPathFilters,
-  PathFilters (..),
+  PathFilters,
 ) where
 
-import App.Fossa.EmbeddedBinary
+import App.Fossa.EmbeddedBinary (BinaryPaths, withWigginsBinary)
 import App.Fossa.ProjectInference (
   inferProjectDefault,
   inferProjectFromVCS,
   mergeOverride,
   saveRevision,
  )
-import App.Fossa.VPS.Scan.RunWiggins
-import App.Types
-import Control.Carrier.Diagnostics
+import App.Fossa.VPS.Scan.RunWiggins (
+  PathFilters,
+  WigginsOpts,
+  execWiggins,
+  generateWigginsMonorepoOpts,
+  toPathFilters,
+ )
+import App.Types (
+  BaseDir (BaseDir),
+  MonorepoAnalysisOpts,
+  OverrideProject,
+  ProjectMetadata,
+ )
+import Control.Carrier.Diagnostics (
+  Diagnostics,
+  Has,
+  context,
+  logWithExit_,
+  (<||>),
+ )
 import Control.Effect.Lift (Lift)
-import Data.Text
+import Data.Text (Text)
 import Effect.Exec (Exec, runExecIO)
-import Effect.Logger
+import Effect.Logger (
+  Logger,
+  Pretty (pretty),
+  Severity,
+  logInfo,
+  withDefaultLogger,
+ )
 import Effect.ReadFS (ReadFS, runReadFSIO)
-import Fossa.API.Types
+import Fossa.API.Types (ApiOpts)
 
-monorepoMain :: BaseDir -> MonorepoAnalysisOpts -> Severity -> ApiOpts -> ProjectMetadata -> OverrideProject -> PathFilters -> IO ()
+monorepoMain ::
+  BaseDir ->
+  MonorepoAnalysisOpts ->
+  Severity ->
+  ApiOpts ->
+  ProjectMetadata ->
+  OverrideProject ->
+  PathFilters ->
+  IO ()
 monorepoMain basedir monoRepoAnalysisOpts logSeverity apiOpts projectMeta overrideProject filters = withDefaultLogger logSeverity $ do
   logWithExit_ $ runReadFSIO $ runExecIO $ withWigginsBinary $ monorepoScan basedir monoRepoAnalysisOpts filters logSeverity apiOpts projectMeta overrideProject
 

--- a/src/App/Fossa/Report/Attribution.hs
+++ b/src/App/Fossa/Report/Attribution.hs
@@ -10,7 +10,18 @@ module App.Fossa.Report.Attribution (
   Project (..),
 ) where
 
-import Data.Aeson
+import Data.Aeson (
+  FromJSON (parseJSON),
+  FromJSONKey,
+  KeyValue ((.=)),
+  ToJSON (toJSON),
+  ToJSONKey,
+  object,
+  withObject,
+  (.!=),
+  (.:),
+  (.:?),
+ )
 import Data.Map.Strict (Map)
 import Data.Maybe (catMaybes)
 import Data.Text (Text)

--- a/src/App/Fossa/Test.hs
+++ b/src/App/Fossa/Test.hs
@@ -36,7 +36,7 @@ import Effect.Logger (
   withDefaultLogger,
  )
 import Effect.ReadFS (runReadFSIO)
-import Fossa.API.Types (ApiOpts, Issues (..))
+import Fossa.API.Types (ApiOpts, Issues (issuesCount, issuesIssues))
 import System.Exit (exitFailure)
 import System.IO (stderr)
 

--- a/src/App/Fossa/VPS/AOSPNotice.hs
+++ b/src/App/Fossa/VPS/AOSPNotice.hs
@@ -2,18 +2,37 @@ module App.Fossa.VPS.AOSPNotice (
   aospNoticeMain,
 ) where
 
-import App.Fossa.EmbeddedBinary
-import App.Fossa.ProjectInference
-import App.Fossa.VPS.Scan.RunWiggins
-import App.Fossa.VPS.Types
-import App.Types (BaseDir (..), OverrideProject)
-import Control.Carrier.Diagnostics
+import App.Fossa.EmbeddedBinary (BinaryPaths, withWigginsBinary)
+import App.Fossa.ProjectInference (
+  inferProjectDefault,
+  inferProjectFromVCS,
+  mergeOverride,
+ )
+import App.Fossa.VPS.Scan.RunWiggins (
+  WigginsOpts,
+  execWiggins,
+  generateWigginsAOSPNoticeOpts,
+ )
+import App.Fossa.VPS.Types (NinjaFilePaths, NinjaScanID)
+import App.Types (BaseDir (BaseDir), OverrideProject)
+import Control.Carrier.Diagnostics (
+  Diagnostics,
+  Has,
+  logWithExit_,
+  (<||>),
+ )
 import Control.Effect.Lift (Lift)
 import Data.Text (Text)
 import Effect.Exec (Exec, runExecIO)
-import Effect.Logger
+import Effect.Logger (
+  Logger,
+  Pretty (pretty),
+  Severity,
+  logInfo,
+  withDefaultLogger,
+ )
 import Effect.ReadFS (ReadFS, runReadFSIO)
-import Fossa.API.Types (ApiOpts (..))
+import Fossa.API.Types (ApiOpts)
 import Path (Abs, Dir, Path)
 
 aospNoticeMain :: BaseDir -> Severity -> OverrideProject -> NinjaScanID -> NinjaFilePaths -> ApiOpts -> IO ()

--- a/src/App/Fossa/VPS/Report.hs
+++ b/src/App/Fossa/VPS/Report.hs
@@ -3,13 +3,26 @@ module App.Fossa.VPS.Report (
   ReportType (..),
 ) where
 
-import App.Fossa.API.BuildWait
+import App.Fossa.API.BuildWait (
+  timeout,
+  waitForIssues,
+  waitForSherlockScan,
+ )
 import App.Fossa.FossaAPIV1 qualified as Fossa
-import App.Fossa.ProjectInference
+import App.Fossa.ProjectInference (
+  inferProjectCached,
+  inferProjectDefault,
+  inferProjectFromVCS,
+  mergeOverride,
+ )
 import App.Fossa.VPS.Scan.Core qualified as VPSCore
 import App.Fossa.VPS.Scan.ScotlandYard qualified as ScotlandYard
-import App.Types
-import Control.Carrier.Diagnostics
+import App.Types (
+  BaseDir (BaseDir),
+  OverrideProject,
+  ProjectRevision (projectName, projectRevision),
+ )
+import Control.Carrier.Diagnostics (logWithExit_, (<||>))
 import Control.Carrier.StickyLogger (logSticky, runStickyLogger)
 import Data.Aeson qualified as Aeson
 import Data.Functor (void)
@@ -17,8 +30,12 @@ import Data.String.Conversion (decodeUtf8)
 import Data.Text (Text)
 import Data.Text.IO (hPutStrLn)
 import Effect.Exec (runExecIO)
-import Effect.Logger
-import Effect.ReadFS
+import Effect.Logger (
+  Severity (SevInfo),
+  logStdout,
+  withDefaultLogger,
+ )
+import Effect.ReadFS (runReadFSIO)
 import Fossa.API.Types (ApiOpts)
 import System.Exit (exitFailure)
 import System.IO (stderr)

--- a/src/App/Fossa/VPS/Scan.hs
+++ b/src/App/Fossa/VPS/Scan.hs
@@ -5,19 +5,40 @@ module App.Fossa.VPS.Scan (
   LicenseOnlyScan (..),
 ) where
 
-import App.Fossa.EmbeddedBinary
-import App.Fossa.ProjectInference
-import App.Fossa.VPS.Scan.RunWiggins
-import App.Fossa.VPS.Types
-import App.Types (BaseDir (..), OverrideProject (..), ProjectMetadata (..))
-import Control.Carrier.Diagnostics
+import App.Fossa.EmbeddedBinary (BinaryPaths, withWigginsBinary)
+import App.Fossa.ProjectInference (
+  inferProjectDefault,
+  inferProjectFromVCS,
+  mergeOverride,
+  saveRevision,
+ )
+import App.Fossa.VPS.Scan.RunWiggins (
+  ScanType (ScanType),
+  WigginsOpts,
+  execWiggins,
+  generateWigginsScanOpts,
+ )
+import App.Fossa.VPS.Types (FilterExpressions)
+import App.Types (BaseDir (BaseDir), OverrideProject, ProjectMetadata)
+import Control.Carrier.Diagnostics (
+  Diagnostics,
+  Has,
+  logWithExit_,
+  (<||>),
+ )
 import Control.Effect.Lift (Lift)
 import Data.Flag (Flag, fromFlag)
-import Data.Text
+import Data.Text (Text)
 import Effect.Exec (Exec, runExecIO)
-import Effect.Logger
+import Effect.Logger (
+  Logger,
+  Pretty (pretty),
+  Severity,
+  logInfo,
+  withDefaultLogger,
+ )
 import Effect.ReadFS (ReadFS, runReadFSIO)
-import Fossa.API.Types (ApiOpts (..))
+import Fossa.API.Types (ApiOpts)
 
 -- | FollowSymlinks bool flag
 data FollowSymlinks = FollowSymlinks

--- a/src/App/Fossa/VPS/Scan/Core.hs
+++ b/src/App/Fossa/VPS/Scan/Core.hs
@@ -9,16 +9,25 @@ module App.Fossa.VPS.Scan.Core (
   SherlockInfo (..),
 ) where
 
-import App.Fossa.VPS.Types
-import Control.Carrier.Trace.Printing
-import Control.Effect.Diagnostics
+import App.Fossa.VPS.Types (runHTTP)
+import Control.Carrier.Trace.Printing (Has)
+import Control.Effect.Diagnostics (Diagnostics)
 import Control.Effect.Lift (Lift)
-import Data.Aeson
+import Data.Aeson (FromJSON (parseJSON), withObject, (.:))
 import Data.String.Conversion (toText)
 import Data.Text (Text)
-import Fossa.API.Types (ApiOpts (..), useApiOpts)
-import Network.HTTP.Req
-import Prelude
+import Fossa.API.Types (ApiOpts, useApiOpts)
+import Network.HTTP.Req (
+  GET (GET),
+  NoReqBody (NoReqBody),
+  Scheme (Https),
+  Url,
+  header,
+  jsonResponse,
+  req,
+  responseBody,
+  (/:),
+ )
 
 data SherlockInfo = SherlockInfo
   { sherlockUrl :: Text

--- a/src/App/Fossa/VPS/Scan/RunWiggins.hs
+++ b/src/App/Fossa/VPS/Scan/RunWiggins.hs
@@ -13,28 +13,49 @@ module App.Fossa.VPS.Scan.RunWiggins (
   PathFilters (..),
 ) where
 
-import App.Fossa.EmbeddedBinary
+import App.Fossa.EmbeddedBinary (BinaryPaths, toExecutablePath)
 import App.Fossa.VPS.Types (
   FilterExpressions (FilterExpressions),
   NinjaFilePaths (unNinjaFilePaths),
   NinjaScanID (unNinjaScanID),
   encodeFilterExpressions,
  )
-import App.Types
-import Control.Carrier.Error.Either
-import Control.Effect.Diagnostics
-import Data.Aeson
+import App.Types (
+  MonorepoAnalysisOpts (MonorepoAnalysisOpts, monorepoAnalysisType),
+  ProjectMetadata (
+    ProjectMetadata,
+    projectJiraKey,
+    projectLink,
+    projectPolicy,
+    projectTeam,
+    projectTitle,
+    projectUrl
+  ),
+  ProjectRevision (ProjectRevision, projectBranch, projectName, projectRevision),
+ )
+import Control.Carrier.Error.Either (Has)
+import Control.Effect.Diagnostics (Diagnostics)
+import Data.Aeson (FromJSON)
 import Data.ByteString.Lazy qualified as BL
 import Data.String.Conversion (toText)
 import Data.Text (Text)
 import Data.Text qualified as Text
 import Data.Text.Encoding (decodeUtf8)
-import Discovery.Filters
-import Effect.Exec
-import Effect.Logger
-import Fossa.API.Types
-import Path
-import Text.URI
+import Discovery.Filters (
+  AllFilters (AllFilters, excludeFilters, includeFilters),
+  FilterCombination (combinedPaths),
+ )
+import Effect.Exec (
+  AllowErr (Never),
+  Command (Command, cmdAllowErr, cmdArgs, cmdName),
+  Exec,
+  execJson,
+  execThrow,
+ )
+import Effect.Logger (Severity (SevDebug))
+import Fossa.API.Types (ApiKey (unApiKey), ApiOpts (ApiOpts, apiOptsApiKey, apiOptsUri))
+import Path (Abs, Dir, Path, Rel, fromAbsFile, toFilePath)
+import Text.URI (render)
 
 data ScanType = ScanType
   { followSymlinks :: Bool

--- a/src/App/Fossa/VPS/Test.hs
+++ b/src/App/Fossa/VPS/Test.hs
@@ -3,22 +3,42 @@ module App.Fossa.VPS.Test (
   TestOutputType (..),
 ) where
 
-import App.Fossa.API.BuildWait
+import App.Fossa.API.BuildWait (
+  timeout,
+  waitForIssues,
+  waitForSherlockScan,
+ )
 import App.Fossa.FossaAPIV1 qualified as Fossa
-import App.Fossa.ProjectInference
+import App.Fossa.ProjectInference (
+  inferProjectCached,
+  inferProjectDefault,
+  inferProjectFromVCS,
+  mergeOverride,
+ )
 import App.Fossa.VPS.Scan.Core qualified as VPSCore
 import App.Fossa.VPS.Scan.ScotlandYard qualified as ScotlandYard
-import App.Types
-import Control.Carrier.Diagnostics hiding (fromMaybe)
+import App.Types (
+  BaseDir (BaseDir),
+  OverrideProject,
+  ProjectRevision (projectName, projectRevision),
+ )
+import Control.Carrier.Diagnostics (logWithExit_, (<||>))
 import Control.Carrier.StickyLogger (logSticky, runStickyLogger)
 import Control.Effect.Lift (sendIO)
 import Data.Aeson qualified as Aeson
-import Data.String.Conversion
+import Data.String.Conversion (ConvertUtf8 (decodeUtf8))
 import Data.Text.IO (hPutStrLn)
 import Effect.Exec (runExecIO)
-import Effect.Logger
-import Effect.ReadFS
-import Fossa.API.Types (ApiOpts, Issues (..))
+import Effect.Logger (
+  Pretty (pretty),
+  Severity (SevInfo),
+  logError,
+  logInfo,
+  logStdout,
+  withDefaultLogger,
+ )
+import Effect.ReadFS (runReadFSIO)
+import Fossa.API.Types (ApiOpts, Issues (issuesCount, issuesIssues))
 import System.Exit (exitFailure)
 import System.IO (stderr)
 

--- a/src/App/Fossa/VPS/Types.hs
+++ b/src/App/Fossa/VPS/Types.hs
@@ -16,17 +16,31 @@ module App.Fossa.VPS.Types (
   NinjaFilePaths (..),
 ) where
 
-import Control.Carrier.Diagnostics
+import Control.Effect.Diagnostics (
+  Algebra,
+  Diagnostics,
+  Has,
+  ToDiagnostic (renderDiagnostic),
+  fatal,
+ )
 import Control.Effect.Lift (Lift, sendIO)
-import Control.Monad.IO.Class (MonadIO (..))
-import Data.Aeson
+import Control.Monad.IO.Class (MonadIO (liftIO))
+import Data.Aeson (
+  FromJSON (parseJSON),
+  KeyValue ((.=)),
+  ToJSON (toJSON),
+  encode,
+  object,
+  withObject,
+  (.:),
+ )
 import Data.ByteString.Lazy qualified as BSL
 import Data.Text (Text)
 import Data.Text.Encoding (decodeUtf8)
 import Fossa.API.Types (ApiOpts)
-import Network.HTTP.Req
+import Network.HTTP.Req (HttpException, MonadHttp (getHttpConfig, handleHttpException))
 import Network.HTTP.Req.Extra (httpConfigRetryTimeouts)
-import Path
+import Path (Abs, File, Path)
 import Prettyprinter (viaShow)
 
 newtype NinjaScanID = NinjaScanID {unNinjaScanID :: Text}

--- a/src/App/Fossa/VSI/IAT/AssertUserDefinedBinaries.hs
+++ b/src/App/Fossa/VSI/IAT/AssertUserDefinedBinaries.hs
@@ -5,7 +5,7 @@ module App.Fossa.VSI.IAT.AssertUserDefinedBinaries (
 import App.Fossa.FossaAPIV1 qualified as Fossa
 import App.Fossa.VSI.IAT.Fingerprint (fingerprintContentsRaw)
 import App.Fossa.VSI.IAT.Types (UserDefinedAssertionMeta)
-import App.Types (BaseDir (..))
+import App.Types (BaseDir (BaseDir))
 import Control.Algebra (Has)
 import Control.Carrier.Diagnostics (Diagnostics, logWithExit_)
 import Control.Effect.Lift (Lift)

--- a/src/App/Fossa/VSI/IAT/Fingerprint.hs
+++ b/src/App/Fossa/VSI/IAT/Fingerprint.hs
@@ -6,7 +6,7 @@ module App.Fossa.VSI.IAT.Fingerprint (
 import App.Fossa.VSI.IAT.Types (Fingerprint (Fingerprint))
 import Conduit (ConduitT, Void, await, runConduitRes, sourceFile, (.|))
 import Control.Algebra (Has)
-import Control.Carrier.Diagnostics (Diagnostics, fatalText)
+import Control.Effect.Diagnostics (Diagnostics, fatalText)
 import Control.Effect.Exception (IOException, Lift, catch)
 import Control.Effect.Lift (sendIO)
 import Crypto.Hash (
@@ -18,8 +18,8 @@ import Crypto.Hash (
   hashUpdate,
  )
 import Data.ByteString qualified as B
-import Data.String.Conversion (ToText (..))
-import Discovery.Walk (WalkStep (..), walk')
+import Data.String.Conversion (toText)
+import Discovery.Walk (WalkStep (WalkContinue), walk')
 import Effect.ReadFS (ReadFS)
 import Path (Abs, Dir, File, Path, toFilePath)
 

--- a/src/App/Fossa/VSI/IAT/Resolve.hs
+++ b/src/App/Fossa/VSI/IAT/Resolve.hs
@@ -8,7 +8,7 @@ module App.Fossa.VSI.IAT.Resolve (
 
 import App.Fossa.FossaAPIV1 qualified as Fossa
 import App.Fossa.VSI.IAT.Types (
-  UserDefinedAssertionMeta (..),
+  UserDefinedAssertionMeta (UserDefinedAssertionMeta),
   UserDep,
  )
 import App.Fossa.VSI.IAT.Types qualified as IAT
@@ -20,7 +20,15 @@ import Data.String.Conversion (toText)
 import Fossa.API.Types (ApiOpts)
 import Graphing (Graphing, direct, edges)
 import Srclib.Types (
-  SourceUserDefDep (..),
+  SourceUserDefDep (
+    SourceUserDefDep,
+    srcUserDepDescription,
+    srcUserDepHomepage,
+    srcUserDepLicense,
+    srcUserDepName,
+    srcUserDepOrigin,
+    srcUserDepVersion
+  ),
  )
 
 resolveUserDefined :: (Has (Lift IO) sig m, Has Diagnostics sig m) => ApiOpts -> [UserDep] -> m (Maybe [SourceUserDefDep])

--- a/src/App/Fossa/VSI/Types.hs
+++ b/src/App/Fossa/VSI/Types.hs
@@ -14,7 +14,7 @@ module App.Fossa.VSI.Types (
 import Control.Effect.Diagnostics (ToDiagnostic, renderDiagnostic)
 import Data.Aeson (FromJSON (parseJSON), withObject, (.:))
 import Data.Text (Text)
-import DepTypes (DepType (..), Dependency (..), VerConstraint (CEq))
+import DepTypes (DepType (CustomType), Dependency (Dependency), VerConstraint (CEq))
 import Effect.Logger (Pretty (pretty), viaShow)
 import Srclib.Converter (depTypeToFetcher, fetcherToDepType)
 import Srclib.Types qualified as Srclib

--- a/src/App/Fossa/VSIDeps.hs
+++ b/src/App/Fossa/VSIDeps.hs
@@ -21,7 +21,7 @@ import Graphing (Graphing)
 import Graphing qualified
 import Path (Abs, Dir, Path)
 import Srclib.Converter qualified as Srclib
-import Srclib.Types (AdditionalDepData (..), SourceUnit (..), SourceUserDefDep)
+import Srclib.Types (AdditionalDepData (AdditionalDepData), SourceUnit (additionalData), SourceUserDefDep)
 import Types (GraphBreadth (Complete))
 
 -- | VSI analysis is sufficiently different from other analysis types that it cannot be just another strategy.

--- a/src/App/OptionExtensions.hs
+++ b/src/App/OptionExtensions.hs
@@ -1,9 +1,17 @@
 module App.OptionExtensions (uriOption, jsonOption) where
 
-import Data.Aeson
-import Data.String
+import Data.Aeson (FromJSON, eitherDecode)
+import Data.String (IsString (fromString))
 import Data.String.Conversion (toText)
-import Options.Applicative
+import Options.Applicative (
+  Mod,
+  OptionFields,
+  Parser,
+  ReadM,
+  eitherReader,
+  maybeReader,
+  option,
+ )
 import Text.URI (URI, mkURI)
 
 uriOption :: Mod OptionFields URI -> Parser URI

--- a/src/App/Pathfinder/Main.hs
+++ b/src/App/Pathfinder/Main.hs
@@ -3,12 +3,31 @@ module App.Pathfinder.Main (
 ) where
 
 import App.Pathfinder.Scan (scanMain)
-import App.Types (BaseDir (..))
+import App.Types (BaseDir (unBaseDir))
 import App.Util (validateDir)
 import Control.Concurrent.CGroup (initRTSThreads)
 import Data.Maybe (fromMaybe)
-import Options.Applicative
-import Path.IO
+import Options.Applicative (
+  Parser,
+  ParserInfo,
+  command,
+  execParser,
+  fullDesc,
+  header,
+  help,
+  helper,
+  hsubparser,
+  info,
+  long,
+  metavar,
+  optional,
+  progDesc,
+  short,
+  strOption,
+  switch,
+  (<**>),
+ )
+import Path.IO (getCurrentDir)
 
 appMain :: IO ()
 appMain = do

--- a/src/App/Pathfinder/Scan.hs
+++ b/src/App/Pathfinder/Scan.hs
@@ -6,34 +6,54 @@ module App.Pathfinder.Scan (
 ) where
 
 import App.Pathfinder.Types (LicenseAnalyzeProject (licenseAnalyzeProject))
+import Control.Algebra (Has)
 import Control.Carrier.AtomicCounter (AtomicCounter, runAtomicCounter)
 import Control.Carrier.Debug (Debug, ignoreDebug)
 import Control.Carrier.Diagnostics qualified as Diag
-import Control.Carrier.Error.Either
-import Control.Carrier.Finally
-import Control.Carrier.Output.IO
+import Control.Carrier.Finally (runFinally)
+import Control.Carrier.Output.IO (Output, output, runOutput)
 import Control.Carrier.StickyLogger (StickyLogger, logSticky', runStickyLogger)
-import Control.Carrier.TaskPool
-import Control.Concurrent
-import Control.Effect.Exception as Exc
+import Control.Carrier.TaskPool (
+  Progress (Progress, pCompleted, pQueued, pRunning),
+  TaskPool,
+  withTaskPool,
+ )
+import Control.Concurrent (getNumCapabilities)
+import Control.Effect.Exception as Exc (Lift)
 import Control.Effect.Lift (sendIO)
 import Control.Monad (unless)
 import Control.Monad.IO.Class (MonadIO)
-import Data.Aeson
+import Data.Aeson (
+  KeyValue ((.=)),
+  ToJSON (toJSON),
+  encode,
+  object,
+ )
 import Data.Bool (bool)
 import Data.ByteString.Lazy qualified as BL
 import Data.Text (Text)
 import Discovery.Projects (withDiscoveredProjects)
-import Effect.Exec
-import Effect.Logger
-import Effect.ReadFS
-import Path
+import Effect.Exec (Exec, runExecIO)
+import Effect.Logger (
+  Color (Cyan, Green, Yellow),
+  Logger,
+  Pretty (pretty),
+  Severity (SevDebug, SevInfo, SevWarn),
+  annotate,
+  color,
+  withDefaultLogger,
+ )
+import Effect.ReadFS (ReadFS, runReadFSIO)
+import Path (Abs, Dir, Path)
 import Path.IO qualified as PIO
 import Strategy.Maven qualified as Maven
 import Strategy.NuGet.Nuspec qualified as Nuspec
 import System.Exit (die)
 import System.IO (BufferMode (NoBuffering), hSetBuffering, stderr, stdout)
-import Types
+import Types (
+  DiscoveredProject (projectData, projectType),
+  LicenseResult,
+ )
 
 scanMain :: Path Abs Dir -> Bool -> IO ()
 scanMain basedir debug = do

--- a/src/App/Pathfinder/Types.hs
+++ b/src/App/Pathfinder/Types.hs
@@ -9,7 +9,7 @@ import Control.Monad.IO.Class (MonadIO)
 import Effect.Exec (Exec)
 import Effect.Logger (Logger)
 import Effect.ReadFS (ReadFS)
-import Types
+import Types (LicenseResult)
 
 type TaskEffs sig m =
   ( Has (Lift IO) sig m

--- a/src/App/Util.hs
+++ b/src/App/Util.hs
@@ -5,7 +5,7 @@ module App.Util (
   validateFile,
 ) where
 
-import App.Types
+import App.Types (BaseDir (BaseDir))
 import Control.Monad (unless)
 import Path (Abs, File, Path)
 import Path.IO qualified as P

--- a/src/App/Version/TH.hs
+++ b/src/App/Version/TH.hs
@@ -15,7 +15,7 @@ import Data.Text qualified as Text
 import Data.Versions (errorBundlePretty, semver)
 import Effect.Exec (
   AllowErr (Always),
-  Command (..),
+  Command (Command, cmdAllowErr, cmdArgs, cmdName),
   Exec,
   Has,
   exec,

--- a/src/Console/Sticky.hs
+++ b/src/Console/Sticky.hs
@@ -6,9 +6,20 @@ module Console.Sticky (
 ) where
 
 import Control.Effect.ConsoleRegion qualified as R
-import Control.Effect.Lift
+import Control.Effect.Lift (Has, Lift, sendIO)
 import Data.Text (Text)
-import Effect.Logger
+import Effect.Logger (
+  AnsiStyle,
+  Doc,
+  Logger,
+  Pretty (pretty),
+  Severity,
+  defaultLayoutOptions,
+  layoutPretty,
+  log,
+  logDebug,
+  renderStrict,
+ )
 import System.Console.ANSI (hSupportsANSI)
 import System.IO (stdout)
 

--- a/src/Control/Carrier/AtomicCounter.hs
+++ b/src/Control/Carrier/AtomicCounter.hs
@@ -9,9 +9,24 @@ module Control.Carrier.AtomicCounter (
   module X,
 ) where
 
-import Control.Carrier.AtomicState
-import Control.Effect.AtomicCounter as X
-import Control.Effect.Lift
+import Control.Carrier.AtomicState (
+  AtomicStateC,
+  getSet,
+  runAtomicState,
+ )
+import Control.Effect.AtomicCounter as X (
+  Algebra (alg),
+  AtomicCounter (GenerateId),
+  Handler,
+  Has,
+  generateId,
+  run,
+  send,
+  thread,
+  (~<~),
+  type (:+:) (L, R),
+ )
+import Control.Effect.Lift (Lift)
 import Control.Monad.IO.Class (MonadIO)
 import Control.Monad.Trans.Class (MonadTrans)
 

--- a/src/Control/Carrier/AtomicState.hs
+++ b/src/Control/Carrier/AtomicState.hs
@@ -9,13 +9,24 @@ module Control.Carrier.AtomicState (
   module X,
 ) where
 
-import Control.Algebra
-import Control.Carrier.Lift
-import Control.Carrier.Reader
-import Control.Effect.AtomicState as X
+import Control.Algebra (Algebra (alg), Has, type (:+:) (L, R))
+import Control.Carrier.Lift (Lift, sendIO)
+import Control.Carrier.Reader (ReaderC, ask, runReader)
+import Control.Effect.AtomicState as X (
+  AtomicState (Modify),
+  get,
+  getSet,
+  modify,
+  put,
+ )
 import Control.Monad.IO.Class (MonadIO)
 import Control.Monad.Trans (MonadTrans)
-import Data.IORef
+import Data.IORef (
+  IORef,
+  atomicModifyIORef',
+  newIORef,
+  readIORef,
+ )
 
 newtype AtomicStateC s m a = AtomicStateC {runAtomicStateC :: ReaderC (IORef s) m a}
   deriving (Functor, Applicative, Monad, MonadIO, MonadTrans)

--- a/src/Control/Carrier/Debug.hs
+++ b/src/Control/Carrier/Debug.hs
@@ -12,18 +12,48 @@ module Control.Carrier.Debug (
   module X,
 ) where
 
-import Control.Carrier.AtomicState
-import Control.Carrier.Diagnostics
-import Control.Carrier.Output.IO
+import Control.Carrier.AtomicState (
+  AtomicStateC,
+  modify,
+  runAtomicState,
+ )
+import Control.Carrier.Diagnostics (errorBoundaryIO)
+import Control.Carrier.Output.IO (OutputC, output, runOutput)
 import Control.Carrier.Simple (Simple, sendSimple)
-import Control.Effect.Debug as X
-import Control.Effect.Lift
+import Control.Effect.Debug as X (
+  Algebra (alg),
+  Debug (DebugEffect, DebugError, DebugLog, DebugMetadata, DebugScope),
+  Handler,
+  Has,
+  debugEffect,
+  debugError,
+  debugLog,
+  debugMetadata,
+  debugScope,
+  run,
+  send,
+  thread,
+  (~<~),
+  type (:+:) (L, R),
+ )
+import Control.Effect.Diagnostics (
+  Diagnostics,
+  SomeDiagnostic (SomeDiagnostic),
+  ToDiagnostic (renderDiagnostic),
+  rethrow,
+ )
+import Control.Effect.Lift (Lift, sendIO)
 import Control.Effect.Record (Recordable, SomeEffectResult (SomeEffectResult), recordEff)
 import Control.Monad.IO.Class (MonadIO)
 import Control.Monad.Trans (MonadTrans, lift)
-import Data.Aeson
+import Data.Aeson (
+  KeyValue ((.=)),
+  ToJSON (toJSON),
+  Value (String),
+  object,
+ )
 import Data.Aeson.Types (Pair)
-import Data.Fixed
+import Data.Fixed (Fixed (MkFixed), Nano)
 import Data.Map.Strict qualified as Map
 import Data.Text (Text)
 import Data.Time.Clock.System (SystemTime (MkSystemTime), getSystemTime)

--- a/src/Control/Carrier/Diagnostics.hs
+++ b/src/Control/Carrier/Diagnostics.hs
@@ -19,18 +19,62 @@ module Control.Carrier.Diagnostics (
   module X,
 ) where
 
-import Control.Carrier.Error.Either
-import Control.Carrier.Reader
-import Control.Carrier.Writer.Church
-import Control.Effect.Diagnostics as X
+import Control.Carrier.Error.Either (
+  Algebra,
+  ErrorC,
+  Has,
+  catchError,
+  run,
+  runError,
+  throwError,
+ )
+import Control.Carrier.Reader (
+  ReaderC,
+  ask,
+  local,
+  runReader,
+ )
+import Control.Carrier.Writer.Church (WriterC, runWriter, tell)
+import Control.Effect.Diagnostics as X (
+  Algebra (alg),
+  Diagnostics (Context, ErrorBoundary, Fatal, Recover', Rethrow),
+  FailureBundle (FailureBundle, failureCause, failureWarnings),
+  Handler,
+  Has,
+  SomeDiagnostic (SomeDiagnostic),
+  ToDiagnostic (renderDiagnostic),
+  combineSuccessful,
+  context,
+  errorBoundary,
+  fatal,
+  fatalText,
+  fromEither,
+  fromEitherShow,
+  fromMaybe,
+  fromMaybeText,
+  recover,
+  recover',
+  renderFailureBundle,
+  renderSomeDiagnostic,
+  rethrow,
+  run,
+  send,
+  tagError,
+  thread,
+  warnMaybe,
+  warnMaybeText,
+  (<||>),
+  (~<~),
+  type (:+:) (L, R),
+ )
 import Control.Effect.Lift (Lift, sendIO)
 import Control.Exception (SomeException)
 import Control.Exception.Extra (safeCatch)
-import Control.Monad.Trans
+import Control.Monad.Trans (MonadIO, MonadTrans (lift))
 import Data.Foldable (traverse_)
-import Data.Monoid (Endo (..))
+import Data.Monoid (Endo (Endo, appEndo))
 import Data.Text (Text)
-import Effect.Logger
+import Effect.Logger (Logger, Severity, log, logError)
 import System.Exit (exitFailure, exitSuccess)
 
 newtype DiagnosticsC m a = DiagnosticsC {runDiagnosticsC :: ReaderC [Text] (ErrorC SomeDiagnostic (WriterC (Endo [SomeDiagnostic]) m)) a}

--- a/src/Control/Carrier/Diagnostics/StickyContext.hs
+++ b/src/Control/Carrier/Diagnostics/StickyContext.hs
@@ -6,16 +6,38 @@ module Control.Carrier.Diagnostics.StickyContext (
 ) where
 
 import Console.Sticky qualified as Sticky
-import Control.Carrier.Diagnostics qualified as Diag
-import Control.Carrier.Reader
-import Control.Effect.AtomicCounter
-import Control.Effect.Lift
+import Control.Carrier.Reader (
+  Algebra,
+  Has,
+  ReaderC,
+  asks,
+  local,
+  runReader,
+ )
+import Control.Effect.AtomicCounter (
+  Algebra (alg),
+  AtomicCounter,
+  generateId,
+  type (:+:) (L, R),
+ )
+import Control.Effect.Diagnostics qualified as Diag (
+  Diagnostics (Context),
+ )
+import Control.Effect.Lift (Lift)
 import Control.Effect.Sum (Member (inj))
 import Control.Monad.IO.Class (MonadIO)
-import Control.Monad.Trans.Class (MonadTrans (..))
+import Control.Monad.Trans.Class (MonadTrans)
 import Data.List (intersperse)
 import Data.Text qualified as Text
-import Effect.Logger
+import Effect.Logger (
+  Color (Green, Yellow),
+  Logger,
+  Pretty (pretty),
+  Severity (SevDebug),
+  annotate,
+  color,
+  hcat,
+ )
 
 stickyDiag :: (Has AtomicCounter sig m, Has (Lift IO) sig m) => StickyDiagC m a -> m a
 stickyDiag act = do

--- a/src/Control/Carrier/Finally.hs
+++ b/src/Control/Carrier/Finally.hs
@@ -11,15 +11,37 @@ module Control.Carrier.Finally (
   module X,
 ) where
 
-import Control.Carrier.Reader
+import Control.Carrier.Reader (
+  Algebra,
+  Has,
+  ReaderC,
+  ask,
+  run,
+  runReader,
+ )
 import Control.Effect.Exception (finally)
-import Control.Effect.Finally as X
-import Control.Effect.Lift
+import Control.Effect.Finally as X (
+  Algebra (alg),
+  Finally (OnExit),
+  Handler,
+  Has,
+  onExit,
+  run,
+  send,
+  thread,
+  (~<~),
+  type (:+:) (L, R),
+ )
+import Control.Effect.Lift (Lift, sendIO)
 import Control.Monad.IO.Class (MonadIO)
 import Data.Foldable (traverse_)
 import Data.Functor (void)
-import Data.IORef
-import Prelude
+import Data.IORef (
+  IORef,
+  atomicModifyIORef',
+  newIORef,
+  readIORef,
+ )
 
 newtype FinallyC m a = FinallyC {runFinallyC :: ReaderC (IORef [FinallyC m ()]) m a}
   deriving (Functor, Applicative, Monad, MonadIO)

--- a/src/Control/Carrier/Output/IO.hs
+++ b/src/Control/Carrier/Output/IO.hs
@@ -7,11 +7,35 @@ module Control.Carrier.Output.IO (
   module X,
 ) where
 
-import Control.Carrier.Reader
-import Control.Carrier.Simple
+import Control.Carrier.Reader (Algebra, Has, run)
+import Control.Carrier.Simple (
+  Handler,
+  SimpleC,
+  interpret,
+  send,
+  thread,
+  (~<~),
+ )
 import Control.Effect.Lift (Lift, sendIO)
-import Control.Effect.Output as X
-import Data.IORef
+import Control.Effect.Output as X (
+  Algebra (alg),
+  Handler,
+  Has,
+  Output,
+  OutputF (Output),
+  output,
+  run,
+  send,
+  thread,
+  (~<~),
+  type (:+:) (L, R),
+ )
+import Data.IORef (
+  IORef,
+  atomicModifyIORef',
+  newIORef,
+  readIORef,
+ )
 
 type OutputC o = SimpleC (OutputF o)
 

--- a/src/Control/Carrier/Simple.hs
+++ b/src/Control/Carrier/Simple.hs
@@ -119,11 +119,20 @@ module Control.Carrier.Simple (
   module X,
 ) where
 
-import Control.Algebra as X
-import Control.Applicative
-import Control.Carrier.Reader
-import Control.Carrier.State.Strict
-import Control.Monad.Trans
+import Control.Algebra as X (
+  Algebra (alg),
+  Handler,
+  Has,
+  run,
+  send,
+  thread,
+  (~<~),
+  type (:+:) (L, R),
+ )
+import Control.Applicative (Alternative)
+import Control.Carrier.Reader (ReaderC (ReaderC), runReader)
+import Control.Carrier.State.Strict (StateC, runState)
+import Control.Monad.Trans (MonadIO, MonadTrans (lift))
 
 ---------- The Simple effect
 

--- a/src/Control/Carrier/StickyLogger.hs
+++ b/src/Control/Carrier/StickyLogger.hs
@@ -11,10 +11,30 @@ module Control.Carrier.StickyLogger (
 ) where
 
 import Console.Sticky (setSticky', withStickyRegion)
-import Control.Carrier.Reader
-import Control.Carrier.Simple
+import Control.Carrier.Reader (Algebra, Has, run)
+import Control.Carrier.Simple (
+  Handler,
+  SimpleC,
+  interpret,
+  send,
+  thread,
+  (~<~),
+ )
 import Control.Effect.Lift (Lift)
-import Control.Effect.StickyLogger as X
+import Control.Effect.StickyLogger as X (
+  Algebra (alg),
+  Handler,
+  Has,
+  StickyLogger,
+  StickyLoggerF (LogSticky'),
+  logSticky,
+  logSticky',
+  run,
+  send,
+  thread,
+  (~<~),
+  type (:+:) (L, R),
+ )
 import Effect.Logger (Logger, Severity)
 
 runStickyLogger ::

--- a/src/Control/Carrier/TaskPool.hs
+++ b/src/Control/Carrier/TaskPool.hs
@@ -9,15 +9,55 @@ module Control.Carrier.TaskPool (
   module X,
 ) where
 
-import Control.Carrier.Reader
-import Control.Carrier.Threaded
-import Control.Concurrent.STM
-import Control.Effect.Exception
+import Control.Algebra (Algebra (alg), type (:+:) (L, R))
+import Control.Carrier.Reader (
+  Has,
+  ReaderC,
+  ask,
+  run,
+  runReader,
+ )
+import Control.Carrier.Threaded (fork, kill)
+import Control.Concurrent.STM (
+  STM,
+  TMVar,
+  TVar,
+  atomically,
+  check,
+  modifyTVar,
+  modifyTVar',
+  newEmptyTMVarIO,
+  newTVarIO,
+  readTVar,
+  retry,
+  tryPutTMVar,
+  tryReadTMVar,
+  writeTVar,
+ )
+import Control.Effect.Exception (
+  Lift,
+  SomeException,
+  bracket,
+  mask,
+  throwIO,
+  try,
+ )
 import Control.Effect.Lift (sendIO)
-import Control.Effect.TaskPool as X
+import Control.Effect.TaskPool as X (
+  Algebra,
+  Handler,
+  Has,
+  TaskPool (ForkTask),
+  forkTask,
+  run,
+  send,
+  thread,
+  (~<~),
+  type (:+:),
+ )
 import Control.Monad (join, replicateM)
 import Control.Monad.IO.Class (MonadIO)
-import Control.Monad.Trans (MonadTrans (..))
+import Control.Monad.Trans (MonadTrans (lift))
 import Data.Foldable (traverse_)
 import Data.Functor (void)
 

--- a/src/Control/Carrier/Threaded.hs
+++ b/src/Control/Carrier/Threaded.hs
@@ -5,14 +5,24 @@ module Control.Carrier.Threaded (
   Handle (..),
 ) where
 
-import Control.Carrier.Lift
+import Control.Carrier.Lift (Has, Lift, liftWith)
 import Control.Concurrent qualified as Conc
 import Control.Concurrent.Async qualified as Async
-import Control.Concurrent.STM
-import Control.Effect.Exception
-import Control.Monad.IO.Class
+import Control.Concurrent.STM (
+  STM,
+  atomically,
+  newEmptyTMVarIO,
+  putTMVar,
+  readTMVar,
+ )
+import Control.Effect.Exception (
+  SomeException,
+  mask,
+  throwTo,
+  try,
+ )
+import Control.Monad.IO.Class (MonadIO (liftIO))
 import Data.Functor (void, ($>))
-import Prelude
 
 data Handle = Handle
   { handleTid :: Conc.ThreadId

--- a/src/Control/Effect/AtomicCounter.hs
+++ b/src/Control/Effect/AtomicCounter.hs
@@ -6,7 +6,16 @@ module Control.Effect.AtomicCounter (
   module X,
 ) where
 
-import Control.Algebra as X
+import Control.Algebra as X (
+  Algebra (alg),
+  Handler,
+  Has,
+  run,
+  send,
+  thread,
+  (~<~),
+  type (:+:) (L, R),
+ )
 
 data AtomicCounter m a where
   GenerateId :: AtomicCounter m Int

--- a/src/Control/Effect/AtomicState.hs
+++ b/src/Control/Effect/AtomicState.hs
@@ -11,8 +11,8 @@ module Control.Effect.AtomicState (
   put,
 ) where
 
-import Control.Algebra
-import Data.Kind
+import Control.Algebra (Has, send)
+import Data.Kind (Type)
 
 data AtomicState s (m :: Type -> Type) a where
   Modify :: (s -> (s, a)) -> AtomicState s m a

--- a/src/Control/Effect/ConsoleRegion.hs
+++ b/src/Control/Effect/ConsoleRegion.hs
@@ -11,11 +11,16 @@ module Control.Effect.ConsoleRegion (
   module X,
 ) where
 
-import Control.Effect.Lift
+import Control.Effect.Lift (Has, Lift, liftWith, sendIO)
 import Data.Text (Text)
 import System.Console.Concurrent as X (Outputable)
 import System.Console.Concurrent qualified as C
-import System.Console.Regions as X (ConsoleRegion, RegionContent, RegionLayout (..), ToRegionContent (..))
+import System.Console.Regions as X (
+  ConsoleRegion,
+  RegionContent,
+  RegionLayout (Linear),
+  ToRegionContent,
+ )
 import System.Console.Regions qualified as R
 
 -- | See @"System.Console.Regions".'R.displayConsoleregions'@.

--- a/src/Control/Effect/Debug.hs
+++ b/src/Control/Effect/Debug.hs
@@ -8,7 +8,16 @@ module Control.Effect.Debug (
   module X,
 ) where
 
-import Control.Algebra as X
+import Control.Algebra as X (
+  Algebra (alg),
+  Handler,
+  Has,
+  run,
+  send,
+  thread,
+  (~<~),
+  type (:+:) (L, R),
+ )
 import Control.Effect.Diagnostics (ToDiagnostic)
 import Control.Effect.Record (Recordable)
 import Data.Aeson (ToJSON)

--- a/src/Control/Effect/Diagnostics.hs
+++ b/src/Control/Effect/Diagnostics.hs
@@ -39,8 +39,17 @@ module Control.Effect.Diagnostics (
   module X,
 ) where
 
-import Control.Algebra as X
-import Control.Exception (SomeException (..))
+import Control.Algebra as X (
+  Algebra (alg),
+  Handler,
+  Has,
+  run,
+  send,
+  thread,
+  (~<~),
+  type (:+:) (L, R),
+ )
+import Control.Exception (SomeException (SomeException))
 import Data.Aeson (ToJSON, object, toJSON, (.=))
 import Data.List (intersperse)
 import Data.List.NonEmpty qualified as NE
@@ -48,9 +57,19 @@ import Data.Maybe (catMaybes)
 import Data.Semigroup (sconcat)
 import Data.String.Conversion (toText)
 import Data.Text (Text)
-import Prettyprinter
-import Prettyprinter.Render.Terminal
-import Prelude
+import Prettyprinter (
+  Doc,
+  Pretty (pretty),
+  annotate,
+  indent,
+  line,
+  vsep,
+ )
+import Prettyprinter.Render.Terminal (
+  AnsiStyle,
+  Color (Cyan, Yellow),
+  color,
+ )
 
 data Diagnostics m k where
   Fatal :: ToDiagnostic diag => diag -> Diagnostics m a

--- a/src/Control/Effect/Finally.hs
+++ b/src/Control/Effect/Finally.hs
@@ -9,8 +9,16 @@ module Control.Effect.Finally (
   module X,
 ) where
 
-import Control.Algebra as X
-import Prelude
+import Control.Algebra as X (
+  Algebra (alg),
+  Handler,
+  Has,
+  run,
+  send,
+  thread,
+  (~<~),
+  type (:+:) (L, R),
+ )
 
 data Finally m k where
   OnExit :: m a -> Finally m ()

--- a/src/Control/Effect/Output.hs
+++ b/src/Control/Effect/Output.hs
@@ -7,7 +7,16 @@ module Control.Effect.Output (
   module X,
 ) where
 
-import Control.Algebra as X
+import Control.Algebra as X (
+  Algebra (alg),
+  Handler,
+  Has,
+  run,
+  send,
+  thread,
+  (~<~),
+  type (:+:) (L, R),
+ )
 import Control.Carrier.Simple (Simple, sendSimple)
 
 data OutputF o a where

--- a/src/Control/Effect/Path.hs
+++ b/src/Control/Effect/Path.hs
@@ -3,10 +3,9 @@ module Control.Effect.Path (
   withSystemTempDir,
 ) where
 
-import Control.Effect.Lift
-import Path
+import Control.Effect.Lift (Has, Lift, liftWith)
+import Path (Abs, Dir, Path)
 import Path.IO qualified as PIO
-import Prelude
 
 withSystemTempDir ::
   Has (Lift IO) sig m =>

--- a/src/Control/Effect/Record.hs
+++ b/src/Control/Effect/Record.hs
@@ -14,26 +14,36 @@ module Control.Effect.Record (
   SomeEffectResult (..),
 ) where
 
-import Control.Algebra
-import Control.Carrier.AtomicState
-import Control.Carrier.Simple
-import Control.Effect.Lift
-import Control.Effect.Sum
-import Control.Monad.Trans
-import Data.Aeson
+import Control.Algebra (Algebra (alg), Has, send, type (:+:) (L, R))
+import Control.Carrier.AtomicState (
+  AtomicStateC,
+  modify,
+  runAtomicState,
+ )
+import Control.Carrier.Simple (Simple (Simple))
+import Control.Effect.Lift (Lift)
+import Control.Effect.Sum (Member)
+import Control.Monad.Trans (MonadIO, MonadTrans (lift))
+import Data.Aeson (
+  FromJSON (parseJSON),
+  KeyValue ((.=)),
+  ToJSON (toEncoding, toJSON),
+  Value (Null),
+  object,
+ )
 import Data.ByteString qualified as BS
 import Data.ByteString.Lazy qualified as BL
-import Data.Kind
+import Data.Kind (Type)
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
 import Data.String.Conversion (decodeUtf8)
 import Data.Text qualified as Text
 import Data.Text.Lazy qualified as LText
 import Data.Void (Void)
-import Path
+import Path (Path, SomeBase)
 import Prettyprinter (Doc, defaultLayoutOptions, layoutPretty)
 import Prettyprinter.Render.Text (renderStrict)
-import System.Exit
+import System.Exit (ExitCode (ExitFailure, ExitSuccess))
 import Unsafe.Coerce (unsafeCoerce)
 
 -- | A class of "recordable" effects -- i.e. an effect whose data constructors

--- a/src/Control/Effect/Record/TH.hs
+++ b/src/Control/Effect/Record/TH.hs
@@ -4,9 +4,33 @@ module Control.Effect.Record.TH (
   deriveRecordable,
 ) where
 
-import Control.Effect.Record
+import Control.Effect.Record (
+  Recordable (recordEff),
+  RecordableValue (toRecordedValue),
+ )
 import Control.Monad (replicateM)
-import Language.Haskell.TH
+import Language.Haskell.TH (
+  ClauseQ,
+  Con (ForallC, GadtC, InfixC, NormalC, RecC, RecGadtC),
+  Dec (DataD),
+  DecQ,
+  ExpQ,
+  Info (TyConI),
+  Name,
+  Q,
+  appT,
+  clause,
+  conP,
+  conT,
+  funD,
+  instanceD,
+  newName,
+  normalB,
+  reify,
+  tupE,
+  varE,
+  varP,
+ )
 
 -- | For the given effect type, derive an instance of 'Recordable'
 deriveRecordable :: Name -> Q [Dec]

--- a/src/Control/Effect/Replay.hs
+++ b/src/Control/Effect/Replay.hs
@@ -9,16 +9,27 @@ module Control.Effect.Replay (
   runReplay,
 ) where
 
-import Control.Algebra
-import Control.Applicative
-import Control.Carrier.Simple
-import Control.Effect.Record
-import Control.Effect.Sum
-import Data.Aeson
+import Control.Algebra (Algebra, send)
+import Control.Applicative (Alternative ((<|>)))
+import Control.Carrier.Simple (Simple (Simple), SimpleC, interpret)
+import Control.Effect.Record (
+  EffectResult (EffectResult),
+  Journal (Journal),
+  Recordable,
+ )
+import Control.Effect.Sum (Member)
+import Data.Aeson (
+  FromJSON (parseJSON),
+  Result (Error, Success),
+  Value (Null),
+  withObject,
+  withText,
+  (.:),
+ )
 import Data.Aeson.Types (Parser, parse)
 import Data.ByteString qualified as BS
 import Data.ByteString.Lazy qualified as BL
-import Data.Kind
+import Data.Kind (Type)
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
 import Data.String.Conversion (encodeUtf8, toString)
@@ -26,9 +37,9 @@ import Data.Text qualified as Text
 import Data.Text.Lazy qualified as LText
 import Data.Text.Lazy qualified as TL
 import Data.Void (Void)
-import Path
-import System.Exit
-import Unsafe.Coerce
+import Path (Abs, Dir, File, Path, Rel, SomeBase)
+import System.Exit (ExitCode (ExitFailure, ExitSuccess))
+import Unsafe.Coerce (unsafeCoerce)
 
 -- | A class of "replayable" effects -- i.e. an effect whose "result values"
 -- (the @a@ in @e a@) can be deserialized from JSON values produced by

--- a/src/Control/Effect/Replay/TH.hs
+++ b/src/Control/Effect/Replay/TH.hs
@@ -5,9 +5,43 @@ module Control.Effect.Replay.TH (
 ) where
 
 import Control.Applicative ((<|>))
-import Control.Effect.Replay
+import Control.Effect.Replay (
+  EffectResult (EffectResult),
+  Replayable (replayDecode),
+  ReplayableValue (fromRecordedValue),
+ )
 import Control.Monad (replicateM)
-import Language.Haskell.TH
+import Language.Haskell.TH (
+  Con (ForallC, GadtC, InfixC, NormalC, RecC, RecGadtC),
+  Dec (DataD),
+  Exp,
+  ExpQ,
+  Info (TyConI),
+  Name,
+  PatQ,
+  Q,
+  Type (AppT),
+  TypeQ,
+  appE,
+  appT,
+  bindS,
+  clause,
+  conE,
+  conT,
+  doE,
+  funD,
+  instanceD,
+  litP,
+  newName,
+  noBindS,
+  normalB,
+  reify,
+  sigP,
+  stringL,
+  tupP,
+  varE,
+  varP,
+ )
 
 deriveReplayable :: Name -> Q [Dec]
 deriveReplayable tyName = do

--- a/src/Control/Effect/StickyLogger.hs
+++ b/src/Control/Effect/StickyLogger.hs
@@ -7,8 +7,17 @@ module Control.Effect.StickyLogger (
   module X,
 ) where
 
-import Control.Algebra as X
-import Control.Carrier.Simple
+import Control.Algebra as X (
+  Algebra (alg),
+  Handler,
+  Has,
+  run,
+  send,
+  thread,
+  (~<~),
+  type (:+:) (L, R),
+ )
+import Control.Carrier.Simple (Simple, sendSimple)
 import Data.Text (Text)
 import Prettyprinter (Doc, pretty)
 import Prettyprinter.Render.Terminal (AnsiStyle)

--- a/src/Control/Effect/TaskPool.hs
+++ b/src/Control/Effect/TaskPool.hs
@@ -6,7 +6,16 @@ module Control.Effect.TaskPool (
   module X,
 ) where
 
-import Control.Algebra as X
+import Control.Algebra as X (
+  Algebra (alg),
+  Handler,
+  Has,
+  run,
+  send,
+  thread,
+  (~<~),
+  type (:+:) (L, R),
+ )
 
 data TaskPool m k where
   ForkTask :: m a -> TaskPool m ()

--- a/src/Control/Exception/Extra.hs
+++ b/src/Control/Exception/Extra.hs
@@ -3,7 +3,14 @@ module Control.Exception.Extra (
   safeCatch,
 ) where
 
-import Control.Effect.Exception
+import Control.Effect.Exception (
+  Exception (fromException, toException),
+  Has,
+  Lift,
+  SomeAsyncException (SomeAsyncException),
+  catch,
+  throwIO,
+ )
 
 safeCatch :: (Exception e, Has (Lift IO) sig m) => m a -> (e -> m a) -> m a
 safeCatch act hdl = act `catch` (\e -> if isSyncException e then hdl e else throwIO e)

--- a/src/Data/FileEmbed/Extra.hs
+++ b/src/Data/FileEmbed/Extra.hs
@@ -3,10 +3,14 @@ module Data.FileEmbed.Extra (
 ) where
 
 import Data.FileEmbed (embedFile)
-import Language.Haskell.TH
-import Path
-import Path.IO
-import Prelude
+import Language.Haskell.TH (
+  Exp (LitE),
+  Lit (StringL),
+  Q,
+  reportWarning,
+ )
+import Path (parseRelFile)
+import Path.IO (doesFileExist)
 
 embedFileIfExists :: FilePath -> Q Exp
 embedFileIfExists inputPath = do

--- a/src/Data/Glob.hs
+++ b/src/Data/Glob.hs
@@ -27,7 +27,7 @@ module Data.Glob (
 ) where
 
 import Data.Aeson.Types (FromJSON, ToJSON)
-import Data.String.Conversion (ToString (..), ToText (..))
+import Data.String.Conversion (ToString (toString), ToText (toText))
 import Path (Abs, Dir, Path, Rel)
 import System.FilePath qualified as FP
 import System.FilePattern qualified as Match

--- a/src/Data/String/Conversion.hs
+++ b/src/Data/String/Conversion.hs
@@ -18,7 +18,7 @@ import Data.Text.Encoding qualified as TE
 import Data.Text.Encoding.Error qualified as TE
 import Data.Text.Lazy qualified as TL
 import Data.Text.Lazy.Encoding qualified as TLE
-import GHC.TypeLits
+import GHC.TypeLits (ErrorMessage (Text), TypeError)
 import Path (Path, SomeBase)
 import Path qualified
 

--- a/src/Discovery/Archive.hs
+++ b/src/Discovery/Archive.hs
@@ -10,20 +10,19 @@ module Discovery.Archive (
 import Codec.Archive.Tar qualified as Tar
 import Codec.Archive.Zip qualified as Zip
 import Codec.Compression.GZip qualified as GZip
-import Control.Carrier.Diagnostics
-import Control.Effect.Finally
-import Control.Effect.Lift
+import Control.Effect.Diagnostics (Diagnostics, Has, context)
+import Control.Effect.Finally (Finally, onExit)
+import Control.Effect.Lift (Lift, sendIO)
 import Control.Effect.TaskPool (TaskPool, forkTask)
 import Data.ByteString.Lazy qualified as BL
 import Data.Foldable (traverse_)
 import Data.List (isSuffixOf)
 import Data.String.Conversion (toText)
 import Discovery.Archive.RPM (extractRpm)
-import Discovery.Walk
+import Discovery.Walk (WalkStep (WalkContinue), fileName, walk)
 import Effect.ReadFS (ReadFS)
-import Path
+import Path (Abs, Dir, File, Path, fromAbsDir, fromAbsFile)
 import Path.IO qualified as PIO
-import Prelude hiding (zip)
 
 -- | Given a function to run over unarchived contents, recursively unpack archives
 discover :: (Has (Lift IO) sig m, Has ReadFS sig m, Has Diagnostics sig m, Has Finally sig m, Has TaskPool sig m) => (Path Abs Dir -> m ()) -> Path Abs Dir -> m ()

--- a/src/Discovery/Archive/RPM.hs
+++ b/src/Discovery/Archive/RPM.hs
@@ -5,10 +5,23 @@ module Discovery.Archive.RPM (
 import Codec.RPM.Conduit qualified as RPM
 import Codec.RPM.Tags qualified as Tags
 import Codec.RPM.Types qualified as RPMTypes
-import Conduit
-import Control.Effect.Lift
+import Conduit (
+  ConduitT,
+  MonadIO (liftIO),
+  MonadThrow,
+  PrimMonad,
+  awaitForever,
+  filterC,
+  mapM_C,
+  runConduit,
+  runResourceT,
+  sourceFileBS,
+  yield,
+  (.|),
+ )
+import Control.Effect.Lift (Has, Lift, sendIO)
 import Control.Exception (throwIO)
-import Control.Monad.Except
+import Control.Monad.Except (runExceptT)
 import Data.ByteString qualified as BS
 import Data.ByteString.Char8 qualified as BS8
 import Data.ByteString.Lazy qualified as BL
@@ -16,9 +29,18 @@ import Data.CPIO qualified as CPIO
 import Data.Conduit.Lzma qualified as Lzma
 import Data.Conduit.Zlib qualified as Zlib
 import Data.Foldable (asum)
-import Path
+import Path (
+  Abs,
+  Dir,
+  File,
+  Path,
+  fromAbsFile,
+  parent,
+  parseRelFile,
+  toFilePath,
+  (</>),
+ )
 import Path.IO qualified as PIO
-import Prelude
 
 extractRpm :: Has (Lift IO) sig m => Path Abs Dir -> Path Abs File -> m ()
 extractRpm dir rpmFile = do

--- a/src/Discovery/Filters.hs
+++ b/src/Discovery/Filters.hs
@@ -26,7 +26,11 @@ import Text.Megaparsec (
   (<|>),
  )
 import Text.Megaparsec.Char (alphaNumChar, char)
-import Types (BuildTarget (..), FoundTargets (FoundTargets, ProjectWithoutTargets), TargetFilter (..))
+import Types (
+  BuildTarget (BuildTarget),
+  FoundTargets (FoundTargets, ProjectWithoutTargets),
+  TargetFilter (TypeDirTarget, TypeDirTargetTarget, TypeTarget),
+ )
 
 data AllFilters = AllFilters
   { legacyFilters :: [TargetFilter]

--- a/src/Discovery/Projects.hs
+++ b/src/Discovery/Projects.hs
@@ -3,17 +3,20 @@ module Discovery.Projects (
 ) where
 
 import App.Fossa.Analyze.Debug (DiagDebugC, diagToDebug)
-import Control.Carrier.Debug (Debug)
+import Control.Algebra (Has)
 import Control.Carrier.Diagnostics qualified as Diag
-import Control.Carrier.Diagnostics.StickyContext
-import Control.Carrier.Output.IO
+import Control.Carrier.Diagnostics.StickyContext (
+  StickyDiagC,
+  stickyDiag,
+ )
 import Control.Effect.AtomicCounter (AtomicCounter)
-import Control.Effect.Lift
-import Control.Effect.TaskPool
+import Control.Effect.Debug (Debug)
+import Control.Effect.Lift (Lift)
+import Control.Effect.TaskPool (TaskPool, forkTask)
 import Data.Foldable (traverse_)
-import Effect.Logger
-import Path
-import Types
+import Effect.Logger (Logger, Severity (SevError))
+import Path (Abs, Dir, Path)
+import Types (DiscoveredProject)
 
 -- | Fork a task to run a discover function, forking a task with the provided
 -- continuation applied to each discovered project

--- a/src/Discovery/Walk.hs
+++ b/src/Discovery/Walk.hs
@@ -9,10 +9,15 @@ module Discovery.Walk (
   findFileNamed,
 ) where
 
-import Control.Carrier.Writer.Church
-import Control.Effect.Diagnostics
-import Control.Monad.Trans
-import Control.Monad.Trans.Maybe
+import Control.Carrier.Writer.Church (
+  Has,
+  WriterC,
+  runWriter,
+  tell,
+ )
+import Control.Effect.Diagnostics (Diagnostics, context)
+import Control.Monad.Trans (MonadTrans (lift))
+import Control.Monad.Trans.Maybe (MaybeT (MaybeT, runMaybeT))
 import Data.Foldable (find)
 import Data.Functor (void)
 import Data.List ((\\))
@@ -20,8 +25,17 @@ import Data.Maybe (mapMaybe)
 import Data.Set qualified as Set
 import Data.String.Conversion (toString)
 import Data.Text (Text)
-import Effect.ReadFS
-import Path
+import Effect.ReadFS (ReadFS, listDir)
+import Path (
+  Abs,
+  Dir,
+  File,
+  Path,
+  dirname,
+  filename,
+  parseRelDir,
+  toFilePath,
+ )
 
 data WalkStep
   = -- | Continue walking subdirectories

--- a/src/Effect/Exec.hs
+++ b/src/Effect/Exec.hs
@@ -20,16 +20,43 @@ module Effect.Exec (
   module X,
 ) where
 
-import Control.Algebra as X
-import Control.Carrier.Simple
-import Control.Effect.Diagnostics
+import Control.Algebra as X (
+  Algebra (alg),
+  Handler,
+  Has,
+  run,
+  send,
+  thread,
+  (~<~),
+  type (:+:) (L, R),
+ )
+import Control.Carrier.Simple (
+  Simple,
+  SimpleC,
+  interpret,
+  sendSimple,
+ )
+import Control.Effect.Diagnostics (
+  Diagnostics,
+  ToDiagnostic (renderDiagnostic),
+  context,
+  fatal,
+ )
 import Control.Effect.Lift (Lift, sendIO)
-import Control.Effect.Record
+import Control.Effect.Record (RecordableValue (toRecordedValue))
 import Control.Effect.Record.TH (deriveRecordable)
-import Control.Effect.Replay
+import Control.Effect.Replay (ReplayableValue (fromRecordedValue))
 import Control.Effect.Replay.TH (deriveReplayable)
 import Control.Exception (IOException, try)
-import Data.Aeson
+import Data.Aeson (
+  FromJSON (parseJSON),
+  KeyValue ((.=)),
+  ToJSON (toJSON),
+  eitherDecode,
+  object,
+  withObject,
+  (.:),
+ )
 import Data.Bifunctor (first)
 import Data.ByteString.Lazy qualified as BL
 import Data.String (fromString)
@@ -37,11 +64,11 @@ import Data.String.Conversion (decodeUtf8, toString, toText)
 import Data.Text (Text)
 import Data.Void (Void)
 import GHC.Generics (Generic)
-import Path
-import Path.IO
+import Path (Abs, Dir, Path, SomeBase (Abs, Rel), fromAbsDir)
+import Path.IO (AnyPath (makeAbsolute))
 import Prettyprinter (indent, line, pretty, viaShow, vsep)
-import System.Exit (ExitCode (..))
-import System.Process.Typed
+import System.Exit (ExitCode (ExitFailure, ExitSuccess))
+import System.Process.Typed (proc, readProcess, setWorkingDir)
 import Text.Megaparsec (Parsec, runParser)
 import Text.Megaparsec.Error (errorBundlePretty)
 

--- a/src/Effect/Grapher.hs
+++ b/src/Effect/Grapher.hs
@@ -31,10 +31,29 @@ module Effect.Grapher (
   module X,
 ) where
 
-import Control.Algebra as X
-import Control.Carrier.Diagnostics (ToDiagnostic (..))
-import Control.Carrier.Simple
-import Control.Carrier.State.Strict
+import Control.Algebra as X (
+  Algebra (alg),
+  Handler,
+  Has,
+  run,
+  send,
+  thread,
+  (~<~),
+  type (:+:) (L, R),
+ )
+import Control.Carrier.Simple (
+  Simple,
+  SimpleStateC,
+  interpretState,
+  sendSimple,
+ )
+import Control.Carrier.State.Strict (
+  State,
+  StateC,
+  modify,
+  runState,
+ )
+import Control.Effect.Diagnostics (ToDiagnostic (renderDiagnostic))
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
 import Data.Maybe (fromMaybe)

--- a/src/Effect/Logger.hs
+++ b/src/Effect/Logger.hs
@@ -22,10 +22,27 @@ module Effect.Logger (
   module X,
 ) where
 
-import Control.Algebra as X
-import Control.Carrier.Simple
-import Control.Effect.ConsoleRegion
-import Control.Effect.Exception
+import Control.Algebra as X (
+  Algebra (alg),
+  Handler,
+  Has,
+  run,
+  send,
+  thread,
+  (~<~),
+  type (:+:) (L, R),
+ )
+import Control.Carrier.Simple (
+  Simple,
+  SimpleC,
+  interpret,
+  sendSimple,
+ )
+import Control.Effect.ConsoleRegion (
+  displayConsoleRegions,
+  withConcurrentOutput,
+ )
+import Control.Effect.Exception (Lift)
 import Control.Effect.Lift (sendIO)
 import Control.Effect.Record (RecordableValue)
 import Control.Effect.Record.TH (deriveRecordable)
@@ -33,12 +50,29 @@ import Control.Monad (when)
 import Data.Aeson (ToJSON)
 import Data.Text (Text)
 import GHC.Generics (Generic)
-import Prettyprinter as X
-import Prettyprinter.Render.Terminal as X
+import Prettyprinter as X (
+  Doc,
+  Pretty (pretty),
+  annotate,
+  defaultLayoutOptions,
+  hang,
+  hcat,
+  hsep,
+  layoutPretty,
+  line,
+  unAnnotate,
+  viaShow,
+ )
+import Prettyprinter.Render.Terminal as X (
+  AnsiStyle,
+  Color (Cyan, Green, Red, White, Yellow),
+  color,
+  renderStrict,
+ )
 import System.Console.ANSI (hSupportsANSI)
 import System.Console.Concurrent (errorConcurrent, outputConcurrent)
 import System.IO (stderr)
-import Prelude hiding (log)
+import Prelude (Applicative, Eq, IO, Ord, Show, String, pure, ($), (.), (<=), (<>))
 
 data LogCtx m = LogCtx
   { logCtxSeverity :: Severity

--- a/src/Effect/ReadFS.hs
+++ b/src/Effect/ReadFS.hs
@@ -38,17 +38,37 @@ module Effect.ReadFS (
   module X,
 ) where
 
-import Control.Algebra as X
-import Control.Carrier.Simple
-import Control.Effect.Diagnostics
+import Control.Algebra as X (
+  Algebra (alg),
+  Handler,
+  Has,
+  run,
+  send,
+  thread,
+  (~<~),
+  type (:+:) (L, R),
+ )
+import Control.Carrier.Simple (
+  Simple,
+  SimpleC,
+  interpret,
+  sendSimple,
+ )
+import Control.Effect.Diagnostics (
+  Diagnostics,
+  ToDiagnostic (renderDiagnostic),
+  context,
+  fatal,
+  fromEither,
+ )
 import Control.Effect.Lift (Lift, sendIO)
-import Control.Effect.Record
+import Control.Effect.Record (RecordableValue)
 import Control.Effect.Record.TH (deriveRecordable)
-import Control.Effect.Replay
+import Control.Effect.Replay (ReplayableValue)
 import Control.Effect.Replay.TH (deriveReplayable)
 import Control.Exception qualified as E
 import Control.Monad ((<=<))
-import Data.Aeson
+import Data.Aeson (FromJSON, ToJSON, eitherDecodeStrict)
 import Data.ByteString (ByteString)
 import Data.ByteString qualified as BS
 import Data.String.Conversion (decodeUtf8, toString, toText)
@@ -57,7 +77,17 @@ import Data.Void (Void)
 import Data.Yaml (decodeEither', prettyPrintParseException)
 import GHC.Generics (Generic)
 import Parse.XML (FromXML, parseXML, xmlErrorPretty)
-import Path
+import Path (
+  Abs,
+  Dir,
+  File,
+  Path,
+  SomeBase (Abs),
+  fromAbsFile,
+  fromSomeDir,
+  fromSomeFile,
+  toFilePath,
+ )
 import Path.IO qualified as PIO
 import Prettyprinter (indent, line, pretty, vsep)
 import System.Directory qualified as Directory

--- a/src/Fossa/API/Types.hs
+++ b/src/Fossa/API/Types.hs
@@ -15,8 +15,19 @@ module Fossa.API.Types (
   Archive (..),
 ) where
 
-import Control.Effect.Diagnostics hiding (fromMaybe)
-import Data.Aeson
+import Control.Effect.Diagnostics (Diagnostics, Has, fatalText)
+import Data.Aeson (
+  FromJSON (parseJSON),
+  KeyValue ((.=)),
+  ToJSON (toJSON),
+  Value (String),
+  object,
+  withObject,
+  withText,
+  (.!=),
+  (.:),
+  (.:?),
+ )
 import Data.Coerce (coerce)
 import Data.List.Extra ((!?))
 import Data.Map.Strict (Map)
@@ -25,8 +36,21 @@ import Data.Maybe (fromMaybe)
 import Data.String.Conversion (encodeUtf8)
 import Data.Text (Text)
 import Data.Text qualified as Text
-import Network.HTTP.Req
-import Prettyprinter
+import Network.HTTP.Req (
+  Option,
+  Scheme (Https),
+  Url,
+  header,
+  useURI,
+ )
+import Prettyprinter (
+  Doc,
+  Pretty (pretty),
+  fill,
+  hsep,
+  line,
+  vsep,
+ )
 import Text.URI (URI, render)
 import Text.URI.QQ (uri)
 import Unsafe.Coerce qualified as Unsafe

--- a/src/Graphing.hs
+++ b/src/Graphing.hs
@@ -55,7 +55,25 @@ import Algebra.Graph.AdjacencyMap.Algorithm qualified as AMA
 import Algebra.Graph.AdjacencyMap.Extra qualified as AME
 import Data.Bifunctor (bimap)
 import Data.Set qualified as Set
-import Prelude hiding (filter)
+import Prelude (
+  Applicative (pure),
+  Bool (False, True),
+  Eq,
+  Foldable (foldMap, foldr, length),
+  Functor (fmap),
+  Int,
+  Maybe (Just, Nothing),
+  Monoid (mempty),
+  Ord,
+  Semigroup ((<>)),
+  Show,
+  Traversable (sequenceA, traverse),
+  map,
+  ($),
+  (++),
+  (.),
+  (<$>),
+ )
 import Prelude qualified
 
 -- | A @Graphing ty@ is a graph of nodes with type @ty@.

--- a/src/Parse/XML.hs
+++ b/src/Parse/XML.hs
@@ -61,12 +61,20 @@ module Parse.XML (
   xmlErrorPretty,
 ) where
 
-import Prelude
-
-import Control.Algebra
-import Control.Carrier.Error.Either
-import Control.Carrier.NonDet.Church
-import Control.Carrier.Reader
+import Control.Algebra (run)
+import Control.Carrier.Error.Either (
+  ErrorC,
+  catchError,
+  runError,
+  throwError,
+ )
+import Control.Carrier.NonDet.Church (Alternative (empty, (<|>)))
+import Control.Carrier.Reader (
+  ReaderC,
+  ask,
+  local,
+  runReader,
+ )
 import Data.Functor.Identity (Identity)
 import Data.Map.Strict qualified as Map
 import Data.Maybe (fromMaybe)

--- a/src/Path/Extra.hs
+++ b/src/Path/Extra.hs
@@ -5,7 +5,14 @@ module Path.Extra (
 
 import Data.String.Conversion (toText)
 import Data.Text (Text)
-import Path (Abs, Dir, File, Path, SomeBase (..), stripProperPrefix)
+import Path (
+  Abs,
+  Dir,
+  File,
+  Path,
+  SomeBase (Abs, Rel),
+  stripProperPrefix,
+ )
 
 -- tryMakeRelative returns the path of an absolute file (Path Abs File) relative to an absolute directory (Path Abs Dir).
 -- If the file is not within the directory, then the absolute file path will be returned

--- a/src/Srclib/Converter.hs
+++ b/src/Srclib/Converter.hs
@@ -6,17 +6,50 @@ module Srclib.Converter (
   fetcherToDepType,
 ) where
 
-import Prelude
-
 import Algebra.Graph.AdjacencyMap qualified as AM
-import App.Fossa.Analyze.Project (ProjectResult (..))
+import App.Fossa.Analyze.Project (
+  ProjectResult (
+    ProjectResult,
+    projectResultGraph,
+    projectResultGraphBreadth,
+    projectResultManifestFiles,
+    projectResultPath,
+    projectResultType
+  ),
+ )
 import Control.Applicative ((<|>))
 import Data.Set qualified as Set
 import Data.String.Conversion (toText)
 import Data.Text (Text)
 import DepTypes (
   DepEnvironment (EnvOther, EnvProduction),
-  DepType (..),
+  DepType (
+    ArchiveType,
+    BowerType,
+    CargoType,
+    CarthageType,
+    ComposerType,
+    CondaType,
+    CpanType,
+    CustomType,
+    GemType,
+    GitType,
+    GoType,
+    GooglesourceType,
+    HackageType,
+    HexType,
+    MavenType,
+    NodeJSType,
+    NuGetType,
+    PipType,
+    PodType,
+    PubType,
+    RPMType,
+    SubprojectType,
+    SwiftType,
+    URLType,
+    UserType
+  ),
   Dependency (
     Dependency,
     dependencyEnvironments,
@@ -24,14 +57,34 @@ import DepTypes (
     dependencyType,
     dependencyVersion
   ),
-  VerConstraint (..),
+  VerConstraint (
+    CAnd,
+    CCompatible,
+    CEq,
+    CGreater,
+    CGreaterOrEq,
+    CLess,
+    CLessOrEq,
+    CNot,
+    COr,
+    CURI
+  ),
  )
 import Graphing (Graphing)
 import Graphing qualified
 import Path (toFilePath)
 import Srclib.Types (
-  Locator (..),
-  SourceUnit (..),
+  Locator (Locator, locatorFetcher, locatorProject, locatorRevision),
+  SourceUnit (
+    SourceUnit,
+    additionalData,
+    sourceUnitBuild,
+    sourceUnitGraphBreadth,
+    sourceUnitManifest,
+    sourceUnitName,
+    sourceUnitOriginPaths,
+    sourceUnitType
+  ),
   SourceUnitBuild (
     SourceUnitBuild,
     buildArtifact,
@@ -39,7 +92,7 @@ import Srclib.Types (
     buildImports,
     buildSucceeded
   ),
-  SourceUnitDependency (..),
+  SourceUnitDependency (SourceUnitDependency, sourceDepImports, sourceDepLocator),
  )
 
 toSourceUnit :: Bool -> ProjectResult -> SourceUnit

--- a/src/Srclib/Types.hs
+++ b/src/Srclib/Types.hs
@@ -12,13 +12,13 @@ module Srclib.Types (
   parseLocator,
 ) where
 
-import Data.Aeson
+import Data.Aeson (KeyValue ((.=)), ToJSON (toJSON), object)
 import Data.Maybe (fromMaybe)
 import Data.String.Conversion (toText)
 import Data.Text (Text)
 import Data.Text qualified as Text
 import Path (File, SomeBase)
-import Types (GraphBreadth (..))
+import Types (GraphBreadth)
 
 data SourceUnit = SourceUnit
   { sourceUnitName :: Text

--- a/src/Strategy/Bundler.hs
+++ b/src/Strategy/Bundler.hs
@@ -9,14 +9,33 @@ import App.Fossa.Analyze.Types (AnalyzeProject, analyzeProject)
 import Control.Effect.Diagnostics (Diagnostics, context, (<||>))
 import Control.Effect.Diagnostics qualified as Diag
 import Data.Aeson (ToJSON)
-import Discovery.Walk
-import Effect.Exec
-import Effect.ReadFS
+import Discovery.Walk (
+  WalkStep (WalkContinue),
+  findFileNamed,
+  walk',
+ )
+import Effect.Exec (Exec, Has)
+import Effect.ReadFS (ReadFS)
 import GHC.Generics (Generic)
-import Path
+import Path (Abs, Dir, File, Path)
 import Strategy.Ruby.BundleShow qualified as BundleShow
 import Strategy.Ruby.GemfileLock qualified as GemfileLock
-import Types
+import Types (
+  DependencyResults (
+    DependencyResults,
+    dependencyGraph,
+    dependencyGraphBreadth,
+    dependencyManifestFiles
+  ),
+  DiscoveredProject (
+    DiscoveredProject,
+    projectBuildTargets,
+    projectData,
+    projectPath,
+    projectType
+  ),
+  GraphBreadth (Complete),
+ )
 
 discover :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs Dir -> m [DiscoveredProject BundlerProject]
 discover dir = context "Bundler" $ do

--- a/src/Strategy/Cargo.hs
+++ b/src/Strategy/Cargo.hs
@@ -13,20 +13,76 @@ module Strategy.Cargo (
 ) where
 
 import App.Fossa.Analyze.Types (AnalyzeProject, analyzeProject)
-import Control.Effect.Diagnostics
-import Data.Aeson.Types
+import Control.Effect.Diagnostics (
+  Diagnostics,
+  Has,
+  context,
+  run,
+ )
+import Data.Aeson.Types (
+  FromJSON (parseJSON),
+  Parser,
+  ToJSON,
+  withObject,
+  (.:),
+  (.:?),
+ )
 import Data.Foldable (for_, traverse_)
 import Data.Map.Strict qualified as Map
 import Data.Set (Set)
 import Data.Text qualified as Text
-import Discovery.Walk
-import Effect.Exec
-import Effect.Grapher
+import Discovery.Walk (
+  WalkStep (WalkContinue, WalkSkipAll),
+  findFileNamed,
+  walk',
+ )
+import Effect.Exec (
+  AllowErr (Never),
+  Command (Command, cmdAllowErr, cmdArgs, cmdName),
+  Exec,
+  execJson,
+  execThrow,
+ )
+import Effect.Grapher (
+  LabeledGrapher,
+  direct,
+  edge,
+  label,
+  withLabeling,
+ )
 import Effect.ReadFS (ReadFS)
 import GHC.Generics (Generic)
 import Graphing (Graphing, stripRoot)
-import Path
-import Types
+import Path (Abs, Dir, File, Path)
+import Types (
+  DepEnvironment (EnvDevelopment, EnvProduction),
+  DepType (CargoType),
+  Dependency (
+    Dependency,
+    dependencyEnvironments,
+    dependencyLocations,
+    dependencyName,
+    dependencyTags,
+    dependencyType,
+    dependencyVersion
+  ),
+  DependencyResults (
+    DependencyResults,
+    dependencyGraph,
+    dependencyGraphBreadth,
+    dependencyManifestFiles
+  ),
+  DiscoveredProject (
+    DiscoveredProject,
+    projectBuildTargets,
+    projectData,
+    projectPath,
+    projectType
+  ),
+  GraphBreadth (Complete),
+  VerConstraint (CEq),
+  insertEnvironment,
+ )
 
 newtype CargoLabel
   = CargoDepKind DepEnvironment

--- a/src/Strategy/Cocoapods.hs
+++ b/src/Strategy/Cocoapods.hs
@@ -10,13 +10,32 @@ import Control.Applicative ((<|>))
 import Control.Effect.Diagnostics (Diagnostics, context, (<||>))
 import Control.Effect.Diagnostics qualified as Diag
 import Data.Aeson (ToJSON)
-import Discovery.Walk
-import Effect.ReadFS
+import Discovery.Walk (
+  WalkStep (WalkContinue),
+  findFileNamed,
+  walk',
+ )
+import Effect.ReadFS (Has, ReadFS)
 import GHC.Generics (Generic)
-import Path
+import Path (Abs, Dir, File, Path)
 import Strategy.Cocoapods.Podfile qualified as Podfile
 import Strategy.Cocoapods.PodfileLock qualified as PodfileLock
-import Types
+import Types (
+  DependencyResults (
+    DependencyResults,
+    dependencyGraph,
+    dependencyGraphBreadth,
+    dependencyManifestFiles
+  ),
+  DiscoveredProject (
+    DiscoveredProject,
+    projectBuildTargets,
+    projectData,
+    projectPath,
+    projectType
+  ),
+  GraphBreadth (Complete, Partial),
+ )
 
 discover :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs Dir -> m [DiscoveredProject CocoapodsProject]
 discover dir = context "Cocoapods" $ do

--- a/src/Strategy/Cocoapods/Podfile.hs
+++ b/src/Strategy/Cocoapods/Podfile.hs
@@ -9,20 +9,44 @@ module Strategy.Cocoapods.Podfile (
   PropertyType (..),
 ) where
 
-import Control.Effect.Diagnostics
+import Control.Effect.Diagnostics (Diagnostics, Has, context)
 import Data.Functor (void)
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
 import Data.String.Conversion (toText)
 import Data.Text (Text)
 import Data.Void (Void)
-import DepTypes
-import Effect.ReadFS
+import DepTypes (
+  DepType (PodType),
+  Dependency (
+    Dependency,
+    dependencyEnvironments,
+    dependencyLocations,
+    dependencyName,
+    dependencyTags,
+    dependencyType,
+    dependencyVersion
+  ),
+  VerConstraint (CEq),
+ )
+import Effect.ReadFS (ReadFS, readContentsParser)
 import Graphing (Graphing)
 import Graphing qualified
-import Path
-import Text.Megaparsec hiding (label)
-import Text.Megaparsec.Char
+import Path (Abs, File, Path)
+import Text.Megaparsec (
+  MonadParsec (eof, takeWhileP, try),
+  Parsec,
+  choice,
+  chunk,
+  empty,
+  many,
+  manyTill,
+  optional,
+  sepBy,
+  some,
+  (<|>),
+ )
+import Text.Megaparsec.Char (char, eol)
 import Text.Megaparsec.Char.Lexer qualified as L
 
 analyze' :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs File -> m (Graphing Dependency)

--- a/src/Strategy/Cocoapods/PodfileLock.hs
+++ b/src/Strategy/Cocoapods/PodfileLock.hs
@@ -27,12 +27,24 @@ import Data.Text (Text)
 import Data.Void (Void)
 import Data.Yaml ((.:), (.:?))
 import Data.Yaml qualified as Yaml
-import DepTypes (DepType (GitType, PodType), Dependency (..), VerConstraint (CEq))
+import DepTypes (
+  DepType (GitType, PodType),
+  Dependency (
+    Dependency,
+    dependencyEnvironments,
+    dependencyLocations,
+    dependencyName,
+    dependencyTags,
+    dependencyType,
+    dependencyVersion
+  ),
+  VerConstraint (CEq),
+ )
 import Effect.Grapher (LabeledGrapher, direct, edge, label, withLabeling)
 import Effect.ReadFS (ReadFS, readContentsYaml)
 import Graphing (Graphing)
 import Options.Applicative (Alternative ((<|>)))
-import Path
+import Path (Abs, File, Path)
 import Text.Megaparsec (MonadParsec (takeWhileP), Parsec, between, empty, errorBundlePretty, parse, some, takeWhile1P)
 import Text.Megaparsec.Char (char)
 import Text.Megaparsec.Char.Lexer qualified as L

--- a/src/Strategy/Conda.hs
+++ b/src/Strategy/Conda.hs
@@ -3,16 +3,35 @@ module Strategy.Conda (
 ) where
 
 import App.Fossa.Analyze.Types (AnalyzeProject, analyzeProject)
-import Control.Carrier.Diagnostics hiding (fromMaybe)
+import Control.Effect.Diagnostics (Diagnostics, (<||>))
 import Data.Aeson (ToJSON)
-import Discovery.Walk
-import Effect.Exec
-import Effect.ReadFS
+import Discovery.Walk (
+  WalkStep (WalkContinue, WalkSkipAll),
+  findFileNamed,
+  walk',
+ )
+import Effect.Exec (Exec, Has)
+import Effect.ReadFS (ReadFS)
 import GHC.Generics (Generic)
-import Path
+import Path (Abs, Dir, File, Path)
 import Strategy.Conda.CondaList qualified as CondaList
 import Strategy.Conda.EnvironmentYml qualified as EnvironmentYml
-import Types
+import Types (
+  DependencyResults (
+    DependencyResults,
+    dependencyGraph,
+    dependencyGraphBreadth,
+    dependencyManifestFiles
+  ),
+  DiscoveredProject (
+    DiscoveredProject,
+    projectBuildTargets,
+    projectData,
+    projectPath,
+    projectType
+  ),
+  GraphBreadth (Complete),
+ )
 
 discover :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs Dir -> m [DiscoveredProject CondaProject]
 discover dir = map mkProject <$> findProjects dir

--- a/src/Strategy/Conda/CondaList.hs
+++ b/src/Strategy/Conda/CondaList.hs
@@ -7,14 +7,31 @@ module Strategy.Conda.CondaList (
   CondaListDep (..),
 ) where
 
-import Control.Carrier.Diagnostics hiding (fromMaybe)
-import Data.Aeson
+import Control.Effect.Diagnostics (Diagnostics, Has)
+import Data.Aeson (FromJSON (parseJSON), withObject, (.:), (.:?))
 import Data.Map.Strict qualified as Map
 import Data.Text (Text)
-import Effect.Exec
+import DepTypes (
+  DepType (CondaType),
+  Dependency (
+    Dependency,
+    dependencyEnvironments,
+    dependencyLocations,
+    dependencyName,
+    dependencyTags,
+    dependencyType,
+    dependencyVersion
+  ),
+  VerConstraint (CEq),
+ )
+import Effect.Exec (
+  AllowErr (Never),
+  Command (Command, cmdAllowErr, cmdArgs, cmdName),
+  Exec,
+  execJson,
+ )
 import Graphing (Graphing, fromList)
-import Path
-import Types
+import Path (Abs, Dir, Path)
 
 -- conda list --json will output dependency data in JSON format
 condaListCmd :: Command

--- a/src/Strategy/Conda/EnvironmentYml.hs
+++ b/src/Strategy/Conda/EnvironmentYml.hs
@@ -7,17 +7,29 @@ module Strategy.Conda.EnvironmentYml (
   EnvironmentYmlFile (..),
 ) where
 
-import Control.Carrier.Diagnostics hiding (fromMaybe)
-import Data.Aeson
+import Control.Effect.Diagnostics (Diagnostics)
+import Data.Aeson (FromJSON (parseJSON), withObject, (.:))
 import Data.List.Extra ((!?))
 import Data.Map.Strict qualified as Map
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import Data.Text qualified as Text
-import Effect.ReadFS
+import DepTypes (
+  DepType (CondaType),
+  Dependency (
+    Dependency,
+    dependencyEnvironments,
+    dependencyLocations,
+    dependencyName,
+    dependencyTags,
+    dependencyType,
+    dependencyVersion
+  ),
+  VerConstraint (CEq),
+ )
+import Effect.ReadFS (Has, ReadFS, readContentsYaml)
 import Graphing (Graphing, fromList)
-import Path
-import Types
+import Path (Abs, File, Path)
 
 buildGraph :: EnvironmentYmlFile -> Graphing Dependency
 buildGraph envYmlFile = Graphing.fromList (map toDependency allDeps)

--- a/src/Strategy/Dart/PubDeps.hs
+++ b/src/Strategy/Dart/PubDeps.hs
@@ -18,19 +18,25 @@ import Data.Set qualified as Set
 import Data.String.Conversion (ToText (toText))
 import Data.Text (Text)
 import Data.Void (Void)
-import DepTypes (Dependency (..))
-import Effect.Exec (AllowErr (Never), Command (..), Exec, execParser)
+import DepTypes (Dependency)
+import Effect.Exec (AllowErr (Never), Command (Command, cmdAllowErr, cmdArgs, cmdName), Exec, execParser)
 import Effect.Logger (Logger)
 import Effect.ReadFS (Has, ReadFS, readContentsYaml)
 import GHC.Generics (Generic)
 import Graphing (Graphing, deeps, directs, edges, gmap, shrink)
-import Path
+import Path (Abs, Dir, File, Path)
 import Strategy.Dart.PubSpecLock (
-  PackageName (..),
-  PubDepSource (..),
-  PubLockContent (..),
-  PubLockPackageHostedSource (..),
-  PubLockPackageMetadata (..),
+  PackageName (PackageName),
+  PubDepSource (HostedSource),
+  PubLockContent (packages),
+  PubLockPackageHostedSource (PubLockPackageHostedSource),
+  PubLockPackageMetadata (
+    PubLockPackageMetadata,
+    pubLockPackageEnvironment,
+    pubLockPackageIsDirect,
+    pubLockPackageSource,
+    pubLockPackageVersion
+  ),
   isSupported,
   logIgnoredPackages,
   toDependency,
@@ -49,7 +55,7 @@ import Text.Megaparsec (
 import Text.Megaparsec qualified as Megaparsec
 import Text.Megaparsec.Char (alphaNumChar, char, space1)
 import Text.Megaparsec.Char.Lexer qualified as L
-import Types (GraphBreadth (..))
+import Types (GraphBreadth (Complete))
 
 type Parser = Parsec Void Text
 

--- a/src/Strategy/Dart/PubSpec.hs
+++ b/src/Strategy/Dart/PubSpec.hs
@@ -24,15 +24,23 @@ import Data.Yaml qualified as Yaml
 import DepTypes (
   DepEnvironment (EnvDevelopment, EnvProduction),
   DepType (GitType, PubType),
-  Dependency (..),
+  Dependency (
+    Dependency,
+    dependencyEnvironments,
+    dependencyLocations,
+    dependencyName,
+    dependencyTags,
+    dependencyType,
+    dependencyVersion
+  ),
   VerConstraint (CEq),
  )
 import Effect.Logger (Logger, Pretty (pretty), logDebug)
 import Effect.ReadFS (Has, ReadFS, readContentsYaml)
 import Graphing (Graphing, directs, induceJust)
-import Path
-import Strategy.Dart.PubSpecLock (PackageName (..))
-import Types (GraphBreadth (..))
+import Path (Abs, File, Path)
+import Strategy.Dart.PubSpecLock (PackageName (unPackageName))
+import Types (GraphBreadth (Partial))
 
 data PubSpecContent = PubSpecContent
   { pubSpecDependencies :: Maybe (Map PackageName PubSpecDepSource)

--- a/src/Strategy/Dart/PubSpecLock.hs
+++ b/src/Strategy/Dart/PubSpecLock.hs
@@ -32,7 +32,15 @@ import Data.Yaml qualified as Yaml
 import DepTypes (
   DepEnvironment (EnvDevelopment, EnvProduction),
   DepType (GitType, PubType),
-  Dependency (..),
+  Dependency (
+    Dependency,
+    dependencyEnvironments,
+    dependencyLocations,
+    dependencyName,
+    dependencyTags,
+    dependencyType,
+    dependencyVersion
+  ),
   VerConstraint (CEq),
  )
 import Effect.Exec (Exec, Has)
@@ -40,8 +48,8 @@ import Effect.Logger (Logger, Pretty (pretty), logDebug)
 import Effect.ReadFS (ReadFS, readContentsYaml)
 import GHC.Generics (Generic)
 import Graphing (Graphing, deeps, directs)
-import Path
-import Types (GraphBreadth (..))
+import Path (Abs, File, Path)
+import Types (GraphBreadth (Partial))
 
 newtype PackageName = PackageName {unPackageName :: Text} deriving (Show, Eq, Ord, FromJSONKey)
 newtype PubLockContent = PubLockContent {packages :: Map PackageName PubLockPackageMetadata} deriving (Show, Eq, Ord)

--- a/src/Strategy/Elixir/MixTree.hs
+++ b/src/Strategy/Elixir/MixTree.hs
@@ -20,7 +20,7 @@ module Strategy.Elixir.MixTree (
 import App.Fossa.Analyze.Types (AnalyzeProject, analyzeProject)
 import Control.Effect.Diagnostics (Diagnostics, Has, context)
 import Control.Monad (void)
-import Control.Monad.Combinators.Expr (Operator (..), makeExprParser)
+import Control.Monad.Combinators.Expr (Operator (InfixL), makeExprParser)
 import Data.Aeson (ToJSON)
 import Data.Foldable (asum)
 import Data.Functor (($>))
@@ -32,7 +32,15 @@ import Data.Text (Text)
 import Data.Void (Void)
 import DepTypes (
   DepType (GitType, HexType),
-  Dependency (..),
+  Dependency (
+    Dependency,
+    dependencyEnvironments,
+    dependencyLocations,
+    dependencyName,
+    dependencyTags,
+    dependencyType,
+    dependencyVersion
+  ),
   VerConstraint (
     CAnd,
     CCompatible,
@@ -45,11 +53,16 @@ import DepTypes (
     COr
   ),
  )
-import Effect.Exec (AllowErr (Never), Command (..), Exec, execParser)
+import Effect.Exec (
+  AllowErr (Never),
+  Command (Command, cmdAllowErr, cmdArgs, cmdName),
+  Exec,
+  execParser,
+ )
 import Effect.Logger (Logger, logWarn)
 import GHC.Generics (Generic)
 import Graphing (Graphing, unfold)
-import Path
+import Path (Abs, Dir, File, Path)
 import Prettyprinter (pretty)
 import Text.Megaparsec (
   MonadParsec (eof, takeWhile1P, takeWhileP, try),
@@ -70,7 +83,15 @@ import Text.Megaparsec (
  )
 import Text.Megaparsec.Char (alphaNumChar, char, eol, newline, string)
 import Text.Megaparsec.Char.Lexer qualified as Lexer
-import Types (DependencyResults (..), GraphBreadth (..))
+import Types (
+  DependencyResults (
+    DependencyResults,
+    dependencyGraph,
+    dependencyGraphBreadth,
+    dependencyManifestFiles
+  ),
+  GraphBreadth (Complete),
+ )
 
 missingDepVersionsMsg :: Text
 missingDepVersionsMsg = "Some of dependencies versions were not resolved from `mix deps` and `mix deps.tree`. Has `mix deps.get` and `mix compile` been executed?"

--- a/src/Strategy/Erlang/ConfigParser.hs
+++ b/src/Strategy/Erlang/ConfigParser.hs
@@ -26,10 +26,22 @@ import Data.Functor (($>))
 import Data.String.Conversion (toText)
 import Data.Text (Text)
 import Data.Text qualified as Text
-import Data.Void
+import Data.Void (Void)
 import GHC.Generics (Generic)
-import Text.Megaparsec
-import Text.Megaparsec.Char
+import Text.Megaparsec (
+  MonadParsec (takeWhile1P, takeWhileP, try),
+  Parsec,
+  between,
+  empty,
+  endBy1,
+  manyTill,
+  satisfy,
+  sepBy,
+  sepBy1,
+  some,
+  (<|>),
+ )
+import Text.Megaparsec.Char (alphaNumChar, char, space1)
 import Text.Megaparsec.Char.Lexer qualified as L
 
 type Parser = Parsec Void Text

--- a/src/Strategy/Fortran/FpmToml.hs
+++ b/src/Strategy/Fortran/FpmToml.hs
@@ -19,12 +19,20 @@ import Data.Text (Text)
 import DepTypes (
   DepEnvironment (EnvDevelopment, EnvProduction),
   DepType (GitType),
-  Dependency (..),
+  Dependency (
+    Dependency,
+    dependencyEnvironments,
+    dependencyLocations,
+    dependencyName,
+    dependencyTags,
+    dependencyType,
+    dependencyVersion
+  ),
   VerConstraint (CEq),
  )
 import Effect.ReadFS (Has, ReadFS, readContentsToml)
 import Graphing (Graphing, directs, induceJust)
-import Path
+import Path (Abs, File, Path)
 import Toml (TomlCodec, (.=))
 import Toml qualified
 

--- a/src/Strategy/Fpm.hs
+++ b/src/Strategy/Fpm.hs
@@ -6,9 +6,24 @@ import Data.Aeson (ToJSON)
 import Discovery.Walk (WalkStep (WalkContinue, WalkSkipSome), findFileNamed, walk')
 import Effect.ReadFS (Has, ReadFS)
 import GHC.Generics (Generic)
-import Path
+import Path (Abs, Dir, File, Path)
 import Strategy.Fortran.FpmToml (analyzeFpmToml)
-import Types (DependencyResults (..), DiscoveredProject (..), GraphBreadth (Partial))
+import Types (
+  DependencyResults (
+    DependencyResults,
+    dependencyGraph,
+    dependencyGraphBreadth,
+    dependencyManifestFiles
+  ),
+  DiscoveredProject (
+    DiscoveredProject,
+    projectBuildTargets,
+    projectData,
+    projectPath,
+    projectType
+  ),
+  GraphBreadth (Partial),
+ )
 
 discover ::
   ( Has ReadFS sig m

--- a/src/Strategy/Glide.hs
+++ b/src/Strategy/Glide.hs
@@ -5,12 +5,25 @@ module Strategy.Glide (
 import App.Fossa.Analyze.Types (AnalyzeProject, analyzeProject)
 import Control.Effect.Diagnostics (Diagnostics, context)
 import Data.Aeson (ToJSON)
-import Discovery.Walk
-import Effect.ReadFS
+import Discovery.Walk (
+  WalkStep (WalkContinue, WalkSkipAll),
+  findFileNamed,
+  walk',
+ )
+import Effect.ReadFS (Has, ReadFS)
 import GHC.Generics (Generic)
-import Path
+import Path (Abs, Dir, File, Path)
 import Strategy.Go.GlideLock qualified as GlideLock
-import Types
+import Types (
+  DependencyResults,
+  DiscoveredProject (
+    DiscoveredProject,
+    projectBuildTargets,
+    projectData,
+    projectPath,
+    projectType
+  ),
+ )
 
 discover :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs Dir -> m [DiscoveredProject GlideProject]
 discover dir = context "Glide" $ do

--- a/src/Strategy/Go/GlideLock.hs
+++ b/src/Strategy/Go/GlideLock.hs
@@ -8,17 +8,37 @@ module Strategy.Go.GlideLock (
 ) where
 
 import Control.Applicative ((<|>))
-import Control.Effect.Diagnostics
-import Data.Aeson
+import Control.Effect.Diagnostics (Diagnostics, Has, context)
+import Data.Aeson (FromJSON (parseJSON), withObject, (.:), (.:?))
 import Data.Map.Strict qualified as Map
 import Data.String.Conversion (toText)
 import Data.Text (Text)
-import DepTypes
-import Effect.ReadFS
+import DepTypes (
+  DepType (GoType),
+  Dependency (
+    Dependency,
+    dependencyEnvironments,
+    dependencyLocations,
+    dependencyName,
+    dependencyTags,
+    dependencyType,
+    dependencyVersion
+  ),
+  VerConstraint (CEq),
+ )
+import Effect.ReadFS (ReadFS, readContentsYaml)
 import Graphing (Graphing)
 import Graphing qualified
-import Path
-import Types (DependencyResults (..), GraphBreadth (..))
+import Path (Abs, File, Path)
+import Types (
+  DependencyResults (
+    DependencyResults,
+    dependencyGraph,
+    dependencyGraphBreadth,
+    dependencyManifestFiles
+  ),
+  GraphBreadth (Complete),
+ )
 
 analyze' :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs File -> m DependencyResults
 analyze' file = do

--- a/src/Strategy/Go/GoList.hs
+++ b/src/Strategy/Go/GoList.hs
@@ -5,21 +5,36 @@ module Strategy.Go.GoList (
   Require (..),
 ) where
 
-import Control.Effect.Diagnostics
+import Control.Effect.Diagnostics (
+  Diagnostics,
+  Has,
+  context,
+  recover,
+ )
 import Data.ByteString.Lazy qualified as BL
 import Data.Foldable (traverse_)
 import Data.Maybe (mapMaybe)
 import Data.String.Conversion (decodeUtf8)
 import Data.Text (Text)
 import Data.Text qualified as Text
-import DepTypes
-import Effect.Exec
-import Effect.Grapher
+import DepTypes (Dependency)
+import Effect.Exec (
+  AllowErr (Never),
+  Command (Command, cmdAllowErr, cmdArgs, cmdName),
+  Exec,
+  execThrow,
+ )
+import Effect.Grapher (direct, label)
 import Graphing (Graphing)
-import Path
+import Path (Abs, Dir, Path)
 import Strategy.Go.Transitive (fillInTransitive)
-import Strategy.Go.Types
-import Types (GraphBreadth (..))
+import Strategy.Go.Types (
+  GolangGrapher,
+  graphingGolang,
+  mkGolangPackage,
+  mkGolangVersion,
+ )
+import Types (GraphBreadth (Complete))
 
 data Require = Require
   { reqPackage :: Text

--- a/src/Strategy/Go/Gomod.hs
+++ b/src/Strategy/Go/Gomod.hs
@@ -24,7 +24,10 @@ import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
 import Data.Maybe (fromMaybe)
 import Data.SemVer qualified as SemVer
-import Data.SemVer.Internal (Identifier (..), Version (..))
+import Data.SemVer.Internal (
+  Identifier (INum, IText),
+  Version (_versionMeta, _versionRelease),
+ )
 import Data.String.Conversion (toText)
 import Data.Text (Text)
 import Data.Void (Void)
@@ -37,7 +40,7 @@ import Path (Abs, File, Path, parent)
 import Strategy.Go.Transitive (fillInTransitive)
 import Strategy.Go.Types (
   GolangGrapher,
-  GolangLabel (..),
+  GolangLabel (GolangLabelVersion),
   graphingGolang,
   mkGolangPackage,
  )
@@ -56,7 +59,7 @@ import Text.Megaparsec (
  )
 import Text.Megaparsec.Char (alphaNumChar, char, numberChar, space1)
 import Text.Megaparsec.Char.Lexer qualified as L
-import Types (GraphBreadth (..))
+import Types (GraphBreadth (Partial))
 
 -- For the file's grammar, see https://golang.org/ref/mod#go-mod-file-grammar.
 --

--- a/src/Strategy/Go/GopkgLock.hs
+++ b/src/Strategy/Go/GopkgLock.hs
@@ -8,18 +8,29 @@ module Strategy.Go.GopkgLock (
   golockCodec,
 ) where
 
-import Control.Effect.Diagnostics
+import Control.Effect.Diagnostics (
+  Diagnostics,
+  Has,
+  context,
+  recover,
+ )
 import Data.Foldable (traverse_)
 import Data.Functor (void)
 import Data.Text (Text)
-import DepTypes
-import Effect.Exec
-import Effect.Grapher
-import Effect.ReadFS
+import DepTypes (Dependency)
+import Effect.Exec (Exec)
+import Effect.Grapher (direct, label)
+import Effect.ReadFS (ReadFS, readContentsToml)
 import Graphing (Graphing)
-import Path
+import Path (Abs, File, Path, parent)
 import Strategy.Go.Transitive (fillInTransitive)
-import Strategy.Go.Types
+import Strategy.Go.Types (
+  GolangGrapher,
+  GolangLabel (GolangLabelLocation),
+  graphingGolang,
+  mkGolangPackage,
+  mkGolangVersion,
+ )
 import Toml (TomlCodec, (.=))
 import Toml qualified
 

--- a/src/Strategy/Go/GopkgToml.hs
+++ b/src/Strategy/Go/GopkgToml.hs
@@ -9,20 +9,31 @@ module Strategy.Go.GopkgToml (
 ) where
 
 import Control.Applicative ((<|>))
-import Control.Effect.Diagnostics
+import Control.Effect.Diagnostics (
+  Diagnostics,
+  Has,
+  context,
+  recover,
+ )
 import Data.Foldable (traverse_)
 import Data.Functor (void)
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
 import Data.Text (Text)
-import DepTypes
-import Effect.Exec
-import Effect.Grapher
-import Effect.ReadFS
+import DepTypes (Dependency)
+import Effect.Exec (Exec)
+import Effect.Grapher (direct, label)
+import Effect.ReadFS (ReadFS, readContentsToml)
 import Graphing (Graphing)
-import Path
+import Path (Abs, File, Path, parent)
 import Strategy.Go.Transitive (fillInTransitive)
-import Strategy.Go.Types
+import Strategy.Go.Types (
+  GolangGrapher,
+  GolangLabel (GolangLabelLocation),
+  graphingGolang,
+  mkGolangPackage,
+  mkGolangVersion,
+ )
 import Toml (TomlCodec, (.=))
 import Toml qualified
 

--- a/src/Strategy/Go/Types.hs
+++ b/src/Strategy/Go/Types.hs
@@ -11,9 +11,26 @@ import Data.Map.Strict qualified as Map
 import Data.Set (Set)
 import Data.Text (Text)
 import Data.Text qualified as Text
-import DepTypes
-import Effect.Grapher
-import Graphing
+import DepTypes (
+  DepType (GoType),
+  Dependency (
+    Dependency,
+    dependencyEnvironments,
+    dependencyLocations,
+    dependencyName,
+    dependencyTags,
+    dependencyType,
+    dependencyVersion
+  ),
+  VerConstraint (CEq),
+ )
+import Effect.Grapher (
+  Algebra,
+  LabeledGrapher,
+  LabeledGrapherC,
+  withLabeling,
+ )
+import Graphing (Graphing)
 
 -- | A golang package is uniquely identified by its import path
 newtype GolangPackage = GolangPackage {goImportPath :: Text} deriving (Eq, Ord, Show)

--- a/src/Strategy/Godep.hs
+++ b/src/Strategy/Godep.hs
@@ -7,14 +7,33 @@ import Control.Applicative ((<|>))
 import Control.Effect.Diagnostics (Diagnostics, context, (<||>))
 import Control.Effect.Diagnostics qualified as Diag
 import Data.Aeson (ToJSON)
-import Discovery.Walk
-import Effect.Exec
-import Effect.ReadFS
+import Discovery.Walk (
+  WalkStep (WalkSkipSome),
+  findFileNamed,
+  walk',
+ )
+import Effect.Exec (Exec, Has)
+import Effect.ReadFS (ReadFS)
 import GHC.Generics (Generic)
-import Path
+import Path (Abs, Dir, File, Path)
 import Strategy.Go.GopkgLock qualified as GopkgLock
 import Strategy.Go.GopkgToml qualified as GopkgToml
-import Types
+import Types (
+  DependencyResults (
+    DependencyResults,
+    dependencyGraph,
+    dependencyGraphBreadth,
+    dependencyManifestFiles
+  ),
+  DiscoveredProject (
+    DiscoveredProject,
+    projectBuildTargets,
+    projectData,
+    projectPath,
+    projectType
+  ),
+  GraphBreadth (Complete),
+ )
 
 discover :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs Dir -> m [DiscoveredProject GodepProject]
 discover dir = map mkProject <$> findProjects dir

--- a/src/Strategy/Gomodules.hs
+++ b/src/Strategy/Gomodules.hs
@@ -8,14 +8,32 @@ module Strategy.Gomodules (
 import App.Fossa.Analyze.Types (AnalyzeProject, analyzeProject)
 import Control.Effect.Diagnostics (Diagnostics, context, (<||>))
 import Data.Aeson (ToJSON)
-import Discovery.Walk
-import Effect.Exec
-import Effect.ReadFS
+import Discovery.Walk (
+  WalkStep (WalkSkipSome),
+  findFileNamed,
+  walk',
+ )
+import Effect.Exec (Exec, Has)
+import Effect.ReadFS (ReadFS)
 import GHC.Generics (Generic)
 import Path (Abs, Dir, File, Path)
 import Strategy.Go.GoList qualified as GoList
 import Strategy.Go.Gomod qualified as Gomod
-import Types
+import Types (
+  DependencyResults (
+    DependencyResults,
+    dependencyGraph,
+    dependencyGraphBreadth,
+    dependencyManifestFiles
+  ),
+  DiscoveredProject (
+    DiscoveredProject,
+    projectBuildTargets,
+    projectData,
+    projectPath,
+    projectType
+  ),
+ )
 
 discover :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs Dir -> m [DiscoveredProject GomodulesProject]
 discover dir = context "Gomodules" $ do

--- a/src/Strategy/Haskell/Stack.hs
+++ b/src/Strategy/Haskell/Stack.hs
@@ -11,22 +11,74 @@ module Strategy.Haskell.Stack (
 ) where
 
 import App.Fossa.Analyze.Types (AnalyzeProject, analyzeProject)
-import Control.Effect.Diagnostics
+import Control.Effect.Diagnostics (
+  Diagnostics,
+  Has,
+  context,
+  fromEither,
+ )
 import Control.Monad (when)
-import Data.Aeson.Types
+import Data.Aeson.Types (
+  FromJSON (parseJSON),
+  ToJSON,
+  withObject,
+  (.!=),
+  (.:),
+  (.:?),
+ )
 import Data.Foldable (for_)
 import Data.Map.Strict qualified as Map
 import Data.String.Conversion (toString)
 import Data.Text (Text)
-import Discovery.Walk
-import Effect.Exec
-import Effect.Grapher
+import Discovery.Walk (
+  WalkStep (WalkContinue, WalkSkipAll),
+  findFileNamed,
+  walk',
+ )
+import Effect.Exec (
+  AllowErr (Never),
+  Command (Command, cmdAllowErr, cmdArgs, cmdName),
+  Exec,
+  execJson,
+ )
+import Effect.Grapher (
+  MappedGrapher,
+  direct,
+  edge,
+  mapping,
+  withMapping,
+ )
 import Effect.ReadFS (ReadFS)
 import GHC.Generics (Generic)
 import Graphing qualified as G
-import Path
-import Types
-import Prelude
+import Path (Abs, Dir, File, Path)
+import Types (
+  DepType (HackageType),
+  Dependency (
+    Dependency,
+    dependencyEnvironments,
+    dependencyLocations,
+    dependencyName,
+    dependencyTags,
+    dependencyType,
+    dependencyVersion
+  ),
+  DependencyResults (
+    DependencyResults,
+    dependencyGraph,
+    dependencyGraphBreadth,
+    dependencyManifestFiles
+  ),
+  DiscoveredProject (
+    DiscoveredProject,
+    projectBuildTargets,
+    projectData,
+    projectPath,
+    projectType
+  ),
+  GraphBreadth (Complete),
+  VerConstraint (CEq),
+ )
 
 newtype PackageName = PackageName {unPackageName :: Text} deriving (FromJSON, Eq, Ord, Show)
 

--- a/src/Strategy/Maven.hs
+++ b/src/Strategy/Maven.hs
@@ -20,7 +20,22 @@ import Strategy.Maven.DepTree qualified as DepTreeCmd
 import Strategy.Maven.PluginStrategy qualified as Plugin
 import Strategy.Maven.Pom qualified as Pom
 import Strategy.Maven.Pom.Closure qualified as PomClosure
-import Types (DependencyResults (..), DiscoveredProject (..), GraphBreadth (..))
+import Types (
+  DependencyResults (
+    DependencyResults,
+    dependencyGraph,
+    dependencyGraphBreadth,
+    dependencyManifestFiles
+  ),
+  DiscoveredProject (
+    DiscoveredProject,
+    projectBuildTargets,
+    projectData,
+    projectPath,
+    projectType
+  ),
+  GraphBreadth (Partial),
+ )
 
 discover ::
   ( MonadIO m

--- a/src/Strategy/Maven/DepTree.hs
+++ b/src/Strategy/Maven/DepTree.hs
@@ -22,12 +22,25 @@ import Data.Text (Text)
 import Data.Text qualified as Text
 import Data.Void (Void)
 import DepTypes (
-  DepEnvironment (..),
+  DepEnvironment (EnvOther, EnvProduction, EnvTesting),
   DepType (MavenType),
-  Dependency (..),
+  Dependency (
+    Dependency,
+    dependencyEnvironments,
+    dependencyLocations,
+    dependencyName,
+    dependencyTags,
+    dependencyType,
+    dependencyVersion
+  ),
   VerConstraint (CEq),
  )
-import Effect.Exec (AllowErr (..), Command (..), Exec, exec)
+import Effect.Exec (
+  AllowErr (Always),
+  Command (Command, cmdAllowErr, cmdArgs, cmdName),
+  Exec,
+  exec,
+ )
 import Effect.Grapher (direct, edge, evalGrapher)
 import Effect.ReadFS (ReadFS, doesFileExist, readContentsParser)
 import Graphing (Graphing, gmap, shrinkRoots)

--- a/src/Strategy/Maven/Plugin.hs
+++ b/src/Strategy/Maven/Plugin.hs
@@ -10,20 +10,40 @@ module Strategy.Maven.Plugin (
   Edge (..),
 ) where
 
-import Control.Algebra
-import Control.Effect.Diagnostics
-import Control.Effect.Exception
+import Control.Algebra (Has)
+import Control.Effect.Diagnostics (Diagnostics)
+import Control.Effect.Exception (Lift, bracket)
 import Control.Effect.Lift (sendIO)
-import Data.Aeson
+import Data.Aeson (
+  FromJSON (parseJSON),
+  withObject,
+  (.!=),
+  (.:),
+  (.:?),
+ )
 import Data.ByteString (ByteString)
 import Data.ByteString qualified as BS
 import Data.FileEmbed (embedFile)
 import Data.Functor (void)
 import Data.String.Conversion (toText)
 import Data.Text (Text)
-import Effect.Exec
-import Effect.ReadFS
-import Path
+import Effect.Exec (
+  AllowErr (Never),
+  Command (Command, cmdAllowErr, cmdArgs, cmdName),
+  Exec,
+  execThrow,
+ )
+import Effect.ReadFS (ReadFS, readContentsJson)
+import Path (
+  Abs,
+  Dir,
+  File,
+  Path,
+  Rel,
+  fromAbsDir,
+  mkRelFile,
+  (</>),
+ )
 import Path.IO (createTempDir, getTempDir, removeDirRecur)
 import System.FilePath qualified as FP
 

--- a/src/Strategy/Maven/PluginStrategy.hs
+++ b/src/Strategy/Maven/PluginStrategy.hs
@@ -13,9 +13,17 @@ import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
 import Data.Set qualified as Set
 import DepTypes (
-  DepEnvironment (..),
+  DepEnvironment (EnvTesting),
   DepType (MavenType),
-  Dependency (..),
+  Dependency (
+    Dependency,
+    dependencyEnvironments,
+    dependencyLocations,
+    dependencyName,
+    dependencyTags,
+    dependencyType,
+    dependencyVersion
+  ),
   VerConstraint (CEq),
  )
 import Effect.Exec (Exec)
@@ -24,15 +32,23 @@ import Effect.ReadFS (ReadFS)
 import Graphing (Graphing)
 import Path (Abs, Dir, Path)
 import Strategy.Maven.Plugin (
-  Artifact (..),
-  Edge (..),
-  PluginOutput (..),
+  Artifact (
+    Artifact,
+    artifactArtifactId,
+    artifactGroupId,
+    artifactNumericId,
+    artifactOptional,
+    artifactScopes,
+    artifactVersion
+  ),
+  Edge (Edge, edgeFrom, edgeTo),
+  PluginOutput (PluginOutput, outArtifacts, outEdges),
   execPlugin,
   installPlugin,
   parsePluginOutput,
   withUnpackedPlugin,
  )
-import Types (GraphBreadth (..))
+import Types (GraphBreadth (Complete))
 
 analyze' ::
   ( Has (Lift IO) sig m

--- a/src/Strategy/Maven/Pom/Closure.hs
+++ b/src/Strategy/Maven/Pom/Closure.hs
@@ -8,9 +8,9 @@ module Strategy.Maven.Pom.Closure (
 
 import Algebra.Graph.AdjacencyMap qualified as AM
 import Algebra.Graph.AdjacencyMap.Algorithm qualified as AM
-import Control.Algebra
-import Control.Carrier.State.Strict
-import Control.Effect.Diagnostics
+import Control.Algebra (Has)
+import Control.Carrier.State.Strict (execState, modify)
+import Control.Effect.Diagnostics (Diagnostics, context)
 import Data.Aeson (ToJSON, object, toJSON, (.=))
 import Data.Foldable (traverse_)
 import Data.List (isSuffixOf)
@@ -19,13 +19,16 @@ import Data.Map.Strict qualified as Map
 import Data.Maybe (mapMaybe)
 import Data.Set (Set)
 import Data.Set qualified as Set
-import Discovery.Walk
-import Effect.ReadFS
+import Discovery.Walk (WalkStep (WalkSkipSome), fileName, walk)
+import Effect.ReadFS (ReadFS)
 import GHC.Generics (Generic)
-import Path
+import Path (Abs, Dir, File, Path)
 import Path.IO qualified as PIO
-import Strategy.Maven.Pom.PomFile
-import Strategy.Maven.Pom.Resolver
+import Strategy.Maven.Pom.PomFile (MavenCoordinate, Pom)
+import Strategy.Maven.Pom.Resolver (
+  GlobalClosure (globalGraph, globalPoms),
+  buildGlobalClosure,
+ )
 
 findProjects :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs Dir -> m [MavenProjectClosure]
 findProjects basedir = do

--- a/src/Strategy/Maven/Pom/PomFile.hs
+++ b/src/Strategy/Maven/Pom/PomFile.hs
@@ -21,7 +21,7 @@ import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
 import Data.Text (Text)
 import GHC.Generics (Generic)
-import Parse.XML
+import Parse.XML (FromXML (parseElement), child, children, defaultsTo)
 
 ----- Validating POM files
 

--- a/src/Strategy/Maven/Pom/Resolver.hs
+++ b/src/Strategy/Maven/Pom/Resolver.hs
@@ -6,18 +6,42 @@ module Strategy.Maven.Pom.Resolver (
 ) where
 
 import Algebra.Graph.AdjacencyMap qualified as AM
-import Control.Algebra
-import Control.Carrier.State.Strict
-import Control.Effect.Diagnostics hiding (fromMaybe)
+import Control.Algebra (Has)
+import Control.Carrier.State.Strict (
+  State,
+  get,
+  modify,
+  runState,
+ )
+import Control.Effect.Diagnostics (
+  Diagnostics,
+  context,
+  fatal,
+  recover,
+  (<||>),
+ )
 import Control.Monad (unless)
 import Data.Foldable (traverse_)
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
-import Effect.ReadFS
-import Path
-import Strategy.Maven.Pom.PomFile
+import Effect.ReadFS (
+  ReadFS,
+  ReadFSErr (FileReadError),
+  doesFileExist,
+  readContentsXML,
+  resolveDir,
+  resolveFile,
+ )
+import Path (Abs, Dir, File, Path, mkRelFile, parent, (</>))
+import Strategy.Maven.Pom.PomFile (
+  MavenCoordinate,
+  Pom (pomCoord, pomParentCoord),
+  RawParent (rawParentRelativePath),
+  RawPom (rawPomModules, rawPomParent),
+  validatePom,
+ )
 
 data GlobalClosure = GlobalClosure
   { globalGraph :: AM.AdjacencyMap MavenCoordinate

--- a/src/Strategy/Mix.hs
+++ b/src/Strategy/Mix.hs
@@ -11,9 +11,17 @@ import Discovery.Walk (
   walk',
  )
 import Effect.ReadFS (Has, ReadFS)
-import Path
-import Strategy.Elixir.MixTree (MixProject (..))
-import Types (DiscoveredProject (..))
+import Path (Abs, Dir, Path)
+import Strategy.Elixir.MixTree (MixProject (MixProject, mixDir))
+import Types (
+  DiscoveredProject (
+    DiscoveredProject,
+    projectBuildTargets,
+    projectData,
+    projectPath,
+    projectType
+  ),
+ )
 
 discover :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs Dir -> m [DiscoveredProject MixProject]
 discover dir = context "Mix" $ do

--- a/src/Strategy/Node.hs
+++ b/src/Strategy/Node.hs
@@ -55,10 +55,10 @@ import Strategy.Node.Npm.PackageLock qualified as PackageLock
 import Strategy.Node.PackageJson (
   Development,
   FlatDeps (FlatDeps),
-  Manifest (..),
+  Manifest (Manifest),
   NodePackage (NodePackage),
-  PackageJson (..),
-  PkgJsonGraph (..),
+  PackageJson (PackageJson, packageWorkspaces),
+  PkgJsonGraph (PkgJsonGraph, jsonLookup),
   PkgJsonWorkspaces (unWorkspaces),
   Production,
   pkgFileList,
@@ -68,7 +68,13 @@ import Strategy.Node.YarnV1.YarnLock qualified as V1
 import Strategy.Node.YarnV2.YarnLock qualified as V2
 import Types (
   DependencyResults (DependencyResults),
-  DiscoveredProject (..),
+  DiscoveredProject (
+    DiscoveredProject,
+    projectBuildTargets,
+    projectData,
+    projectPath,
+    projectType
+  ),
   FoundTargets (ProjectWithoutTargets),
   GraphBreadth (Complete, Partial),
  )

--- a/src/Strategy/Node/Npm/PackageLock.hs
+++ b/src/Strategy/Node/Npm/PackageLock.hs
@@ -7,9 +7,20 @@ module Strategy.Node.Npm.PackageLock (
   NpmDep (..),
 ) where
 
-import Control.Effect.Diagnostics
+import Control.Effect.Diagnostics (
+  Diagnostics,
+  Has,
+  context,
+  run,
+ )
 import Control.Monad (when)
-import Data.Aeson
+import Data.Aeson (
+  FromJSON (parseJSON),
+  withObject,
+  (.!=),
+  (.:),
+  (.:?),
+ )
 import Data.Foldable (traverse_)
 import Data.Functor (void)
 import Data.Map.Strict (Map)
@@ -20,11 +31,33 @@ import Data.Set qualified as Set
 import Data.Tagged (unTag)
 import Data.Text (Text)
 import Data.Text qualified as Text
-import DepTypes
-import Effect.Grapher
-import Effect.ReadFS
+import DepTypes (
+  DepEnvironment (EnvDevelopment, EnvProduction),
+  DepType (NodeJSType),
+  Dependency (
+    Dependency,
+    dependencyEnvironments,
+    dependencyLocations,
+    dependencyName,
+    dependencyTags,
+    dependencyType,
+    dependencyVersion
+  ),
+  VerConstraint (CEq),
+  insertEnvironment,
+  insertLocation,
+ )
+import Effect.Grapher (
+  LabeledGrapher,
+  deep,
+  direct,
+  edge,
+  label,
+  withLabeling,
+ )
+import Effect.ReadFS (ReadFS, readContentsJson)
 import Graphing (Graphing)
-import Path
+import Path (Abs, File, Path)
 import Strategy.Node.PackageJson (FlatDeps (directDeps), NodePackage (pkgName), Production)
 
 data NpmPackageJson = NpmPackageJson

--- a/src/Strategy/Node/PackageJson.hs
+++ b/src/Strategy/Node/PackageJson.hs
@@ -40,9 +40,17 @@ import Data.Set (Set)
 import Data.Tagged (Tagged)
 import Data.Text (Text)
 import DepTypes (
-  DepEnvironment (..),
+  DepEnvironment (EnvDevelopment, EnvProduction),
   DepType (NodeJSType),
-  Dependency (..),
+  Dependency (
+    Dependency,
+    dependencyEnvironments,
+    dependencyLocations,
+    dependencyName,
+    dependencyTags,
+    dependencyType,
+    dependencyVersion
+  ),
   VerConstraint (CCompatible),
   insertEnvironment,
  )

--- a/src/Strategy/Node/YarnV1/YarnLock.hs
+++ b/src/Strategy/Node/YarnV1/YarnLock.hs
@@ -19,7 +19,15 @@ import Data.Text (Text)
 import DepTypes (
   DepEnvironment (EnvDevelopment, EnvProduction),
   DepType (NodeJSType),
-  Dependency (..),
+  Dependency (
+    Dependency,
+    dependencyEnvironments,
+    dependencyLocations,
+    dependencyName,
+    dependencyTags,
+    dependencyType,
+    dependencyVersion
+  ),
   VerConstraint (CEq),
   hydrateDepEnvs,
   insertEnvironment,
@@ -43,7 +51,12 @@ import Effect.Logger (
 import Effect.ReadFS (ReadFS, ReadFSErr (FileParseError), readContentsText)
 import Graphing (Graphing)
 import Path (Abs, File, Path)
-import Strategy.Node.PackageJson (Development, FlatDeps (..), NodePackage (..), Production)
+import Strategy.Node.PackageJson (
+  Development,
+  FlatDeps (FlatDeps, devDeps, directDeps),
+  NodePackage (NodePackage),
+  Production,
+ )
 import Yarn.Lock qualified as YL
 import Yarn.Lock.Types qualified as YL
 

--- a/src/Strategy/Node/YarnV2/Lockfile.hs
+++ b/src/Strategy/Node/YarnV2/Lockfile.hs
@@ -11,17 +11,34 @@ module Strategy.Node.YarnV2.Lockfile (
   tryParseDescriptor,
 ) where
 
-import Data.Aeson
-import Data.Aeson.Extra (TextLike (..))
+import Data.Aeson (
+  FromJSON (parseJSON),
+  FromJSONKeyFunction (FromJSONKeyTextParser),
+  Value (Object),
+  withObject,
+  withText,
+  (.!=),
+  (.:),
+  (.:?),
+ )
+import Data.Aeson.Extra (TextLike (unTextLike))
+import Data.Aeson.Types (FromJSONKey (fromJSONKey, fromJSONKeyList))
 import Data.HashMap.Strict qualified as HM
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
 import Data.Text (Text)
 import Data.Text qualified as Text
 import Data.Void (Void)
-import Strategy.Node.PackageJson (NodePackage (..))
-import Text.Megaparsec
-import Text.Megaparsec.Char
+import Strategy.Node.PackageJson (NodePackage (NodePackage, pkgConstraint, pkgName))
+import Text.Megaparsec (
+  MonadParsec (takeWhile1P),
+  Parsec,
+  errorBundlePretty,
+  optional,
+  runParser,
+  takeRest,
+ )
+import Text.Megaparsec.Char (char)
 
 ---------- Types
 

--- a/src/Strategy/Node/YarnV2/Resolvers.hs
+++ b/src/Strategy/Node/YarnV2/Resolvers.hs
@@ -27,7 +27,13 @@ module Strategy.Node.YarnV2.Resolvers (
   patchResolver,
 ) where
 
-import Control.Effect.Diagnostics
+import Control.Effect.Diagnostics (
+  Diagnostics,
+  Has,
+  context,
+  fromEither,
+  fromMaybe,
+ )
 import Data.Foldable (find)
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
@@ -35,8 +41,19 @@ import Data.Text (Text)
 import Data.Text qualified as Text
 import Data.Text.Extra (dropPrefix, showT)
 import Data.Void (Void)
-import Strategy.Node.YarnV2.Lockfile
-import Text.Megaparsec
+import Strategy.Node.YarnV2.Lockfile (
+  Locator (locatorName, locatorReference, locatorScope),
+ )
+import Text.Megaparsec (
+  MonadParsec (eof, takeWhileP),
+  Parsec,
+  chunk,
+  optional,
+  runParser,
+  single,
+  takeRest,
+  (<|>),
+ )
 
 data Resolver = Resolver
   { -- | Used for error messages

--- a/src/Strategy/Node/YarnV2/YarnLock.hs
+++ b/src/Strategy/Node/YarnV2/YarnLock.hs
@@ -28,7 +28,15 @@ import Data.Text.Extra (showT)
 import DepTypes (
   DepEnvironment (EnvDevelopment, EnvProduction),
   DepType (GitType, NodeJSType, URLType),
-  Dependency (..),
+  Dependency (
+    Dependency,
+    dependencyEnvironments,
+    dependencyLocations,
+    dependencyName,
+    dependencyTags,
+    dependencyType,
+    dependencyVersion
+  ),
   VerConstraint (CEq),
   hydrateDepEnvs,
   insertEnvironment,
@@ -39,19 +47,29 @@ import Graphing qualified
 import Path (Abs, File, Path)
 import Strategy.Node.PackageJson (
   Development,
-  FlatDeps (..),
-  NodePackage (..),
+  FlatDeps (FlatDeps, devDeps, directDeps),
+  NodePackage,
   Production,
  )
 import Strategy.Node.YarnV2.Lockfile (
   Descriptor (descriptorName, descriptorRange, descriptorScope),
   Locator,
   PackageDescription (descDependencies, descResolution),
-  YarnLockfile (..),
+  YarnLockfile (YarnLockfile),
   tryParseDescriptor,
  )
 import Strategy.Node.YarnV2.Resolvers (
-  Package (..),
+  Package (
+    ExecPackage,
+    FilePackage,
+    GitPackage,
+    LinkPackage,
+    NpmPackage,
+    PatchPackage,
+    PortalPackage,
+    TarPackage,
+    WorkspacePackage
+  ),
   resolveLocatorToPackage,
  )
 

--- a/src/Strategy/NuGet/Nuspec.hs
+++ b/src/Strategy/NuGet/Nuspec.hs
@@ -15,28 +15,58 @@ module Strategy.NuGet.Nuspec (
 import App.Fossa.Analyze.Types (AnalyzeProject, analyzeProject)
 import App.Pathfinder.Types (LicenseAnalyzeProject, licenseAnalyzeProject)
 import Control.Applicative (optional)
-import Control.Effect.Diagnostics
+import Control.Effect.Diagnostics (Diagnostics, Has, context)
 import Data.Aeson (ToJSON)
 import Data.Foldable (find)
 import Data.List qualified as L
 import Data.Map.Strict qualified as Map
 import Data.String.Conversion (toString)
 import Data.Text (Text)
-import DepTypes
-import Discovery.Walk
-import Effect.ReadFS
+import DepTypes (
+  DepType (NuGetType),
+  Dependency (
+    Dependency,
+    dependencyEnvironments,
+    dependencyLocations,
+    dependencyName,
+    dependencyTags,
+    dependencyType,
+    dependencyVersion
+  ),
+  VerConstraint (CEq),
+ )
+import Discovery.Walk (WalkStep (WalkContinue), fileName, walk')
+import Effect.ReadFS (ReadFS, readContentsXML)
 import GHC.Generics (Generic)
 import Graphing (Graphing)
 import Graphing qualified
-import Parse.XML
-import Path
+import Parse.XML (
+  FromXML (parseElement),
+  attr,
+  child,
+  children,
+  content,
+  defaultsTo,
+ )
+import Path (Abs, Dir, File, Path, parent, toFilePath)
 import Types (
-  DependencyResults (..),
-  DiscoveredProject (..),
+  DependencyResults (
+    DependencyResults,
+    dependencyGraph,
+    dependencyGraphBreadth,
+    dependencyManifestFiles
+  ),
+  DiscoveredProject (
+    DiscoveredProject,
+    projectBuildTargets,
+    projectData,
+    projectPath,
+    projectType
+  ),
   GraphBreadth (Partial),
   License (License),
   LicenseResult (LicenseResult),
-  LicenseType (..),
+  LicenseType (LicenseFile, LicenseSPDX, LicenseURL, UnknownType),
  )
 
 discover :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs Dir -> m [DiscoveredProject NuspecProject]

--- a/src/Strategy/NuGet/PackageReference.hs
+++ b/src/Strategy/NuGet/PackageReference.hs
@@ -13,21 +13,48 @@ module Strategy.NuGet.PackageReference (
 
 import App.Fossa.Analyze.Types (AnalyzeProject, analyzeProject)
 import Control.Applicative (optional, (<|>))
-import Control.Effect.Diagnostics
+import Control.Effect.Diagnostics (Diagnostics, Has, context)
 import Data.Aeson (ToJSON)
 import Data.Foldable (find)
 import Data.List qualified as L
 import Data.Map.Strict qualified as Map
 import Data.Text (Text)
-import DepTypes
-import Discovery.Walk
-import Effect.ReadFS
+import DepTypes (
+  DepType (NuGetType),
+  Dependency (
+    Dependency,
+    dependencyEnvironments,
+    dependencyLocations,
+    dependencyName,
+    dependencyTags,
+    dependencyType,
+    dependencyVersion
+  ),
+  VerConstraint (CEq),
+ )
+import Discovery.Walk (WalkStep (WalkContinue), fileName, walk')
+import Effect.ReadFS (ReadFS, readContentsXML)
 import GHC.Generics (Generic)
 import Graphing (Graphing)
 import Graphing qualified
-import Parse.XML
-import Path
-import Types
+import Parse.XML (FromXML (parseElement), attr, child, children)
+import Path (Abs, Dir, File, Path, parent)
+import Types (
+  DependencyResults (
+    DependencyResults,
+    dependencyGraph,
+    dependencyGraphBreadth,
+    dependencyManifestFiles
+  ),
+  DiscoveredProject (
+    DiscoveredProject,
+    projectBuildTargets,
+    projectData,
+    projectPath,
+    projectType
+  ),
+  GraphBreadth (Partial),
+ )
 
 isPackageRefFile :: Path b File -> Bool
 isPackageRefFile file = any (\x -> x `L.isSuffixOf` fileName file) [".csproj", ".xproj", ".vbproj", ".dbproj", ".fsproj"]

--- a/src/Strategy/NuGet/PackagesConfig.hs
+++ b/src/Strategy/NuGet/PackagesConfig.hs
@@ -11,20 +11,47 @@ module Strategy.NuGet.PackagesConfig (
 ) where
 
 import App.Fossa.Analyze.Types (AnalyzeProject, analyzeProject)
-import Control.Effect.Diagnostics
+import Control.Effect.Diagnostics (Diagnostics, Has, context)
 import Data.Aeson (ToJSON)
 import Data.Foldable (find)
 import Data.Map.Strict qualified as Map
 import Data.Text (Text)
-import DepTypes
-import Discovery.Walk
-import Effect.ReadFS
+import DepTypes (
+  DepType (NuGetType),
+  VerConstraint (CEq),
+ )
+import Discovery.Walk (WalkStep (WalkContinue), fileName, walk')
+import Effect.ReadFS (ReadFS, readContentsXML)
 import GHC.Generics (Generic)
 import Graphing (Graphing)
 import Graphing qualified
-import Parse.XML
-import Path
-import Types
+import Parse.XML (FromXML (parseElement), attr, children)
+import Path (Abs, Dir, File, Path, parent)
+import Types (
+  Dependency (
+    Dependency,
+    dependencyEnvironments,
+    dependencyLocations,
+    dependencyName,
+    dependencyTags,
+    dependencyType,
+    dependencyVersion
+  ),
+  DependencyResults (
+    DependencyResults,
+    dependencyGraph,
+    dependencyGraphBreadth,
+    dependencyManifestFiles
+  ),
+  DiscoveredProject (
+    DiscoveredProject,
+    projectBuildTargets,
+    projectData,
+    projectPath,
+    projectType
+  ),
+  GraphBreadth (Partial),
+ )
 
 discover :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs Dir -> m [DiscoveredProject PackagesConfigProject]
 discover dir = context "PackagesConfig" $ do

--- a/src/Strategy/NuGet/ProjectAssetsJson.hs
+++ b/src/Strategy/NuGet/ProjectAssetsJson.hs
@@ -10,19 +10,57 @@ module Strategy.NuGet.ProjectAssetsJson (
 ) where
 
 import App.Fossa.Analyze.Types (AnalyzeProject, analyzeProject)
-import Control.Effect.Diagnostics
-import Data.Aeson
+import Control.Effect.Diagnostics (Diagnostics, Has, context)
+import Data.Aeson (
+  FromJSON (parseJSON),
+  ToJSON,
+  withObject,
+  (.!=),
+  (.:),
+  (.:?),
+ )
 import Data.Map.Strict qualified as Map
-import Data.Maybe
+import Data.Maybe (mapMaybe)
 import Data.Text (Text)
 import Data.Text qualified as Text
-import DepTypes
-import Discovery.Walk
-import Effect.ReadFS
+import DepTypes (
+  DepType (NuGetType),
+  VerConstraint (CEq),
+ )
+import Discovery.Walk (
+  WalkStep (WalkContinue),
+  findFileNamed,
+  walk',
+ )
+import Effect.ReadFS (ReadFS, readContentsJson)
 import GHC.Generics (Generic)
 import Graphing (Graphing, unfold)
-import Path
-import Types
+import Path (Abs, Dir, File, Path, parent)
+import Types (
+  Dependency (
+    Dependency,
+    dependencyEnvironments,
+    dependencyLocations,
+    dependencyName,
+    dependencyTags,
+    dependencyType,
+    dependencyVersion
+  ),
+  DependencyResults (
+    DependencyResults,
+    dependencyGraph,
+    dependencyGraphBreadth,
+    dependencyManifestFiles
+  ),
+  DiscoveredProject (
+    DiscoveredProject,
+    projectBuildTargets,
+    projectData,
+    projectPath,
+    projectType
+  ),
+  GraphBreadth (Complete),
+ )
 
 discover :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs Dir -> m [DiscoveredProject ProjectAssetsJsonProject]
 discover dir = context "ProjectAssetsJson" $ do

--- a/src/Strategy/NuGet/ProjectJson.hs
+++ b/src/Strategy/NuGet/ProjectJson.hs
@@ -11,20 +11,60 @@ module Strategy.NuGet.ProjectJson (
 
 import App.Fossa.Analyze.Types (AnalyzeProject, analyzeProject)
 import Control.Applicative ((<|>))
-import Control.Effect.Diagnostics
-import Data.Aeson.Types
+import Control.Effect.Diagnostics (Diagnostics, Has)
+import Data.Aeson.Types (
+  FromJSON (parseJSON),
+  Parser,
+  ToJSON,
+  Value,
+  withObject,
+  withText,
+  (.:),
+  (.:?),
+ )
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
 import Data.Text (Text)
 import Data.Text qualified as Text
-import DepTypes
-import Discovery.Walk
-import Effect.ReadFS
+import DepTypes (
+  DepType (NuGetType),
+  VerConstraint (CCompatible, CEq),
+ )
+import Discovery.Walk (
+  WalkStep (WalkContinue),
+  findFileNamed,
+  walk',
+ )
+import Effect.ReadFS (ReadFS, readContentsJson)
 import GHC.Generics (Generic)
 import Graphing (Graphing)
 import Graphing qualified
-import Path
-import Types
+import Path (Abs, Dir, File, Path, parent)
+import Types (
+  Dependency (
+    Dependency,
+    dependencyEnvironments,
+    dependencyLocations,
+    dependencyName,
+    dependencyTags,
+    dependencyType,
+    dependencyVersion
+  ),
+  DependencyResults (
+    DependencyResults,
+    dependencyGraph,
+    dependencyGraphBreadth,
+    dependencyManifestFiles
+  ),
+  DiscoveredProject (
+    DiscoveredProject,
+    projectBuildTargets,
+    projectData,
+    projectPath,
+    projectType
+  ),
+  GraphBreadth (Partial),
+ )
 
 discover :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs Dir -> m [DiscoveredProject ProjectJsonProject]
 discover dir = map mkProject <$> findProjects dir

--- a/src/Strategy/Pub.hs
+++ b/src/Strategy/Pub.hs
@@ -8,11 +8,25 @@ import Effect.Exec (Exec, Has)
 import Effect.Logger (Logger)
 import Effect.ReadFS (ReadFS)
 import GHC.Generics (Generic)
-import Path
+import Path (Abs, Dir, File, Path)
 import Strategy.Dart.PubDeps (analyzeDepsCmd)
 import Strategy.Dart.PubSpec (analyzePubSpecFile)
 import Strategy.Dart.PubSpecLock (analyzePubLockFile)
-import Types (DependencyResults (..), DiscoveredProject (..))
+import Types (
+  DependencyResults (
+    DependencyResults,
+    dependencyGraph,
+    dependencyGraphBreadth,
+    dependencyManifestFiles
+  ),
+  DiscoveredProject (
+    DiscoveredProject,
+    projectBuildTargets,
+    projectData,
+    projectPath,
+    projectType
+  ),
+ )
 
 discover :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs Dir -> m [DiscoveredProject PubProject]
 discover dir = context "Pub" $ do

--- a/src/Strategy/Python/Poetry.hs
+++ b/src/Strategy/Python/Poetry.hs
@@ -16,7 +16,6 @@ import Data.Map (Map)
 import Data.Map.Strict qualified as Map
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
-import DepTypes (DepType (..), Dependency (..))
 import Discovery.Walk (
   WalkStep (WalkContinue, WalkSkipAll),
   findFileNamed,
@@ -28,10 +27,49 @@ import GHC.Generics (Generic)
 import Graphing (Graphing)
 import Graphing qualified
 import Path (Abs, Dir, File, Path)
-import Strategy.Python.Poetry.Common (getPoetryBuildBackend, logIgnoredDeps, pyProjectDeps, toCanonicalName, toMap)
-import Strategy.Python.Poetry.PoetryLock (PackageName (..), PoetryLock (..), PoetryLockPackage (..), poetryLockCodec)
-import Strategy.Python.Poetry.PyProject (PyProject (..), pyProjectCodec)
-import Types (DependencyResults (..), DiscoveredProject (..), GraphBreadth (..))
+import Strategy.Python.Poetry.Common (
+  getPoetryBuildBackend,
+  logIgnoredDeps,
+  pyProjectDeps,
+  toCanonicalName,
+  toMap,
+ )
+import Strategy.Python.Poetry.PoetryLock (
+  PackageName (PackageName, unPackageName),
+  PoetryLock (poetryLockPackages),
+  PoetryLockPackage (poetryLockPackageDependencies, poetryLockPackageName),
+  poetryLockCodec,
+ )
+import Strategy.Python.Poetry.PyProject (
+  PyProject (pyprojectPoetry),
+  pyProjectCodec,
+ )
+import Types (
+  DepType (PipType),
+  Dependency (
+    Dependency,
+    dependencyEnvironments,
+    dependencyLocations,
+    dependencyName,
+    dependencyTags,
+    dependencyType,
+    dependencyVersion
+  ),
+  DependencyResults (
+    DependencyResults,
+    dependencyGraph,
+    dependencyGraphBreadth,
+    dependencyManifestFiles
+  ),
+  DiscoveredProject (
+    DiscoveredProject,
+    projectBuildTargets,
+    projectData,
+    projectPath,
+    projectType
+  ),
+  GraphBreadth (Complete, Partial),
+ )
 
 newtype PyProjectTomlFile = PyProjectTomlFile {pyProjectTomlPath :: Path Abs File} deriving (Eq, Ord, Show, Generic)
 newtype PoetryLockFile = PoetryLockFile {poetryLockPath :: Path Abs File} deriving (Eq, Ord, Show, Generic)

--- a/src/Strategy/Python/Poetry/Common.hs
+++ b/src/Strategy/Python/Poetry/Common.hs
@@ -19,22 +19,48 @@ import Data.Text (Text, replace, toLower)
 import DepTypes (
   DepEnvironment (EnvDevelopment, EnvOther, EnvProduction, EnvTesting),
   DepType (GitType, PipType, URLType),
-  Dependency (..),
-  VerConstraint (
-    CEq
+  Dependency (
+    Dependency,
+    dependencyEnvironments,
+    dependencyLocations,
+    dependencyName,
+    dependencyTags,
+    dependencyType,
+    dependencyVersion
   ),
+  VerConstraint (CEq),
  )
 import Effect.Logger (Has, Logger, Pretty (pretty), logDebug)
-import Strategy.Python.Poetry.PoetryLock (PackageName (..), PoetryLock (..), PoetryLockPackage (..), PoetryLockPackageSource (..))
+import Strategy.Python.Poetry.PoetryLock (
+  PackageName (PackageName, unPackageName),
+  PoetryLock (poetryLockPackages),
+  PoetryLockPackage (
+    poetryLockPackageCategory,
+    poetryLockPackageName,
+    poetryLockPackageSource,
+    poetryLockPackageVersion
+  ),
+  PoetryLockPackageSource (
+    poetryLockPackageSourceReference,
+    poetryLockPackageSourceType,
+    poetryLockPackageSourceUrl
+  ),
+ )
 import Strategy.Python.Poetry.PyProject (
-  PoetryDependency (..),
-  PyProject (..),
-  PyProjectBuildSystem (..),
-  PyProjectPoetry (..),
-  PyProjectPoetryDetailedVersionDependency (..),
-  PyProjectPoetryGitDependency (..),
-  PyProjectPoetryPathDependency (..),
-  PyProjectPoetryUrlDependency (..),
+  PoetryDependency (
+    PoetryTextVersion,
+    PyProjectPoetryDetailedVersionDependencySpec,
+    PyProjectPoetryGitDependencySpec,
+    PyProjectPoetryPathDependencySpec,
+    PyProjectPoetryUrlDependencySpec
+  ),
+  PyProject (pyprojectBuildSystem, pyprojectPoetry),
+  PyProjectBuildSystem (buildBackend),
+  PyProjectPoetry (dependencies, devDependencies),
+  PyProjectPoetryDetailedVersionDependency (poetryDependencyVersion),
+  PyProjectPoetryGitDependency (gitBranch, gitRev, gitTag, gitUrl),
+  PyProjectPoetryPathDependency (sourcePath),
+  PyProjectPoetryUrlDependency (sourceUrl),
   toDependencyVersion,
  )
 

--- a/src/Strategy/Python/Poetry/PyProject.hs
+++ b/src/Strategy/Python/Poetry/PyProject.hs
@@ -14,7 +14,7 @@ module Strategy.Python.Poetry.PyProject (
   toDependencyVersion,
 ) where
 
-import Control.Monad.Combinators.Expr (Operator (..), makeExprParser)
+import Control.Monad.Combinators.Expr (Operator (InfixL), makeExprParser)
 import Data.Foldable (asum)
 import Data.Functor (void)
 import Data.Map (Map)

--- a/src/Strategy/Python/ReqTxt.hs
+++ b/src/Strategy/Python/ReqTxt.hs
@@ -3,18 +3,23 @@ module Strategy.Python.ReqTxt (
   requirementsTxtParser,
 ) where
 
-import Control.Effect.Diagnostics
+import Control.Effect.Diagnostics (Diagnostics, Has, context)
 import Control.Monad (void)
 import Data.Foldable (asum)
 import Data.Text (Text)
 import Data.Void (Void)
-import Effect.ReadFS
+import DepTypes (Dependency)
+import Effect.ReadFS (ReadFS, readContentsParser)
 import Graphing (Graphing)
-import Path
-import Strategy.Python.Util
-import Text.Megaparsec
-import Text.Megaparsec.Char
-import Types
+import Path (Abs, File, Path)
+import Strategy.Python.Util (Req, buildGraph, requirementParser)
+import Text.Megaparsec (
+  MonadParsec (eof, takeWhileP, try),
+  Parsec,
+  manyTill,
+  (<|>),
+ )
+import Text.Megaparsec.Char (char, string)
 
 analyze' :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs File -> m (Graphing Dependency)
 analyze' file = do

--- a/src/Strategy/Python/SetupPy.hs
+++ b/src/Strategy/Python/SetupPy.hs
@@ -2,17 +2,24 @@ module Strategy.Python.SetupPy (
   analyze',
 ) where
 
-import Control.Effect.Diagnostics
+import Control.Effect.Diagnostics (Diagnostics, Has, context)
 import Data.Text (Text)
 import Data.Void (Void)
-import Effect.ReadFS
+import DepTypes (Dependency)
+import Effect.ReadFS (ReadFS, readContentsParser)
 import Graphing (Graphing)
-import Path
-import Strategy.Python.Util
-import Text.Megaparsec
-import Text.Megaparsec.Char
+import Path (Abs, File, Path)
+import Strategy.Python.Util (Req, buildGraph, requirementParser)
+import Text.Megaparsec (
+  Parsec,
+  anySingle,
+  between,
+  sepEndBy,
+  skipManyTill,
+  (<|>),
+ )
+import Text.Megaparsec.Char (space)
 import Text.Megaparsec.Char.Lexer qualified as L
-import Types
 
 analyze' :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs File -> m (Graphing Dependency)
 analyze' file = do

--- a/src/Strategy/Python/Setuptools.hs
+++ b/src/Strategy/Python/Setuptools.hs
@@ -6,20 +6,40 @@ module Strategy.Python.Setuptools (
 ) where
 
 import App.Fossa.Analyze.Types (AnalyzeProject, analyzeProject)
-import Control.Carrier.Output.IO
 import Control.Effect.Diagnostics (Diagnostics, context)
 import Control.Effect.Diagnostics qualified as Diag
 import Data.Aeson (ToJSON)
 import Data.List (isInfixOf, isSuffixOf)
 import Data.Maybe (maybeToList)
-import Discovery.Walk
-import Effect.ReadFS
+import Discovery.Walk (
+  WalkStep (WalkContinue),
+  fileName,
+  findFileNamed,
+  walk',
+ )
+import Effect.ReadFS (Has, ReadFS)
 import GHC.Generics (Generic)
 import Graphing (Graphing)
-import Path
+import Path (Abs, Dir, File, Path)
 import Strategy.Python.ReqTxt qualified as ReqTxt
 import Strategy.Python.SetupPy qualified as SetupPy
-import Types
+import Types (
+  Dependency,
+  DependencyResults (
+    DependencyResults,
+    dependencyGraph,
+    dependencyGraphBreadth,
+    dependencyManifestFiles
+  ),
+  DiscoveredProject (
+    DiscoveredProject,
+    projectBuildTargets,
+    projectData,
+    projectPath,
+    projectType
+  ),
+  GraphBreadth (Partial),
+ )
 
 discover :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs Dir -> m [DiscoveredProject SetuptoolsProject]
 discover dir = context "Setuptools" $ do

--- a/src/Strategy/Python/Util.hs
+++ b/src/Strategy/Python/Util.hs
@@ -15,11 +15,45 @@ import Data.Map.Strict qualified as Map
 import Data.String.Conversion (toText)
 import Data.Text (Text)
 import Data.Void (Void)
-import DepTypes
+import DepTypes (
+  DepType (PipType),
+  Dependency (
+    Dependency,
+    dependencyEnvironments,
+    dependencyLocations,
+    dependencyName,
+    dependencyTags,
+    dependencyType,
+    dependencyVersion
+  ),
+  VerConstraint (
+    CAnd,
+    CCompatible,
+    CEq,
+    CGreater,
+    CGreaterOrEq,
+    CLess,
+    CLessOrEq,
+    CNot,
+    CURI
+  ),
+ )
 import Graphing (Graphing)
 import Graphing qualified
-import Text.Megaparsec
-import Text.Megaparsec.Char
+import Text.Megaparsec (
+  MonadParsec (label, takeWhile1P, takeWhileP, try),
+  Parsec,
+  between,
+  many,
+  oneOf,
+  optional,
+  satisfy,
+  sepBy,
+  sepBy1,
+  some,
+  (<|>),
+ )
+import Text.Megaparsec.Char (char, string)
 import Text.URI qualified as URI
 
 buildGraph :: [Req] -> Graphing Dependency

--- a/src/Strategy/RPM.hs
+++ b/src/Strategy/RPM.hs
@@ -12,7 +12,7 @@ module Strategy.RPM (
 ) where
 
 import App.Fossa.Analyze.Types (AnalyzeProject, analyzeProject)
-import Control.Effect.Diagnostics
+import Control.Effect.Diagnostics (Diagnostics, Has, context)
 import Control.Effect.Diagnostics qualified as Diag
 import Data.Aeson (ToJSON)
 import Data.List (isSuffixOf)
@@ -21,14 +21,42 @@ import Data.Maybe (mapMaybe)
 import Data.Text (Text)
 import Data.Text qualified as Text
 import Data.Text.Extra (splitOnceOn)
-import DepTypes
-import Discovery.Walk
-import Effect.ReadFS
+import DepTypes (
+  DepEnvironment,
+  DepType (RPMType),
+  VerConstraint (CEq, CGreater, CGreaterOrEq, CLess, CLessOrEq),
+ )
+import Discovery.Walk (WalkStep (WalkContinue), fileName, walk')
+import Effect.ReadFS (ReadFS, readContentsText)
 import GHC.Generics (Generic)
 import Graphing (Graphing)
 import Graphing qualified as G
-import Path
-import Types
+import Path (Abs, Dir, File, Path)
+import Types (
+  Dependency (
+    Dependency,
+    dependencyEnvironments,
+    dependencyLocations,
+    dependencyName,
+    dependencyTags,
+    dependencyType,
+    dependencyVersion
+  ),
+  DependencyResults (
+    DependencyResults,
+    dependencyGraph,
+    dependencyGraphBreadth,
+    dependencyManifestFiles
+  ),
+  DiscoveredProject (
+    DiscoveredProject,
+    projectBuildTargets,
+    projectData,
+    projectPath,
+    projectType
+  ),
+  GraphBreadth (Partial),
+ )
 
 newtype SpecFileLabel
   = RequiresType DepEnvironment

--- a/src/Strategy/Rebar3.hs
+++ b/src/Strategy/Rebar3.hs
@@ -8,13 +8,31 @@ module Strategy.Rebar3 (
 import App.Fossa.Analyze.Types (AnalyzeProject, analyzeProject)
 import Control.Effect.Diagnostics (Diagnostics, context)
 import Data.Aeson (ToJSON)
-import Discovery.Walk
-import Effect.Exec
-import Effect.ReadFS
+import Discovery.Walk (
+  WalkStep (WalkContinue, WalkSkipAll),
+  findFileNamed,
+  walk',
+ )
+import Effect.Exec (Exec, Has)
+import Effect.ReadFS (ReadFS)
 import GHC.Generics (Generic)
-import Path
+import Path (Abs, Dir, File, Path)
 import Strategy.Erlang.Rebar3Tree qualified as Rebar3Tree
-import Types
+import Types (
+  DependencyResults (
+    DependencyResults,
+    dependencyGraph,
+    dependencyGraphBreadth,
+    dependencyManifestFiles
+  ),
+  DiscoveredProject (
+    DiscoveredProject,
+    projectBuildTargets,
+    projectData,
+    projectPath,
+    projectType
+  ),
+ )
 
 discover :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs Dir -> m [DiscoveredProject RebarProject]
 discover dir = context "Rebar3" $ do

--- a/src/Strategy/Ruby/BundleShow.hs
+++ b/src/Strategy/Ruby/BundleShow.hs
@@ -7,18 +7,41 @@ module Strategy.Ruby.BundleShow (
   bundleShowParser,
 ) where
 
-import Control.Effect.Diagnostics
+import Control.Effect.Diagnostics (Diagnostics, Has, context)
 import Control.Monad (void)
 import Data.Map.Strict qualified as Map
 import Data.Text (Text)
 import Data.Void (Void)
-import DepTypes
-import Effect.Exec
+import DepTypes (
+  DepType (GemType),
+  Dependency (
+    Dependency,
+    dependencyEnvironments,
+    dependencyLocations,
+    dependencyName,
+    dependencyTags,
+    dependencyType,
+    dependencyVersion
+  ),
+  VerConstraint (CEq),
+ )
+import Effect.Exec (
+  AllowErr (Never),
+  Command (Command, cmdAllowErr, cmdArgs, cmdName),
+  Exec,
+  execParser,
+ )
 import Graphing (Graphing)
 import Graphing qualified
-import Path
-import Text.Megaparsec
-import Text.Megaparsec.Char
+import Path (Abs, Dir, Path)
+import Text.Megaparsec (
+  MonadParsec (eof, takeWhileP),
+  Parsec,
+  chunk,
+  sepBy,
+  (<|>),
+ )
+import Text.Megaparsec.Char (char, eol)
 
 bundleShowCmd :: Command
 bundleShowCmd =

--- a/src/Strategy/Ruby/GemfileLock.hs
+++ b/src/Strategy/Ruby/GemfileLock.hs
@@ -8,7 +8,12 @@ module Strategy.Ruby.GemfileLock (
   Section (..),
 ) where
 
-import Control.Effect.Diagnostics
+import Control.Effect.Diagnostics (
+  Diagnostics,
+  Has,
+  context,
+  run,
+ )
 import Data.Char qualified as C
 import Data.Foldable (traverse_)
 import Data.Functor (void)
@@ -18,13 +23,39 @@ import Data.Set (Set)
 import Data.String.Conversion (toString)
 import Data.Text (Text)
 import Data.Void (Void)
-import DepTypes
-import Effect.Grapher
-import Effect.ReadFS
+import DepTypes (
+  DepType (GemType),
+  Dependency (
+    Dependency,
+    dependencyEnvironments,
+    dependencyLocations,
+    dependencyName,
+    dependencyTags,
+    dependencyType,
+    dependencyVersion
+  ),
+  VerConstraint (CEq),
+ )
+import Effect.Grapher (
+  LabeledGrapher,
+  direct,
+  edge,
+  label,
+  withLabeling,
+ )
+import Effect.ReadFS (ReadFS, readContentsParser)
 import Graphing (Graphing)
-import Path
-import Text.Megaparsec hiding (label)
-import Text.Megaparsec.Char
+import Path (Abs, File, Path)
+import Text.Megaparsec (
+  MonadParsec (eof, takeWhile1P, takeWhileP, try),
+  Parsec,
+  chunk,
+  empty,
+  manyTill,
+  some,
+  (<|>),
+ )
+import Text.Megaparsec.Char (char, space1)
 import Text.Megaparsec.Char.Lexer qualified as L
 
 type Remote = Text

--- a/src/Strategy/Swift/PackageResolved.hs
+++ b/src/Strategy/Swift/PackageResolved.hs
@@ -14,7 +14,19 @@ import Data.Aeson (
 import Data.Aeson.Types (Parser)
 import Data.Foldable (asum)
 import Data.Text (Text)
-import DepTypes (DepType (GitType), Dependency (..), VerConstraint (CEq))
+import DepTypes (
+  DepType (GitType),
+  Dependency (
+    Dependency,
+    dependencyEnvironments,
+    dependencyLocations,
+    dependencyName,
+    dependencyTags,
+    dependencyType,
+    dependencyVersion
+  ),
+  VerConstraint (CEq),
+ )
 
 data SwiftPackageResolvedFile = SwiftPackageResolvedFile
   { version :: Integer

--- a/src/Strategy/Swift/PackageSwift.hs
+++ b/src/Strategy/Swift/PackageSwift.hs
@@ -20,10 +20,22 @@ import Data.Map.Strict qualified as Map
 import Data.Set (Set, fromList, member)
 import Data.Text (Text)
 import Data.Void (Void)
-import DepTypes (DepType (GitType, SwiftType), Dependency (..), VerConstraint (CEq))
+import DepTypes (
+  DepType (GitType, SwiftType),
+  Dependency (
+    Dependency,
+    dependencyEnvironments,
+    dependencyLocations,
+    dependencyName,
+    dependencyTags,
+    dependencyType,
+    dependencyVersion
+  ),
+  VerConstraint (CEq),
+ )
 import Effect.ReadFS (Has, ReadFS, readContentsJson, readContentsParser)
 import Graphing (Graphing, deeps, directs, induceJust, promoteToDirect)
-import Path
+import Path (Abs, File, Path)
 import Strategy.Swift.PackageResolved (SwiftPackageResolvedFile, resolvedDependenciesOf)
 import Text.Megaparsec (
   MonadParsec (takeWhile1P, try),

--- a/src/Strategy/Swift/Xcode/Pbxproj.hs
+++ b/src/Strategy/Swift/Xcode/Pbxproj.hs
@@ -14,17 +14,42 @@ import Data.Map.Strict qualified as Map
 import Data.Maybe (mapMaybe)
 import Data.Set (fromList, member)
 import Data.Text (Text)
-import DepTypes (DepType (GitType, SwiftType), Dependency (..))
+import DepTypes (
+  DepType (GitType, SwiftType),
+  Dependency (
+    Dependency,
+    dependencyEnvironments,
+    dependencyLocations,
+    dependencyName,
+    dependencyTags,
+    dependencyType,
+    dependencyVersion
+  ),
+ )
 import Effect.ReadFS (Has, ReadFS, readContentsJson, readContentsParser)
 import Graphing (Graphing, deeps, directs, promoteToDirect)
-import Path
+import Path (Abs, File, Path)
 import Strategy.Swift.PackageResolved (SwiftPackageResolvedFile, resolvedDependenciesOf)
 import Strategy.Swift.PackageSwift (
-  SwiftPackageGitDepRequirement (..),
+  SwiftPackageGitDepRequirement (
+    Branch,
+    ClosedInterval,
+    Exact,
+    Revision,
+    UpToNextMajor,
+    UpToNextMinor
+  ),
   isGitRefConstraint,
   toConstraint,
  )
-import Strategy.Swift.Xcode.PbxprojParser (AsciiValue (..), PbxProj (..), lookupText, objectsFromIsa, parsePbxProj, textOf)
+import Strategy.Swift.Xcode.PbxprojParser (
+  AsciiValue,
+  PbxProj (objects),
+  lookupText,
+  objectsFromIsa,
+  parsePbxProj,
+  textOf,
+ )
 
 -- | Represents the version rules for a Swift Package as defined in Xcode project file.
 data XCRemoteSwiftPackageReference = XCRemoteSwiftPackageReference

--- a/src/Strategy/SwiftPM.hs
+++ b/src/Strategy/SwiftPM.hs
@@ -5,7 +5,7 @@ module Strategy.SwiftPM (
   mkProject,
 ) where
 
-import App.Fossa.Analyze.Types (AnalyzeProject (..))
+import App.Fossa.Analyze.Types (AnalyzeProject (analyzeProject))
 import Control.Carrier.Simple (Has)
 import Control.Effect.Diagnostics (Diagnostics, context)
 import Data.Aeson (ToJSON)
@@ -19,10 +19,25 @@ import Discovery.Walk (
 import Effect.Logger (Logger, Pretty (pretty), logDebug)
 import Effect.ReadFS (ReadFS)
 import GHC.Generics (Generic)
-import Path
+import Path (Abs, Dir, File, Path, dirname, reldir)
 import Strategy.Swift.PackageSwift (analyzePackageSwift)
 import Strategy.Swift.Xcode.Pbxproj (analyzeXcodeProjForSwiftPkg, hasSomeSwiftDeps)
-import Types (DependencyResults (..), DiscoveredProject (..), GraphBreadth (..))
+import Types (
+  DependencyResults (
+    DependencyResults,
+    dependencyGraph,
+    dependencyGraphBreadth,
+    dependencyManifestFiles
+  ),
+  DiscoveredProject (
+    DiscoveredProject,
+    projectBuildTargets,
+    projectData,
+    projectPath,
+    projectType
+  ),
+  GraphBreadth (Partial),
+ )
 
 data SwiftProject
   = PackageProject SwiftPackageProject

--- a/src/Text/URI/Builder.hs
+++ b/src/Text/URI/Builder.hs
@@ -10,10 +10,20 @@ module Text.URI.Builder (
   setQuery,
 ) where
 
-import Control.Effect.Diagnostics
-import Data.List.NonEmpty (NonEmpty (..))
-import Data.Text
-import Text.URI
+import Control.Effect.Diagnostics (Diagnostics, Has, fromEither)
+import Data.List.NonEmpty (NonEmpty ((:|)))
+import Data.Text (Text)
+import Text.URI (
+  QueryParam (QueryFlag, QueryParam),
+  RText,
+  RTextLabel (PathPiece),
+  URI (uriAuthority, uriPath, uriQuery),
+  emptyURI,
+  mkPathPiece,
+  mkQueryKey,
+  mkQueryValue,
+  render,
+ )
 
 newtype PathComponent = PathComponent {unPathComponent :: Text} deriving (Eq, Ord, Show)
 

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -27,10 +27,18 @@ import Data.Set.NonEmpty (NonEmptySet)
 import Data.String.Conversion (toString)
 import Data.Text (Text)
 import DepTypes (
-  DepEnvironment (..),
-  DepType (..),
-  Dependency (..),
-  VerConstraint (..),
+  DepEnvironment (EnvDevelopment, EnvOther, EnvProduction, EnvTesting),
+  DepType (CargoType, HackageType, MavenType, PipType),
+  Dependency (
+    Dependency,
+    dependencyEnvironments,
+    dependencyLocations,
+    dependencyName,
+    dependencyTags,
+    dependencyType,
+    dependencyVersion
+  ),
+  VerConstraint (CEq),
   insertEnvironment,
   insertLocation,
   insertTag,

--- a/src/VCS/Git.hs
+++ b/src/VCS/Git.hs
@@ -3,8 +3,8 @@ module VCS.Git (
   fetchGitContributors,
 ) where
 
-import App.Fossa.FossaAPIV1 (Contributors (..))
-import Control.Carrier.Diagnostics qualified as Diag
+import App.Fossa.FossaAPIV1 (Contributors (Contributors))
+import Control.Effect.Diagnostics qualified as Diag
 import Control.Effect.Lift (Lift, sendIO)
 import Data.Map qualified as Map
 import Data.Maybe (mapMaybe)
@@ -12,10 +12,24 @@ import Data.String.Conversion (decodeUtf8, toString, toText)
 import Data.Text (Text)
 import Data.Text qualified as Text
 import Data.Text.Extra (splitOnceOn)
-import Data.Time
+import Data.Time (
+  Day,
+  UTCTime (utctDay),
+  addUTCTime,
+  defaultTimeLocale,
+  getCurrentTime,
+  nominalDay,
+  parseTimeM,
+ )
 import Data.Time.Format.ISO8601 (iso8601Show)
-import Effect.Exec
-import Path
+import Effect.Exec (
+  AllowErr (Never),
+  Command (Command, cmdAllowErr, cmdArgs, cmdName),
+  Exec,
+  Has,
+  execThrow,
+ )
+import Path (Abs, Dir, Path)
 
 gitLogCmd :: UTCTime -> Command
 gitLogCmd now =


### PR DESCRIPTION
# Overview

Statically enforcing explicit imports might be okay, except that includes the `import Module (SomeLargeType (..))` form, and theres no exception for the stdlib prelude, which prevents us from doing `import Prelude hiding (filter)` if we wanted to define our own function named filter.  In these cases, we either have to rename the function, or import every used item from the prelude explicitly.

This PR took hours of work, it should have taken minutes.  The tooling only gets us so far, and we have to expand inner `(..)` forms everywhere.  

I would like to get team agreement that this is a bad direction to go in, until either GHC provides a more fine-grained import lint, or HLS gets better import expansion.

This doesn't even fix the test code and still hit 168 files!