### PR TITLE
Makes Fossa API Upload Analysis Effectful (for early feedback)

### DIFF
--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -228,6 +228,7 @@ library
     Discovery.Projects
     Discovery.Walk
     Effect.Exec
+    Effect.FossaAPI
     Effect.Grapher
     Effect.Logger
     Effect.ReadFS

--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -25,7 +25,7 @@ import App.Fossa.Analyze.Types (
   AnalyzeTaskEffs,
  )
 import App.Fossa.BinaryDeps (analyzeBinaryDeps)
-import App.Fossa.FossaAPIV1 (UploadResponse (..), getProject, projectIsMonorepo, uploadAnalysis, uploadContributors)
+import App.Fossa.FossaAPIV1 (UploadResponse (..), getProject, projectIsMonorepo, uploadContributors)
 import App.Fossa.ManualDeps (analyzeFossaDepsFile)
 import App.Fossa.ProjectInference (inferProjectDefault, inferProjectFromVCS, mergeOverride, saveRevision)
 import App.Fossa.VSI.IAT.AssertRevisionBinaries (assertRevisionBinaries)
@@ -74,6 +74,7 @@ import Discovery.Archive qualified as Archive
 import Discovery.Filters (AllFilters, applyFilters, filterIsVSIOnly)
 import Discovery.Projects (withDiscoveredProjects)
 import Effect.Exec (Exec, runExecIO)
+import Effect.FossaAPI (FossaAPI, runFossaAPI, uploadAnalysis)
 import Effect.Logger (
   Logger,
   Severity (..),
@@ -194,6 +195,7 @@ analyzeMain workdir logSeverity destination project unpackArchives jsonOutput in
     . runReadFSIO
     . runReader preferences
     . runExecIO
+    . runFossaAPI
     $ case logSeverity of
       -- In --debug mode, emit a debug bundle to "fossa.debug.json"
       SevDebug -> do
@@ -326,6 +328,7 @@ analyze ::
   , Has Exec sig m
   , Has ReadFS sig m
   , Has (Reader AnalyzeExperimentalPreferences) sig m
+  , Has FossaAPI sig m
   , MonadIO m
   ) =>
   BaseDir ->
@@ -458,6 +461,7 @@ uploadSuccessfulAnalysis ::
   , Has (Lift IO) sig m
   , Has Exec sig m
   , Has ReadFS sig m
+  , Has FossaAPI sig m
   ) =>
   BaseDir ->
   ApiOpts ->

--- a/src/App/Fossa/Analyze/Debug.hs
+++ b/src/App/Fossa/Analyze/Debug.hs
@@ -33,7 +33,7 @@ import Data.Text (Text)
 import Data.Text.IO qualified as TIO
 import Data.Word (Word64)
 import Effect.Exec (Exec, ExecF (..))
-import Effect.FossaAPI (FossaAPI, FossaAPIC, FossaAPIFS (UploadAnalysis), runFossaAPI)
+import Effect.FossaAPI (FossaAPI, FossaAPIFS (UploadAnalysis))
 import Effect.Logger (Logger, LoggerF (..))
 import Effect.ReadFS (ReadFS, ReadFSF (..))
 import GHC.Conc qualified as Conc

--- a/src/App/Types.hs
+++ b/src/App/Types.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE RecordWildCards #-}
+
 module App.Types (
   BaseDir (..),
   NinjaGraphCLIOptions (..),
@@ -8,7 +10,9 @@ module App.Types (
   MonorepoAnalysisOpts (..),
 ) where
 
-import Data.Aeson (FromJSON (parseJSON), withObject, (.:))
+import Control.Effect.Record (RecordableValue)
+import Data.Aeson (FromJSON (parseJSON), KeyValue ((.=)), object, withObject, (.:))
+import Data.Aeson.Types (ToJSON (toJSON))
 import Data.Text (Text)
 import Path (Abs, Dir, Path)
 
@@ -31,11 +35,32 @@ data ProjectMetadata = ProjectMetadata
   }
   deriving (Eq, Ord, Show)
 
+instance ToJSON ProjectMetadata where
+  toJSON ProjectMetadata{..} =
+    object
+      [ "projectTitle" .= projectTitle
+      , "projectUrl" .= projectUrl
+      , "projectJiraKey" .= projectJiraKey
+      , "projectLink" .= projectLink
+      , "projectTeam" .= projectTeam
+      , "projectPolicy" .= projectPolicy
+      , "projectReleaseGroup" .= projectReleaseGroup
+      ]
+
+instance RecordableValue (ProjectMetadata)
+
 data ReleaseGroupMetadata = ReleaseGroupMetadata
   { releaseGroupName :: Text
   , releaseGroupRelease :: Text
   }
   deriving (Eq, Ord, Show)
+
+instance ToJSON ReleaseGroupMetadata where
+  toJSON ReleaseGroupMetadata{..} =
+    object
+      [ "releaseGroupName" .= releaseGroupName
+      , "releaseGroupRelease" .= releaseGroupRelease
+      ]
 
 instance FromJSON ReleaseGroupMetadata where
   parseJSON = withObject "ReleaseGroupMetadata" $ \obj ->
@@ -52,6 +77,16 @@ data ProjectRevision = ProjectRevision
   , projectBranch :: Maybe Text
   }
   deriving (Eq, Ord, Show)
