### PR TITLE
Remove `packageVersion` from `NpmPackageJson`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Spectrometer Changelog
 
+## v2.19.7
+
+- Resolves a regression when parsing npm `package-lock.json` files that do not contain a `version` field ([#445](https://github.com/fossas/spectrometer/pull/445))
+
 ## v2.19.6
 
 - Special cases scans with a single VSI only filter to skip other analysis strategies ([#407](https://github.com/fossas/spectrometer/pull/407))

--- a/src/Strategy/Node/Npm/PackageLock.hs
+++ b/src/Strategy/Node/Npm/PackageLock.hs
@@ -29,7 +29,6 @@ import Strategy.Node.PackageJson (FlatDeps (directDeps), NodePackage (pkgName), 
 
 data NpmPackageJson = NpmPackageJson
   { packageName :: Text
-  , packageVersion :: Text
   , packageDependencies :: Map Text NpmDep
   }
   deriving (Eq, Ord, Show)
@@ -47,7 +46,6 @@ data NpmDep = NpmDep
 instance FromJSON NpmPackageJson where
   parseJSON = withObject "NpmPackageJson" $ \obj ->
     NpmPackageJson <$> obj .: "name"
-      <*> obj .: "version"
       <*> obj .: "dependencies"
 
 instance FromJSON NpmDep where

--- a/test/Node/NpmLockSpec.hs
+++ b/test/Node/NpmLockSpec.hs
@@ -13,7 +13,6 @@ mockInput :: NpmPackageJson
 mockInput =
   NpmPackageJson
     { packageName = "example"
-    , packageVersion = "1.0.0"
     , packageDependencies =
         Map.fromList
           [


### PR DESCRIPTION
# Overview

No longer attempts to parse the `version` field in `package-lock.json`.

This field denotes the version of the project being scanned, which we don't care about. However, `package-lock.json` files without this field fail parsing.

## Acceptance criteria

1. `package-lock.json` files without the `version` field present now parse correctly.
2. The `--output` is the same between a project parsed with the `version` field intact and without the `version` field.

## Testing plan

I used the example `package.json` and `package-lock.json` in the [attached archive file](https://github.com/fossas/spectrometer/files/7515353/Example-Project.zip).

I then:

* Verified that the CLI fails to parse the project.
* Inserted a `version` field into `package-lock.json` and recorded the result of running analysis with `--output`.
* Removed the `version` field, applied the changes in this PR, and then recorded the result of running analysis with `--output`.
* Compared the two recorded results (recorded in [pkglock-outputs.zip](https://github.com/fossas/spectrometer/files/7515361/pkglock-outputs.zip)), and observed they are identical.

## Risks

I don't think this is very risky, as far as I can tell this field is totally unused.

## References

Closes https://github.com/fossas/team-analysis/issues/810

## Checklist

- [x] I added tests for this PR's change (or confirmed tests are not viable).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] I updated `*schema.json` if I have made changes for `.fossa.yml`, `fossa-deps.{json, yaml, yml}`. You may also need to update these if you have added/removed new dependency (e.g. pip) or analysis target type (e.g. poetry).
- [x] I linked this PR to any referenced GitHub issues, if they exist.

