### PR TITLE
Remove partial functions from the codebase

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -20,7 +20,22 @@
 - suggest: {lhs: Data.Text.pack x, rhs: Data.String.Conversion.toText x}
 - suggest: {lhs: Data.Text.unpack x, rhs: Data.String.Conversion.toString x}
 
-# Forbidden items
+# Forbidden items, only allowed in compile-time code, or test code.
 - functions:
   - {name: error, within: [Data.String.Conversion, Control.Effect.Replay]}
   - {name: undefined, within: []}
+  - {name: Prelude.head, within: [Control.Effect.Replay.TH, Control.Effect.Record.TH, Elixir.MixTreeSpec]}
+  - {name: Prelude.tail, within: []}
+  - {name: Prelude.init, within: []}
+  - {name: Prelude.last, within: []}
+  - {name: Data.ByteString.head, within: []}
+  - {name: Data.Bytestring.tail, within: []}
+  - {name: Data.Bytestring.init, within: []}
+  - {name: Data.Bytestring.last, within: []}
+  - {name: Data.Text.head, within: []}
+  - {name: Data.Text.tail, within: []}
+  - {name: Data.Text.init, within: []}
+  - {name: Data.Text.last, within: []}
+  - {name: "Prelude.!!", within: [Elixir.MixTreeSpec]}
+  - {name: "Data.Map.!", within: []}
+  - {name: fromJust, within: [App.DocsSpec]}

--- a/src/App/Fossa/BinaryDeps/Jar.hs
+++ b/src/App/Fossa/BinaryDeps/Jar.hs
@@ -56,7 +56,7 @@ parseMetaInfManifest :: Text -> Map Text Text
 parseMetaInfManifest t = Map.fromList . map strip' . filter' $ map (Text.breakOn ":") (Text.lines t)
   where
     null' (a, b) = any Text.null [a, b]
-    strip' (a, b) = (Text.strip a, Text.strip $ Text.tail b)
+    strip' (a, b) = (Text.strip a, Text.strip $ Text.drop 1 b)
     filter' = filter (not . null')
 
 metaInfManifestToMeta :: Has Diagnostics sig m => Map Text Text -> m JarMetadata

--- a/src/App/Fossa/VPS/NinjaGraph.hs
+++ b/src/App/Fossa/VPS/NinjaGraph.hs
@@ -18,6 +18,7 @@ import Control.Effect.Lift (Lift, sendIO)
 import Data.ByteString (ByteString)
 import Data.ByteString qualified as BS
 import Data.ByteString.Lazy qualified as BL
+import Data.Char (ord)
 import Data.Maybe (fromMaybe)
 import Data.String.Conversion (toString, toText)
 import Data.Text (Text)
@@ -156,7 +157,7 @@ parseNinjaDeps ninjaDepsLines =
     Parsing -> fatal NoNinjaDepsEndLineFound
     Error -> fatal NinjaDepsParseError
   where
-    newLine = BS.head "\n" -- This is gross, but I couldn't get "BS.split '\n' ninjaDepsLines" to work
+    newLine = fromIntegral $ ord '\n'
     nLines = BS.split newLine ninjaDepsLines
     (finalState, results) = foldl parseNinjaLine (Starting, []) nLines
     reversedDependenciesResults = map reverseDependencies results
@@ -259,4 +260,4 @@ parseDepLine line =
     hasDeps = BS.isPrefixOf "out/" path
 
 stripLeadingSpace :: ByteString -> ByteString
-stripLeadingSpace = BS.dropWhile (\c -> c == BS.head " ")
+stripLeadingSpace = BS.dropWhile (== (fromIntegral $ ord ' '))

--- a/src/App/Fossa/VPS/Scan/RunWiggins.hs
+++ b/src/App/Fossa/VPS/Scan/RunWiggins.hs
@@ -22,9 +22,10 @@ import App.Fossa.VPS.Types (
  )
 import App.Types
 import Control.Carrier.Error.Either
-import Control.Effect.Diagnostics
+import Control.Effect.Diagnostics (Diagnostics)
 import Data.Aeson
 import Data.ByteString.Lazy qualified as BL
+import Data.Maybe (fromMaybe)
 import Data.String.Conversion (toText)
 import Data.Text (Text)
 import Data.Text qualified as Text