+
+instance ToJSON ProjectRevision where
+  toJSON ProjectRevision{..} =
+    object
+      [ "projectName" .= projectName
+      , "projectRevision" .= projectRevision
+      , "projectBranch" .= projectBranch
+      ]
+
+instance RecordableValue (ProjectRevision)
 
 data NinjaGraphCLIOptions = NinjaGraphCLIOptions
   { ninjaBaseDir :: FilePath

--- a/src/Effect/FossaAPI.hs
+++ b/src/Effect/FossaAPI.hs
@@ -1,0 +1,58 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+module Effect.FossaAPI (
+  FossaAPIFS (..),
+  FossaAPIC,
+  FossaAPI,
+  uploadAnalysis,
+  runFossaAPI,
+) where
+
+import App.Fossa.FossaAPIV1 (UploadResponse, cliVersion, fossaReq, mkMetadataOpts, uploadUrl)
+import App.Types (ProjectMetadata, ProjectRevision (..))
+import Control.Carrier.Simple (Has, Simple, SimpleC, interpret, sendSimple)
+import Control.Effect.Diagnostics (Diagnostics)
+import Control.Effect.Lift (Lift)
+import Control.Effect.Record.TH (deriveRecordable)
+import Data.List.NonEmpty qualified as NE
+import Fossa.API.Types (ApiOpts, useApiOpts)
+import Network.HTTP.Req (POST (POST), ReqBodyJson (ReqBodyJson), jsonResponse, req, responseBody, (=:))
+import Srclib.Types (Locator (Locator), SourceUnit, renderLocator)
+
+data FossaAPIFS a where
+  UploadAnalysis :: ApiOpts -> ProjectRevision -> ProjectMetadata -> NE.NonEmpty SourceUnit -> FossaAPIFS (UploadResponse)
+
+type FossaAPI = Simple FossaAPIFS
+type FossaAPIC = SimpleC FossaAPIFS
+
+$(deriveRecordable ''FossaAPIFS)
+
+deriving instance Show (FossaAPIFS a)
+deriving instance Eq (FossaAPIFS a)
+deriving instance Ord (FossaAPIFS a)
+
+uploadAnalysis ::
+  (Has (Lift IO) sig m, Has FossaAPI sig m) =>
+  ApiOpts ->
+  ProjectRevision ->
+  ProjectMetadata ->
+  NE.NonEmpty SourceUnit ->
+  m UploadResponse
+uploadAnalysis apiOpts rev meta srcUnit = sendSimple $ UploadAnalysis apiOpts rev meta srcUnit
+
+runFossaAPI :: (Has (Lift IO) sig m, Has Diagnostics sig m) => FossaAPIC m a -> m a
+runFossaAPI = interpret $ \case
+  UploadAnalysis apiOpts ProjectRevision{..} metadata sourceUnits ->
+    fossaReq $ do
+      (baseUrl, baseOpts) <- useApiOpts apiOpts
+      let opts =
+            "locator" =: renderLocator (Locator "custom" projectName (Just projectRevision))
+              <> "cliVersion" =: cliVersion
+              <> "managedBuild" =: True
+              <> mkMetadataOpts metadata projectName
+              -- Don't include branch if it doesn't exist, core may not handle empty string properly.
+              <> maybe mempty ("branch" =:) projectBranch
+      resp <- req POST (uploadUrl baseUrl) (ReqBodyJson $ NE.toList sourceUnits) jsonResponse (baseOpts <> opts)
+      pure (responseBody resp)

--- a/src/Fossa/API/Types.hs
+++ b/src/Fossa/API/Types.hs
@@ -16,6 +16,7 @@ module Fossa.API.Types (
 ) where
 
 import Control.Effect.Diagnostics hiding (fromMaybe)
+import Control.Effect.Record (RecordableValue)
 import Data.Aeson
 import Data.Coerce (coerce)
 import Data.List.Extra ((!?))
@@ -39,6 +40,14 @@ data ApiOpts = ApiOpts
   , apiOptsApiKey :: ApiKey
   }
   deriving (Eq, Ord, Show)
+
+instance ToJSON ApiOpts where
+  toJSON ApiOpts{..} =
+    object
+      [ "apiOptsUri" .= (render <$> apiOptsUri)
+      ]
+
+instance RecordableValue (ApiOpts)
 
 newtype SignedURL = SignedURL
   { signedURL :: Text

--- a/src/Srclib/Types.hs
+++ b/src/Srclib/Types.hs
@@ -12,7 +12,9 @@ module Srclib.Types (
   parseLocator,
 ) where
 
+import Control.Effect.Record (RecordableValue)
 import Data.Aeson
+import Data.List.NonEmpty qualified as NE
 import Data.Maybe (fromMaybe)
 import Data.String.Conversion (toText)
 import Data.Text (Text)
@@ -31,6 +33,8 @@ data SourceUnit = SourceUnit
   , additionalData :: Maybe AdditionalDepData
   }
   deriving (Eq, Ord, Show)
+
+instance RecordableValue (NE.NonEmpty SourceUnit)
 
 data SourceUnitBuild = SourceUnitBuild
   { -- | always "default"


### PR DESCRIPTION
# Overview

Adds Recordable to Upload Analysis, so we can mock FOSSA API for integration tests

## Acceptance criteria

- FOSSA API's API request and response are captured in debug bundles

## Testing plan

1. Perform analysis
```
./fossa analyze /path/to/proj --endpoint https://staging.int.fossa.io/ --fossa-api-key=yourAPIKey --project my-test-proj --debug
```

2. `gunzip fossa.debug.json.gz`
3. Note that, FOSSA API effects are captured in debug bundles

## Risks

FOSSA API is not replayable

## References

TBD

## Checklist

- [ ] I added tests for this PR's change (or confirmed tests are not viable).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] I updated `*schema.json` if I have made changes for `.fossa.yml`, `fossa-deps.{json, yaml, yml}`. You may also need to update these if you have added/removed new dependency (e.g. pip) or analysis target type (e.g. poetry).
- [ ] I linked this PR to any referenced GitHub issues, if they exist.
