### PR TITLE
ci: Cache local packages

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -26,8 +26,9 @@ _Example:_ Closes org/repo#123.
 
 ## Checklist
 
-- [ ] I added tests for this PR's change (or confirmed tests are not viable).
+- [ ] I added tests for this PR's change (or explained in the PR description why tests are not viable).
 - [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
-- [ ] I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
-- [ ] I updated `*schema.json` if I have made changes for `.fossa.yml`, `fossa-deps.{json, yaml, yml}`. You may also need to update these if you have added/removed new dependency (e.g. pip) or analysis target type (e.g. poetry).
+- [ ] If this PR introduced a user-visible change, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
+- [ ] If this PR changed the shape of `.fossa.yml` or `fossa-deps.{json,yaml,yml}`, I updated `docs/references/files/*.schema.json`. (You may also need to update these if you have added or removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).)
+- [ ] If this PR added Template Haskell that needs to re-run when external files change (e.g. for embedding files), I added those external files to the list of `extra-source-files` in `spectrometer.cabal`.
 - [ ] I linked this PR to any referenced GitHub issues, if they exist.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,20 +18,20 @@ jobs:
       uses: actions/setup-go@v2
       with:
         go-version: '1.17.1'
-    
+
     - name: Check out commit
       uses: actions/checkout@v2
-    
+
     - uses: actions/cache@v2
       with:
         path: ~/go/pkg/mod
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-go-
-    
+
     - name: Get dependencies
       run: go get -v -t -d ./...
-    
+
     - name: Build attribution-compat
       run: |
         GOOS=windows go build -ldflags="-s -w" -o release/windows/compat-attribution.exe scripts/compat-attribution/main.go
@@ -113,9 +113,10 @@ jobs:
         cabal --version || echo "no cabal"
         ghcup --version || echo "no ghcup"
 
-    # Build Spectrometer.
+    # Cache packages.
+    # See also: https://cabal.readthedocs.io/en/3.6/nix-local-build.html#how-it-works
     - uses: actions/cache@v2
-      name: Cache cabal store
+      name: Cache external packages
       with:
         path: ${{ steps.setup-haskell.outputs.cabal-store || '~/.cabal/store' }}
         key: ${{ runner.os }}-${{ matrix.ghc }}-cabal-cache-${{ hashFiles('**/*.cabal') }}
@@ -124,6 +125,22 @@ jobs:
           ${{ runner.os }}-${{ matrix.ghc }}-
           ${{ runner.os }}-
 
+    - name: Get parent commit hash for local package caching
+      run: |
+        echo "parent_commit=$(git rev-parse HEAD^)" >> $GITHUB_ENV
+
+    - uses: actions/cache@v2
+      name: Cache local packages
+      with:
+        path: ./dist-newstyle
+        key: ${{ runner.os }}-${{ matrix.ghc }}-local-cache-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-${{ matrix.ghc }}-local-cache-${{ env.parent_commit }}
+          ${{ runner.os }}-${{ matrix.ghc }}-local-cache-
+          ${{ runner.os }}-${{ matrix.ghc }}-
+          ${{ runner.os }}-
+
+    # Build Spectrometer.
     - name: Update vendored binaries
       run: |
         mkdir vendor-bins

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,6 +86,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
 
     # Install tools used in `vendor_download.sh`.
     - name: Install alpine binary dependencies

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -9,6 +9,7 @@ extra-source-files:
   vendor-bins/cliv1
   vendor-bins/syft
   vendor-bins/wiggins
+  .git
 
 common lang
   build-depends:      base >=4.12 && <4.15


### PR DESCRIPTION
# Overview

This PR adds caching for _local_ packages in addition to the existing caching for external packages. This means that local packages which haven't changed will not get recompiled.

Local packages are those in the local directory (as opposed to packages downloaded from Hackage). See [the docs](https://cabal.readthedocs.io/en/3.6/nix-local-build.html#how-it-works) for more details.

The local package cache is restored first from the current commit (for re-runs) then from the parent commit in order to maximize the number of modules that haven't changed (and hence don't need to be recompiled).

Follow-on work:

- [ ] Why aren't tests being cached when no code has changed? Does `cabal` support caching test runs?
- [ ] Bake container images for Windows and Mac instead of using `haskell/actions/setup-haskell` (which takes almost half the CI run time after caching).
- [ ] Investigate why checking Markdown links takes so long (it takes longer than our Linux builds!).

## Acceptance criteria

1. CI runs are faster.
2. The resulting builds are correct (i.e. caching should not change the build output).

## Testing plan

1. Download a CLI build from a GH Actions run that uses this caching ([example](https://github.com/fossas/spectrometer/actions/runs/1427490869)).
2. Using the downloaded build, run `fossa analyze --output --filter 'cabal@./'` on the Spectrometer codebase, and double-check that results are sane.

## Risks

I think this caching is safe for Haskell modules, but I'm not sure whether it interacts weirdly with compile-time code. For example, I worry that `cabal` might not be smart enough to re-run Template Haskell for `$$(tGitInfoCwd)` or `embedFile`.

For Haskell modules, caching should be safe since [cache-busting occurs based on module hash](https://gitlab.haskell.org/ghc/ghc/-/issues/16495). I think Cabal implements this via [`PackageFileMonitor`](https://gitlab.haskell.org/ghc/packages/Cabal/-/blob/980a532875efc2ddbab0761d4feb95fd247866a6/cabal-install/src/Distribution/Client/ProjectBuilding.hs#L310-328), which tracks the corresponding source hashes to each built module, although I haven't followed this code end-to-end.

## References

See also (but does not quite resolve):

- https://github.com/fossas/team-analysis/issues/632
- https://github.com/fossas/team-analysis/issues/695

## Checklist

- [x] I added tests for this PR's change (or confirmed tests are not viable).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] I updated `*schema.json` if I have made changes for `.fossa.yml`, `fossa-deps.{json, yaml, yml}`. You may also need to update these if you have added/removed new dependency (e.g. pip) or analysis target type (e.g. poetry).
- [x] I linked this PR to any referenced GitHub issues, if they exist.