@@ -148,7 +149,9 @@ optExplodeText flag (a : as) = [flag, a] ++ optExplodeText flag as
 -- Path Rel Dir renders with a trailing /, but wiggins needs it to not have that trailing slash when used as an exclude or include-only filter.
 -- Strip the / postfix from the returned value.
 optPathAsFilter :: Path Rel Dir -> Text
-optPathAsFilter p = Text.init (toText p)
+optPathAsFilter p = fromMaybe t $ Text.stripSuffix "/" t
+  where
+    t = toText p
 
 execWiggins :: (Has Exec sig m, Has Diagnostics sig m) => BinaryPaths -> WigginsOpts -> m Text
 execWiggins binaryPaths opts = decodeUtf8 . BL.toStrict <$> execThrow (scanDir opts) (wigginsCommand binaryPaths opts)

--- a/src/Data/List/Extra.hs
+++ b/src/Data/List/Extra.hs
@@ -4,6 +4,6 @@ module Data.List.Extra ((!?)) where
 -- if the index doesn't exist, return Nothing, otherwise
 -- return Just (value)
 (!?) :: [a] -> Int -> Maybe a
-xs !? ix
-  | length xs <= ix = Nothing
-  | otherwise = Just (xs !! ix)
+xs !? ix = case drop ix xs of
+  [] -> Nothing
+  a : _ -> Just a

--- a/src/Strategy/Carthage.hs
+++ b/src/Strategy/Carthage.hs
@@ -19,7 +19,6 @@ import Data.Functor (void)
 import Data.Map.Strict qualified as Map
 import Data.String.Conversion (toString, toText)
 import Data.Text (Text)
-import Data.Text qualified as Text
 import Data.Text.Extra qualified as Text
 import Data.Void (Void)
 import DepTypes
@@ -137,7 +136,7 @@ entryToCheckoutName entry =
   case resolvedType entry of
     GitEntry -> resolvedName entry
     -- this is safe because Text.splitOn always returns a non-empty list
-    GithubType -> snd . TextExt.splitOnceOnEnd "/" $ resolvedName entry
+    GithubType -> snd . Text.splitOnceOnEnd "/" $ resolvedName entry
     BinaryType -> resolvedName entry
 
 entryToDepName :: ResolvedEntry -> Text

--- a/src/Strategy/Carthage.hs
+++ b/src/Strategy/Carthage.hs
@@ -20,6 +20,7 @@ import Data.Map.Strict qualified as Map
 import Data.String.Conversion (toString, toText)
 import Data.Text (Text)
 import Data.Text qualified as Text
+import Data.Text.Extra qualified as Text
 import Data.Void (Void)
 import DepTypes
 import Discovery.Walk
@@ -136,7 +137,7 @@ entryToCheckoutName entry =
   case resolvedType entry of
     GitEntry -> resolvedName entry
     -- this is safe because Text.splitOn always returns a non-empty list
-    GithubType -> last . Text.splitOn "/" $ resolvedName entry
+    GithubType -> snd . TextExt.splitOnceOnEnd "/" $ resolvedName entry
     BinaryType -> resolvedName entry
 
 entryToDepName :: ResolvedEntry -> Text

--- a/src/Strategy/Go/Types.hs
+++ b/src/Strategy/Go/Types.hs
@@ -11,6 +11,7 @@ import Data.Map.Strict qualified as Map
 import Data.Set (Set)
 import Data.Text (Text)
 import Data.Text qualified as Text
+import Data.Text.Extra qualified as Text
 import DepTypes
 import Effect.Grapher
 import Graphing
@@ -71,8 +72,8 @@ golangPackageToDependency pkg = foldr applyLabel start
 -- TODO: In `go.mod`, we handle this in the parser. Do we even need to handle
 -- this format in other Go analyzers? Can we just remove this code?
 fixVersion :: Text -> Text
-fixVersion = last . Text.splitOn "-" . Text.replace "+incompatible" ""
+fixVersion = snd . Text.splitOnceOnEnd "-" . Text.replace "+incompatible" ""
 
 -- replace "github.com/A/B/vendor/github.com/X/Y" with "github.com/X/Y"
 unvendor :: Text -> Text
-unvendor = last . Text.splitOn "/vendor/"
+unvendor = snd . Text.splitOnceOnEnd "/vendor/"


### PR DESCRIPTION
# Overview

Remove partial functions from the codebase.  We only really care about partial functions in the code we ship, so test- and compile-time code are ignored.
